### PR TITLE
Fix CMake package install dir on Windows not being considered by the search procedure

### DIFF
--- a/config/cmake_ext_mod/HDFMacros.cmake
+++ b/config/cmake_ext_mod/HDFMacros.cmake
@@ -356,7 +356,7 @@ macro (HDF_DIR_PATHS package_prefix)
       set (${package_prefix}_INSTALL_CMAKE_DIR share/cmake)
     else ()
       set (${package_prefix}_INSTALL_DATA_DIR ".")
-      set (${package_prefix}_INSTALL_CMAKE_DIR cmake)
+      set (${package_prefix}_INSTALL_CMAKE_DIR lib/cmake)
     endif ()
   endif ()
 
@@ -428,4 +428,3 @@ macro (HDF_DIR_PATHS package_prefix)
     endif ()
   endif ()
 endmacro ()
-


### PR DESCRIPTION
Fixes #75 

It would be nice if it could be backported to the 1.10 branch as well.