### PR TITLE
Updates CMake files to work with VFD SWMR

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ set (H5_SOURCES
     ${HDF5_SRC_DIR}/H5system.c
     ${HDF5_SRC_DIR}/H5timer.c
     ${HDF5_SRC_DIR}/H5trace.c
+    ${HDF5_SRC_DIR}/hlog.c
 )
 
 set (H5_HDRS
@@ -199,6 +200,7 @@ set (H5F_SOURCES
     ${HDF5_SRC_DIR}/H5Fsuper.c
     ${HDF5_SRC_DIR}/H5Fsuper_cache.c
     ${HDF5_SRC_DIR}/H5Ftest.c
+    ${HDF5_SRC_DIR}/H5Fvfd_swmr.c
 )
 
 set (H5F_HDRS
@@ -242,6 +244,8 @@ set (H5FD_SOURCES
     ${HDF5_SRC_DIR}/H5FDsplitter.c
     ${HDF5_SRC_DIR}/H5FDstdio.c
     ${HDF5_SRC_DIR}/H5FDtest.c
+    ${HDF5_SRC_DIR}/H5FDvfd_swmr.c
+    ${HDF5_SRC_DIR}/H5FDvfd_swmr_instr.c
     ${HDF5_SRC_DIR}/H5FDwindows.c
 )
 
@@ -261,6 +265,7 @@ set (H5FD_HDRS
     ${HDF5_SRC_DIR}/H5FDsec2.h
     ${HDF5_SRC_DIR}/H5FDsplitter.h
     ${HDF5_SRC_DIR}/H5FDstdio.h
+    ${HDF5_SRC_DIR}/H5FDvfd_swmr.h
     ${HDF5_SRC_DIR}/H5FDwindows.h
 )
 IDE_GENERATED_PROPERTIES ("H5FD" "${H5FD_HDRS}" "${H5FD_SOURCES}" )
@@ -350,6 +355,7 @@ set (H5HG_SOURCES
     ${HDF5_SRC_DIR}/H5HGcache.c
     ${HDF5_SRC_DIR}/H5HGdbg.c
     ${HDF5_SRC_DIR}/H5HGquery.c
+    ${HDF5_SRC_DIR}/H5HGtrap.c
 )
 
 set (H5HG_HDRS
@@ -437,6 +443,14 @@ set (H5MP_SOURCES
 set (H5MP_HDRS
 )
 IDE_GENERATED_PROPERTIES ("H5MP" "${H5MP_HDRS}" "${H5MP_SOURCES}" )
+
+set (H5MV_SOURCES
+    ${HDF5_SRC_DIR}/H5MV.c
+    ${HDF5_SRC_DIR}/H5MVsection.c
+)
+set (H5MV_HDRS
+)
+IDE_GENERATED_PROPERTIES ("H5MV" "${H5MV_HDRS}" "${H5MV_SOURCES}" )
 
 set (H5O_SOURCES
     ${HDF5_SRC_DIR}/H5O.c
@@ -742,6 +756,7 @@ set (common_SRCS
     ${H5MF_SOURCES}
     ${H5MM_SOURCES}
     ${H5MP_SOURCES}
+    ${H5MV_SOURCES}
     ${H5O_SOURCES}
     ${H5P_SOURCES}
     ${H5PB_SOURCES}
@@ -786,6 +801,7 @@ set (H5_PUBLIC_HEADERS
     ${H5MF_HDRS}
     ${H5MM_HDRS}
     ${H5MP_HDRS}
+    ${H5MV_HDRS}
     ${H5O_HDRS}
     ${H5P_HDRS}
     ${H5PB_HDRS}
@@ -800,6 +816,7 @@ set (H5_PUBLIC_HEADERS
 
 set (H5_PRIVATE_HEADERS
     ${HDF5_SRC_DIR}/H5private.h
+    ${HDF5_SRC_DIR}/hlog.h
 
     ${HDF5_SRC_DIR}/H5Apkg.h
     ${HDF5_SRC_DIR}/H5Aprivate.h
@@ -841,6 +858,7 @@ set (H5_PRIVATE_HEADERS
 
     ${HDF5_SRC_DIR}/H5FDpkg.h
     ${HDF5_SRC_DIR}/H5FDprivate.h
+    ${HDF5_SRC_DIR}/H5FDvfd_swmr_private.h
 
     ${HDF5_SRC_DIR}/H5FLprivate.h
 
@@ -878,6 +896,9 @@ set (H5_PRIVATE_HEADERS
 
     ${HDF5_SRC_DIR}/H5MPpkg.h
     ${HDF5_SRC_DIR}/H5MPprivate.h
+
+    ${HDF5_SRC_DIR}/H5MVpkg.h
+    ${HDF5_SRC_DIR}/H5MVprivate.h
 
     ${HDF5_SRC_DIR}/H5Opkg.h
     ${HDF5_SRC_DIR}/H5Oprivate.h

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,8 +16,8 @@ set (TEST_LIB_SOURCES
     ${HDF5_TEST_SOURCE_DIR}/cache_common.c
     ${HDF5_TEST_SOURCE_DIR}/external_common.c
     ${HDF5_TEST_SOURCE_DIR}/swmr_common.c
+    ${HDF5_TEST_SOURCE_DIR}/stubs.c
     ${HDF5_TEST_SOURCE_DIR}/vfd_swmr_common.c
-    ${HDF5_TEST_SOURCE_DIR}/vds_swmr_common.c
 )
 
 set (TEST_LIB_HEADERS
@@ -219,6 +219,16 @@ set(mirror_vfd_SOURCES
     ${HDF5_TEST_SOURCE_DIR}/genall5.c
 )
 
+set(vfd_swmr_zoo_reader_SOURCES
+    ${HDF5_TEST_SOURCE_DIR}/vfd_swmr_zoo_reader.c
+    ${HDF5_TEST_SOURCE_DIR}/genall5.c
+)
+
+set(vfd_swmr_zoo_writer_SOURCES
+    ${HDF5_TEST_SOURCE_DIR}/vfd_swmr_zoo_writer.c
+    ${HDF5_TEST_SOURCE_DIR}/genall5.c
+)
+
 set (ttsafe_SOURCES
     ${HDF5_TEST_SOURCE_DIR}/ttsafe.c
     ${HDF5_TEST_SOURCE_DIR}/ttsafe_dcreate.c
@@ -298,6 +308,7 @@ set (H5_TESTS
     cork
     swmr
     thread_id # special link
+    vfd_swmr
     vol
     timer
 )
@@ -504,12 +515,17 @@ foreach (h5_test ${H5_VDS_SWMR_TESTS})
 endforeach ()
 
 set (H5_VFD_SWMR_TESTS
-    vds_swmr_addrem_writer
+    vfd_swmr_addrem_writer
+    vfd_swmr_bigset_writer
     vfd_swmr_generator
+    vfd_swmr_group_writer
     vfd_swmr_reader
     vfd_swmr_remove_reader
     vfd_swmr_remove_writer
+    vfd_swmr_sparse_reader
     vfd_swmr_sparse_writer
+    vfd_swmr_vlstr_reader
+    vfd_swmr_vlstr_writer
     vfd_swmr_writer
 )
 

--- a/test/testfiles/links_env.out
+++ b/test/testfiles/links_env.out
@@ -1,3 +1,3 @@
-Testing external links via environment variable                        PASSED
-Testing external links via environment variable (w/new group format)   PASSED
+Testing external links via environment variable PASSED
+Testing external links via environment variable (w/new group format) PASSED
 All external Link (HDF5_EXT_PREFIX) tests passed.


### PR DESCRIPTION
- CMake files were updated to build new files in src and test.

- As with legacy SWMR, the test programs that are run via shell
  scripts are built but not run.

- Updated whitespace in the links_env output file. It's unclear why
  this changed, but CMake does an exact diff on the file whereas
  the autotools do not.