### PR TITLE
Removes -Wimplicit-fallthrough=5 from the gcc warnings

### DIFF
--- a/config/gnu-warnings/7
+++ b/config/gnu-warnings/7
@@ -3,5 +3,4 @@
 -Wduplicated-branches
 -Wformat-overflow=2
 -Wformat-truncation=1
--Wimplicit-fallthrough=5
 -Wrestrict

--- a/src/H5SM.c
+++ b/src/H5SM.c
@@ -266,7 +266,7 @@ H5SM__type_to_flag(unsigned type_id, unsigned *type_flag)
     switch (type_id) {
         case H5O_FILL_ID:
             type_id = H5O_FILL_NEW_ID;
-            /* Fall through... */
+            /* FALLTHROUGH */
             H5_ATTR_FALLTHROUGH
 
         case H5O_SDSPACE_ID:

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -2138,24 +2138,31 @@ H5S__hyper_iter_get_seq_list_opt(H5S_sel_iter_t *iter, size_t maxseq, size_t max
                 case 0:
                     do {
                         DUFF_GUTS
+                        /* FALLTHROUGH */
                         H5_ATTR_FALLTHROUGH
                         case 7:
                             DUFF_GUTS
+                            /* FALLTHROUGH */
                             H5_ATTR_FALLTHROUGH
                         case 6:
                             DUFF_GUTS
+                            /* FALLTHROUGH */
                             H5_ATTR_FALLTHROUGH
                         case 5:
                             DUFF_GUTS
+                            /* FALLTHROUGH */
                             H5_ATTR_FALLTHROUGH
                         case 4:
                             DUFF_GUTS
+                            /* FALLTHROUGH */
                             H5_ATTR_FALLTHROUGH
                         case 3:
                             DUFF_GUTS
+                            /* FALLTHROUGH */
                             H5_ATTR_FALLTHROUGH
                         case 2:
                             DUFF_GUTS
+                            /* FALLTHROUGH */
                             H5_ATTR_FALLTHROUGH
                         case 1:
                             DUFF_GUTS
@@ -10101,7 +10108,7 @@ H5S_select_hyperslab(H5S_t *space, H5S_seloper_t op, const hsize_t start[], cons
         case H5S_SEL_POINTS:          /* Can't combine hyperslab operations and point selections currently */
             if (op == H5S_SELECT_SET) /* Allow only "set" operation to proceed */
                 break;
-            /* Else fall through to error */
+            /* FALLTHROUGH (to error) */
             H5_ATTR_FALLTHROUGH
 
         case H5S_SEL_ERROR:

--- a/src/H5Tref.c
+++ b/src/H5Tref.c
@@ -650,6 +650,7 @@ H5T__ref_mem_write(H5VL_object_t *src_file, const void *src_buf, size_t src_size
             /* Pass the correct encoding version for the selection depending on the
              * file libver bounds, this is later retrieved in H5S hyper decode */
             H5CX_set_libver_bounds(src_f);
+            /* FALLTHROUGH */
             H5_ATTR_FALLTHROUGH
         case H5R_OBJECT2:
         case H5R_ATTR:

--- a/src/H5Zshuffle.c
+++ b/src/H5Zshuffle.c
@@ -177,24 +177,31 @@ H5Z__filter_shuffle(unsigned flags, size_t cd_nelmts, const unsigned cd_values[]
                         case 0:
                             do {
                                 DUFF_GUTS
+                                /* FALLTHROUGH */
                                 H5_ATTR_FALLTHROUGH
                                 case 7:
                                     DUFF_GUTS
+                                    /* FALLTHROUGH */
                                     H5_ATTR_FALLTHROUGH
                                 case 6:
                                     DUFF_GUTS
+                                    /* FALLTHROUGH */
                                     H5_ATTR_FALLTHROUGH
                                 case 5:
                                     DUFF_GUTS
+                                    /* FALLTHROUGH */
                                     H5_ATTR_FALLTHROUGH
                                 case 4:
                                     DUFF_GUTS
+                                    /* FALLTHROUGH */
                                     H5_ATTR_FALLTHROUGH
                                 case 3:
                                     DUFF_GUTS
+                                    /* FALLTHROUGH */
                                     H5_ATTR_FALLTHROUGH
                                 case 2:
                                     DUFF_GUTS
+                                    /* FALLTHROUGH */
                                     H5_ATTR_FALLTHROUGH
                                 case 1:
                                     DUFF_GUTS
@@ -241,24 +248,31 @@ H5Z__filter_shuffle(unsigned flags, size_t cd_nelmts, const unsigned cd_values[]
                         case 0:
                             do {
                                 DUFF_GUTS
+                                /* FALLTHROUGH */
                                 H5_ATTR_FALLTHROUGH
                                 case 7:
                                     DUFF_GUTS
+                                    /* FALLTHROUGH */
                                     H5_ATTR_FALLTHROUGH
                                 case 6:
                                     DUFF_GUTS
+                                    /* FALLTHROUGH */
                                     H5_ATTR_FALLTHROUGH
                                 case 5:
                                     DUFF_GUTS
+                                    /* FALLTHROUGH */
                                     H5_ATTR_FALLTHROUGH
                                 case 4:
                                     DUFF_GUTS
+                                    /* FALLTHROUGH */
                                     H5_ATTR_FALLTHROUGH
                                 case 3:
                                     DUFF_GUTS
+                                    /* FALLTHROUGH */
                                     H5_ATTR_FALLTHROUGH
                                 case 2:
                                     DUFF_GUTS
+                                    /* FALLTHROUGH */
                                     H5_ATTR_FALLTHROUGH
                                 case 1:
                                     DUFF_GUTS

--- a/src/H5checksum.c
+++ b/src/H5checksum.c
@@ -414,36 +414,47 @@ H5_checksum_lookup3(const void *key, size_t length, uint32_t initval)
     {
         case 12:
             c += ((uint32_t)k[11]) << 24;
+            /* FALLTHROUGH */
             H5_ATTR_FALLTHROUGH
         case 11:
             c += ((uint32_t)k[10]) << 16;
+            /* FALLTHROUGH */
             H5_ATTR_FALLTHROUGH
         case 10:
             c += ((uint32_t)k[9]) << 8;
+            /* FALLTHROUGH */
             H5_ATTR_FALLTHROUGH
         case 9:
             c += k[8];
+            /* FALLTHROUGH */
             H5_ATTR_FALLTHROUGH
         case 8:
             b += ((uint32_t)k[7]) << 24;
+            /* FALLTHROUGH */
             H5_ATTR_FALLTHROUGH
         case 7:
             b += ((uint32_t)k[6]) << 16;
+            /* FALLTHROUGH */
             H5_ATTR_FALLTHROUGH
         case 6:
             b += ((uint32_t)k[5]) << 8;
+            /* FALLTHROUGH */
             H5_ATTR_FALLTHROUGH
         case 5:
             b += k[4];
+            /* FALLTHROUGH */
             H5_ATTR_FALLTHROUGH
         case 4:
             a += ((uint32_t)k[3]) << 24;
+            /* FALLTHROUGH */
             H5_ATTR_FALLTHROUGH
         case 3:
             a += ((uint32_t)k[2]) << 16;
+            /* FALLTHROUGH */
             H5_ATTR_FALLTHROUGH
         case 2:
             a += ((uint32_t)k[1]) << 8;
+            /* FALLTHROUGH */
             H5_ATTR_FALLTHROUGH
         case 1:
             a += k[0];

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -298,6 +298,10 @@
  * Note that Solaris Studio supports attribute, but does not support the
  * attributes we use.
  *
+ * When using H5_ATTR_FALLTHROUGH, you should also include a comment that
+ * says FALLTHROUGH to reduce warnings on compilers that don't use
+ * attributes but do respect fall-through comments.
+ *
  * H5_ATTR_CONST is redefined in tools/h5repack/dynlib_rpk.c to quiet
  * gcc warnings (it has to use the public API and can't include this
  * file). Be sure to update that file if the #ifdefs change here.


### PR DESCRIPTION
-Wimplicit-fallthrough=3 is added by -Wextra, which we already set.
Bumping the warning level only changes how fall-through comments are
parsed, with level 5 turning off fall-through comments entirely.
This is unnecessary and results in having to do extra work to squash
warnings when included external code uses fall-through.

This change also adds /* FALLTHROUGH */ comments where
H5_ATTR_FALLTHROUGH is used so compilers that don't use attributes
but do respect fall-through comments don't raise spurious warnings.