### PR TITLE
obsolete CMAKE_BUILD_TOOL => CMAKE_MAKE_PROGRAM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,7 +603,7 @@ if (MSVC)
 endif ()
 
 set (MAKE_SYSTEM)
-if (CMAKE_BUILD_TOOL MATCHES "make")
+if (CMAKE_MAKE_PROGRAM MATCHES "make")
   set (MAKE_SYSTEM 1)
 endif ()
 


### PR DESCRIPTION
CMAKE_BUILD_TOOL has been [replaced](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TOOL.html) by CMAKE_MAKE_PROGRAM