### PR TITLE
Update javadoc comments to reduce warnings

### DIFF
--- a/java/src/hdf/hdf5lib/H5.java
+++ b/java/src/hdf/hdf5lib/H5.java
@@ -241,10 +241,14 @@ public class H5 implements java.io.Serializable {
      */
     public final static int LIB_VERSION[] = { 1, 13, 0 };
 
+    /**
+    *  add system property to load library by path
+    */
     public final static String H5PATH_PROPERTY_KEY = "hdf.hdf5lib.H5.hdf5lib";
 
-    // add system property to load library by name from library path, via
-    // System.loadLibrary()
+    /**
+    *  add system property to load library by name from library path, via System.loadLibrary()
+    */
     public final static String H5_LIBRARY_NAME_PROPERTY_KEY = "hdf.hdf5lib.H5.loadLibraryName";
     private static String s_libraryName;
     private static boolean isLibraryLoaded = false;
@@ -257,6 +261,9 @@ public class H5 implements java.io.Serializable {
         loadH5Lib();
     }
 
+    /**
+    *  load native library
+    */
     public static void loadH5Lib() {
         // Make sure that the library is loaded only once
         if (isLibraryLoaded)
@@ -468,6 +475,35 @@ public class H5 implements java.io.Serializable {
      **/
     public synchronized static native int H5get_libversion(int[] libversion) throws HDF5LibraryException;
 
+    /**
+     * H5set_free_list_limits
+     *      Sets limits on the different kinds of free lists.  Setting a value
+     *      of -1 for a limit means no limit of that type.  These limits are global
+     *      for the entire library.  Each "global" limit only applies to free lists
+     *      of that type, so if an application sets a limit of 1 MB on each of the
+     *      global lists, up to 3 MB of total storage might be allocated (1MB on
+     *      each of regular, array and block type lists).
+     *
+     *      The settings for block free lists are duplicated to factory free lists.
+     *      Factory free list limits cannot be set independently currently.
+     *
+     * @param reg_global_lim
+     *           The limit on all "regular" free list memory used
+     * @param reg_list_lim
+     *           The limit on memory used in each "regular" free list
+     * @param arr_global_lim
+     *           The limit on all "array" free list memory used
+     * @param arr_list_lim
+     *           The limit on memory used in each "array" free list
+     * @param blk_global_lim
+     *           The limit on all "block" free list memory used
+     * @param blk_list_lim
+     *           The limit on memory used in each "block" free list
+     * @return a non-negative value if successful, along with the version information.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+    */
     public synchronized static native int H5set_free_list_limits(int reg_global_lim, int reg_list_lim,
             int arr_global_lim, int arr_list_lim, int blk_global_lim, int blk_list_lim) throws HDF5LibraryException;
 
@@ -1016,7 +1052,7 @@ public class H5 implements java.io.Serializable {
 
     /**
      * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
-     * mem_type_id. The entire attribute is read into buf from the file.
+     * mem_type_id. The entire attribute is read into buffer from the file.
      *
      * @param attr_id
      *            IN: Identifier of an attribute to read.
@@ -1037,11 +1073,47 @@ public class H5 implements java.io.Serializable {
     public synchronized static native int H5Aread(long attr_id, long mem_type_id, byte[] obj, boolean isCriticalPinning)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer from the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            Buffer to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static int H5Aread(long attr_id, long mem_type_id, byte[] buf) throws HDF5LibraryException, NullPointerException
     {
         return H5Aread(attr_id, mem_type_id, buf, true);
     }
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer from the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param obj
+     *            Buffer to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static int H5Aread(long attr_id, long mem_type_id, Object obj) throws HDF5Exception, HDF5LibraryException, NullPointerException
     {
         return H5Aread(attr_id, mem_type_id, obj, true);
@@ -1141,63 +1213,343 @@ public class H5 implements java.io.Serializable {
         return status;
     }
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer of double from the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            Buffer of double to store data read from the file.
+     * @param isCriticalPinning
+     *            request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5Aread_double(long attr_id, long mem_type_id, double[] buf, boolean isCriticalPinning)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer of double from the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            Buffer of double to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static int H5Aread_double(long attr_id, long mem_type_id, double[] buf)
             throws HDF5LibraryException, NullPointerException
     {
         return H5Aread_double(attr_id, mem_type_id, buf, true);
     }
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer of float from the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            Buffer of float to store data read from the file.
+     * @param isCriticalPinning
+     *            request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5Aread_float(long attr_id, long mem_type_id, float[] buf, boolean isCriticalPinning)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer of float from the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            Buffer of float to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static int H5Aread_float(long attr_id, long mem_type_id, float[] buf)
             throws HDF5LibraryException, NullPointerException
     {
         return H5Aread_float(attr_id, mem_type_id, buf, true);
     }
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer of int from the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            Buffer of int to store data read from the file.
+     * @param isCriticalPinning
+     *            request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5Aread_int(long attr_id, long mem_type_id, int[] buf, boolean isCriticalPinning)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer of int from the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            Buffer of int to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static int H5Aread_int(long attr_id, long mem_type_id, int[] buf)
             throws HDF5LibraryException, NullPointerException
     {
         return H5Aread_int(attr_id, mem_type_id, buf, true);
     }
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer of long from the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            Buffer of long to store data read from the file.
+     * @param isCriticalPinning
+     *            request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5Aread_long(long attr_id, long mem_type_id, long[] buf, boolean isCriticalPinning)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer of long from the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            Buffer of long to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static int H5Aread_long(long attr_id, long mem_type_id, long[] buf)
             throws HDF5LibraryException, NullPointerException
     {
         return H5Aread_long(attr_id, mem_type_id, buf, true);
     }
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer of String from the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            Buffer of String to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5Aread_reg_ref(long attr_id, long mem_type_id, String[] buf)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer of short from the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            Buffer of short to store data read from the file.
+     * @param isCriticalPinning
+     *            request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5Aread_short(long attr_id, long mem_type_id, short[] buf, boolean isCriticalPinning)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer  of shortfrom the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            Buffer of short to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static int H5Aread_short(long attr_id, long mem_type_id, short[] buf)
             throws HDF5LibraryException, NullPointerException
     {
         return H5Aread_short(attr_id, mem_type_id, buf, true);
     }
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer of variable-lenght from the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            Buffer of variable-lenght to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5AreadVL(long attr_id, long mem_type_id, Object[] buf)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer of String from the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            Buffer of String to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5Aread_string(long attr_id, long mem_type_id, String[] buf)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer of variable-lenght strings from the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            Buffer of variable-lenght strings to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5Aread_VLStrings(long attr_id, long mem_type_id, Object[] buf)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Aread reads an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is read into buffer of string from the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to read.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            Buffer of string to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5AreadComplex(long attr_id, long mem_type_id, String[] buf)
             throws HDF5LibraryException, NullPointerException;
 
@@ -1270,12 +1622,48 @@ public class H5 implements java.io.Serializable {
     public synchronized static native int H5Awrite(long attr_id, long mem_type_id, byte[] buf, boolean isCriticalPinning)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Awrite writes an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is written from buf to the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to write.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            IN: Buffer with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data is null.
+     **/
     public synchronized static int H5Awrite(long attr_id, long mem_type_id, byte[] buf)
             throws HDF5LibraryException, NullPointerException
     {
         return H5Awrite(attr_id, mem_type_id, buf, true);
     }
 
+    /**
+     * H5Awrite writes an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is written from buf to the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to write.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param obj
+     *            IN: Buffer with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data is null.
+     **/
     public synchronized static int H5Awrite(long attr_id, long mem_type_id, Object obj)
             throws HDF5Exception, HDF5LibraryException, NullPointerException
     {
@@ -1353,60 +1741,286 @@ public class H5 implements java.io.Serializable {
         return status;
     }
 
+    /**
+     * H5Awrite writes an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is written from buffer of double to the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to write.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            IN: Buffer of double with data to be written to the file.
+     * @param isCriticalPinning
+     *            IN: request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data is null.
+     **/
     public synchronized static native int H5Awrite_double(long attr_id, long mem_type_id, double[] buf, boolean isCriticalPinning)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Awrite writes an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is written from buffer of double to the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to write.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            IN: Buffer of double with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data is null.
+     **/
     public synchronized static int H5Awrite_double(long attr_id, long mem_type_id, double[] buf)
             throws HDF5LibraryException, NullPointerException
     {
         return H5Awrite_double(attr_id, mem_type_id, buf, true);
     }
 
+    /**
+     * H5Awrite writes an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is written from buffer of float to the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to write.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            IN: Buffer of float with data to be written to the file.
+     * @param isCriticalPinning
+     *            IN: request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data is null.
+     **/
     public synchronized static native int H5Awrite_float(long attr_id, long mem_type_id, float[] buf, boolean isCriticalPinning)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Awrite writes an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is written from buffer of float to the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to write.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            IN: Buffer of float with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data is null.
+     **/
     public synchronized static int H5Awrite_float(long attr_id, long mem_type_id, float[] buf)
             throws HDF5LibraryException, NullPointerException
     {
         return H5Awrite_float(attr_id, mem_type_id, buf, true);
     }
 
+    /**
+     * H5Awrite writes an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is written from buffer of int to the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to write.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            IN: Buffer of int with data to be written to the file.
+     * @param isCriticalPinning
+     *            IN: request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data is null.
+     **/
     public synchronized static native int H5Awrite_int(long attr_id, long mem_type_id, int[] buf, boolean isCriticalPinning)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Awrite writes an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is written from buffer of int to the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to write.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            IN: Buffer of int with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data is null.
+     **/
     public synchronized static int H5Awrite_int(long attr_id, long mem_type_id, int[] buf)
             throws HDF5LibraryException, NullPointerException
     {
         return H5Awrite_int(attr_id, mem_type_id, buf, true);
     }
 
+    /**
+     * H5Awrite writes an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is written from buffer of long to the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to write.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            IN: Buffer of long with data to be written to the file.
+     * @param isCriticalPinning
+     *            IN: request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data is null.
+     **/
     public synchronized static native int H5Awrite_long(long attr_id, long mem_type_id, long[] buf, boolean isCriticalPinning)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Awrite writes an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is written from buffer of long to the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to write.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            IN: Buffer of long with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data is null.
+     **/
     public synchronized static int H5Awrite_long(long attr_id, long mem_type_id, long[] buf)
             throws HDF5LibraryException, NullPointerException
     {
         return H5Awrite_long(attr_id, mem_type_id, buf, true);
     }
 
+    /**
+     * H5Awrite writes an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is written from buffer of short to the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to write.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            IN: Buffer of short with data to be written to the file.
+     * @param isCriticalPinning
+     *            IN: request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data is null.
+     **/
     public synchronized static native int H5Awrite_short(long attr_id, long mem_type_id, short[] buf, boolean isCriticalPinning)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Awrite writes an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is written from buffer of short to the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to write.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            IN: Buffer of short with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data is null.
+     **/
     public synchronized static int H5Awrite_short(long attr_id, long mem_type_id, short[] buf)
             throws HDF5LibraryException, NullPointerException
     {
         return H5Awrite_short(attr_id, mem_type_id, buf, true);
     }
 
+    /**
+     * H5Awrite writes an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is written from buffer of string to the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to write.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            IN: Buffer of string with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data is null.
+     **/
     public synchronized static native int H5Awrite_string(long attr_id, long mem_type_id, String[] buf)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Awrite writes an attribute, specified with attr_id. The attribute's memory datatype is specified with
+     * mem_type_id. The entire attribute is written from buffer of variable-lenght to the file.
+     *
+     * @param attr_id
+     *            IN: Identifier of an attribute to write.
+     * @param mem_type_id
+     *            IN: Identifier of the attribute datatype (in memory).
+     * @param buf
+     *            IN: Buffer of variable-lenght with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data is null.
+     **/
     public synchronized static native int H5AwriteVL(long attr_id, long mem_type_id, Object[] buf)
             throws HDF5LibraryException, NullPointerException;
 
     /**
      * H5Awrite_VLStrings writes a variable length String dataset, specified by its identifier attr_id, from
-     * the application memory buffer buf into the file.
+     * the application memory buffer buffer of variable-lenght strings into the file.
      *
      * ---- contributed by Rosetta Biosoftware
      *
@@ -1415,7 +2029,7 @@ public class H5 implements java.io.Serializable {
      * @param mem_type_id
      *            Identifier of the memory datatype.
      * @param buf
-     *            Buffer with data to be written to the file.
+     *            Buffer of variable-lenght strings with data to be written to the file.
      *
      * @return a non-negative value if successful
      *
@@ -1922,12 +2536,60 @@ public class H5 implements java.io.Serializable {
             long file_space_id, long xfer_plist_id, byte[] obj, boolean isCriticalPinning) throws HDF5LibraryException,
             NullPointerException;
 
+    /**
+     * H5Dread reads a (partial) dataset, specified by its identifier dataset_id, from the file into the application
+     * memory buffer buf.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static int H5Dread(long dataset_id, long mem_type_id, long mem_space_id, long file_space_id,
             long xfer_plist_id, byte[] buf) throws HDF5LibraryException, NullPointerException
     {
         return H5Dread(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf, true);
     }
 
+    /**
+     * H5Dread reads a (partial) dataset, specified by its identifier dataset_id, from the file into the application
+     * memory buffer buf.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param obj
+     *            Buffer to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static int H5Dread(long dataset_id, long mem_type_id, long mem_space_id, long file_space_id,
             long xfer_plist_id, Object obj) throws HDF5Exception, HDF5LibraryException, NullPointerException
     {
@@ -2043,65 +2705,411 @@ public class H5 implements java.io.Serializable {
         return status;
     }
 
+    /**
+     * H5Dread reads a (partial) dataset, specified by its identifier dataset_id, from the file into the application
+     * memory buffer of type double.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of type double to store data read from the file.
+     * @param isCriticalPinning
+     *            request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5Dread_double(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, double[] buf, boolean isCriticalPinning)
                     throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Dread reads a (partial) dataset, specified by its identifier dataset_id, from the file into the application
+     * memory buffer of type double.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of double to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static int H5Dread_double(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, double[] buf) throws HDF5LibraryException, NullPointerException
     {
         return H5Dread_double(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf, true);
     }
 
+    /**
+     * H5Dread reads a (partial) dataset, specified by its identifier dataset_id, from the file into the application
+     * memory buffer of float.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of float to store data read from the file.
+     * @param isCriticalPinning
+     *            request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5Dread_float(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, float[] buf, boolean isCriticalPinning)
                     throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Dread reads a (partial) dataset, specified by its identifier dataset_id, from the file into the application
+     * memory buffer of float.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of float to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static int H5Dread_float(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, float[] buf) throws HDF5LibraryException, NullPointerException
     {
         return H5Dread_float(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf, true);
     }
 
+    /**
+     * H5Dread reads a (partial) dataset, specified by its identifier dataset_id, from the file into the application
+     * memory buffer of int.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of int to store data read from the file.
+     * @param isCriticalPinning
+     *            request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5Dread_int(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, int[] buf, boolean isCriticalPinning) throws HDF5LibraryException,
             NullPointerException;
 
+    /**
+     * H5Dread reads a (partial) dataset, specified by its identifier dataset_id, from the file into the application
+     * memory buffer of int.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of int to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static int H5Dread_int(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, int[] buf) throws HDF5LibraryException, NullPointerException
     {
         return H5Dread_int(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf, true);
     }
 
+    /**
+     * H5Dread reads a (partial) dataset, specified by its identifier dataset_id, from the file into the application
+     * memory buffer of long.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of long to store data read from the file.
+     * @param isCriticalPinning
+     *            request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5Dread_long(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, long[] buf, boolean isCriticalPinning) throws HDF5LibraryException,
             NullPointerException;
 
+    /**
+     * H5Dread reads a (partial) dataset, specified by its identifier dataset_id, from the file into the application
+     * memory buffer of long.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of long to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static int H5Dread_long(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, long[] buf) throws HDF5LibraryException, NullPointerException
     {
         return H5Dread_long(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf, true);
     }
 
+    /**
+     * H5Dread reads a (partial) dataset, specified by its identifier dataset_id, from the file into the application
+     * memory buffer of string.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of string to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5Dread_reg_ref(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, String[] buf) throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Dread reads a (partial) dataset, specified by its identifier dataset_id, from the file into the application
+     * memory buffer of short.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of short to store data read from the file.
+     * @param isCriticalPinning
+     *            request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5Dread_short(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, short[] buf, boolean isCriticalPinning)
                     throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Dread reads a (partial) dataset, specified by its identifier dataset_id, from the file into the application
+     * memory buffer of short.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of short to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static int H5Dread_short(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, short[] buf) throws HDF5LibraryException, NullPointerException
     {
         return H5Dread_short(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf, true);
     }
 
+    /**
+     * H5Dread reads a (partial) dataset, specified by its identifier dataset_id, from the file into the application
+     * memory buffer of variable-lenght.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of variable-lenght to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5DreadVL(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, Object[] buf) throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Dread reads a (partial) dataset, specified by its identifier dataset_id, from the file into the application
+     * memory buffer of string.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of string to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5Dread_string(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, String[] buf) throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Dread reads a (partial) dataset, specified by its identifier dataset_id, from the file into the application
+     * memory buffer of variable-lenght strings.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of variable-lenght strings to store data read from the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - data buffer is null.
+     **/
     public synchronized static native int H5Dread_VLStrings(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, Object[] buf) throws HDF5LibraryException, NullPointerException;
 
@@ -2170,7 +3178,7 @@ public class H5 implements java.io.Serializable {
 
     /**
      * H5Dwrite writes a (partial) dataset, specified by its identifier dataset_id, from the application memory buffer
-     * buf into the file.
+     * into the file.
      *
      * @param dataset_id
      *            Identifier of the dataset read from.
@@ -2198,12 +3206,60 @@ public class H5 implements java.io.Serializable {
             long file_space_id, long xfer_plist_id, byte[] buf, boolean isCriticalPinning) throws HDF5LibraryException,
             NullPointerException;
 
+    /**
+     * H5Dwrite writes a (partial) dataset, specified by its identifier dataset_id, from the application memory buffer
+     * into the file.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     **/
     public synchronized static int H5Dwrite(long dataset_id, long mem_type_id, long mem_space_id, long file_space_id,
             long xfer_plist_id, byte[] buf) throws HDF5LibraryException, NullPointerException
     {
         return H5Dwrite(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf, true);
     }
 
+    /**
+     * H5Dwrite writes a (partial) dataset, specified by its identifier dataset_id, from the application memory buffer
+     * into the file.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param obj
+     *            Buffer with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     **/
     public synchronized static int H5Dwrite(long dataset_id, long mem_type_id, long mem_space_id, long file_space_id,
             long xfer_plist_id, Object obj) throws HDF5Exception, HDF5LibraryException, NullPointerException
     {
@@ -2299,59 +3355,357 @@ public class H5 implements java.io.Serializable {
         return status;
     }
 
+    /**
+     * H5Dwrite writes a (partial) dataset, specified by its identifier dataset_id, from the application memory buffer
+     * into the file.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of double with data to be written to the file.
+     * @param isCriticalPinning
+     *            request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     **/
     public synchronized static native int H5Dwrite_double(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, double[] buf, boolean isCriticalPinning)
                     throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Dwrite writes a (partial) dataset, specified by its identifier dataset_id, from the application memory buffer
+     * into the file.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of double with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     **/
     public synchronized static int H5Dwrite_double(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, double[] buf) throws HDF5LibraryException, NullPointerException
     {
         return H5Dwrite_double(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf, true);
     }
 
+    /**
+     * H5Dwrite writes a (partial) dataset, specified by its identifier dataset_id, from the application memory buffer
+     * into the file.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of float with data to be written to the file.
+     * @param isCriticalPinning
+     *            request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     **/
     public synchronized static native int H5Dwrite_float(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, float[] buf, boolean isCriticalPinning)
                     throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Dwrite writes a (partial) dataset, specified by its identifier dataset_id, from the application memory buffer
+     * into the file.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of float with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     **/
     public synchronized static int H5Dwrite_float(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, float[] buf) throws HDF5LibraryException, NullPointerException
     {
         return H5Dwrite_float(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf, true);
     }
 
+    /**
+     * H5Dwrite writes a (partial) dataset, specified by its identifier dataset_id, from the application memory buffer
+     * into the file.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of int with data to be written to the file.
+     * @param isCriticalPinning
+     *            request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     **/
     public synchronized static native int H5Dwrite_int(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, int[] buf, boolean isCriticalPinning) throws HDF5LibraryException,
             NullPointerException;
 
+    /**
+     * H5Dwrite writes a (partial) dataset, specified by its identifier dataset_id, from the application memory buffer
+     * into the file.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of int with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     **/
     public synchronized static int H5Dwrite_int(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, int[] buf) throws HDF5LibraryException, NullPointerException
     {
         return H5Dwrite_int(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf, true);
     }
 
+    /**
+     * H5Dwrite writes a (partial) dataset, specified by its identifier dataset_id, from the application memory buffer
+     * into the file.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of long with data to be written to the file.
+     * @param isCriticalPinning
+     *            request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     **/
     public synchronized static native int H5Dwrite_long(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, long[] buf, boolean isCriticalPinning) throws HDF5LibraryException,
             NullPointerException;
 
+    /**
+     * H5Dwrite writes a (partial) dataset, specified by its identifier dataset_id, from the application memory buffer
+     * into the file.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of long with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     **/
     public synchronized static int H5Dwrite_long(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, long[] buf) throws HDF5LibraryException, NullPointerException
     {
         return H5Dwrite_long(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf, true);
     }
 
+    /**
+     * H5Dwrite writes a (partial) dataset, specified by its identifier dataset_id, from the application memory buffer
+     * into the file.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of short with data to be written to the file.
+     * @param isCriticalPinning
+     *            request lock on data reference.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     **/
     public synchronized static native int H5Dwrite_short(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, short[] buf, boolean isCriticalPinning)
                     throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Dwrite writes a (partial) dataset, specified by its identifier dataset_id, from the application memory buffer
+     * into the file.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of short with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     **/
     public synchronized static int H5Dwrite_short(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, short[] buf) throws HDF5LibraryException, NullPointerException
     {
         return H5Dwrite_short(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf, true);
     }
 
+    /**
+     * H5Dwrite writes a (partial) dataset, specified by its identifier dataset_id, from the application memory buffer
+     * into the file.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of string with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     **/
     public synchronized static native int H5Dwrite_string(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, String[] buf) throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Dwrite writes a (partial) dataset, specified by its identifier dataset_id, from the application memory buffer
+     * into the file.
+     *
+     * @param dataset_id
+     *            Identifier of the dataset read from.
+     * @param mem_type_id
+     *            Identifier of the memory datatype.
+     * @param mem_space_id
+     *            Identifier of the memory dataspace.
+     * @param file_space_id
+     *            Identifier of the dataset's dataspace in the file.
+     * @param xfer_plist_id
+     *            Identifier of a transfer property list for this I/O operation.
+     * @param buf
+     *            Buffer of variable-length with data to be written to the file.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     **/
     public synchronized static native int H5DwriteVL(long dataset_id, long mem_type_id, long mem_space_id,
             long file_space_id, long xfer_plist_id, Object[] buf) throws HDF5LibraryException, NullPointerException;
 
@@ -2628,7 +3982,7 @@ public class H5 implements java.io.Serializable {
 
 
     /**
-     * H5Epush2 pushes a new error record onto the error stack specified by estack_id.
+     * H5Epush pushes a new error record onto the error stack specified by estack_id.
      *
      * @param stack_id
      *            IN: Error stack identifier.
@@ -2657,6 +4011,31 @@ public class H5 implements java.io.Serializable {
     {
              H5Epush2(stack_id, file, func, line, cls_id, maj_id, min_id, msg);
     }
+    /**
+     * H5Epush2 pushes a new error record onto the error stack specified by estack_id.
+     *
+     * @param stack_id
+     *            IN: Error stack identifier.
+     * @param file
+     *            IN: Name of the file in which the error was detected.
+     * @param func
+     *            IN: Name of the function in which the error was detected.
+     * @param line
+     *            IN: Line number within the file at which the error was detected.
+     * @param cls_id
+     *            IN: Error class identifier.
+     * @param maj_id
+     *            IN: Major error identifier.
+     * @param min_id
+     *            IN: Minor error identifier.
+     * @param msg
+     *            IN: Error description string.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - file, func, or msg is null.
+      **/
     public synchronized static native void H5Epush2(long stack_id, String file, String func, int line,
                 long cls_id, long maj_id, long min_id, String msg) throws HDF5LibraryException, NullPointerException;
 
@@ -2714,6 +4093,24 @@ public class H5 implements java.io.Serializable {
     {
             H5Ewalk2(stack_id, direction, func, client_data);
     }
+    /**
+     * H5Ewalk2 walks the error stack specified by estack_id for the current thread and calls the
+     * function specified in func for each error along the way.
+     *
+     * @param stack_id
+     *            IN: Error stack identifier.
+     * @param direction
+     *            IN: Direction in which the error stack is to be walked.
+     * @param func
+     *            IN: Function to be called for each error encountered.
+     * @param client_data
+     *            IN: Data to be passed with func.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - func is null.
+     **/
     public synchronized static native void H5Ewalk2(long stack_id, long direction, H5E_walk_cb func, H5E_walk_t client_data)
             throws HDF5LibraryException, NullPointerException;
 
@@ -2950,6 +4347,19 @@ public class H5 implements java.io.Serializable {
 
     private synchronized static native long _H5Fget_create_plist(long file_id) throws HDF5LibraryException;
 
+    /**
+     * H5Fget_filesize retrieves the file size of the HDF5 file. This function
+     *              is called after an existing file is opened in order
+     *              to learn the true size of the underlying file.
+     *
+     * @param file_id
+     *            IN: File identifier for a currently-open HDF5 file
+     *
+     * @return the file size of the HDF5 file
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native long H5Fget_filesize(long file_id) throws HDF5LibraryException;
 
     /**
@@ -3598,37 +5008,118 @@ public class H5 implements java.io.Serializable {
         return H5Gget_obj_info_all(loc_id, name, objNames, objTypes, null, null, tokens, HDF5Constants.H5_INDEX_NAME);
     }
 
-    public synchronized static int H5Gget_obj_info_all(long loc_id, String name, String[] oname, int[] otype,
+    /**
+     * retrieves information of all objects under the group (name) located in the file or group specified by loc_id.
+     *
+     * @param loc_id
+     *            IN: File or group identifier
+     * @param name
+     *            IN: Name of group for which information is to be retrieved
+     * @param objNames
+     *            OUT: Names of all objects under the group, name.
+     * @param objTypes
+     *            OUT: Types of all objects under the group, name.
+     * @param ltype
+     *            OUT: Link type
+     * @param tokens
+     *            OUT: Object token of all objects under the group, name.
+     * @param indx_type
+     *            IN: Index type for iterate
+     *
+     * @return the number of items found
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     */
+    public synchronized static int H5Gget_obj_info_all(long loc_id, String name, String[] objNames, int[] objTypes,
             int[] ltype, H5O_token_t[] tokens, int indx_type) throws HDF5LibraryException, NullPointerException {
-        return H5Gget_obj_info_full(loc_id, name, oname, otype, ltype, null, tokens, indx_type, -1);
+        return H5Gget_obj_info_full(loc_id, name, objNames, objTypes, ltype, null, tokens, indx_type, -1);
     }
 
-    public synchronized static int H5Gget_obj_info_all(long loc_id, String name, String[] oname, int[] otype,
+    /**
+     * retrieves information of all objects under the group (name) located in the file or group specified by loc_id.
+     *
+     * @param loc_id
+     *            IN: File or group identifier
+     * @param name
+     *            IN: Name of group for which information is to be retrieved
+     * @param objNames
+     *            OUT: Names of all objects under the group, name.
+     * @param objTypes
+     *            OUT: Types of all objects under the group, name.
+     * @param ltype
+     *            OUT: Link type
+     * @param fno
+     *            OUT: File number
+     * @param tokens
+     *            OUT: Object token of all objects under the group, name.
+     * @param indx_type
+     *            IN: Index type for iterate
+     *
+     * @return the number of items found
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     */
+    public synchronized static int H5Gget_obj_info_all(long loc_id, String name, String[] objNames, int[] objTypes,
             int[] ltype, long[] fno, H5O_token_t[] tokens, int indx_type) throws HDF5LibraryException, NullPointerException {
-        return H5Gget_obj_info_full(loc_id, name, oname, otype, ltype, fno, tokens, indx_type, -1);
+        return H5Gget_obj_info_full(loc_id, name, objNames, objTypes, ltype, fno, tokens, indx_type, -1);
     }
 
-    public synchronized static int H5Gget_obj_info_full(long loc_id, String name, String[] oname, int[] otype,
+    /**
+     * retrieves information of all objects under the group (name) located in the file or group specified by loc_id.
+     *
+     * @param loc_id
+     *            IN: File or group identifier
+     * @param name
+     *            IN: Name of group for which information is to be retrieved
+     * @param objNames
+     *            OUT: Names of all objects under the group, name.
+     * @param objTypes
+     *            OUT: Types of all objects under the group, name.
+     * @param ltype
+     *            OUT: Link type
+     * @param fno
+     *            OUT: File number
+     * @param tokens
+     *            OUT: Object token of all objects under the group, name.
+     * @param indx_type
+     *            IN: Index type for iterate
+     * @param indx_order
+     *            IN: Index order for iterate
+     *
+     * @return the number of items found
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     */
+    public synchronized static int H5Gget_obj_info_full(long loc_id, String name, String[] objNames, int[] objTypes,
             int[] ltype, long[] fno, H5O_token_t[] tokens, int indx_type, int indx_order) throws HDF5LibraryException,
             NullPointerException {
-        if (oname == null) {
+        if (objNames == null) {
             throw new NullPointerException("H5Gget_obj_info_full(): name array is null");
         }
 
-        if (otype == null) {
+        if (objTypes == null) {
             throw new NullPointerException("H5Gget_obj_info_full(): object type array is null");
         }
 
-        if (oname.length == 0) {
+        if (objNames.length == 0) {
             throw new HDF5LibraryException("H5Gget_obj_info_full(): array size is zero");
         }
 
-        if (oname.length != otype.length) {
+        if (objNames.length != objTypes.length) {
             throw new HDF5LibraryException("H5Gget_obj_info_full(): name and type array sizes are different");
         }
 
         if (ltype == null)
-            ltype = new int[otype.length];
+            ltype = new int[objTypes.length];
 
         if (fno == null)
             fno = new long[tokens.length];
@@ -3639,15 +5130,15 @@ public class H5 implements java.io.Serializable {
         if (indx_order < 0)
             indx_order = HDF5Constants.H5_ITER_INC;
 
-        log.trace("H5Gget_obj_info_full: oname_len={}", oname.length);
-        int status = H5Gget_obj_info_full(loc_id, name, oname, otype, ltype, fno, tokens, oname.length, indx_type,
+        log.trace("H5Gget_obj_info_full: objNames_len={}", objNames.length);
+        int status = H5Gget_obj_info_full(loc_id, name, objNames, objTypes, ltype, fno, tokens, objNames.length, indx_type,
                 indx_order);
-        for (int indx = 0; indx < oname.length; indx++)
-            log.trace("H5Gget_obj_info_full: oname={}", oname[indx]);
+        for (int indx = 0; indx < objNames.length; indx++)
+            log.trace("H5Gget_obj_info_full: objNames={}", objNames[indx]);
         return status;
     }
 
-    private synchronized static native int H5Gget_obj_info_full(long loc_id, String name, String[] oname, int[] otype,
+    private synchronized static native int H5Gget_obj_info_full(long loc_id, String name, String[] objNames, int[] objTypes,
             int[] ltype, long[] fno, H5O_token_t[] tokens, int n, int indx_type, int indx_order) throws HDF5LibraryException,
             NullPointerException;
 
@@ -3663,9 +5154,9 @@ public class H5 implements java.io.Serializable {
      * @param idx
      *            IN: the index of the object to iterate.
      * @param oname
-     *            the name of the object [OUT]
+     *            OUT: the name of the object
      * @param type
-     *            the type of the object [OUT]
+     *            OUT: the type of the object
      *
      * @return non-negative if successful, -1 if not.
      *
@@ -3866,13 +5357,40 @@ public class H5 implements java.io.Serializable {
     // //
     // ////////////////////////////////////////////////////////////
 
+    /**
+     * H5Iget_file_id obtains the file ID specified by the identifier, obj_id.
+     *
+     * @param obj_id
+     *            IN: Identifier of the object.
+     *
+     * @return the file ID.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native long H5Iget_file_id(long obj_id) throws HDF5LibraryException;
 
-    @Deprecated
+
+    /**
+     * H5Iget_name_long retrieves the name of an object specified by the identifier, obj_id.
+     * @deprecated
+     *
+     * @param obj_id
+     *            IN: Identifier of the object.
+     * @param name
+     *            OUT: Attribute name buffer.
+     * @param size
+     *            IN: Maximum length of the name to retrieve.
+     *
+     * @return the length of the name retrieved.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native long H5Iget_name_long(long obj_id, String[] name, long size)
             throws HDF5LibraryException, NullPointerException;
     /**
-     * H5Iget_name_str retrieves the name of an object specified by the identifier, obj_id.
+     * H5Iget_name retrieves the name of an object specified by the identifier, obj_id.
      *
      * @param obj_id
      *            IN: Identifier of the object.
@@ -3885,10 +5403,44 @@ public class H5 implements java.io.Serializable {
     public synchronized static native String H5Iget_name(long obj_id)
             throws HDF5LibraryException;
 
+    /**
+     * H5Iget_ref obtains the number of references outstanding specified by the identifier, obj_id.
+     *
+     * @param obj_id
+     *            IN: Identifier of the object.
+     *
+     * @return the reference count.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native int H5Iget_ref(long obj_id) throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Idec_ref decrements the reference count specified by the identifier, obj_id.
+     *            If the reference count for an ID reaches zero, the object will be closed.
+     *
+     * @param obj_id
+     *            IN: Identifier of the object.
+     *
+     * @return the reference count.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native int H5Idec_ref(long obj_id) throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Iinc_ref increments the reference count specified by the identifier, obj_id.
+     *
+     * @param obj_id
+     *            IN: Identifier of the object.
+     *
+     * @return the reference count.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native int H5Iinc_ref(long obj_id) throws HDF5LibraryException, NullPointerException;
 
     /**
@@ -5179,7 +6731,7 @@ public class H5 implements java.io.Serializable {
         return id;
     }
 
-    public synchronized static native long _H5Oopen_by_idx(long loc_id, String group_name,
+    private synchronized static native long _H5Oopen_by_idx(long loc_id, String group_name,
             int idx_type, int order, long n, long lapl_id) throws HDF5LibraryException, NullPointerException;
 
     /**
@@ -5210,8 +6762,30 @@ public class H5 implements java.io.Serializable {
      **/
     public synchronized static native void H5Orefresh(long object_id) throws HDF5LibraryException;
 
+    /**
+     * H5Odisable_mdc_flushes corks an object, keeping dirty entries associated with the object in the metadata cache.
+     *
+     * @param object_id
+     *            IN: Identifier of the object to be corked.
+     **/
     public synchronized static native void  H5Odisable_mdc_flushes(long object_id);
+    /**
+     * H5Oenable_mdc_flushes uncorks an object, keeping dirty entries associated with the object in the metadata cache.
+     *
+     * @param object_id
+     *            IN: Identifier of the object to be uncorked.
+     **/
     public synchronized static native void  H5Oenable_mdc_flushes(long object_id);
+    /**
+     * H5Oare_mdc_flushes_disabled retrieve the object's "cork" status.
+     *
+     * @param object_id
+     *            IN: Identifier of the object to be flushed.
+     *
+     * @return the cork status
+     *             TRUE if mdc flushes for the object is disabled
+     *             FALSE if mdc flushes for the object is not disabled
+     **/
     public synchronized static native boolean  H5Oare_mdc_flushes_disabled(long object_id);
 
     // /////// unimplemented ////////
@@ -5364,6 +6938,7 @@ public class H5 implements java.io.Serializable {
      *            IN: First property object to be compared
      * @param plid2
      *            IN: Second property object to be compared
+     *
      * @return positive value if equal; zero if unequal, a negative value if failed
      *
      * @exception HDF5LibraryException
@@ -5371,6 +6946,19 @@ public class H5 implements java.io.Serializable {
      */
     public synchronized static native int H5Pequal(long plid1, long plid2) throws HDF5LibraryException;
 
+    /**
+     * H5Pequal determines if two property lists or classes are equal
+     *
+     * @param plid1
+     *            IN: First property object to be compared
+     * @param plid2
+     *            IN: Second property object to be compared
+     *
+     * @return TRUE if equal, FALSE if unequal
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     */
     public static boolean H5P_equal(long plid1, long plid2) throws HDF5LibraryException {
         if (H5Pequal(plid1, plid2) == 1)
             return true;
@@ -5456,7 +7044,7 @@ public class H5 implements java.io.Serializable {
         return _H5Pclose_class(plid);
     }
 
-    public synchronized static native int _H5Pclose_class(long plid) throws HDF5LibraryException;
+    private synchronized static native int _H5Pclose_class(long plid) throws HDF5LibraryException;
 
     /**
      * H5Pclose terminates access to a property list.
@@ -5524,6 +7112,19 @@ public class H5 implements java.io.Serializable {
     // Define property list iteration function type
     // typedef herr_t (*H5P_iterate_t)(hid_t id, const char *name, void *iter_data);
 
+    /**
+     * H5Pcreate_class_nocb creates an new property class with no callback functions.
+     *
+     * @param parent_class
+     *            IN: Identifier of the parent property class.
+     * @param name
+     *            IN: Name of the property class.
+     *
+     * @return a property list identifier if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public static long H5Pcreate_class_nocb(long parent_class, String name) throws HDF5LibraryException {
         long id = _H5Pcreate_class_nocb(parent_class, name);
           if (id > 0) {
@@ -5550,17 +7151,69 @@ public class H5 implements java.io.Serializable {
 //    private synchronized static native long _H5Pcreate_class(long parent_class, String name, H5P_cls_create_func_cb create_op, H5P_cls_create_func_t create_data,
 //            H5P_cls_copy_func_cb copy_op, H5P_cls_copy_func_t copy_data, H5P_cls_close_func_cb close_op, H5P_cls_close_func_t close_data) throws HDF5LibraryException;
 
+    /**
+     * H5Pregister2_nocb registers a property list with no callback functions.
+     *
+     * @param plist_class
+     *            IN: Identifier of the property list.
+     * @param name
+     *            IN: Name of the property.
+     * @param size
+     *            IN: Size the property value.
+     * @param def_value
+     *            IN: Defaul value of the property
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native void H5Pregister2_nocb(long plist_class, String name, long size, byte[] def_value) throws HDF5LibraryException;
 
 //    public synchronized static native void H5Pregister2(long plist_class, String name, long size, byte[] def_value, H5P_prp_create_func_cb prp_create, H5P_prp_set_func_cb prp_set,
 //          H5P_prp_get_func_cb prp_get, H5P_prp_delete_func_cb prp_delete, H5P_prp_copy_func_cb prp_copy, H5P_prp_compare_func_cb prp_cmp, H5P_prp_close_func_cb prp_close) throws HDF5LibraryException;
 
+    /**
+     * H5Pinsert2_nocb inserts a property list with no callback functions.
+     *
+     * @param plist
+     *            IN: Identifier of the property list.
+     * @param name
+     *            IN: Name of the property.
+     * @param size
+     *            IN: Size the property value.
+     * @param value
+     *            IN: Defaul value of the property
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
      public synchronized static native void H5Pinsert2_nocb(long plist, String name, long size,  byte[] value) throws HDF5LibraryException;
 
 
     // public synchronized static native void H5Pinsert2(long plist, String name, long size,  byte[] value, H5P_prp_set_func_cb prp_set, H5P_prp_get_func_cb prp_get,
     //      H5P_prp_delete_func_cb prp_delete, H5P_prp_copy_func_cb prp_copy, H5P_prp_compare_func_cb prp_cmp, H5P_prp_close_func_cb prp_close) throws HDF5LibraryException;
 
+    /**
+     * H5Piterate iterates over the properties in a property list or class
+     *
+     * @param  plist
+     *             IN: ID of property object to iterate over
+     * @param  idx
+     *             IN/OUT: index of the property to begin with
+     * @param  op
+     *             IN: function to be called with each property iterated over.
+     * @param  op_data
+     *             IN: iteration data from user
+     *
+     * @return
+     *          the return value of the last call to op if it was non-zero,
+     *          zero if all properties have been processed
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - size is null.
+     *
+     **/
     public synchronized static native int H5Piterate(long plist, int[] idx, H5P_iterate_cb op, H5P_iterate_t op_data) throws HDF5LibraryException;
 
     // /////// Object creation property list (OCPL) routines ///////
@@ -5573,7 +7226,7 @@ public class H5 implements java.io.Serializable {
      * @param attributes
      *            The maximun and minimum no. of attributes to be stored.
      *
-     *            <pre>
+     * <pre>
      *      attributes[0] =  The maximum number of attributes to be stored in compact storage
      *      attributes[1] =  The minimum number of attributes to be stored in dense storage
      * </pre>
@@ -5673,6 +7326,51 @@ public class H5 implements java.io.Serializable {
     public synchronized static native void H5Pset_obj_track_times(long ocpl_id, boolean track_times)
             throws HDF5LibraryException;
 
+    /**
+     * H5Pmodify_filter modifies the specified FILTER in the transient or permanent output filter pipeline
+     *              depending on whether PLIST is a dataset creation or dataset
+     *              transfer property list.  The FLAGS argument specifies certain
+     *              general properties of the filter and is documented below.
+     *              The CD_VALUES is an array of CD_NELMTS integers which are
+     *              auxiliary data for the filter.  The integer vlues will be
+     *              stored in the dataset object header as part of the filter
+     *              information.
+     *<p>
+     *              The FLAGS argument is a bit vector of the following fields:
+     *<p>
+     *              H5Z_FLAG_OPTIONAL(0x0001)
+     *              If this bit is set then the filter is optional.  If the
+     *              filter fails during an H5Dwrite() operation then the filter
+     *              is just excluded from the pipeline for the chunk for which it
+     *              failed; the filter will not participate in the pipeline
+     *              during an H5Dread() of the chunk.  If this bit is clear and
+     *              the filter fails then the entire I/O operation fails.
+     *              If this bit is set but encoding is disabled for a filter,
+     *              attempting to write will generate an error.
+     *<p>
+     * Note:        This function currently supports only the permanent filter
+     *              pipeline.  That is, PLIST_ID must be a dataset creation
+     *              property list.
+     *
+     * @param plist
+     *            IN: Property list identifier.
+     * @param filter
+     *            IN: Filter to be modified to the pipeline.
+     * @param flags
+     *            IN: Bit vector specifying certain general properties of the filter.
+     * @param cd_nelmts
+     *            IN: Number of elements in cd_values
+     * @param cd_values
+     *            IN: Auxiliary data for the filter.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name or an array is null.
+     *
+     **/
     public synchronized static native int H5Pmodify_filter(long plist, long filter, int flags, long cd_nelmts,
             int[] cd_values) throws HDF5LibraryException, NullPointerException;
 
@@ -5844,9 +7542,37 @@ public class H5 implements java.io.Serializable {
                     throws HDF5LibraryException, NullPointerException;
 
 
+    /**
+     * H5Pall_filters_avail query to verify that all the filters set
+     *                      in the dataset creation property list are available currently.
+     *
+     * @param dcpl_id
+     *            IN: Property list identifier.
+     *
+     * @return
+     *            TRUE if all filters available
+     *            FALSE if one or more filters not currently available.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native boolean H5Pall_filters_avail(long dcpl_id) throws HDF5LibraryException,
     NullPointerException;
 
+    /**
+     * H5Premove_filter deletes a filter from the dataset creation property list;
+     *                  deletes all filters if filter is H5Z_FILTER_NONE
+     *
+     * @param obj_id
+     *            IN: Property list identifier.
+     * @param filter
+     *            IN: Filter identifier.
+     *
+     * @return a non-negative value and the size of the user block; if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native int H5Premove_filter(long obj_id, long filter) throws HDF5LibraryException;
 
     /**
@@ -5864,6 +7590,18 @@ public class H5 implements java.io.Serializable {
      **/
     public synchronized static native int H5Pset_deflate(long plist, int level) throws HDF5LibraryException;
 
+    /**
+     * H5Pset_fletcher32 sets Fletcher32 checksum of EDC for a dataset creation
+     *                   property list or group creation property list.
+     *
+     * @param plist
+     *            IN: Property list identifier.
+     *
+     * @return a non-negative value and the size of the user block; if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native int H5Pset_fletcher32(long plist) throws HDF5LibraryException,
     NullPointerException;
 
@@ -6334,11 +8072,35 @@ public class H5 implements java.io.Serializable {
      */
     public synchronized static native long H5Pget_driver(long plid) throws HDF5LibraryException;
 
-    public synchronized static native long H5Pget_family_offset(long fapl_id) throws HDF5LibraryException,
-    NullPointerException;
+    /**
+     * H5Pget_family_offset gets offset for family driver.
+     *
+     * @param fapl_id
+     *            IN: File access property list identifier
+     *
+     * @return the offset.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
+    public synchronized static native long H5Pget_family_offset(long fapl_id) throws HDF5LibraryException;
 
-    public synchronized static native int H5Pset_family_offset(long fapl_id, long offset) throws HDF5LibraryException,
-    NullPointerException;
+    /**
+     * H5Pset_family_offset sets the offset for family driver.
+     *
+     * @param fapl_id
+     *            IN: File access property list identifier
+     * @param offset
+     *            IN: the offset value
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
+    public synchronized static native int H5Pset_family_offset(long fapl_id, long offset) throws HDF5LibraryException;
 
     /**
      * Retrieves the maximum possible number of elements in the meta data cache and the maximum possible number of bytes
@@ -6389,9 +8151,8 @@ public class H5 implements java.io.Serializable {
             double rdcc_w0) throws HDF5LibraryException;
 
     /**
-     * H5Pget_mdc_config gets the initial metadata cache configuration contained in a file access property list and
-     * loads it into the instance of H5AC_cache_config_t pointed to by the config_ptr parameter. This configuration is
-     * used when the file is opened.
+     * H5Pget_mdc_config gets the initial metadata cache configuration contained in a file access property list.
+     *                   This configuration is used when the file is opened.
      *
      * @param plist_id
      *            IN: Identifier of the file access property list.
@@ -6403,6 +8164,19 @@ public class H5 implements java.io.Serializable {
      **/
     public synchronized static native H5AC_cache_config_t H5Pget_mdc_config(long plist_id) throws HDF5LibraryException;
 
+    /**
+     * H5Pset_mdc_config sets the initial metadata cache configuration contained in a file access property list and
+     * loads it into the instance of H5AC_cache_config_t pointed to by the config_ptr parameter. This configuration is
+     * used when the file is opened.
+     *
+     * @param plist_id
+     *            IN: Identifier of the file access property list.
+     * @param config_ptr
+     *            IN: H5AC_cache_config_t, the initial metadata cache configuration.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native void H5Pset_mdc_config(long plist_id, H5AC_cache_config_t config_ptr)
             throws HDF5LibraryException;
 
@@ -6437,10 +8211,35 @@ public class H5 implements java.io.Serializable {
     public synchronized static native int H5Pset_gc_references(long fapl_id, boolean gc_ref)
             throws HDF5LibraryException;
 
-    public synchronized static native int H5Pget_fclose_degree(long plist_id) throws HDF5LibraryException,
+    /**
+     * H5Pget_fclose_degree returns the degree for the file close behavior for a file access
+     * property list.
+     *
+     * @param fapl_id
+     *            IN File access property list
+     *
+     * @return the degree for the file close behavior
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
+    public synchronized static native int H5Pget_fclose_degree(long fapl_id) throws HDF5LibraryException,
     NullPointerException;
 
-    public synchronized static native int H5Pset_fclose_degree(long plist, int degree) throws HDF5LibraryException,
+    /**
+     * H5Pset_fclose_degree sets the degree for the file close behavior.
+     *
+     * @param fapl_id
+     *            IN File access property list
+     * @param degree
+     *            IN the degree for the file close behavior
+     *
+     * @return non-negative if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
+    public synchronized static native int H5Pset_fclose_degree(long fapl_id, int degree) throws HDF5LibraryException,
     NullPointerException;
 
     /**
@@ -6471,8 +8270,40 @@ public class H5 implements java.io.Serializable {
      **/
     public synchronized static native void H5Pset_meta_block_size(long fapl_id, long size) throws HDF5LibraryException;
 
+    /**
+     * H5Pget_sieve_buf_size retrieves the current settings for the data sieve buffer size
+     *      property from a file access property list.
+     *
+     * @param fapl_id
+     *            IN: Identifier for property list to query.
+     *
+     * @return a non-negative value and the size of the user block; if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native long H5Pget_sieve_buf_size(long fapl_id) throws HDF5LibraryException;
 
+    /**
+     * H5Pset_sieve_buf_size Sets the maximum size of the data seive buffer used for file
+     *      drivers which are capable of using data sieving.  The data sieve
+     *      buffer is used when performing I/O on datasets in the file.  Using a
+     *      buffer which is large anough to hold several pieces of the dataset
+     *      being read in for hyperslab selections boosts performance by quite a
+     *      bit.
+     * <p>
+     *      The default value is set to 64KB, indicating that file I/O for raw data
+     *      reads and writes will occur in at least 64KB blocks. Setting the value to 0
+     *      with this function will turn off the data sieving
+     *
+     * @param fapl_id
+     *            IN: Identifier of property list to modify.
+     * @param size
+     *            IN: maximum size of the data seive buffer.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native void H5Pset_sieve_buf_size(long fapl_id, long size) throws HDF5LibraryException;
 
     /**
@@ -6816,6 +8647,25 @@ public class H5 implements java.io.Serializable {
     public synchronized static native int H5Pset_chunk(long plist, int ndims, byte[] dim) throws HDF5LibraryException,
     NullPointerException, IllegalArgumentException;
 
+    /**
+     * H5Pset_chunk sets the size of the chunks used to store a chunked layout dataset.
+     *
+     * @param plist
+     *            IN: Identifier for property list to query.
+     * @param ndims
+     *            IN: The number of dimensions of each chunk.
+     * @param dim
+     *            IN: An array containing the size of each chunk.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5Exception
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - dims array is null.
+     * @exception IllegalArgumentException
+     *                - dims &lt;=0
+     **/
     public synchronized static int H5Pset_chunk(long plist, int ndims, long[] dim) throws HDF5Exception,
     NullPointerException, IllegalArgumentException {
         if (dim == null) {
@@ -7051,9 +8901,37 @@ public class H5 implements java.io.Serializable {
      **/
     public synchronized static native int H5Pget_external_count(long plist) throws HDF5LibraryException;
 
+    /**
+     * H5Pset_szip Sets up the use of the szip filter.
+     *
+     * @param plist
+     *            IN: Dataset creation property list identifier.
+     * @param options_mask
+     *            IN: Bit vector specifying certain general properties of the filter.
+     * @param pixels_per_block
+     *            IN: Number of pixels in blocks
+     *
+     * @return a non-negative value if successful; otherwise returns a negative value.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native int H5Pset_szip(long plist, int options_mask, int pixels_per_block)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Pset_shuffle Sets up the use of the shuffle filter.
+     *
+     * @param plist_id
+     *            IN: Dataset creation property list identifier.
+     *
+     * @return a non-negative value if successful; otherwise returns a negative value.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native int H5Pset_shuffle(long plist_id) throws HDF5LibraryException,
     NullPointerException;
 
@@ -7181,20 +9059,91 @@ public class H5 implements java.io.Serializable {
         return retVal;
     }
 
+    /**
+     * H5Pset_fill_value checks if the fill value is defined for a dataset creation property list.
+     *
+     * @param plist_id
+     *            IN: Property list identifier.
+     * @param status
+     *            IN: The fill value setting:
+     *                H5D_FILL_VALUE_UNDEFINED
+     *                H5D_FILL_VALUE_DEFAULT
+     *                H5D_FILL_VALUE_USER_DEFINED
+     *                H5D_FILL_VALUE_ERROR
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5Exception
+     *                - Error converting data array
+     **/
     public synchronized static native int H5Pfill_value_defined(long plist_id, int[] status)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Pset_alloc_time Gets space allocation time for dataset during creation.
+     *
+     * @param plist_id
+     *            IN: Dataset creation property list identifier.
+     * @param alloc_time
+     *            OUT: allocation time.
+     *
+     * @return a non-negative value if successful; otherwise returns a negative value.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native int H5Pget_alloc_time(long plist_id, int[] alloc_time)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Pset_alloc_time Sets space allocation time for dataset during creation.
+     *
+     * @param plist_id
+     *            IN: Dataset creation property list identifier.
+     * @param alloc_time
+     *            IN: allocation time.
+     *
+     * @return a non-negative value if successful; otherwise returns a negative value.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native int H5Pset_alloc_time(long plist_id, int alloc_time) throws HDF5LibraryException,
     NullPointerException;
 
-    public synchronized static native int H5Pget_fill_time(long plist_id, int[] fill_time) throws HDF5LibraryException,
-    NullPointerException;
+    /**
+     * H5Pset_fill_time Gets fill value writing time.
+     *
+     * @param plist_id
+     *            IN: Dataset creation property list identifier.
+     * @param fill_time
+     *            OUT: fill time.
+     *
+     * @return a non-negative value if successful; otherwise returns a negative value.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
+    public synchronized static native int H5Pget_fill_time(long plist_id, int[] fill_time) throws HDF5LibraryException;
 
-    public synchronized static native int H5Pset_fill_time(long plist_id, int fill_time) throws HDF5LibraryException,
-    NullPointerException;
+    /**
+     * H5Pset_fill_time Sets the fill value writing time.
+     *
+     * @param plist_id
+     *            IN: Dataset creation property list identifier.
+     * @param fill_time
+     *            IN: fill time.
+     *
+     * @return a non-negative value if successful; otherwise returns a negative value.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
+    public synchronized static native int H5Pset_fill_time(long plist_id, int fill_time) throws HDF5LibraryException;
 
     /**
      * H5Pset_chunk_opts Sets the edge chunk option in a dataset creation property list.
@@ -7494,6 +9443,20 @@ public class H5 implements java.io.Serializable {
     public synchronized static native int H5Pget_buffer(long plist, byte[] tconv, byte[] bkg)
             throws HDF5LibraryException, IllegalArgumentException;
 
+    /**
+     * H5Pget_buffer_size gets type conversion and background buffer size, in bytes, if successful;
+     * otherwise 0 on failure.
+     *
+     * @param plist
+     *            Identifier for the dataset transfer property list.
+     *
+     * @return buffer size, in bytes, if successful; otherwise 0 on failure
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception IllegalArgumentException
+     *                - plist is invalid.
+     **/
     public synchronized static native long H5Pget_buffer_size(long plist)
             throws HDF5LibraryException, IllegalArgumentException;
 
@@ -7524,11 +9487,33 @@ public class H5 implements java.io.Serializable {
     public synchronized static native void H5Pset_buffer_size(long plist, long size) throws HDF5LibraryException,
     IllegalArgumentException;
 
-    public synchronized static native int H5Pget_edc_check(long plist) throws HDF5LibraryException,
-    NullPointerException;
+    /**
+     * H5Pget_edc_check gets the error-detecting algorithm in use.
+     *
+     * @param plist
+     *            Identifier for the dataset transfer property list.
+     *
+     * @return the error-detecting algorithm
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
+    public synchronized static native int H5Pget_edc_check(long plist) throws HDF5LibraryException;
 
-    public synchronized static native int H5Pset_edc_check(long plist, int check) throws HDF5LibraryException,
-    NullPointerException;
+    /**
+     * H5Pset_edc_check sets the error-detecting algorithm.
+     *
+     * @param plist
+     *            Identifier for the dataset transfer property list.
+     * @param check
+     *            the error-detecting algorithm to use.
+     *
+     * @return non-negative if succeed
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
+    public synchronized static native int H5Pset_edc_check(long plist, int check) throws HDF5LibraryException;
 
     /**
      * H5Pget_btree_ratio Get the B-tree split ratios for a dataset transfer property list.
@@ -7573,9 +9558,46 @@ public class H5 implements java.io.Serializable {
     public synchronized static native int H5Pset_btree_ratios(long plist_id, double left, double middle, double right)
             throws HDF5LibraryException;
 
+    /**
+     * H5Pget_hyper_vector_size reads values previously set with H5Pset_hyper_vector_size.
+     *
+     * @param dxpl_id
+     *            IN: Dataset transfer property list identifier.
+     * @param vector_size
+     *            OUT:  hyper vector size.
+     *
+     * @return a non-negative value if successful; otherwise returns a negative value.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native int H5Pget_hyper_vector_size(long dxpl_id, long[] vector_size)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Pset_hyper_vector_size sets the number of
+     *              "I/O vectors" (offset and length pairs) which are to be
+     *              accumulated in memory before being issued to the lower levels
+     *              of the library for reading or writing the actual data.
+     *              Increasing the number should give better performance, but use
+     *              more memory during hyperslab I/O.  The vector size must be
+     *              greater than 1.
+     *,p.
+     *              The default is to use 1024 vectors for I/O during hyperslab
+     *              reading/writing.
+     *
+     * @param dxpl_id
+     *            IN: Dataset transfer property list identifier.
+     * @param vector_size
+     *            IN: hyper vestor size.
+     *
+     * @return a non-negative value if successful; otherwise returns a negative value.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native int H5Pset_hyper_vector_size(long dxpl_id, long vector_size)
             throws HDF5LibraryException, NullPointerException;
 
@@ -7773,8 +9795,32 @@ public class H5 implements java.io.Serializable {
 
     // /////// String creation property list (STRCPL) routines ///////
 
+    /**
+     * H5Pget_char_encoding gets the character encoding of the string.
+     *
+     * @param plist_id
+     *            IN: the property list identifier
+     *
+     * @return Returns the character encoding of the string.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native int H5Pget_char_encoding(long plist_id) throws HDF5LibraryException;
 
+    /**
+     * H5Pset_char_encoding sets the character encoding of the string.
+     *
+     * @param plist_id
+     *            IN: the property list identifier
+     * @param encoding
+     *            IN: the character encoding of the string
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native void H5Pset_char_encoding(long plist_id, int encoding)
             throws HDF5LibraryException;
 
@@ -7964,20 +10010,51 @@ public class H5 implements java.io.Serializable {
 
     // /////// file drivers property list routines ///////
 
+    /**
+     * H5Pget_fapl_core retrieve H5FD_CORE I/O settings.
+     *
+     * @param fapl_id
+     *            IN: File access property list identifier
+     * @param increment
+     *            OUT: how much to grow the memory each time
+     * @param backing_store
+     *            OUT: write to file name on flush setting
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native void H5Pget_fapl_core(long fapl_id, long[] increment, boolean[] backing_store)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Pset_fapl_core modifies the file access property list to use the H5FD_CORE driver.
+     *
+     * @param fapl_id
+     *            IN: File access property list identifier
+     * @param increment
+     *            IN: how much to grow the memory each time
+     * @param backing_store
+     *            IN: write to file name on flush setting
+     *
+     * @return a non-negative value if successful; otherwise returns a negative value.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native int H5Pset_fapl_core(long fapl_id, long increment, boolean backing_store)
             throws HDF5LibraryException, NullPointerException;
 
     /**
-     * H5Pget_fapl_direct Retrieve direct I/O settings.
+     * H5Pget_fapl_direct queries properties set by the H5Pset_fapl_core.
      *
      * @param fapl_id
      *            IN: File access property list identifier
      * @param info
-     *            OUT: Returned property list information info[0] = alignment Required memory alignment boundary info[1]
-     *            = block_size File system block size info[2] = cbuf_size Copy buffer size
+     *            OUT: Returned property list information
+     *                 info[0] = increment -how much to grow the memory each time
+     *                 info[1] = backing_store - write to file name on flush setting
      *
      * @return a non-negative value if successful; otherwise returns a negative value.
      *
@@ -8008,14 +10085,72 @@ public class H5 implements java.io.Serializable {
     public synchronized static native int H5Pset_fapl_direct(long fapl_id, long alignment, long block_size,
             long cbuf_size) throws HDF5LibraryException;
 
+    /**
+     * H5Pget_fapl_family Returns information about the family file access property list.
+     *
+     * @param fapl_id
+     *            IN: File access property list identifier
+     * @param memb_size
+     *            OUT: the size in bytes of each file member (used only when creating a new file)
+     * @param memb_fapl_id
+     *            OUT: the file access property list to be used for each family member
+     *
+     * @return a non-negative value if successful; otherwise returns a negative value.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native int H5Pget_fapl_family(long fapl_id, long[] memb_size, long[] memb_fapl_id)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Pset_fapl_family Sets up use of the direct I/O driver.
+     *
+     * @param fapl_id
+     *            IN: File access property list identifier
+     * @param memb_size
+     *            IN: the size in bytes of each file member (used only when creating a new file)
+     * @param memb_fapl_id
+     *            IN: the file access property list to be used for each family member
+     *
+     * @return a non-negative value if successful; otherwise returns a negative value.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native int H5Pset_fapl_family(long fapl_id, long memb_size, long memb_fapl_id)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Pset_fapl_hdfs Modify the file access property list to use the H5FD_HDFS driver.
+     *
+     * @param fapl_id
+     *            IN: File access property list identifier
+     * @param fapl_conf
+     *            IN: the properties of the hdfs driver
+     *
+     * @return a non-negative value if successful; otherwise returns a negative value.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native int H5Pset_fapl_hdfs(long fapl_id, H5FD_hdfs_fapl_t fapl_conf) throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Pget_fapl_hdfs gets the properties hdfs I/O driver.
+     *
+     * @param fapl_id
+     *            IN: File access property list identifier
+     *
+     * @return the properties of the hdfs driver.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native H5FD_hdfs_fapl_t H5Pget_fapl_hdfs(long fapl_id) throws HDF5LibraryException, NullPointerException;
 
     /**
@@ -8093,17 +10228,99 @@ public class H5 implements java.io.Serializable {
     public synchronized static native void H5Pset_fapl_log(long fapl_id, String logfile, long flags, long buf_size)
             throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Pset_fapl_sec2 Sets up use of the sec2 I/O driver.
+     *
+     * @param fapl_id
+     *            IN: File access property list identifier
+     *
+     * @return a non-negative value if successful; otherwise returns a negative value.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native int H5Pset_fapl_sec2(long fapl_id) throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Pset_fapl_split Sets up use of the split I/O driver. Makes the multi driver act like the
+     *        old split driver which stored meta data in one file and raw
+     *        data in another file
+     *
+     * @param fapl_id
+     *            IN: File access property list identifier
+     * @param meta_ext
+     *            IN: meta filename extension
+     * @param meta_plist_id
+     *            IN: File access property list identifier for metadata
+     * @param raw_ext
+     *            IN: raw data filename extension
+     * @param raw_plist_id
+     *            IN: File access property list identifier raw data
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native void H5Pset_fapl_split(long fapl_id, String meta_ext, long meta_plist_id,
             String raw_ext, long raw_plist_id) throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Pset_fapl_stdio Sets up use of the stdio I/O driver.
+     *
+     * @param fapl_id
+     *            IN: File access property list identifier
+     *
+     * @return a non-negative value if successful; otherwise returns a negative value.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native int H5Pset_fapl_stdio(long fapl_id) throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Pset_fapl_windows Sets up use of the windows I/O driver.
+     *
+     * @param fapl_id
+     *            IN: File access property list identifier
+     *
+     * @return a non-negative value if successful; otherwise returns a negative value.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native int H5Pset_fapl_windows(long fapl_id) throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Pset_fapl_ros3 Modify the file access property list to use the H5FD_ROS3 driver.
+     *
+     * @param fapl_id
+     *            IN: File access property list identifier
+     * @param fapl_conf
+     *            IN: the properties of the ros3 driver
+     *
+     * @return a non-negative value if successful; otherwise returns a negative value.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native int H5Pset_fapl_ros3(long fapl_id, H5FD_ros3_fapl_t fapl_conf) throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Pget_fapl_ros3 gets the properties of the ros3 I/O driver.
+     *
+     * @param fapl_id
+     *            IN: File access property list identifier
+     *
+     * @return the properties of the ros3 driver.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     *
+     **/
     public synchronized static native H5FD_ros3_fapl_t H5Pget_fapl_ros3(long fapl_id) throws HDF5LibraryException, NullPointerException;
 
     // /////// unimplemented ////////
@@ -9191,6 +11408,21 @@ public class H5 implements java.io.Serializable {
     public synchronized static native int H5Soffset_simple(long space_id, byte[] offset) throws HDF5LibraryException,
             NullPointerException;
 
+    /**
+     * H5Soffset_simple sets the offset of a simple dataspace space_id.
+     *
+     * @param space_id
+     *            IN: The identifier for the dataspace object to reset.
+     * @param offset
+     *            IN: The offset at which to position the selection.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - offset array is null.
+     **/
     public synchronized static int H5Soffset_simple(long space_id, long[] offset) throws HDF5Exception,
             NullPointerException {
         if (offset == null) {
@@ -9317,6 +11549,32 @@ public class H5 implements java.io.Serializable {
         return H5Sselect_hyperslab(space_id, op, lastart, lastride, lacount, lablock);
     }
 
+    /**
+     * H5Sselect_hyperslab selects a hyperslab region to add to the current selected region for the dataspace specified
+     * by space_id. The start, stride, count, and block arrays must be the same size as the rank of the dataspace.
+     *
+     * @param space_id
+     *            IN: Identifier of dataspace selection to modify
+     * @param op
+     *            IN: Operation to perform on current selection.
+     * @param start
+     *            IN: Offset of start of hyperslab
+     * @param stride
+     *            IN: Hyperslab stride.
+     * @param count
+     *            IN: Number of blocks included in hyperslab.
+     * @param block
+     *            IN: Size of block in hyperslab.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - an input array is null.
+     * @exception IllegalArgumentException
+     *                - an input array is invalid.
+     **/
     public synchronized static native int H5Sselect_hyperslab(long space_id, int op, long[] start, long[] stride,
             long[] count, long[] block) throws HDF5LibraryException, NullPointerException, IllegalArgumentException;
 
@@ -9378,6 +11636,23 @@ public class H5 implements java.io.Serializable {
     public synchronized static native long H5Sset_extent_simple(long space_id, int rank, long[] current_size,
             long[] maximum_size) throws HDF5LibraryException, NullPointerException;
 
+    /**
+     * H5Sset_extent_simple sets or resets the size of an existing dataspace.
+     *
+     * @param space_id
+     *            Dataspace identifier.
+     * @param rank
+     *            Rank, or dimensionality, of the dataspace.
+     * @param current_size
+     *            Array containing current size of dataspace.
+     * @param maximum_size
+     *            Array containing maximum size of dataspace.
+     *
+     * @return a dataspace identifier if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static long H5Sset_extent_simple(long space_id, int rank, byte[] current_size,
             byte[] maximum_size) throws HDF5LibraryException, NullPointerException {
         ByteBuffer csbb = ByteBuffer.wrap(current_size);
@@ -9786,6 +12061,23 @@ public class H5 implements java.io.Serializable {
         return H5Tenum_insert_int(type, name, value);
     }
 
+    /**
+     * H5Tenum_insert inserts a new enumeration datatype member into an enumeration datatype.
+     *
+     * @param type
+     *            IN: Identifier of datatype.
+     * @param name
+     *            IN: The name of the member
+     * @param value
+     *            IN: The value of the member, data of the correct type
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     * @exception NullPointerException
+     *                - name is null.
+     **/
     public static int H5Tenum_insert(long type, String name, int value) throws HDF5LibraryException,
             NullPointerException {
         int[] val = { value };
@@ -10942,15 +13234,128 @@ public class H5 implements java.io.Serializable {
     // ////////////////////////////////////////////////////////////
 
     /// VOL Connector Functionality
+    /**
+     * H5VLregister_connector_by_name registers a new VOL connector as a member of the virtual object layer class.
+     *
+     * @param connector_name
+     *            IN: name of the connector.
+     * @param vipl_id
+     *            IN: VOL initialization property list which must be
+     *                created with H5Pcreate(H5P_VOL_INITIALIZE) (or H5P_DEFAULT).
+     *
+     * @return a VOL connector ID
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native long H5VLregister_connector_by_name(String connector_name, long vipl_id);
+    /**
+     * H5VLregister_connector_by_value registers a new VOL connector as a member of the virtual object layer class.
+     *
+     * @param connector_value
+     *            IN: value of the connector.
+     * @param vipl_id
+     *            IN: VOL initialization property list which must be
+     *                created with H5Pcreate(H5P_VOL_INITIALIZE) (or H5P_DEFAULT).
+     *
+     * @return a VOL connector ID
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native long H5VLregister_connector_by_value(int connector_value, long vipl_id);
+    /**
+     * H5VLis_connector_registered_by_name tests whether a VOL class has been registered.
+     *
+     * @param name
+     *            IN: name of the connector.
+     *
+     * @return true if a VOL connector with that name has been registered
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native boolean H5VLis_connector_registered_by_name(String name);
+    /**
+     * H5VLis_connector_registered_by_value tests whether a VOL class has been registered.
+     *
+     * @param connector_value
+     *            IN: value of the connector.
+     *
+     * @return  true if a VOL connector with that value has been registered
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native boolean H5VLis_connector_registered_by_value(int connector_value);
+    /**
+     * H5VLget_connector_id retrieves the ID for a registered VOL connector for a given object.
+     *
+     * @param object_id
+     *            IN: Identifier of the object.
+     *
+     * @return a VOL connector ID
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native long H5VLget_connector_id(long object_id);
+    /**
+     * H5VLget_connector_id_by_name retrieves the ID for a registered VOL connector.
+     *
+     * @param name
+     *            IN: name of the connector.
+     *
+     * @return a VOL connector ID
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native long H5VLget_connector_id_by_name(String name);
+    /**
+     * H5VLget_connector_id_by_value retrieves the ID for a registered VOL connector.
+     *
+     * @param connector_value
+     *            IN: value of the connector.
+     *
+     * @return a VOL connector ID
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native long H5VLget_connector_id_by_value(int connector_value);
+    /**
+     * H5VLget_connector_name returns the connector name for the VOL associated with the
+     *              object or file ID.
+     *
+     * @param object_id
+     *            IN: Identifier of the object.
+     *
+     * @return the connector name
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native String H5VLget_connector_name(long object_id);
+    /**
+     * H5VLclose closes a VOL connector ID.
+     *
+     * @param connector_id
+     *            IN: Identifier of the connector.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native void H5VLclose(long connector_id);
+    /**
+     * H5VLunregister_connector removes a VOL connector ID from the library.
+     *
+     * @param connector_id
+     *            IN: Identifier of the connector.
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native void H5VLunregister_connector(long connector_id);
 
     // /////// unimplemented ////////
@@ -10963,11 +13368,44 @@ public class H5 implements java.io.Serializable {
     // //
     // ////////////////////////////////////////////////////////////
 
-    public synchronized static native int H5Zfilter_avail(int filter) throws HDF5LibraryException, NullPointerException;
+    /**
+     * H5Zfilter_avail checks if a filter is available.
+     *
+     * @param filter
+     *            IN: filter number.
+     *
+     * @return a non-negative(TRUE/FALSE) value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
+    public synchronized static native int H5Zfilter_avail(int filter) throws HDF5LibraryException;
 
+    /**
+     * H5Zget_filter_info gets information about a pipeline data filter.
+     *
+     * @param filter
+     *            IN: filter number.
+     *
+     * @return the filter information flags
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
     public synchronized static native int H5Zget_filter_info(int filter) throws HDF5LibraryException;
 
-    public synchronized static native int H5Zunregister(int filter) throws HDF5LibraryException, NullPointerException;
+    /**
+     * H5Zunregister unregisters a filter.
+     *
+     * @param filter
+     *            IN: filter number.
+     *
+     * @return a non-negative value if successful
+     *
+     * @exception HDF5LibraryException
+     *                - Error from the HDF-5 Library.
+     **/
+    public synchronized static native int H5Zunregister(int filter) throws HDF5LibraryException;
 
     // /////// unimplemented ////////
 

--- a/java/src/hdf/hdf5lib/callbacks/H5A_iterate_cb.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5A_iterate_cb.java
@@ -15,7 +15,28 @@ package hdf.hdf5lib.callbacks;
 
 import hdf.hdf5lib.structs.H5A_info_t;
 
-//Information class for link callback(for H5Aiterate)
+/**
+ * Information class for link callback for H5Aiterate.
+ *
+ */
 public interface H5A_iterate_cb extends Callbacks {
-    int callback(long group, String name, H5A_info_t info, H5A_iterate_t op_data);
+    /**
+     *  application callback for each attribute
+     *
+     *  @param loc_id    the ID for the group or dataset being iterated over
+     *  @param name      the name of the current attribute about the object
+     *  @param info      the attribute's "info" struct
+     *  @param op_data   the operator data passed in to H5Aiterate
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
+    int callback(long loc_id, String name, H5A_info_t info, H5A_iterate_t op_data);
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5A_iterate_t.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5A_iterate_t.java
@@ -13,6 +13,10 @@
 
 package hdf.hdf5lib.callbacks;
 
+/**
+ * Data class for link callback for H5Aiterate.
+ *
+ */
 public interface H5A_iterate_t {
 /**    public ArrayList iterdata = new ArrayList();
   * Any derived interfaces must define the single public variable as above.

--- a/java/src/hdf/hdf5lib/callbacks/H5D_append_cb.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5D_append_cb.java
@@ -13,7 +13,27 @@
 
 package hdf.hdf5lib.callbacks;
 
-//Information class for link callback(for H5Pset/get_append_flush)
+/**
+ * Information class for link callback for H5Pset/get_append_flush.
+ *
+ */
 public interface H5D_append_cb extends Callbacks {
+    /**
+     *  application callback for each dataset access property list
+     *
+     *  @param dataset_id    the ID for the dataset being iterated over
+     *  @param cur_dims      the dimension sizes for determining boundary
+     *  @param op_data       the operator data passed in to H5Pset/get_append_flush
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
     int callback(long dataset_id, long[] cur_dims, H5D_append_t op_data);
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5D_append_t.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5D_append_t.java
@@ -13,6 +13,10 @@
 
 package hdf.hdf5lib.callbacks;
 
+/**
+ * Data class for link callback for H5Dappend.
+ *
+ */
 public interface H5D_append_t {
 /**    public ArrayList iterdata = new ArrayList();
   * Any derived interfaces must define the single public variable as above.

--- a/java/src/hdf/hdf5lib/callbacks/H5D_iterate_cb.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5D_iterate_cb.java
@@ -13,7 +13,29 @@
 
 package hdf.hdf5lib.callbacks;
 
-//Information class for link callback(for H5Diterate)
+/**
+ * Information class for link callback for H5Diterate.
+ *
+ */
 public interface H5D_iterate_cb extends Callbacks {
+    /**
+     *  application callback for each dataset element
+     *
+     *  @param elem      the pointer to the element in memory containing the current point
+     *  @param elem_type the datatype ID for the elements stored in elem
+     *  @param ndim      the number of dimensions for POINT array
+     *  @param point     the array containing the location of the element within the original dataspace
+     *  @param op_data   the operator data passed in to H5Diterate
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
     int callback(byte[] elem, long elem_type, int ndim, long[] point, H5D_iterate_t op_data);
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5D_iterate_t.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5D_iterate_t.java
@@ -13,6 +13,10 @@
 
 package hdf.hdf5lib.callbacks;
 
+/**
+ * Data class for link callback for H5Diterate.
+ *
+ */
 public interface H5D_iterate_t {
 /**    public ArrayList iterdata = new ArrayList();
   * Any derived interfaces must define the single public variable as above.

--- a/java/src/hdf/hdf5lib/callbacks/H5E_walk_cb.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5E_walk_cb.java
@@ -15,7 +15,27 @@ package hdf.hdf5lib.callbacks;
 
 import hdf.hdf5lib.structs.H5E_error2_t;
 
-//Information class for link callback(for H5Ewalk)
+/**
+ * Information class for link callback for H5Ewalk.
+ *
+ */
 public interface H5E_walk_cb extends Callbacks {
+    /**
+     *  application callback for each error stack element
+     *
+     *  @param nidx      the index of the current error stack element
+     *  @param info      the error stack "info" struct
+     *  @param op_data   the operator data passed in to H5Ewalk
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
     int callback(int nidx, H5E_error2_t info, H5E_walk_t op_data);
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5E_walk_t.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5E_walk_t.java
@@ -13,6 +13,10 @@
 
 package hdf.hdf5lib.callbacks;
 
+/**
+ * Data class for link callback for H5Ewalk.
+ *
+ */
 public interface H5E_walk_t {
 /**    public ArrayList iterdata = new ArrayList();
   * Any derived interfaces must define the single public variable as above.

--- a/java/src/hdf/hdf5lib/callbacks/H5L_iterate_opdata_t.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5L_iterate_opdata_t.java
@@ -13,6 +13,10 @@
 
 package hdf.hdf5lib.callbacks;
 
+/**
+ * Data class for link callback for H5Lvisit/H5Lvisit_by_name.
+ *
+ */
 public interface H5L_iterate_opdata_t {
 
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5L_iterate_t.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5L_iterate_t.java
@@ -15,7 +15,28 @@ package hdf.hdf5lib.callbacks;
 
 import hdf.hdf5lib.structs.H5L_info_t;
 
-// Information class for link callback (for H5Lvisit/H5Lvisit_by_name).
+/**
+ * Information class for link callback for H5Lvisit/H5Lvisit_by_name.
+ *
+ */
 public interface H5L_iterate_t extends Callbacks {
-    int callback(long group, String name, H5L_info_t info, H5L_iterate_opdata_t op_data);
+    /**
+     *  application callback for each group
+     *
+     *  @param loc_id    the ID for the group being iterated over
+     *  @param name      the name of the current link
+     *  @param info      the link's "info" struct
+     *  @param op_data   the operator data passed in to H5Literate
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
+    int callback(long loc_id, String name, H5L_info_t info, H5L_iterate_opdata_t op_data);
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5O_iterate_opdata_t.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5O_iterate_opdata_t.java
@@ -13,6 +13,10 @@
 
 package hdf.hdf5lib.callbacks;
 
+/**
+ * Data class for link callback for H5Ovisit/H5Ovisit_by_name.
+ *
+ */
 public interface H5O_iterate_opdata_t {
 
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5O_iterate_t.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5O_iterate_t.java
@@ -15,7 +15,28 @@ package hdf.hdf5lib.callbacks;
 
 import hdf.hdf5lib.structs.H5O_info_t;
 
-// Information class for link callback(for H5Ovisit/H5Ovisit_by_name)
+/**
+ * Information class for link callback for H5Ovisit/H5Ovisit_by_name.
+ *
+ */
 public interface H5O_iterate_t extends Callbacks {
-    int callback(long group, String name, H5O_info_t info, H5O_iterate_opdata_t op_data);
+    /**
+     *  application callback for each group
+     *
+     *  @param loc_id    the ID for the group or dataset being iterated over
+     *  @param name      the name of the current object
+     *  @param info      the object's "info" struct
+     *  @param op_data   the operator data passed in to H5Oiterate
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
+    int callback(long loc_id, String name, H5O_info_t info, H5O_iterate_opdata_t op_data);
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5P_cls_close_func_cb.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5P_cls_close_func_cb.java
@@ -13,7 +13,26 @@
 
 package hdf.hdf5lib.callbacks;
 
-//Information class for link callback(for H5Pcreate_class)
+/**
+ * Information class for link callback for H5Pcreate_class.
+ *
+ */
 public interface H5P_cls_close_func_cb extends Callbacks {
+    /**
+     *  application callback for each property list
+     *
+     *  @param prop_id     the ID for the property list class being iterated over
+     *  @param close_data  the function to call when a property list is closed
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
     int callback(long prop_id, H5P_cls_close_func_t close_data);
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5P_cls_close_func_t.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5P_cls_close_func_t.java
@@ -13,6 +13,10 @@
 
 package hdf.hdf5lib.callbacks;
 
+/**
+ * Data class for link callback for H5Pcreate_class.
+ *
+ */
 public interface H5P_cls_close_func_t {
 /**    public ArrayList iterdata = new ArrayList();
   * Any derived interfaces must define the single public variable as above.

--- a/java/src/hdf/hdf5lib/callbacks/H5P_cls_copy_func_cb.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5P_cls_copy_func_cb.java
@@ -13,7 +13,27 @@
 
 package hdf.hdf5lib.callbacks;
 
-//Information class for link callback(for H5Pcreate_class)
+/**
+ * Information class for link callback for H5Pcreate_class
+ *
+ */
 public interface H5P_cls_copy_func_cb extends Callbacks {
+    /**
+     *  application callback for each property list
+     *
+     *  @param new_prop_id   the ID for the property list copy
+     *  @param old_prop_id   the ID for the property list class being copied
+     *  @param copy_data     the function to call when each property list in this class is copied
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
     int callback(long new_prop_id, long old_prop_id, H5P_cls_copy_func_t copy_data);
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5P_cls_copy_func_t.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5P_cls_copy_func_t.java
@@ -13,6 +13,10 @@
 
 package hdf.hdf5lib.callbacks;
 
+/**
+ * Data class for link callback for H5Pcreate_class.
+ *
+ */
 public interface H5P_cls_copy_func_t {
 /**    public ArrayList iterdata = new ArrayList();
   * Any derived interfaces must define the single public variable as above.

--- a/java/src/hdf/hdf5lib/callbacks/H5P_cls_create_func_cb.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5P_cls_create_func_cb.java
@@ -13,7 +13,26 @@
 
 package hdf.hdf5lib.callbacks;
 
-//Information class for link callback(for H5Pcreate_class)
+/**
+ * Information class for link callback for H5Pcreate_class.
+ *
+ */
 public interface H5P_cls_create_func_cb extends Callbacks {
+    /**
+     *  application callback for each property list
+     *
+     *  @param prop_id       the ID for the property list class being iterated over
+     *  @param create_data   the function to call when each property list in this class is created
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
     int callback(long prop_id, H5P_cls_create_func_t create_data);
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5P_cls_create_func_t.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5P_cls_create_func_t.java
@@ -13,6 +13,10 @@
 
 package hdf.hdf5lib.callbacks;
 
+/**
+ * Data class for link callback for H5Pcreate_class.
+ *
+ */
 public interface H5P_cls_create_func_t {
 /**    public ArrayList iterdata = new ArrayList();
   * Any derived interfaces must define the single public variable as above.

--- a/java/src/hdf/hdf5lib/callbacks/H5P_iterate_cb.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5P_iterate_cb.java
@@ -13,7 +13,27 @@
 
 package hdf.hdf5lib.callbacks;
 
-//Information class for link callback(for H5Piterate)
+/**
+ * Information class for link callback for H5Piterate.
+ *
+ */
 public interface H5P_iterate_cb extends Callbacks {
+    /**
+     *  application callback for each property list
+     *
+     *  @param plist     the ID for the property list being iterated over
+     *  @param name      the name of the current property list
+     *  @param op_data   the operator data passed in to H5Piterate
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
     int callback(long plist, String name, H5P_iterate_t op_data);
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5P_iterate_t.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5P_iterate_t.java
@@ -13,6 +13,10 @@
 
 package hdf.hdf5lib.callbacks;
 
+/**
+ * Data class for link callback for H5Piterate.
+ *
+ */
 public interface H5P_iterate_t {
 /**    public ArrayList iterdata = new ArrayList();
   * Any derived interfaces must define the single public variable as above.

--- a/java/src/hdf/hdf5lib/callbacks/H5P_prp_close_func_cb.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5P_prp_close_func_cb.java
@@ -13,7 +13,27 @@
 
 package hdf.hdf5lib.callbacks;
 
-//Information class for link callback(for H5Pregister2)
+/**
+ * Information class for link callback for H5Pregister2.
+ *
+ */
 public interface H5P_prp_close_func_cb extends Callbacks {
+    /**
+     *  application callback for each property list
+     *
+     *  @param name    the name of the property being closed
+     *  @param size    the size of the property value
+     *  @param value   the value of the property being closed
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
     int callback(String name, long size, byte[] value);
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5P_prp_compare_func_cb.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5P_prp_compare_func_cb.java
@@ -13,7 +13,27 @@
 
 package hdf.hdf5lib.callbacks;
 
-//Information class for link callback(for H5Pregister2)
+/**
+ * Information class for link callback for H5Pregister2.
+ *
+ */
 public interface H5P_prp_compare_func_cb extends Callbacks {
+    /**
+     *  application callback for each property list
+     *
+     *  @param value1  the value of the first property being compared
+     *  @param value2  the value of the second property being compared
+     *  @param size    the size of the property value
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
     int callback(byte[] value1, byte[] value2, long size);
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5P_prp_copy_func_cb.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5P_prp_copy_func_cb.java
@@ -13,7 +13,27 @@
 
 package hdf.hdf5lib.callbacks;
 
-//Information class for link callback(for H5Pregister2)
+/**
+ * Information class for link callback for H5Pregister2.
+ *
+ */
 public interface H5P_prp_copy_func_cb extends Callbacks {
+    /**
+     *  application callback for each property list
+     *
+     *  @param name      the name of the property being copied
+     *  @param size      the size of the property value
+     *  @param value     the value of the property being copied
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
     int callback(String name, long size, byte[] value);
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5P_prp_create_func_cb.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5P_prp_create_func_cb.java
@@ -13,7 +13,27 @@
 
 package hdf.hdf5lib.callbacks;
 
-//Information class for link callback(for H5Pregister2)
+/**
+ * Information class for link callback for H5Pregister2.
+ *
+ */
 public interface H5P_prp_create_func_cb extends Callbacks {
+    /**
+     *  application callback for each property list
+     *
+     *  @param name      the name of the property list being created
+     *  @param size      the size of the property value
+     *  @param value     the initial value for the property being created
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
     int callback(String name, long size, byte[] value);
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5P_prp_delete_func_cb.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5P_prp_delete_func_cb.java
@@ -13,7 +13,28 @@
 
 package hdf.hdf5lib.callbacks;
 
-//Information class for link callback(for H5Pregister2)
+/**
+ * Information class for link callback for H5Pregister2.
+ *
+ */
 public interface H5P_prp_delete_func_cb extends Callbacks {
+    /**
+     *  application callback for each property list
+     *
+     *  @param prop_id   the ID of the property list the property is deleted from
+     *  @param name      the name of the property being deleted
+     *  @param size      the size of the property value
+     *  @param value     the value of the property being deleted
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
     int callback(long prop_id, String name, long size, byte[] value);
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5P_prp_get_func_cb.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5P_prp_get_func_cb.java
@@ -13,7 +13,28 @@
 
 package hdf.hdf5lib.callbacks;
 
-//Information class for link callback(for H5Pregister2)
+/**
+ * Information class for link callback for H5Pregister2.
+ *
+ */
 public interface H5P_prp_get_func_cb extends Callbacks {
+    /**
+     *  application callback for each property list
+     *
+     *  @param prop_id   the ID for the property list being queried
+     *  @param name      the name of the property being queried
+     *  @param size      the size of the property value
+     *  @param value     the value being retrieved for the property
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
     int callback(long prop_id, String name, long size, byte[] value);
 }

--- a/java/src/hdf/hdf5lib/callbacks/H5P_prp_set_func_cb.java
+++ b/java/src/hdf/hdf5lib/callbacks/H5P_prp_set_func_cb.java
@@ -13,7 +13,28 @@
 
 package hdf.hdf5lib.callbacks;
 
-//Information class for link callback(for H5Pregister2)
+/**
+ * Information class for link callback for H5Pregister2.
+ *
+ */
 public interface H5P_prp_set_func_cb extends Callbacks {
+    /**
+     *  application callback for each property list
+     *
+     *  @param prop_id   the ID for the property list being modified
+     *  @param name      the name of the property being modified
+     *  @param size      the size of the property value
+     *  @param value     the value being set for the property
+     *
+     *  @return operation status
+     *      A. Zero causes the iterator to continue, returning zero when all
+     *          attributes have been processed.
+     *      B. Positive causes the iterator to immediately return that positive
+     *          value, indicating short-circuit success.  The iterator can be
+     *          restarted at the next attribute.
+     *      C. Negative causes the iterator to immediately return that value,
+     *          indicating failure.  The iterator can be restarted at the next
+     *          attribute.
+     */
     int callback(long prop_id, String name, long size, byte[] value);
 }

--- a/java/src/hdf/hdf5lib/exceptions/HDF5Exception.java
+++ b/java/src/hdf/hdf5lib/exceptions/HDF5Exception.java
@@ -31,6 +31,9 @@ package hdf.hdf5lib.exceptions;
  *
  */
 public class HDF5Exception extends RuntimeException {
+    /**
+     *  the specified detail message of this exception
+     */
     protected String detailMessage;
 
     /**

--- a/java/src/hdf/hdf5lib/exceptions/HDF5ReferenceException.java
+++ b/java/src/hdf/hdf5lib/exceptions/HDF5ReferenceException.java
@@ -13,6 +13,12 @@
 
 package hdf.hdf5lib.exceptions;
 
+/**
+ * The class HDF5LibraryException returns errors raised by the HDF5 library.
+ * <p>
+ * This sub-class represents HDF-5 major error code <b>H5E_REFERENCE</b>
+ */
+
 public class HDF5ReferenceException extends HDF5LibraryException {
     /**
      * Constructs an <code>HDF5ReferenceException</code> with no specified

--- a/java/src/hdf/hdf5lib/structs/H5AC_cache_config_t.java
+++ b/java/src/hdf/hdf5lib/structs/H5AC_cache_config_t.java
@@ -15,7 +15,10 @@ package hdf.hdf5lib.structs;
 
 import java.io.Serializable;
 
-//Information struct for H5Pget_mdc_config/H5Pset_mdc_config
+/**
+ * Information struct for H5Pget_mdc_config/H5Pset_mdc_config
+ *
+ */
 public class H5AC_cache_config_t implements Serializable{
     private static final long serialVersionUID = -6748085696476149972L;
     // general configuration fields:

--- a/java/src/hdf/hdf5lib/structs/H5A_info_t.java
+++ b/java/src/hdf/hdf5lib/structs/H5A_info_t.java
@@ -15,7 +15,10 @@ package hdf.hdf5lib.structs;
 
 import java.io.Serializable;
 
-//Information struct for Attribute (For H5Aget_info/H5Aget_info_by_idx/H5Aget_info_by_name)
+/**
+ * Information struct for Attribute (For H5Aget_info/H5Aget_info_by_idx/H5Aget_info_by_name)
+ *
+ */
 public class H5A_info_t implements Serializable{
     private static final long serialVersionUID = 2791443594041667613L;
     public boolean corder_valid; // Indicate if creation order is valid

--- a/java/src/hdf/hdf5lib/structs/H5E_error2_t.java
+++ b/java/src/hdf/hdf5lib/structs/H5E_error2_t.java
@@ -15,7 +15,10 @@ package hdf.hdf5lib.structs;
 
 import java.io.Serializable;
 
-//Information struct for Attribute (For H5Ewalk)
+/**
+ * Information struct for Attribute (For H5Ewalk)
+ *
+ */
 public class H5E_error2_t implements Serializable{
     private static final long serialVersionUID = 279144359041667613L;
 

--- a/java/src/hdf/hdf5lib/structs/H5FD_hdfs_fapl_t.java
+++ b/java/src/hdf/hdf5lib/structs/H5FD_hdfs_fapl_t.java
@@ -16,7 +16,7 @@ package hdf.hdf5lib.structs;
 
 import java.io.Serializable;
 
-/*
+/**
  * Java representation of the HDFS VFD file access property list (fapl)
  * structure.
  *

--- a/java/src/hdf/hdf5lib/structs/H5FD_ros3_fapl_t.java
+++ b/java/src/hdf/hdf5lib/structs/H5FD_ros3_fapl_t.java
@@ -16,7 +16,7 @@ package hdf.hdf5lib.structs;
 
 import java.io.Serializable;
 
-/*
+/**
  * Java representation of the ROS3 VFD file access property list (fapl)
  * structure.
  *

--- a/java/src/hdf/hdf5lib/structs/H5F_info2_t.java
+++ b/java/src/hdf/hdf5lib/structs/H5F_info2_t.java
@@ -15,7 +15,10 @@ package hdf.hdf5lib.structs;
 
 import java.io.Serializable;
 
-//Information struct for object (for H5Fget_info)
+/**
+ * Information struct for object (for H5Fget_info)
+ *
+ */
 public class H5F_info2_t implements Serializable{
     private static final long serialVersionUID = 4691681162544054518L;
     public int         super_version;    // Superblock version #

--- a/java/src/hdf/hdf5lib/structs/H5G_info_t.java
+++ b/java/src/hdf/hdf5lib/structs/H5G_info_t.java
@@ -15,7 +15,10 @@ package hdf.hdf5lib.structs;
 
 import java.io.Serializable;
 
-//Information struct for group (for H5Gget_info/H5Gget_info_by_name/H5Gget_info_by_idx)
+/**
+ * Information struct for group (for H5Gget_info/H5Gget_info_by_name/H5Gget_info_by_idx)
+ *
+ */
 public class H5G_info_t implements Serializable{
     private static final long serialVersionUID = -3746463015312132912L;
     public int storage_type; // Type of storage for links in group

--- a/java/src/hdf/hdf5lib/structs/H5L_info_t.java
+++ b/java/src/hdf/hdf5lib/structs/H5L_info_t.java
@@ -17,7 +17,10 @@ import java.io.Serializable;
 
 import hdf.hdf5lib.HDF5Constants;
 
-// Information struct for link (for H5Lget_info/H5Lget_info_by_idx)
+/**
+ * Information struct for link (for H5Lget_info/H5Lget_info_by_idx)
+ *
+ */
 public class H5L_info_t implements Serializable {
     private static final long serialVersionUID = -4754320605310155033L;
     public int         type;

--- a/java/src/hdf/hdf5lib/structs/H5O_hdr_info_t.java
+++ b/java/src/hdf/hdf5lib/structs/H5O_hdr_info_t.java
@@ -15,7 +15,10 @@ package hdf.hdf5lib.structs;
 
 import java.io.Serializable;
 
-// Information struct for object header metadata (for H5Oget_info/H5Oget_info_by_name/H5Oget_info_by_idx)
+/**
+ * Information struct for object header metadata (for H5Oget_info/H5Oget_info_by_name/H5Oget_info_by_idx)
+ *
+ */
 public class H5O_hdr_info_t implements Serializable {
     private static final long serialVersionUID = 7883826382952577189L;
     public int version;       /* Version number of header format in file */
@@ -56,25 +59,25 @@ public class H5O_hdr_info_t implements Serializable {
         H5O_hdr_info_t info = (H5O_hdr_info_t) o;
 
         if (this.version != info.version)
-        	return false;
+            return false;
         if (this.nmesgs != info.nmesgs)
-        	return false;
+            return false;
         if (this.nchunks != info.nchunks)
-        	return false;
+            return false;
         if (this.flags != info.flags)
-        	return false;
+            return false;
         if (this.space_total != info.space_total)
-        	return false;
+            return false;
         if (this.space_meta != info.space_meta)
-        	return false;
+            return false;
         if (this.space_mesg != info.space_mesg)
-        	return false;
+            return false;
         if (this.space_free != info.space_free)
-        	return false;
+            return false;
         if (this.mesg_present != info.mesg_present)
-        	return false;
+            return false;
         if (this.mesg_shared != info.mesg_shared)
-        	return false;
+            return false;
 
         return true;
     }

--- a/java/src/hdf/hdf5lib/structs/H5O_info_t.java
+++ b/java/src/hdf/hdf5lib/structs/H5O_info_t.java
@@ -15,7 +15,10 @@ package hdf.hdf5lib.structs;
 
 import java.io.Serializable;
 
-// Information struct for object (for H5Oget_info/H5Oget_info_by_name/H5Oget_info_by_idx)
+/**
+ * Information struct for object (for H5Oget_info/H5Oget_info_by_name/H5Oget_info_by_idx)
+ *
+ */
 public class H5O_info_t implements Serializable {
     private static final long serialVersionUID = 4691681163544054518L;
     public long        fileno;     /* File number that object is located in */

--- a/java/src/hdf/hdf5lib/structs/H5O_native_info_t.java
+++ b/java/src/hdf/hdf5lib/structs/H5O_native_info_t.java
@@ -15,7 +15,10 @@ package hdf.hdf5lib.structs;
 
 import java.io.Serializable;
 
-// Information struct for native HDF5 object info, such as object header metadata (for H5Oget_info/H5Oget_info_by_name/H5Oget_info_by_idx).
+/**
+ * Information struct for native HDF5 object info, such as object header metadata (for H5Oget_info/H5Oget_info_by_name/H5Oget_info_by_idx).
+ *
+ */
 public class H5O_native_info_t implements Serializable {
     private static final long serialVersionUID = 7883826382952577189L;
 
@@ -45,7 +48,7 @@ public class H5O_native_info_t implements Serializable {
         if (!this.hdr_info.equals(info.hdr_info)
          || !this.obj_info.equals(info.obj_info)
          || !this.attr_info.equals(info.attr_info))
-        	return false;
+            return false;
 
         return true;
     }

--- a/java/src/hdf/hdf5lib/structs/H5O_token_t.java
+++ b/java/src/hdf/hdf5lib/structs/H5O_token_t.java
@@ -17,7 +17,10 @@ import java.util.Arrays;
 
 import hdf.hdf5lib.HDF5Constants;
 
-// Object token, which is a unique and permanent identifier, for an HDF5 object within a container.
+/**
+ * Object token, which is a unique and permanent identifier, for an HDF5 object within a container.
+ *
+ */
 public class H5O_token_t implements Serializable {
     private static final long serialVersionUID = -4754320605310155032L;
     public byte[] data;

--- a/java/src/hdf/hdf5lib/structs/H5_ih_info_t.java
+++ b/java/src/hdf/hdf5lib/structs/H5_ih_info_t.java
@@ -15,7 +15,10 @@ package hdf.hdf5lib.structs;
 
 import java.io.Serializable;
 
-//Information struct for group (for H5Gget_info/H5Gget_info_by_name/H5Gget_info_by_idx)
+/**
+ * Information struct for group (for H5Gget_info/H5Gget_info_by_name/H5Gget_info_by_idx)
+ *
+ */
 public class H5_ih_info_t implements Serializable {
     private static final long serialVersionUID = -142238015615462707L;
     public long     index_size;     /* btree and/or list */
@@ -38,9 +41,9 @@ public class H5_ih_info_t implements Serializable {
         H5_ih_info_t info = (H5_ih_info_t) o;
 
         if (this.index_size != info.index_size)
-        	return false;
+            return false;
         if (this.heap_size != info.heap_size)
-        	return false;
+            return false;
 
         return true;
     }

--- a/src/H5FDhdfs.c
+++ b/src/H5FDhdfs.c
@@ -593,7 +593,7 @@ done:
  * Function:    H5Pset_fapl_hdfs
  *
  * Purpose:     Modify the file access property list to use the H5FD_HDFS
- *              driver defined in this source file.  All driver specfic
+ *              driver defined in this source file.  All driver specific
  *              properties are passed in as a pointer to a suitably
  *              initialized instance of H5FD_hdfs_fapl_t
  *


### PR DESCRIPTION
This quiets the warnings for javadoc, except for the HDF5Constants.java file. Need to find a way to ignore that file, or autogenerate javadoc comments.