### PR TITLE
Fixes minor issues in various virtual file drivers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3124,6 +3124,9 @@ if test "x$HAVE_LIBHDFS" = "xyes"; then
             [Proceed to build with libhdfs])
 fi
 
+## Read-only HDFS files are not built if not required.
+AM_CONDITIONAL([HDFS_VFD_CONDITIONAL], [test "X$HAVE_LIBHDFS" = "Xyes"])
+
 ## Checkpoint the cache
 AC_CACHE_SAVE
 

--- a/src/H5FDdirect.c
+++ b/src/H5FDdirect.c
@@ -384,14 +384,13 @@ static void *
 H5FD__direct_fapl_get(H5FD_t *_file)
 {
     H5FD_direct_t *file = (H5FD_direct_t *)_file;
-    void *         ret_value; /* Return value */
+    void          *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_STATIC_NOERR
 
     /* Set return value */
     ret_value = H5FD__direct_fapl_copy(&(file->fa));
 
-done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5FD__direct_fapl_get() */
 
@@ -447,7 +446,7 @@ H5FD__direct_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxad
     int                 o_flags;
     int                 fd   = (-1);
     H5FD_direct_t *     file = NULL;
-    H5FD_direct_fapl_t *fa;
+    const H5FD_direct_fapl_t *fa;
 #ifdef H5_HAVE_WIN32_API
     HFILE                              filehandle;
     struct _BY_HANDLE_FILE_INFORMATION fileinfo;
@@ -496,7 +495,7 @@ H5FD__direct_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxad
     /* Get the driver specific information */
     if (NULL == (plist = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "not a file access property list")
-    if (NULL == (fa = (H5FD_direct_fapl_t *)H5P_peek_driver_info(plist)))
+    if (NULL == (fa = (const H5FD_direct_fapl_t *)H5P_peek_driver_info(plist)))
         HGOTO_ERROR(H5E_PLIST, H5E_BADVALUE, NULL, "bad VFL driver info")
 
     file->fd = fd;
@@ -546,7 +545,8 @@ H5FD__direct_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxad
         }
         else {
             file->fa.must_align = FALSE;
-            HDftruncate(file->fd, (HDoff_t)0);
+            if (-1 == HDftruncate(file->fd, (HDoff_t)0))
+                HSYS_GOTO_ERROR(H5E_IO, H5E_SEEKERROR, NULL, "unable to truncate file")
         }
     }
     else {
@@ -793,7 +793,7 @@ H5FD__direct_get_eof(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_direct_t *file = (const H5FD_direct_t *)_file;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_STATIC_NOERR
 
     FUNC_LEAVE_NOAPI(file->eof)
 }

--- a/src/H5FDdirect.h
+++ b/src/H5FDdirect.h
@@ -23,7 +23,7 @@
 #ifdef H5_HAVE_DIRECT
 #define H5FD_DIRECT (H5FD_direct_init())
 #else
-#define H5FD_DIRECT (-1)
+#define H5FD_DIRECT (H5I_INVALID_HID)
 #endif /* H5_HAVE_DIRECT */
 
 #ifdef H5_HAVE_DIRECT

--- a/src/H5FDhdfs.c
+++ b/src/H5FDhdfs.c
@@ -20,6 +20,9 @@
  *             File System (HDFS).
  */
 
+/* This source code file is part of the H5FD driver module */
+#include "H5FDdrvr_module.h"
+
 #include "H5private.h"   /* Generic Functions        */
 #include "H5Eprivate.h"  /* Error handling           */
 #include "H5FDprivate.h" /* File drivers             */
@@ -29,9 +32,6 @@
 #include "H5MMprivate.h" /* Memory management        */
 
 #ifdef H5_HAVE_LIBHDFS
-
-/* This source code file is part of the H5FD driver module */
-#include "H5FDdrvr_module.h"
 
 /* HDFS routines */
 #include "hdfs.h"
@@ -356,7 +356,7 @@ done:
 hid_t
 H5FD_hdfs_init(void)
 {
-    hid_t ret_value = H5I_INVALID_HID; /* Return value */
+    hid_t ret_value = H5I_INVALID_HID;
 #if HDFS_STATS
     unsigned int bin_i;
 #endif

--- a/src/H5FDhdfs.h
+++ b/src/H5FDhdfs.h
@@ -25,7 +25,7 @@
 #ifdef H5_HAVE_LIBHDFS
 #define H5FD_HDFS (H5FD_hdfs_init())
 #else /* H5_HAVE_LIBHDFS */
-#define H5FD_HDFS (-1)
+#define H5FD_HDFS (H5I_INVALID_HID)
 #endif /* H5_HAVE_LIBHDFS */
 
 #ifdef H5_HAVE_LIBHDFS

--- a/src/H5FDmirror.c
+++ b/src/H5FDmirror.c
@@ -242,7 +242,7 @@ H5FD_mirror_init(void)
 {
     hid_t ret_value = H5I_INVALID_HID;
 
-    FUNC_ENTER_NOAPI(FAIL)
+    FUNC_ENTER_NOAPI(H5I_INVALID_HID)
 
     LOG_OP_CALL(FUNC);
 

--- a/src/H5FDmpio.c
+++ b/src/H5FDmpio.c
@@ -1746,33 +1746,4 @@ H5FD__mpio_communicator(const H5FD_t *_file)
     FUNC_LEAVE_NOAPI(file->comm)
 } /* end H5FD__mpio_communicator() */
 
-/*-------------------------------------------------------------------------
- * Function:       H5FD__mpio_get_info
- *
- * Purpose:        Returns the file info of MPIO file driver.
- *
- * Returns:        Non-negative if succeed or negative if fails.
- *
- * Programmer:     John Mainzer
- *                 April 4, 2017
- *
- *-------------------------------------------------------------------------
- */
-static herr_t
-H5FD__mpio_get_info(H5FD_t *_file, void **mpi_info)
-{
-    H5FD_mpio_t *file      = (H5FD_mpio_t *)_file;
-    herr_t       ret_value = SUCCEED;
-
-    FUNC_ENTER_STATIC
-
-    if (!mpi_info)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "mpi info not valid")
-
-    *mpi_info = &(file->info);
-
-done:
-    FUNC_LEAVE_NOAPI(ret_value)
-} /* H5FD__mpio_get_info() */
-
 #endif /* H5_HAVE_PARALLEL */

--- a/src/H5FDmpio.h
+++ b/src/H5FDmpio.h
@@ -25,7 +25,7 @@
 #ifdef H5_HAVE_PARALLEL
 #define H5FD_MPIO (H5FD_mpio_init())
 #else
-#define H5FD_MPIO (-1)
+#define H5FD_MPIO (H5I_INVALID_HID)
 #endif /* H5_HAVE_PARALLEL */
 
 #ifdef H5_HAVE_PARALLEL

--- a/src/H5FDros3.c
+++ b/src/H5FDros3.c
@@ -320,7 +320,7 @@ H5FD_ros3_init(void)
     unsigned int bin_i;
 #endif
 
-    FUNC_ENTER_NOAPI(FAIL)
+    FUNC_ENTER_NOAPI(H5I_INVALID_HID)
 
 #if ROS3_DEBUG
     HDfprintf(stdout, "H5FD_ros3_init() called.\n");
@@ -340,7 +340,6 @@ H5FD_ros3_init(void)
     }
 #endif
 
-    /* Set return value */
     ret_value = H5FD_ROS3_g;
 
 done:

--- a/src/H5FDsplitter.c
+++ b/src/H5FDsplitter.c
@@ -210,7 +210,7 @@ H5FD_splitter_init(void)
 {
     hid_t ret_value = H5I_INVALID_HID;
 
-    FUNC_ENTER_NOAPI(FAIL)
+    FUNC_ENTER_NOAPI(H5I_INVALID_HID)
 
     H5FD_SPLITTER_LOG_CALL(FUNC);
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,7 +39,7 @@ DISTCLEANFILES=H5pubconf.h
 
 # library sources
 libhdf5_la_SOURCES= H5.c H5checksum.c H5dbg.c H5lib_settings.c H5system.c \
-	H5timer.c H5trace.c \
+		H5timer.c H5trace.c \
         H5A.c H5Abtree2.c H5Adense.c H5Adeprec.c H5Aint.c H5Atest.c \
         H5AC.c H5ACdbg.c H5ACproxy_entry.c \
         H5B.c H5Bcache.c H5Bdbg.c \
@@ -61,7 +61,7 @@ libhdf5_la_SOURCES= H5.c H5checksum.c H5dbg.c H5lib_settings.c H5system.c \
         H5Fsuper.c H5Fsuper_cache.c H5Ftest.c \
         H5FA.c H5FAcache.c H5FAdbg.c H5FAdblock.c H5FAdblkpage.c H5FAhdr.c \
         H5FAint.c H5FAstat.c H5FAtest.c \
-        H5FD.c H5FDcore.c H5FDfamily.c H5FDhdfs.c H5FDint.c H5FDlog.c \
+        H5FD.c H5FDcore.c H5FDfamily.c H5FDint.c H5FDlog.c \
         H5FDmulti.c H5FDsec2.c H5FDspace.c \
         H5FDsplitter.c H5FDstdio.c H5FDtest.c \
         H5FL.c H5FO.c H5FS.c H5FScache.c H5FSdbg.c H5FSint.c H5FSsection.c \
@@ -124,6 +124,11 @@ endif
 # Only compile the direct VFD if necessary
 if DIRECT_VFD_CONDITIONAL
     libhdf5_la_SOURCES += H5FDdirect.c
+endif
+
+# Only compile the read-only HDFS VFD if necessary
+if HDFS_VFD_CONDITIONAL
+    libhdf5_la_SOURCES += H5FDhdfs.c
 endif
 
 # Only compile the mirror VFD if necessary

--- a/test/hdfs.c
+++ b/test/hdfs.c
@@ -564,9 +564,9 @@ test_fapl_config_validation(void)
             JSVERIFY(config.version, fa_fetch.version, "version number mismatch")
             JSVERIFY(config.namenode_port, fa_fetch.namenode_port, "namenode port mismatch")
             JSVERIFY(config.stream_buffer_size, fa_fetch.stream_buffer_size, "streambuffer size mismatch")
-            JSVERIFY_STR(config.namenode_name, fa_fetch.namenode_name, NULL)
-            JSVERIFY_STR(config.user_name, fa_fetch.user_name, NULL)
-            JSVERIFY_STR(config.kerberos_ticket_cache, fa_fetch.kerberos_ticket_cache, NULL)
+            JSVERIFY_STR(config.namenode_name, fa_fetch.namenode_name, "node name mismatch")
+            JSVERIFY_STR(config.user_name, fa_fetch.user_name, "user name mismatch")
+            JSVERIFY_STR(config.kerberos_ticket_cache, fa_fetch.kerberos_ticket_cache, "kerberos ticket cache mismatch")
         }
 
         /*-----------------------------
@@ -996,7 +996,7 @@ test_eof_eoa(void)
 
     /* verify as found
      */
-    JSVERIFY(5458199, H5FDget_eof(fd_shakespeare, H5FD_MEM_DEFAULT), NULL)
+    JSVERIFY(5458199, H5FDget_eof(fd_shakespeare, H5FD_MEM_DEFAULT), "EOF mismatch")
     JSVERIFY(H5FDget_eof(fd_shakespeare, H5FD_MEM_DEFAULT), H5FDget_eof(fd_shakespeare, H5FD_MEM_DRAW),
              "mismatch between DEFAULT and RAW memory types")
     JSVERIFY(0, H5FDget_eoa(fd_shakespeare, H5FD_MEM_DEFAULT), "EoA should be unset by H5FDopen")
@@ -1272,7 +1272,7 @@ test_read(void)
                           HADDR_UNDEF); /* Demonstrate success with "automatic" value */
     FAIL_IF(NULL == file_raven)
 
-    JSVERIFY(6464, H5FDget_eof(file_raven, H5FD_MEM_DEFAULT), NULL)
+    JSVERIFY(6464, H5FDget_eof(file_raven, H5FD_MEM_DEFAULT), "EOF mismatch")
 
     /*********
      * TESTS *
@@ -1432,8 +1432,8 @@ test_noops_and_autofails(void)
     /* no-op calls to `lock()` and `unlock()`
      */
     JSVERIFY(SUCCEED, H5FDlock(file, TRUE), "lock always succeeds; has no effect")
-    JSVERIFY(SUCCEED, H5FDlock(file, FALSE), NULL)
-    JSVERIFY(SUCCEED, H5FDunlock(file), NULL)
+    JSVERIFY(SUCCEED, H5FDlock(file, FALSE), "lock issue")
+    JSVERIFY(SUCCEED, H5FDunlock(file), "unlock issue")
     /* Lock/unlock with null file or similar error crashes tests.
      * HDassert in calling heirarchy, `H5FD[un]lock()` and `H5FD_[un]lock()`
      */

--- a/test/vfd.c
+++ b/test/vfd.c
@@ -2168,8 +2168,6 @@ test_ros3(void)
     hid_t            driver_id    = -1;     /* ID for this VFD              */
     unsigned long    driver_flags = 0;      /* VFD feature flags            */
     char             filename[1024];        /* filename                     */
-    void *           os_file_handle = NULL; /* OS file handle               */
-    hsize_t          file_size;             /* file size                    */
     H5FD_ros3_fapl_t test_ros3_fa;
     H5FD_ros3_fapl_t ros3_fa_0 = {
         /* version      = */ H5FD_CURR_ROS3_FAPL_T_VERSION,


### PR DESCRIPTION
- HDFS VFD files now ignored in the Autotools when the HDFS VFD is not
  being built.
- All VFD init code uses idiomatic H5I_INVALID_HID instead of -1
  or FAIL.
- The HDFS VFD now includes H5FDdrvr_module.h in the right place.
- The HDFS tests in test/hdfs.c no longer pass NULL to VERIFY macros, which
  raised warnings.
- Minor tweaks to fix const, unused variables, etc. warnings in
  several VFDs.