### PR TITLE
CMake: Add an option to opt-out MSVC naming convention

### DIFF
--- a/config/cmake_ext_mod/HDFMacros.cmake
+++ b/config/cmake_ext_mod/HDFMacros.cmake
@@ -143,8 +143,8 @@ macro (HDF_SET_LIB_OPTIONS libtarget libname libtype)
     endif ()
   endif ()
 
-  #----- Use MSVC Naming conventions for Shared Libraries
-  if (MINGW AND ${libtype} MATCHES "SHARED")
+  option (HDF5_MSVC_NAMING_CONVENTION "Use MSVC Naming conventions for Shared Libraries" OFF)
+  if (HDF5_MSVC_NAMING_CONVENTION AND MINGW AND ${libtype} MATCHES "SHARED")
     set_target_properties (${libtarget} PROPERTIES
         IMPORT_SUFFIX ".lib"
         IMPORT_PREFIX ""

--- a/release_docs/INSTALL_CMake.txt
+++ b/release_docs/INSTALL_CMake.txt
@@ -777,6 +777,7 @@ HDF5_USE_FOLDERS               "Enable folder grouping of projects in IDEs."    
 HDF5_WANT_DATA_ACCURACY        "IF data accuracy is guaranteed during data conversions"       ON
 HDF5_WANT_DCONV_EXCEPTION      "exception handling functions is checked during data conversions" ON
 HDF5_ENABLE_THREADSAFE         "Enable Threadsafety"                                          OFF
+HDF5_MSVC_NAMING_CONVENTION    "Use MSVC Naming conventions for Shared Libraries"             OFF
 if (APPLE)
     HDF5_BUILD_WITH_INSTALL_NAME "Build with library install_name set to the installation path"  OFF
 if (CMAKE_BUILD_TYPE MATCHES Debug)

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -48,6 +48,13 @@ New Features
 
     Configuration:
     -------------
+    - CMake option to use MSVC naming conventions with MinGW
+
+      HDF5_MSVC_NAMING_CONVENTION option enable to use MSVC naming conventions
+      when using a MinGW toolchain
+
+      (xan - 2020/10/30)
+
     - CMake option to build the HDF filter plugins project as an external project
 
       The HDF filter plugins project is a collection of registered compression


### PR DESCRIPTION
We might want to keep the default mingw import name, see:
https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-hdf5/hdf5-default-import-suffix.patch