### PR TITLE
CMake: Add an option to opt-out static libgcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,6 +578,8 @@ if (WIN32 OR MINGW)
   add_compile_definitions (_BIND_TO_CURRENT_VCLIBS_VERSION=1 _CRT_SECURE_NO_WARNINGS _CONSOLE)
 endif ()
 
+option (HDF5_MINGW_STATIC_GCC_LIBS "Statically link libgcc/libstdc++" OFF)
+
 if (MSVC)
   set (CMAKE_MFC_FLAG 0)
   set (WIN_COMPILE_FLAGS "")

--- a/c++/examples/CMakeLists.txt
+++ b/c++/examples/CMakeLists.txt
@@ -41,7 +41,7 @@ foreach (example ${examples})
   else ()
     TARGET_C_PROPERTIES (cpp_ex_${example} SHARED)
     target_link_libraries (cpp_ex_${example} PRIVATE ${HDF5_CPP_LIBSH_TARGET} ${HDF5_LIBSH_TARGET})
-    if (MINGW)
+    if (MINGW AND HDF5_MINGW_STATIC_GCC_LIBS)
       target_link_options (${HDF5_CPP_LIBSH_TARGET}
           PRIVATE -static-libgcc -static-libstdc++
       )
@@ -66,7 +66,7 @@ foreach (example ${tutr_examples})
   else ()
     TARGET_C_PROPERTIES (cpp_ex_${example} SHARED)
     target_link_libraries (cpp_ex_${example} PRIVATE ${HDF5_CPP_LIBSH_TARGET} ${HDF5_LIBSH_TARGET})
-    if (MINGW)
+    if (MINGW AND HDF5_MINGW_STATIC_GCC_LIBS)
       target_link_options (${HDF5_CPP_LIBSH_TARGET}
           PRIVATE -static-libgcc -static-libstdc++
       )

--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -117,7 +117,7 @@ if (BUILD_SHARED_LIBS)
   target_link_libraries (${HDF5_CPP_LIBSH_TARGET}
       PUBLIC ${HDF5_LIBSH_TARGET}
   )
-  if (MINGW)
+  if (MINGW AND HDF5_MINGW_STATIC_GCC_LIBS)
     target_link_options (${HDF5_CPP_LIBSH_TARGET}
         PRIVATE -static-libgcc -static-libstdc++
     )

--- a/c++/test/CMakeLists.txt
+++ b/c++/test/CMakeLists.txt
@@ -49,7 +49,7 @@ if (NOT BUILD_SHARED_LIBS)
 else ()
   TARGET_C_PROPERTIES (cpp_testhdf5 SHARED)
   target_link_libraries (cpp_testhdf5 PRIVATE ${HDF5_CPP_LIBSH_TARGET} ${HDF5_LIBSH_TARGET} ${HDF5_TEST_LIBSH_TARGET})
-  if (MINGW)
+  if (MINGW AND HDF5_MINGW_STATIC_GCC_LIBS)
     target_link_options (${HDF5_CPP_LIBSH_TARGET}
         PRIVATE -static-libgcc -static-libstdc++
     )

--- a/config/cmake/cacheinit.cmake
+++ b/config/cmake/cacheinit.cmake
@@ -40,6 +40,8 @@ set (HDF5_ENABLE_ALL_WARNINGS ON CACHE BOOL "Enable all warnings" FORCE)
 
 set (HDF_TEST_EXPRESS "2" CACHE STRING "Control testing framework (0-3)" FORCE)
 
+set (HDF5_MINGW_STATIC_GCC_LIBS ON CACHE BOOL "Statically link libgcc/libstdc++" FORCE)
+
 set (HDF5_ALLOW_EXTERNAL_SUPPORT "NO" CACHE STRING "Allow External Library Building (NO GIT TGZ)" FORCE)
 set_property (CACHE HDF5_ALLOW_EXTERNAL_SUPPORT PROPERTY STRINGS NO GIT TGZ)
 

--- a/release_docs/INSTALL_CMake.txt
+++ b/release_docs/INSTALL_CMake.txt
@@ -778,6 +778,7 @@ HDF5_WANT_DATA_ACCURACY        "IF data accuracy is guaranteed during data conve
 HDF5_WANT_DCONV_EXCEPTION      "exception handling functions is checked during data conversions" ON
 HDF5_ENABLE_THREADSAFE         "Enable Threadsafety"                                          OFF
 HDF5_MSVC_NAMING_CONVENTION    "Use MSVC Naming conventions for Shared Libraries"             OFF
+HDF5_MINGW_STATIC_GCC_LIBS     "Statically link libgcc/libstdc++"                             OFF
 if (APPLE)
     HDF5_BUILD_WITH_INSTALL_NAME "Build with library install_name set to the installation path"  OFF
 if (CMAKE_BUILD_TYPE MATCHES Debug)

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -54,6 +54,13 @@ New Features
       when using a MinGW toolchain
 
       (xan - 2020/10/30)
+    
+    - CMake option to statically link gcc libs with MinGW
+
+      HDF5_MINGW_STATIC_GCC_LIBS allows to statically link libg/libstdc++
+      with the MinGW toolchain
+
+      (xan - 2020/10/30)
 
     - CMake option to build the HDF filter plugins project as an external project
 


### PR DESCRIPTION
With sjlj exception model, statically link to libgcc/libstdc++
prevents exceptions to be caught from other dynamic libraries, this is fine with seh however.