### PR TITLE
Note that the description for system errors may be used by h5py

### DIFF
--- a/src/H5Eprivate.h
+++ b/src/H5Eprivate.h
@@ -114,14 +114,18 @@ typedef struct H5E_t H5E_t;
 #define HSYS_DONE_ERROR(majorcode, minorcode, retcode, str)                                                  \
     {                                                                                                        \
         int myerrno = errno;                                                                                 \
-        /* h5py may rely on the description format to get the errno - please try to avoid breaking it */     \
+        /* Other projects may rely on the description format to get the errno and any changes should be      \
+         * considered as an API change                                                                       \
+         */                                                                                                  \
         HDONE_ERROR(majorcode, minorcode, retcode, "%s, errno = %d, error message = '%s'", str, myerrno,     \
                     HDstrerror(myerrno));                                                                    \
     }
 #define HSYS_GOTO_ERROR(majorcode, minorcode, retcode, str)                                                  \
     {                                                                                                        \
         int myerrno = errno;                                                                                 \
-        /* h5py may rely on the description format to get the errno - please try to avoid breaking it */     \
+        /* Other projects may rely on the description format to get the errno and any changes should be      \
+         * considered as an API change                                                                       \
+         */                                                                                                  \
         HGOTO_ERROR(majorcode, minorcode, retcode, "%s, errno = %d, error message = '%s'", str, myerrno,     \
                     HDstrerror(myerrno));                                                                    \
     }

--- a/src/H5Eprivate.h
+++ b/src/H5Eprivate.h
@@ -114,12 +114,14 @@ typedef struct H5E_t H5E_t;
 #define HSYS_DONE_ERROR(majorcode, minorcode, retcode, str)                                                  \
     {                                                                                                        \
         int myerrno = errno;                                                                                 \
+        /* h5py may rely on the description format to get the errno - please try to avoid breaking it */     \
         HDONE_ERROR(majorcode, minorcode, retcode, "%s, errno = %d, error message = '%s'", str, myerrno,     \
                     HDstrerror(myerrno));                                                                    \
     }
 #define HSYS_GOTO_ERROR(majorcode, minorcode, retcode, str)                                                  \
     {                                                                                                        \
         int myerrno = errno;                                                                                 \
+        /* h5py may rely on the description format to get the errno - please try to avoid breaking it */     \
         HGOTO_ERROR(majorcode, minorcode, retcode, "%s, errno = %d, error message = '%s'", str, myerrno,     \
                     HDstrerror(myerrno));                                                                    \
     }


### PR DESCRIPTION
Following discussion on #34, we decided that this could simply be a comment in the source code. The string format here has been stable for 11 years (since a44328438aa5bbe4c4927b584af18d7965e6794a), so hopefully there's no major pressure to change it.

We're just about to release h5py 3.0, so we'll look into getting the errno from the string after that.