### PR TITLE
Correct entries related to --enable-build-mode and --enable-profiling in

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -97,10 +97,4 @@ and/or accompanying materials:
 
 -----------------------------------------------------------------------------
 
-HDF5 is available with the SZIP compression library but SZIP is not part 
-of HDF5 and has separate copyright and license terms. See SZIP Compression 
-in HDF Products (www.hdfgroup.org/doc_resource/SZIP/) for further details.
-
------------------------------------------------------------------------------
-
 

--- a/release_docs/INSTALL
+++ b/release_docs/INSTALL
@@ -351,15 +351,18 @@ CONTENTS
         so it can be debugged with gdb, dbx, ddd, etc., or it can be
         compiled with various optimizations. To compile for symbolic
         debugging (the default for snapshots), say
-        `--enable-build-mode=production'; to compile with optimizations
+        `--enable-build-mode=debug'; to compile with optimizations
         (the default for supported public releases),
-        say `--enable-build-mode=production'. On some systems the
+        say `--enable-build-mode=production'. For a 'clean slate' configuration
+        with optimization disabled and nothing turned on,
+        say `--enable-build-mode=clean'. On some systems the
         library can also be compiled for profiling with gprof by saying
-        `--enable-production=profile'.
+        `--enable-profiling'.
 
             $ ./configure --enable-build-mode=debug       #symbolic debugging
             $ ./configure --enable-build-mode=production  #optimized code
-            $ ./configure --enable-production=profile     #for use with gprof
+            $ ./configure --enable-build-mode=clean       #'clean slate'
+            $ ./configure --enable-profiling              #for use with gprof
 
         Regardless of whether support for symbolic debugging is enabled,
         the library can also perform runtime debugging of certain packages

--- a/src/H5PLpath.c
+++ b/src/H5PLpath.c
@@ -669,8 +669,10 @@ H5PL__find_plugin_in_path(const H5PL_search_params_t *search_params, hbool_t *fo
                             HDstrerror(errno))
 
             /* If it is a directory, skip it */
-            if (S_ISDIR(my_stat.st_mode))
+            if (S_ISDIR(my_stat.st_mode)) {
+                path = (char *)H5MM_xfree(path);
                 continue;
+            }
 
             /* attempt to open the dynamic library as a filter library */
             if (H5PL__open(path, search_params->type, search_params->key, found, plugin_info) < 0)


### PR DESCRIPTION
INSTALL file, and remove obsolete SZIP paragraph from COPYING file.
Fix #9 