### PR TITLE
(a) Add async APIs for H5O module as listed in jira issue ID-283.

### DIFF
--- a/src/H5A.c
+++ b/src/H5A.c
@@ -310,13 +310,13 @@ H5A__create_by_name_api_common(hid_t loc_id, const char *obj_name, const char *a
     /* Check arguments */
     if (H5I_ATTR == H5I_get_type(loc_id))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "location is not valid for an attribute")
-    if (!obj_name || !*obj_name)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5I_INVALID_HID, "no object name")
+
     if (!attr_name)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5I_INVALID_HID, "attr_name parameter cannot be NULL")
     if (!*attr_name)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5I_INVALID_HID, "attr_name parameter cannot be an empty string")
 
+    /* obj_name is verified in H5VL_setup_name_args() */
     /* Set up object access arguments */
     if (H5VL_setup_name_args(loc_id, obj_name, H5P_CLS_LACC, TRUE, lapl_id, vol_obj_ptr, &loc_params) < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, H5I_INVALID_HID, "can't set object access arguments")
@@ -618,11 +618,11 @@ H5A__open_by_name_api_common(hid_t loc_id, const char *obj_name, const char *att
     /* Check arguments */
     if (H5I_ATTR == H5I_get_type(loc_id))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "location is not valid for an attribute")
-    if (!obj_name || !*obj_name)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5I_INVALID_HID, "no object name")
-    if (!attr_name || !*attr_name)
+
+    if(!attr_name || !*attr_name)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5I_INVALID_HID, "no attribute name")
 
+    /* obj_name is verified in H5VL_setup_name_args() */
     /* Set up object access arguments */
     if (H5VL_setup_name_args(loc_id, obj_name, H5P_CLS_LACC, FALSE, lapl_id, vol_obj_ptr, &loc_params) < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, H5I_INVALID_HID, "can't set object access arguments")
@@ -1672,9 +1672,8 @@ H5A__rename_by_name_api_common(hid_t loc_id, const char *obj_name, const char *o
     /* Check arguments */
     if (H5I_ATTR == H5I_get_type(loc_id))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "location is not valid for an attribute")
-    if (!obj_name || !*obj_name)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no object name")
-    if (!old_name)
+
+    if(!old_name)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "old attribute name cannot be NULL")
     if (!*old_name)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "old attribute name cannot be an empty string")
@@ -1683,6 +1682,7 @@ H5A__rename_by_name_api_common(hid_t loc_id, const char *obj_name, const char *o
     if (!*new_name)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "new attribute name cannot be an empty string")
 
+    /* obj_name is verified in H5VL_setup_name_args() */
     /* Set up object access arguments */
     if (H5VL_setup_name_args(loc_id, obj_name, H5P_CLS_LACC, TRUE, lapl_id, vol_obj_ptr, &loc_params) < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, FAIL, "can't set object access arguments")
@@ -2327,7 +2327,7 @@ H5Aexists_async(const char *app_file, const char *app_func, unsigned app_line, h
 
     /* Asynchronously check if an attribute exists */
     if ((ret_value = H5A__exists_api_common(obj_id, attr_name, token_ptr, &vol_obj)) < 0)
-        HGOTO_ERROR(H5E_ATTR, H5E_CANTRENAME, FAIL, "can't asynchronously rename attribute")
+        HGOTO_ERROR(H5E_ATTR, H5E_CANTRENAME, FAIL, "can't asynchronously check if attribute exists")
 
     /* If a token was created, add the token to the event set */
     if (NULL != token)
@@ -2363,11 +2363,10 @@ H5A__exists_by_name_api_common(hid_t loc_id, const char *obj_name, const char *a
     /* Check arguments */
     if (H5I_ATTR == H5I_get_type(loc_id))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "location is not valid for an attribute")
-    if (!obj_name || !*obj_name)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no object name")
-    if (!attr_name || !*attr_name)
+    if(!attr_name || !*attr_name)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no attribute name")
 
+    /* obj_name is verified in H5VL_setup_name_args() */
     /* Set up object access arguments */
     if (H5VL_setup_name_args(loc_id, obj_name, H5P_CLS_LACC, FALSE, lapl_id, vol_obj_ptr, &loc_params) < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, FAIL, "can't set object access arguments")

--- a/src/H5L.c
+++ b/src/H5L.c
@@ -466,10 +466,6 @@ H5L__create_soft_api_common(const char *link_target, hid_t link_loc_id, const ch
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "link_target parameter cannot be NULL")
     if (!*link_target)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "link_target parameter cannot be an empty string")
-    if (!link_name)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "link_name parameter cannot be NULL")
-    if (!*link_name)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "link_name parameter cannot be an empty string")
     if (lcpl_id != H5P_DEFAULT && (TRUE != H5P_isa_class(lcpl_id, H5P_LINK_CREATE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a link creation property list")
 
@@ -480,6 +476,7 @@ H5L__create_soft_api_common(const char *link_target, hid_t link_loc_id, const ch
     /* Set the LCPL for the API context */
     H5CX_set_lcpl(lcpl_id);
 
+    /* link_name is verified in H5VL_setup_name_args() */
     /* Set up object access arguments */
     if (H5VL_setup_name_args(link_loc_id, link_name, H5P_CLS_LACC, TRUE, lapl_id, vol_obj_ptr, &loc_params) <
         0)
@@ -830,8 +827,7 @@ H5L__delete_api_common(hid_t loc_id, const char *name, hid_t lapl_id, void **tok
     FUNC_ENTER_STATIC
 
     /* Check arguments */
-    if (!name || !*name)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no name")
+    /* name is verified in H5VL_setup_name_args() */
 
     /* Set up object access arguments */
     if (H5VL_setup_name_args(loc_id, name, H5P_CLS_LACC, TRUE, lapl_id, vol_obj_ptr, &loc_params) < 0)
@@ -1180,10 +1176,7 @@ H5L__exists_api_common(hid_t loc_id, const char *name, hid_t lapl_id, void **tok
     FUNC_ENTER_STATIC
 
     /* Check arguments */
-    if (!name)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "name parameter cannot be NULL")
-    if (!*name)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "name parameter cannot be an empty string")
+    /* name is verified in H5VL_setup_name_args() */
 
     /* Set up object access arguments */
     if (H5VL_setup_name_args(loc_id, name, H5P_CLS_LACC, FALSE, lapl_id, vol_obj_ptr, &loc_params) < 0)

--- a/src/H5O.c
+++ b/src/H5O.c
@@ -68,7 +68,7 @@ static herr_t H5O__get_info_by_name_api_common(hid_t loc_id, const char *name,
     H5O_info2_t *oinfo /*out*/, unsigned fields, hid_t lapl_id, void **token_ptr, 
     H5VL_object_t ** _vol_obj_ptr);
 
-static herr_t H5O__close_api_common(hid_t object_id);
+static htri_t H5O__close_check_common(hid_t object_id);
 
 /*********************/
 /* Package Variables */
@@ -1373,18 +1373,19 @@ done:
 } /* end H5Ovisit_by_name3() */
 
 /*-------------------------------------------------------------------------
- * Function:    H5O__close_api_common
+ * Function:    H5O__close_check_common
  *
- * Purpose:     This is the common function for closing an object.
+ * Purpose:     This is the common function to validate an object
+ *              when closing it.
  *
- * Return:      SUCCEED/FAIL
+ * Return:      TRUE/FALSE/FAIL
  *
  *-------------------------------------------------------------------------
  */
-static herr_t
-H5O__close_api_common(hid_t object_id)
+static htri_t
+H5O__close_check_common(hid_t object_id)
 {
-    herr_t              ret_value = SUCCEED;    /* Return value */
+    htri_t ret_value = TRUE;    /* Return value */
 
     FUNC_ENTER_STATIC
 
@@ -1414,7 +1415,7 @@ H5O__close_api_common(hid_t object_id)
         case H5I_EVENTSET:
         case H5I_NTYPES:
         default:
-            HGOTO_ERROR(H5E_ARGS, H5E_CANTRELEASE, FAIL,
+            HGOTO_ERROR(H5E_ARGS, H5E_CANTRELEASE, FALSE,
                         "not a valid file object ID (dataset, group, or datatype)")
             break;
     } /* end switch */
@@ -1448,8 +1449,8 @@ H5Oclose(hid_t object_id)
     FUNC_ENTER_API(FAIL)
     H5TRACE1("e", "i", object_id);
 
-    /* Retrieve group information asynchronously */
-    if(H5O__close_api_common(object_id) < 0)
+    /* Validate the object type before closing */
+    if(H5O__close_check_common(object_id) <= 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTRELEASE, FAIL, "not a valid object")
 
     if (H5I_dec_app_ref(object_id) < 0)
@@ -1481,8 +1482,8 @@ H5Oclose_async(const char *app_file, const char *app_func, unsigned app_line,
     FUNC_ENTER_API(FAIL)
     H5TRACE5("e", "*s*sIuii", app_file, app_func, app_line, object_id, es_id);
 
-    /* Retrieve group information asynchronously */
-    if(H5O__close_api_common(object_id) < 0)
+    /* Validate the object type before closing */
+    if(H5O__close_check_common(object_id) <= 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTRELEASE, FAIL, "not a valid object")
 
     /* Prepare for possible asynchronous operation */

--- a/src/H5O.c
+++ b/src/H5O.c
@@ -32,6 +32,7 @@
 #include "H5private.h"   /* Generic Functions                        */
 #include "H5CXprivate.h" /* API Contexts                             */
 #include "H5Eprivate.h"  /* Error handling                           */
+#include "H5ESprivate.h" /* Event Sets                               */
 #include "H5Fprivate.h"  /* File access                              */
 #include "H5Iprivate.h"  /* IDs                                      */
 #include "H5Lprivate.h"  /* Links                                    */
@@ -55,6 +56,18 @@
 /* Local Prototypes */
 /********************/
 
+/* Helper routines for sync/async API calls */
+static hid_t H5O__open_api_common(hid_t loc_id, const char *name, hid_t lapl_id,
+    void **token_ptr, H5VL_object_t ** _vol_obj_ptr);
+
+static hid_t H5O__open_by_idx_api_common(hid_t loc_id, const char *group_name, 
+    H5_index_t idx_type, H5_iter_order_t order, hsize_t n, hid_t lapl_id, 
+    void **token_ptr, H5VL_object_t ** _vol_obj_ptr);
+
+static herr_t H5O__get_info_by_name_api_common(hid_t loc_id, const char *name, 
+    H5O_info2_t *oinfo /*out*/, unsigned fields, hid_t lapl_id, void **token_ptr, 
+    H5VL_object_t ** _vol_obj_ptr);
+
 /*********************/
 /* Package Variables */
 /*********************/
@@ -66,6 +79,49 @@
 /*******************/
 /* Local Variables */
 /*******************/
+
+/*-------------------------------------------------------------------------
+ * Function:    H5O__open_api_common
+ *
+ * Purpose:     This is the common function for opening an object
+ *
+ * Return:      Success:    An open object identifier
+ *              Failure:    H5I_INVALID_HID
+ *
+ *-------------------------------------------------------------------------
+ */
+static hid_t
+H5O__open_api_common(hid_t loc_id, const char *name, hid_t lapl_id,
+    void **token_ptr, H5VL_object_t ** _vol_obj_ptr)
+{
+    H5VL_object_t *   tmp_vol_obj   = NULL;         /* Object for loc_id */
+    H5VL_object_t **  vol_obj_ptr  = (_vol_obj_ptr ? _vol_obj_ptr : &tmp_vol_obj);   /* Ptr to object ptr for loc_id */
+    H5I_type_t        opened_type;
+    void *            opened_obj = NULL;
+    H5VL_loc_params_t loc_params;
+    hid_t             ret_value = H5I_INVALID_HID;
+
+    FUNC_ENTER_STATIC
+
+    /* Check args */
+
+    /* name is checked in this H5VL_setup_name_args() */
+    /* Set up object access arguments */
+    if (H5VL_setup_name_args(loc_id, name, H5P_CLS_LACC, FALSE, lapl_id, vol_obj_ptr, &loc_params) < 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, H5I_INVALID_HID, "can't set object access arguments")
+
+    /* Open the object */
+    if (NULL == (opened_obj = H5VL_object_open(*vol_obj_ptr, &loc_params, &opened_type, H5P_DATASET_XFER_DEFAULT,
+                                               token_ptr)))
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTOPENOBJ, H5I_INVALID_HID, "unable to open object")
+
+    /* Get an atom for the object */
+    if ((ret_value = H5VL_register(opened_type, opened_obj, (*vol_obj_ptr)->connector, TRUE)) < 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to atomize object handle")
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* H5O__open_api_common() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5Oopen
@@ -93,47 +149,100 @@
 hid_t
 H5Oopen(hid_t loc_id, const char *name, hid_t lapl_id)
 {
-    H5VL_object_t *   vol_obj; /* Object of loc_id */
-    H5I_type_t        opened_type;
-    void *            opened_obj = NULL;
-    H5VL_loc_params_t loc_params;
     hid_t             ret_value = H5I_INVALID_HID;
 
     FUNC_ENTER_API(H5I_INVALID_HID)
     H5TRACE3("i", "i*si", loc_id, name, lapl_id);
 
-    /* Check args */
-    if (!name)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5I_INVALID_HID, "name parameter cannot be NULL")
-    if (!*name)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5I_INVALID_HID, "name parameter cannot be an empty string")
-
-    /* Verify access property list and set up collective metadata if appropriate */
-    if (H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE) < 0)
-        HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, H5I_INVALID_HID, "can't set access property list info")
-
-    /* Get the location object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(loc_id)))
-        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "invalid location identifier")
-
-    /* Set location struct fields */
-    loc_params.type                         = H5VL_OBJECT_BY_NAME;
-    loc_params.loc_data.loc_by_name.name    = name;
-    loc_params.loc_data.loc_by_name.lapl_id = lapl_id;
-    loc_params.obj_type                     = H5I_get_type(loc_id);
-
-    /* Open the object */
-    if (NULL == (opened_obj = H5VL_object_open(vol_obj, &loc_params, &opened_type, H5P_DATASET_XFER_DEFAULT,
-                                               H5_REQUEST_NULL)))
-        HGOTO_ERROR(H5E_OHDR, H5E_CANTOPENOBJ, H5I_INVALID_HID, "unable to open object")
-
-    /* Get an atom for the object */
-    if ((ret_value = H5VL_register(opened_type, opened_obj, vol_obj->connector, TRUE)) < 0)
-        HGOTO_ERROR(H5E_OHDR, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to atomize object handle")
+    /* Open the object synchronously */
+    if((ret_value = H5O__open_api_common(loc_id, name, lapl_id, NULL, NULL)) < 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTOPENOBJ, H5I_INVALID_HID, "unable to synchronously open object")
 
 done:
     FUNC_LEAVE_API(ret_value)
 } /* end H5Oopen() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5Oopen_async
+ *
+ * Purpose:     Asynchronous version of H5Oopen
+ *
+ * Return:      Success:    An open object identifier
+ *              Failure:    H5I_INVALID_HID
+ *
+ *-------------------------------------------------------------------------
+ */
+hid_t
+H5Oopen_async(const char *app_file, const char *app_func, unsigned app_line,
+    hid_t loc_id, const char *name, hid_t lapl_id, hid_t es_id)
+{
+    H5VL_object_t *   vol_obj   = NULL;         /* Object for loc_id */
+    void *            token     = NULL;         /* Request token for async operation        */
+    void **token_ptr = H5_REQUEST_NULL;         /* Pointer to request token for async operation        */
+    hid_t ret_value;            /* Return value */
+
+    FUNC_ENTER_API(H5I_INVALID_HID)
+    H5TRACE7("i", "*s*sIui*sii", app_file, app_func, app_line, loc_id, name, lapl_id, es_id);
+
+    /* Set up request token pointer for asynchronous operation */
+    if (H5ES_NONE != es_id)
+        token_ptr = &token;     /* Point at token for VOL connector to set up */
+
+    /* Open the object asynchronously */
+    if((ret_value = H5O__open_api_common(loc_id, name, lapl_id, token_ptr, &vol_obj)) < 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTOPENOBJ, H5I_INVALID_HID, "unable to asynchronously open object")
+
+    /* If a token was created, add the token to the event set */
+    if (NULL != token)
+        if (H5ES_insert(es_id, vol_obj->connector, token,
+                H5ARG_TRACE7(FUNC, "*s*sIui*sii", app_file, app_func, app_line, loc_id, name, lapl_id, es_id)) < 0)
+            HGOTO_ERROR(H5E_OHDR, H5E_CANTINSERT, H5I_INVALID_HID, "can't insert token into event set")
+
+done:
+    FUNC_LEAVE_API(ret_value)
+} /* end H5Dopen_async() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5O__open_by_idx_api_common
+ *
+ * Purpose:     This is the common function for opening an object within an index
+ *
+ * Return:      Success:    An open object identifier
+ *              Failure:    H5I_INVALID_HID
+ *
+ *-------------------------------------------------------------------------
+ */
+static hid_t
+H5O__open_by_idx_api_common(hid_t loc_id, const char *group_name, H5_index_t idx_type, 
+    H5_iter_order_t order, hsize_t n, hid_t lapl_id, 
+    void **token_ptr, H5VL_object_t ** _vol_obj_ptr)
+{
+    H5VL_object_t *   tmp_vol_obj   = NULL;         /* Object for loc_id */
+    H5VL_object_t **  vol_obj_ptr  = (_vol_obj_ptr ? _vol_obj_ptr : &tmp_vol_obj);   /* Ptr to object ptr for loc_id */
+    H5I_type_t        opened_type;
+    void *            opened_obj = NULL;
+    H5VL_loc_params_t loc_params;
+    hid_t             ret_value = H5I_INVALID_HID;
+
+    FUNC_ENTER_STATIC
+
+    /* Check args */
+    /* group_name, idx_type, order are checked in H5VL_setup_idx-args() */
+    /* Set up object access arguments */
+    if (H5VL_setup_idx_args(loc_id, group_name, idx_type, order, n, H5P_CLS_LACC, FALSE, lapl_id, vol_obj_ptr, &loc_params) < 0)
+        HGOTO_ERROR(H5E_LINK, H5E_CANTSET, H5I_INVALID_HID, "can't set object access arguments")
+
+    /* Open the object */
+    if (NULL == (opened_obj = H5VL_object_open(*vol_obj_ptr, &loc_params, &opened_type, H5P_DATASET_XFER_DEFAULT,
+                                               token_ptr)))
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTOPENOBJ, H5I_INVALID_HID, "unable to open object")
+
+    if ((ret_value = H5VL_register(opened_type, opened_obj, (*vol_obj_ptr)->connector, TRUE)) < 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to atomize object handle")
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* H5O__open_by_idx_api_common() */
 
 /*-------------------------------------------------------------------------
  * Function:	H5Oopen_by_idx
@@ -162,50 +271,60 @@ hid_t
 H5Oopen_by_idx(hid_t loc_id, const char *group_name, H5_index_t idx_type, H5_iter_order_t order, hsize_t n,
                hid_t lapl_id)
 {
-    H5VL_object_t *   vol_obj; /* Object of loc_id */
-    H5I_type_t        opened_type;
-    void *            opened_obj = NULL;
-    H5VL_loc_params_t loc_params;
     hid_t             ret_value = H5I_INVALID_HID;
 
     FUNC_ENTER_API(H5I_INVALID_HID)
     H5TRACE6("i", "i*sIiIohi", loc_id, group_name, idx_type, order, n, lapl_id);
-
-    /* Check args */
-    if (!group_name || !*group_name)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5I_INVALID_HID, "no name specified")
-    if (idx_type <= H5_INDEX_UNKNOWN || idx_type >= H5_INDEX_N)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5I_INVALID_HID, "invalid index type specified")
-    if (order <= H5_ITER_UNKNOWN || order >= H5_ITER_N)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5I_INVALID_HID, "invalid iteration order specified")
-
-    /* Verify access property list and set up collective metadata if appropriate */
-    if (H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE) < 0)
-        HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, H5I_INVALID_HID, "can't set access property list info")
-
-    loc_params.type                         = H5VL_OBJECT_BY_IDX;
-    loc_params.loc_data.loc_by_idx.name     = group_name;
-    loc_params.loc_data.loc_by_idx.idx_type = idx_type;
-    loc_params.loc_data.loc_by_idx.order    = order;
-    loc_params.loc_data.loc_by_idx.n        = n;
-    loc_params.loc_data.loc_by_idx.lapl_id  = lapl_id;
-    loc_params.obj_type                     = H5I_get_type(loc_id);
-
-    /* get the location object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(loc_id)))
-        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "invalid location identifier")
-
-    /* Open the object */
-    if (NULL == (opened_obj = H5VL_object_open(vol_obj, &loc_params, &opened_type, H5P_DATASET_XFER_DEFAULT,
-                                               H5_REQUEST_NULL)))
-        HGOTO_ERROR(H5E_OHDR, H5E_CANTOPENOBJ, H5I_INVALID_HID, "unable to open object")
-
-    if ((ret_value = H5VL_register(opened_type, opened_obj, vol_obj->connector, TRUE)) < 0)
-        HGOTO_ERROR(H5E_OHDR, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to atomize object handle")
+ 
+    /* Open the object synchronously */
+    if((ret_value = H5O__open_by_idx_api_common(loc_id, group_name, idx_type, order, n, lapl_id, NULL, NULL)) < 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTOPENOBJ, H5I_INVALID_HID, "unable to synchronously open object")
 
 done:
     FUNC_LEAVE_API(ret_value)
 } /* end H5Oopen_by_idx() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5Oopen_by_idx_async
+ *
+ * Purpose:     Asynchronous version of H5Oopen_by_idx
+ *
+ * Return:      Success:    An open object identifier
+ *              Failure:    H5I_INVALID_HID
+ *
+ *-------------------------------------------------------------------------
+ */
+hid_t
+H5Oopen_by_idx_async(const char *app_file, const char *app_func, unsigned app_line,
+    hid_t loc_id, const char *group_name, H5_index_t idx_type, H5_iter_order_t order, 
+    hsize_t n, hid_t lapl_id, hid_t es_id)
+{
+    H5VL_object_t *   vol_obj   = NULL;         /* Object for loc_id */
+    void *            token     = NULL;         /* Request token for async operation        */
+    void **token_ptr = H5_REQUEST_NULL;         /* Pointer to request token for async operation        */
+    hid_t ret_value;            /* Return value */
+
+    FUNC_ENTER_API(H5I_INVALID_HID)
+    H5TRACE10("i", "*s*sIui*sIiIohii", app_file, app_func, app_line, loc_id, group_name, idx_type, order, n,
+              lapl_id, es_id);
+
+    /* Set up request token pointer for asynchronous operation */
+    if (H5ES_NONE != es_id)
+        token_ptr = &token;     /* Point at token for VOL connector to set up */
+
+    /* Open the object asynchronously */
+    if((ret_value = H5O__open_by_idx_api_common(loc_id, group_name, idx_type, order, n, lapl_id, token_ptr, &vol_obj)) < 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTOPENOBJ, H5I_INVALID_HID, "unable to asynchronously open object")
+
+    /* If a token was created, add the token to the event set */
+    if (NULL != token)
+        if (H5ES_insert(es_id, vol_obj->connector, token,
+                H5ARG_TRACE10(FUNC, "*s*sIui*sIiIohii", app_file, app_func, app_line, loc_id, group_name, idx_type, order, n, lapl_id, es_id)) < 0)
+            HGOTO_ERROR(H5E_OHDR, H5E_CANTINSERT, H5I_INVALID_HID, "can't insert token into event set")
+
+done:
+    FUNC_LEAVE_API(ret_value)
+} /* end H5Dopen_by_idx_async() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5Oopen_by_token
@@ -555,6 +674,47 @@ done:
 } /* end H5Oget_info3() */
 
 /*-------------------------------------------------------------------------
+ * Function:    H5O__get_info_by_name_api_common
+ *
+ * Purpose:     This is the common function for retrieving information
+ *              about an object.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5O__get_info_by_name_api_common(hid_t loc_id, const char *name, H5O_info2_t *oinfo /*out*/, 
+    unsigned fields, hid_t lapl_id, void **token_ptr, H5VL_object_t ** _vol_obj_ptr)
+{
+    H5VL_object_t *   tmp_vol_obj   = NULL;         /* Object for loc_id */
+    H5VL_object_t **  vol_obj_ptr  = (_vol_obj_ptr ? _vol_obj_ptr : &tmp_vol_obj);   /* Ptr to object ptr for loc_id */
+    H5VL_loc_params_t loc_params;               /* Location parameters for object access */
+    herr_t              ret_value = SUCCEED;    /* Return value */
+
+    FUNC_ENTER_STATIC
+
+    /* Check args */
+    if (!oinfo)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "oinfo parameter cannot be NULL")
+    if (fields & ~H5O_INFO_ALL)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid fields")
+
+    /* "name" is checked in H5VL_setup_name_args() */
+    /* Set up object access arguments */
+    if (H5VL_setup_name_args(loc_id, name, H5P_CLS_LACC, FALSE, lapl_id, vol_obj_ptr, &loc_params) < 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, H5I_INVALID_HID, "can't set object access arguments")
+
+    /* Retrieve the object's information */
+    if (H5VL_object_get(*vol_obj_ptr, &loc_params, H5VL_OBJECT_GET_INFO, H5P_DATASET_XFER_DEFAULT, token_ptr,
+                        oinfo, fields) < 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTGET, FAIL, "can't get data model info for object")
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* H5O__get_info_by_name_api_common() */
+
+/*-------------------------------------------------------------------------
  * Function:    H5Oget_info_by_name3
  *
  * Purpose:     Retrieve information about an object
@@ -570,45 +730,58 @@ herr_t
 H5Oget_info_by_name3(hid_t loc_id, const char *name, H5O_info2_t *oinfo /*out*/, unsigned fields,
                      hid_t lapl_id)
 {
-    H5VL_object_t *   vol_obj; /* Object of loc_id */
-    H5VL_loc_params_t loc_params;
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
     H5TRACE5("e", "i*sxIui", loc_id, name, oinfo, fields, lapl_id);
 
-    /* Check args */
-    if (!name)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "name parameter cannot be NULL")
-    if (!*name)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "name parameter cannot be an empty string")
-    if (!oinfo)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "oinfo parameter cannot be NULL")
-    if (fields & ~H5O_INFO_ALL)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid fields")
-
-    /* Verify access property list and set up collective metadata if appropriate */
-    if (H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE) < 0)
-        HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, FAIL, "can't set access property list info")
-
-    /* Fill out location struct */
-    loc_params.type                         = H5VL_OBJECT_BY_NAME;
-    loc_params.loc_data.loc_by_name.name    = name;
-    loc_params.loc_data.loc_by_name.lapl_id = lapl_id;
-    loc_params.obj_type                     = H5I_get_type(loc_id);
-
-    /* Get the location object */
-    if (NULL == (vol_obj = H5VL_vol_object(loc_id)))
-        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier")
-
-    /* Retrieve the object's information */
-    if (H5VL_object_get(vol_obj, &loc_params, H5VL_OBJECT_GET_INFO, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL,
-                        oinfo, fields) < 0)
-        HGOTO_ERROR(H5E_OHDR, H5E_CANTGET, FAIL, "can't get data model info for object")
+    /* Retrieve object information synchronously */
+    if(H5O__get_info_by_name_api_common(loc_id, name, oinfo, fields, lapl_id, NULL, NULL) < 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTGET, FAIL, "can't synchronously retrieve object info")
 
 done:
     FUNC_LEAVE_API(ret_value)
 } /* end H5Oget_info_by_name3() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5Oget_info_by_name_async
+ *
+ * Purpose:     Asynchronous version of H5Oget_info_by_name3
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5Oget_info_by_name_async(const char *app_file, const char *app_func, unsigned app_line,
+    hid_t loc_id, const char *name, H5O_info2_t *oinfo /*out*/, unsigned fields,
+    hid_t lapl_id, hid_t es_id)
+{
+    H5VL_object_t *   vol_obj   = NULL;         /* Object for loc_id */
+    void *            token     = NULL;         /* Request token for async operation        */
+    void **token_ptr = H5_REQUEST_NULL;         /* Pointer to request token for async operation        */
+    herr_t              ret_value = SUCCEED;    /* Return value */
+
+    FUNC_ENTER_API(FAIL)
+    H5TRACE9("e", "*s*sIui*sxIuii", app_file, app_func, app_line, loc_id, name, oinfo, fields, lapl_id, es_id);
+
+    /* Set up request token pointer for asynchronous operation */
+    if (H5ES_NONE != es_id)
+        token_ptr = &token;     /* Point at token for VOL connector to set up */
+
+    /* Retrieve group information asynchronously */
+    if(H5O__get_info_by_name_api_common(loc_id, name, oinfo, fields, lapl_id, token_ptr, &vol_obj) < 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTGET, FAIL, "can't asynchronously retrieve object info")
+
+    /* If a token was created, add the token to the event set */
+    if (NULL != token)
+        if (H5ES_insert(es_id, vol_obj->connector, token,
+                H5ARG_TRACE9(FUNC, "*s*sIui*sxIuii", app_file, app_func, app_line, loc_id, name, oinfo, fields, lapl_id, es_id)) < 0)
+            HGOTO_ERROR(H5E_OHDR, H5E_CANTINSERT, FAIL, "can't insert token into event set")
+
+done:
+    FUNC_LEAVE_API(ret_value)
+} /* H5Oget_info_by_name_async() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5Oget_info_by_idx3
@@ -1252,6 +1425,102 @@ H5Oclose(hid_t object_id)
 done:
     FUNC_LEAVE_API(ret_value)
 } /* end H5Oclose() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5Oclose
+ *
+ * Purpose:     Close an open file object.
+ *
+ *              This is the companion to H5Oopen. It is used to close any
+ *              open object in an HDF5 file (but not IDs are that not file
+ *              objects, such as property lists and dataspaces). It has
+ *              the same effect as calling H5Gclose, H5Dclose, or H5Tclose.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ * Programmer:	James Laird
+ *		July 14 2006
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5Oclose_async(const char *app_file, const char *app_func, unsigned app_line, 
+    hid_t object_id, hid_t es_id)
+{
+    H5VL_object_t *vol_obj = NULL;  /* Object for loc_id */
+    H5VL_t *connector = NULL;       /* VOL connector */
+    void *token = NULL;             /* Request token for async operation        */
+    void **token_ptr = H5_REQUEST_NULL; /* Pointer to request token for async operation        */
+    herr_t ret_value = SUCCEED;
+
+    FUNC_ENTER_API(FAIL)
+    H5TRACE5("e", "*s*sIuii", app_file, app_func, app_line, object_id, es_id);
+
+    /* Get the type of the object and close it in the correct way */
+    switch (H5I_get_type(object_id)) {
+        case H5I_GROUP:
+        case H5I_DATATYPE:
+        case H5I_DATASET:
+        case H5I_MAP:
+            if (H5I_object(object_id) == NULL)
+                HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "not a valid object")
+
+            /* Prepare for possible asynchronous operation */
+            if (H5ES_NONE != es_id) {
+                /* Get file object's connector */
+                if (NULL == (vol_obj = H5VL_vol_object(object_id)))
+                    HGOTO_ERROR(H5E_OHDR, H5E_CANTGET, FAIL, "can't get VOL object for object")
+
+                /* Increase connector's refcount, so it doesn't get closed if closing
+                 * this object ID closes the file */
+                connector = vol_obj->connector;
+                H5VL_conn_inc_rc(connector);
+
+                /* Point at token for operation to set up */
+                token_ptr = &token;
+            } /* end if */
+
+            /* Asynchronously decrement reference count on ID.
+             * When it reaches zero the object will be closed.
+             */
+            if (H5I_dec_app_ref_async(object_id, token_ptr) < 0)
+                HGOTO_ERROR(H5E_OHDR, H5E_CANTCLOSEFILE, FAIL, "decrementing object ID failed")
+
+            /* If a token was created, add the token to the event set */
+            if (NULL != token)
+                if (H5ES_insert(es_id, vol_obj->connector, token, 
+                        H5ARG_TRACE5(FUNC, "*s*sIuii", app_file, app_func, app_line, object_id, es_id)) < 0)
+                    HGOTO_ERROR(H5E_OHDR, H5E_CANTINSERT, FAIL, "can't insert token into event set")
+
+            break;
+
+        case H5I_UNINIT:
+        case H5I_BADID:
+        case H5I_FILE:
+        case H5I_DATASPACE:
+        case H5I_ATTR:
+        case H5I_VFL:
+        case H5I_VOL:
+        case H5I_GENPROP_CLS:
+        case H5I_GENPROP_LST:
+        case H5I_ERROR_CLASS:
+        case H5I_ERROR_MSG:
+        case H5I_ERROR_STACK:
+        case H5I_SPACE_SEL_ITER:
+        case H5I_EVENTSET:
+        case H5I_NTYPES:
+        default:
+            HGOTO_ERROR(H5E_ARGS, H5E_CANTRELEASE, FAIL,
+                        "not a valid file object ID (dataset, group, or datatype)")
+            break;
+    } /* end switch */
+
+done:
+    if (connector && H5VL_conn_dec_rc(connector) < 0)
+        HDONE_ERROR(H5E_SYM, H5E_CANTDEC, FAIL, "can't decrement ref count on connector")
+
+    FUNC_LEAVE_API(ret_value)
+} /* end H5Oclose_async() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5O_disable_mdc_flushes

--- a/src/H5Ocopy.c
+++ b/src/H5Ocopy.c
@@ -33,6 +33,7 @@
 #include "H5Aprivate.h"  /* Attributes                               */
 #include "H5CXprivate.h" /* API Contexts                             */
 #include "H5Eprivate.h"  /* Error handling                           */
+#include "H5ESprivate.h" /* Event Sets                               */
 #include "H5FLprivate.h" /* Free lists                               */
 #include "H5Iprivate.h"  /* IDs                                      */
 #include "H5HGprivate.h" /* Global Heaps                             */
@@ -89,6 +90,11 @@ static htri_t H5O__copy_search_comm_dt(H5F_t *file_src, H5O_t *oh_src, H5O_loc_t
 static herr_t H5O__copy_insert_comm_dt(H5F_t *file_src, H5O_t *oh_src, H5O_loc_t *oloc_dst,
                                        H5O_copy_t *cpy_info);
 
+static herr_t H5O__copy_api_common(hid_t src_loc_id, const char *src_name, hid_t dst_loc_id,
+                                   const char *dst_name, hid_t ocpypl_id, hid_t lcpl_id,
+                                   void **token_ptr, H5VL_object_t ** _vol_obj_ptr);
+
+
 /*********************/
 /* Package Variables */
 /*********************/
@@ -109,6 +115,72 @@ H5FL_DEFINE(haddr_t);
 /*******************/
 /* Local Variables */
 /*******************/
+
+/*-------------------------------------------------------------------------
+ * Function:    H5O__copy_api_common
+ *
+ * Purpose:     This is the common function for copying an object.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5O__copy_api_common(hid_t src_loc_id, const char *src_name, hid_t dst_loc_id, 
+    const char *dst_name, hid_t ocpypl_id, hid_t lcpl_id,
+    void **token_ptr, H5VL_object_t ** _vol_obj_ptr)
+{
+    /* dst_id */
+    H5VL_object_t *   tmp_vol_obj   = NULL;         /* Object for loc_id */
+    H5VL_object_t **  vol_obj_ptr  = (_vol_obj_ptr ? _vol_obj_ptr : &tmp_vol_obj);   /* Ptr to object ptr for loc_id */
+    H5VL_loc_params_t loc_params2;
+
+    /* src_id */
+    H5VL_object_t *   vol_obj1 = NULL; /* object of src_id */
+    H5VL_loc_params_t loc_params1;
+
+    herr_t            ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_STATIC
+
+    /* Check arguments */
+    if (!src_name || !*src_name)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no source name specified")
+    if (!dst_name || !*dst_name)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no destination name specified")
+
+    /* Get correct property lists */
+    if (H5P_DEFAULT == lcpl_id)
+        lcpl_id = H5P_LINK_CREATE_DEFAULT;
+    else if (TRUE != H5P_isa_class(lcpl_id, H5P_LINK_CREATE))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not link creation property list")
+
+    /* Get object copy property list */
+    if (H5P_DEFAULT == ocpypl_id)
+        ocpypl_id = H5P_OBJECT_COPY_DEFAULT;
+    else if (TRUE != H5P_isa_class(ocpypl_id, H5P_OBJECT_COPY))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not object copy property list")
+
+    /* Set the LCPL for the API context */
+    H5CX_set_lcpl(lcpl_id);
+
+    if (H5VL_setup_loc_args(src_loc_id, &vol_obj1, &loc_params1) < 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, FAIL, "can't set object access arguments")
+
+    /* get the object */
+    if (NULL == (*vol_obj_ptr = (H5VL_object_t *)H5I_object(dst_loc_id)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier")
+    loc_params2.type     = H5VL_OBJECT_BY_SELF;
+    loc_params2.obj_type = H5I_get_type(dst_loc_id);
+
+    /* Copy the object */
+    if (H5VL_object_copy(vol_obj1, &loc_params1, src_name, *vol_obj_ptr, &loc_params2, dst_name, ocpypl_id,
+                         lcpl_id, H5P_DATASET_XFER_DEFAULT, token_ptr) < 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTCOPY, FAIL, "unable to copy object")
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* H5O__copy_api_common() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5Ocopy
@@ -188,60 +260,61 @@ herr_t
 H5Ocopy(hid_t src_loc_id, const char *src_name, hid_t dst_loc_id, const char *dst_name, hid_t ocpypl_id,
         hid_t lcpl_id)
 {
-    H5VL_object_t *   vol_obj1 = NULL; /* object of src_id */
-    H5VL_loc_params_t loc_params1;
-    H5VL_object_t *   vol_obj2 = NULL; /* object of dst_id */
-    H5VL_loc_params_t loc_params2;
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
     H5TRACE6("e", "i*si*sii", src_loc_id, src_name, dst_loc_id, dst_name, ocpypl_id, lcpl_id);
 
-    /* Check arguments */
-    if (!src_name || !*src_name)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no source name specified")
-    if (!dst_name || !*dst_name)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no destination name specified")
-
-    /* Get correct property lists */
-    if (H5P_DEFAULT == lcpl_id)
-        lcpl_id = H5P_LINK_CREATE_DEFAULT;
-    else if (TRUE != H5P_isa_class(lcpl_id, H5P_LINK_CREATE))
-        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not link creation property list")
-
-    /* Get object copy property list */
-    if (H5P_DEFAULT == ocpypl_id)
-        ocpypl_id = H5P_OBJECT_COPY_DEFAULT;
-    else if (TRUE != H5P_isa_class(ocpypl_id, H5P_OBJECT_COPY))
-        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not object copy property list")
-
-    /* Set the LCPL for the API context */
-    H5CX_set_lcpl(lcpl_id);
-
-    /* Set up collective metadata if appropriate */
-    if (H5CX_set_loc(src_loc_id) < 0)
-        HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, FAIL, "can't set collective metadata read info")
-
-    /* get the object */
-    if (NULL == (vol_obj1 = (H5VL_object_t *)H5I_object(src_loc_id)))
-        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier")
-    loc_params1.type     = H5VL_OBJECT_BY_SELF;
-    loc_params1.obj_type = H5I_get_type(src_loc_id);
-
-    /* get the object */
-    if (NULL == (vol_obj2 = (H5VL_object_t *)H5I_object(dst_loc_id)))
-        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier")
-    loc_params2.type     = H5VL_OBJECT_BY_SELF;
-    loc_params2.obj_type = H5I_get_type(dst_loc_id);
-
-    /* Copy the object */
-    if (H5VL_object_copy(vol_obj1, &loc_params1, src_name, vol_obj2, &loc_params2, dst_name, ocpypl_id,
-                         lcpl_id, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL) < 0)
-        HGOTO_ERROR(H5E_OHDR, H5E_CANTCOPY, FAIL, "unable to copy object")
+    /* To copy an object synchronously */
+    if(H5O__copy_api_common(src_loc_id, src_name, dst_loc_id, dst_name, ocpypl_id, lcpl_id, NULL, NULL) < 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTCOPY, FAIL, "unable to synchronously copy object")
 
 done:
     FUNC_LEAVE_API(ret_value)
 } /* end H5Ocopy() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    H5Ocopy_async
+ *
+ * Purpose:     Asynchronous version of H5Ocopy
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5Ocopy_async(const char *app_file, const char *app_func, unsigned app_line, 
+    hid_t src_loc_id, const char *src_name, hid_t dst_loc_id, const char *dst_name, 
+    hid_t ocpypl_id, hid_t lcpl_id, hid_t es_id)
+{
+    H5VL_object_t *   vol_obj   = NULL;         /* Object for loc_id */
+    void *            token     = NULL;         /* Request token for async operation        */
+    void **token_ptr = H5_REQUEST_NULL;         /* Pointer to request token for async operation        */
+    herr_t              ret_value = SUCCEED;    /* Return value */
+
+    FUNC_ENTER_API(FAIL)
+    H5TRACE10("e", "*s*sIui*si*siii", app_file, app_func, app_line, src_loc_id, src_name, dst_loc_id,
+              dst_name, ocpypl_id, lcpl_id, es_id);
+
+    /* Set up request token pointer for asynchronous operation */
+    if (H5ES_NONE != es_id)
+        token_ptr = &token;     /* Point at token for VOL connector to set up */
+
+    /* To copy an object asynchronously */
+    if(H5O__copy_api_common(src_loc_id, src_name, dst_loc_id, dst_name, ocpypl_id, lcpl_id, token_ptr, &vol_obj) < 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTCOPY, FAIL, "unable to asynchronously copy object")
+
+    /* If a token was created, add the token to the event set */
+    if (NULL != token)
+        if (H5ES_insert(es_id, vol_obj->connector, token,
+                H5ARG_TRACE10(FUNC, "*s*sIui*si*siii", app_file, app_func, app_line, src_loc_id, src_name, 
+                dst_loc_id, dst_name, ocpypl_id, lcpl_id, es_id)) < 0)
+            HGOTO_ERROR(H5E_SYM, H5E_CANTINSERT, FAIL, "can't insert token into event set")
+
+done:
+    FUNC_LEAVE_API(ret_value)
+} /* H5Ocopy_async() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5O__copy

--- a/src/H5Opublic.h
+++ b/src/H5Opublic.h
@@ -183,13 +183,21 @@ extern "C" {
 #endif
 
 H5_DLL hid_t  H5Oopen(hid_t loc_id, const char *name, hid_t lapl_id);
+H5_DLL hid_t  H5Oopen_async(const char *app_file, const char *app_func, unsigned app_line,
+                            hid_t loc_id, const char *name, hid_t lapl_id, hid_t es_id);
 H5_DLL hid_t  H5Oopen_by_token(hid_t loc_id, H5O_token_t token);
 H5_DLL hid_t  H5Oopen_by_idx(hid_t loc_id, const char *group_name, H5_index_t idx_type, H5_iter_order_t order,
                              hsize_t n, hid_t lapl_id);
+H5_DLL hid_t  H5Oopen_by_idx_async(const char *app_file, const char *app_func, unsigned app_line,
+                                   hid_t loc_id, const char *group_name, H5_index_t idx_type, 
+                                   H5_iter_order_t order, hsize_t n, hid_t lapl_id, hid_t es_id);
 H5_DLL htri_t H5Oexists_by_name(hid_t loc_id, const char *name, hid_t lapl_id);
 H5_DLL herr_t H5Oget_info3(hid_t loc_id, H5O_info2_t *oinfo, unsigned fields);
 H5_DLL herr_t H5Oget_info_by_name3(hid_t loc_id, const char *name, H5O_info2_t *oinfo, unsigned fields,
                                    hid_t lapl_id);
+H5_DLL herr_t H5Oget_info_by_name_async(const char *app_file, const char *app_func, unsigned app_line,
+                                         hid_t loc_id, const char *name, H5O_info2_t *oinfo /*out*/, 
+                                         unsigned fields, hid_t lapl_id, hid_t es_id);
 H5_DLL herr_t H5Oget_info_by_idx3(hid_t loc_id, const char *group_name, H5_index_t idx_type,
                                   H5_iter_order_t order, hsize_t n, H5O_info2_t *oinfo, unsigned fields,
                                   hid_t lapl_id);
@@ -204,6 +212,9 @@ H5_DLL herr_t H5Oincr_refcount(hid_t object_id);
 H5_DLL herr_t H5Odecr_refcount(hid_t object_id);
 H5_DLL herr_t H5Ocopy(hid_t src_loc_id, const char *src_name, hid_t dst_loc_id, const char *dst_name,
                       hid_t ocpypl_id, hid_t lcpl_id);
+H5_DLL herr_t H5Ocopy_async(const char *app_file, const char *app_func, unsigned app_line,
+                            hid_t src_loc_id, const char *src_name, hid_t dst_loc_id, 
+                            const char *dst_name, hid_t ocpypl_id, hid_t lcpl_id, hid_t es_id);
 H5_DLL herr_t H5Oset_comment(hid_t obj_id, const char *comment);
 H5_DLL herr_t H5Oset_comment_by_name(hid_t loc_id, const char *name, const char *comment, hid_t lapl_id);
 H5_DLL ssize_t H5Oget_comment(hid_t obj_id, char *comment, size_t bufsize);
@@ -215,8 +226,14 @@ H5_DLL herr_t  H5Ovisit_by_name3(hid_t loc_id, const char *obj_name, H5_index_t 
                                  H5_iter_order_t order, H5O_iterate2_t op, void *op_data, unsigned fields,
                                  hid_t lapl_id);
 H5_DLL herr_t  H5Oclose(hid_t object_id);
+H5_DLL herr_t  H5Oclose_async(const char *app_file, const char *app_func, unsigned app_line,
+                              hid_t object_id, hid_t es_id);
 H5_DLL herr_t  H5Oflush(hid_t obj_id);
+H5_DLL herr_t  H5Oflush_async(const char *app_file, const char *app_func, unsigned app_line,
+                              hid_t obj_id, hid_t es_id);
 H5_DLL herr_t  H5Orefresh(hid_t oid);
+H5_DLL herr_t  H5Orefresh_async(const char *app_file, const char *app_func, unsigned app_line,
+                                hid_t oid, hid_t es_id);
 H5_DLL herr_t  H5Odisable_mdc_flushes(hid_t object_id);
 H5_DLL herr_t  H5Oenable_mdc_flushes(hid_t object_id);
 H5_DLL herr_t  H5Oare_mdc_flushes_disabled(hid_t object_id, hbool_t *are_disabled);
@@ -224,6 +241,22 @@ H5_DLL herr_t  H5Otoken_cmp(hid_t loc_id, const H5O_token_t *token1, const H5O_t
                             int *cmp_value);
 H5_DLL herr_t  H5Otoken_to_str(hid_t loc_id, const H5O_token_t *token, char **token_str);
 H5_DLL herr_t  H5Otoken_from_str(hid_t loc_id, const char *token_str, H5O_token_t *token);
+
+
+/* API Wrappers for async routines */
+/* (Must be defined _after_ the function prototype) */
+/* (And must only defined when included in application code, not the library) */
+#ifndef H5O_MODULE
+
+#define H5Oopen_async(...) H5Oopen_async(__FILE__, __func__, __LINE__, __VA_ARGS__)
+#define H5Oopen_by_idx_async(...) H5Oopen_by_idx_async(__FILE__, __func__, __LINE__, __VA_ARGS__)
+#define H5Oget_info_by_name_async(...) H5Oget_info_by_name_async(__FILE__, __func__, __LINE__, __VA_ARGS__)
+#define H5Oclose_async(...) H5Oclose_async(__FILE__, __func__, __LINE__, __VA_ARGS__)
+#define H5Oflush_async(...) H5Oflush_async(__FILE__, __func__, __LINE__, __VA_ARGS__)
+#define H5Orefresh_async(...) H5Orefresh_async(__FILE__, __func__, __LINE__, __VA_ARGS__)
+#define H5Ocopy_async(...) H5Ocopy_async(__FILE__, __func__, __LINE__, __VA_ARGS__)
+
+#endif
 
 /* The canonical 'undefined' token value */
 #define H5O_TOKEN_UNDEF (H5OPEN H5O_TOKEN_UNDEF_g)

--- a/tools/test/h5dump/errfiles/tall-1.err
+++ b/tools/test/h5dump/errfiles/tall-1.err
@@ -1,34 +1,37 @@
 HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
-  #000: (file name) line (number) in H5Oopen(): unable to open object
+  #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object
-  #001: (file name) line (number) in H5VL_object_open(): object open failed
+  #001: (file name) line (number) in H5O__open_api_common(): unable to open object
+    major: Object header
+    minor: Can't open object
+  #002: (file name) line (number) in H5VL_object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #002: (file name) line (number) in H5VL__object_open(): object open failed
+  #003: (file name) line (number) in H5VL__object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #003: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
+  #004: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
     major: Object header
     minor: Can't open object
-  #004: (file name) line (number) in H5O_open_name(): object not found
+  #005: (file name) line (number) in H5O_open_name(): object not found
     major: Object header
     minor: Object not found
-  #005: (file name) line (number) in H5G_loc_find(): can't find object
+  #006: (file name) line (number) in H5G_loc_find(): can't find object
     major: Symbol table
     minor: Object not found
-  #006: (file name) line (number) in H5G_traverse(): internal path traversal failed
+  #007: (file name) line (number) in H5G_traverse(): internal path traversal failed
     major: Symbol table
     minor: Object not found
-  #007: (file name) line (number) in H5G__traverse_real(): special link traversal failed
+  #008: (file name) line (number) in H5G__traverse_real(): special link traversal failed
     major: Links
     minor: Link traversal failure
-  #008: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
+  #009: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
     major: Links
     minor: Link traversal failure
-  #009: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
+  #010: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
     major: Symbol table
     minor: Unable to find atom information (already closed?)
-  #010: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'somefile'
+  #011: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'somefile'
     major: Links
     minor: Unable to open file

--- a/tools/test/h5dump/errfiles/tall-2A.err
+++ b/tools/test/h5dump/errfiles/tall-2A.err
@@ -1,34 +1,37 @@
 HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
-  #000: (file name) line (number) in H5Oopen(): unable to open object
+  #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object
-  #001: (file name) line (number) in H5VL_object_open(): object open failed
+  #001: (file name) line (number) in H5O__open_api_common(): unable to open object
+    major: Object header
+    minor: Can't open object
+  #002: (file name) line (number) in H5VL_object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #002: (file name) line (number) in H5VL__object_open(): object open failed
+  #003: (file name) line (number) in H5VL__object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #003: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
+  #004: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
     major: Object header
     minor: Can't open object
-  #004: (file name) line (number) in H5O_open_name(): object not found
+  #005: (file name) line (number) in H5O_open_name(): object not found
     major: Object header
     minor: Object not found
-  #005: (file name) line (number) in H5G_loc_find(): can't find object
+  #006: (file name) line (number) in H5G_loc_find(): can't find object
     major: Symbol table
     minor: Object not found
-  #006: (file name) line (number) in H5G_traverse(): internal path traversal failed
+  #007: (file name) line (number) in H5G_traverse(): internal path traversal failed
     major: Symbol table
     minor: Object not found
-  #007: (file name) line (number) in H5G__traverse_real(): special link traversal failed
+  #008: (file name) line (number) in H5G__traverse_real(): special link traversal failed
     major: Links
     minor: Link traversal failure
-  #008: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
+  #009: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
     major: Links
     minor: Link traversal failure
-  #009: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
+  #010: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
     major: Symbol table
     minor: Unable to find atom information (already closed?)
-  #010: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'somefile'
+  #011: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'somefile'
     major: Links
     minor: Unable to open file

--- a/tools/test/h5dump/errfiles/tall-2A0.err
+++ b/tools/test/h5dump/errfiles/tall-2A0.err
@@ -1,34 +1,37 @@
 HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
-  #000: (file name) line (number) in H5Oopen(): unable to open object
+  #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object
-  #001: (file name) line (number) in H5VL_object_open(): object open failed
+  #001: (file name) line (number) in H5O__open_api_common(): unable to open object
+    major: Object header
+    minor: Can't open object
+  #002: (file name) line (number) in H5VL_object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #002: (file name) line (number) in H5VL__object_open(): object open failed
+  #003: (file name) line (number) in H5VL__object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #003: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
+  #004: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
     major: Object header
     minor: Can't open object
-  #004: (file name) line (number) in H5O_open_name(): object not found
+  #005: (file name) line (number) in H5O_open_name(): object not found
     major: Object header
     minor: Object not found
-  #005: (file name) line (number) in H5G_loc_find(): can't find object
+  #006: (file name) line (number) in H5G_loc_find(): can't find object
     major: Symbol table
     minor: Object not found
-  #006: (file name) line (number) in H5G_traverse(): internal path traversal failed
+  #007: (file name) line (number) in H5G_traverse(): internal path traversal failed
     major: Symbol table
     minor: Object not found
-  #007: (file name) line (number) in H5G__traverse_real(): special link traversal failed
+  #008: (file name) line (number) in H5G__traverse_real(): special link traversal failed
     major: Links
     minor: Link traversal failure
-  #008: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
+  #009: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
     major: Links
     minor: Link traversal failure
-  #009: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
+  #010: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
     major: Symbol table
     minor: Unable to find atom information (already closed?)
-  #010: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'somefile'
+  #011: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'somefile'
     major: Links
     minor: Unable to open file

--- a/tools/test/h5dump/errfiles/tall-2B.err
+++ b/tools/test/h5dump/errfiles/tall-2B.err
@@ -1,34 +1,37 @@
 HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
-  #000: (file name) line (number) in H5Oopen(): unable to open object
+  #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object
-  #001: (file name) line (number) in H5VL_object_open(): object open failed
+  #001: (file name) line (number) in H5O__open_api_common(): unable to open object
+    major: Object header
+    minor: Can't open object
+  #002: (file name) line (number) in H5VL_object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #002: (file name) line (number) in H5VL__object_open(): object open failed
+  #003: (file name) line (number) in H5VL__object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #003: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
+  #004: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
     major: Object header
     minor: Can't open object
-  #004: (file name) line (number) in H5O_open_name(): object not found
+  #005: (file name) line (number) in H5O_open_name(): object not found
     major: Object header
     minor: Object not found
-  #005: (file name) line (number) in H5G_loc_find(): can't find object
+  #006: (file name) line (number) in H5G_loc_find(): can't find object
     major: Symbol table
     minor: Object not found
-  #006: (file name) line (number) in H5G_traverse(): internal path traversal failed
+  #007: (file name) line (number) in H5G_traverse(): internal path traversal failed
     major: Symbol table
     minor: Object not found
-  #007: (file name) line (number) in H5G__traverse_real(): special link traversal failed
+  #008: (file name) line (number) in H5G__traverse_real(): special link traversal failed
     major: Links
     minor: Link traversal failure
-  #008: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
+  #009: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
     major: Links
     minor: Link traversal failure
-  #009: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
+  #010: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
     major: Symbol table
     minor: Unable to find atom information (already closed?)
-  #010: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'somefile'
+  #011: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'somefile'
     major: Links
     minor: Unable to open file

--- a/tools/test/h5dump/errfiles/textlink.err
+++ b/tools/test/h5dump/errfiles/textlink.err
@@ -1,68 +1,74 @@
 HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
-  #000: (file name) line (number) in H5Oopen(): unable to open object
+  #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object
-  #001: (file name) line (number) in H5VL_object_open(): object open failed
+  #001: (file name) line (number) in H5O__open_api_common(): unable to open object
+    major: Object header
+    minor: Can't open object
+  #002: (file name) line (number) in H5VL_object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #002: (file name) line (number) in H5VL__object_open(): object open failed
+  #003: (file name) line (number) in H5VL__object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #003: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
+  #004: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
     major: Object header
     minor: Can't open object
-  #004: (file name) line (number) in H5O_open_name(): object not found
+  #005: (file name) line (number) in H5O_open_name(): object not found
     major: Object header
     minor: Object not found
-  #005: (file name) line (number) in H5G_loc_find(): can't find object
+  #006: (file name) line (number) in H5G_loc_find(): can't find object
     major: Symbol table
     minor: Object not found
-  #006: (file name) line (number) in H5G_traverse(): internal path traversal failed
+  #007: (file name) line (number) in H5G_traverse(): internal path traversal failed
     major: Symbol table
     minor: Object not found
-  #007: (file name) line (number) in H5G__traverse_real(): special link traversal failed
+  #008: (file name) line (number) in H5G__traverse_real(): special link traversal failed
     major: Links
     minor: Link traversal failure
-  #008: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
+  #009: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
     major: Links
     minor: Link traversal failure
-  #009: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
+  #010: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
     major: Symbol table
     minor: Unable to find atom information (already closed?)
-  #010: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'filename'
+  #011: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'filename'
     major: Links
     minor: Unable to open file
 HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
-  #000: (file name) line (number) in H5Oopen(): unable to open object
+  #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object
-  #001: (file name) line (number) in H5VL_object_open(): object open failed
+  #001: (file name) line (number) in H5O__open_api_common(): unable to open object
+    major: Object header
+    minor: Can't open object
+  #002: (file name) line (number) in H5VL_object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #002: (file name) line (number) in H5VL__object_open(): object open failed
+  #003: (file name) line (number) in H5VL__object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #003: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
+  #004: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
     major: Object header
     minor: Can't open object
-  #004: (file name) line (number) in H5O_open_name(): object not found
+  #005: (file name) line (number) in H5O_open_name(): object not found
     major: Object header
     minor: Object not found
-  #005: (file name) line (number) in H5G_loc_find(): can't find object
+  #006: (file name) line (number) in H5G_loc_find(): can't find object
     major: Symbol table
     minor: Object not found
-  #006: (file name) line (number) in H5G_traverse(): internal path traversal failed
+  #007: (file name) line (number) in H5G_traverse(): internal path traversal failed
     major: Symbol table
     minor: Object not found
-  #007: (file name) line (number) in H5G__traverse_real(): special link traversal failed
+  #008: (file name) line (number) in H5G__traverse_real(): special link traversal failed
     major: Links
     minor: Link traversal failure
-  #008: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
+  #009: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
     major: Links
     minor: Link traversal failure
-  #009: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
+  #010: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
     major: Symbol table
     minor: Unable to find atom information (already closed?)
-  #010: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'anotherfile'
+  #011: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'anotherfile'
     major: Links
     minor: Unable to open file

--- a/tools/test/h5dump/errfiles/textlinkfar.err
+++ b/tools/test/h5dump/errfiles/textlinkfar.err
@@ -1,59 +1,62 @@
 HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
-  #000: (file name) line (number) in H5Oopen(): unable to open object
+  #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object
-  #001: (file name) line (number) in H5VL_object_open(): object open failed
+  #001: (file name) line (number) in H5O__open_api_common(): unable to open object
+    major: Object header
+    minor: Can't open object
+  #002: (file name) line (number) in H5VL_object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #002: (file name) line (number) in H5VL__object_open(): object open failed
+  #003: (file name) line (number) in H5VL__object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #003: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
+  #004: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
     major: Object header
     minor: Can't open object
-  #004: (file name) line (number) in H5O_open_name(): object not found
+  #005: (file name) line (number) in H5O_open_name(): object not found
     major: Object header
     minor: Object not found
-  #005: (file name) line (number) in H5G_loc_find(): can't find object
+  #006: (file name) line (number) in H5G_loc_find(): can't find object
     major: Symbol table
     minor: Object not found
-  #006: (file name) line (number) in H5G_traverse(): internal path traversal failed
+  #007: (file name) line (number) in H5G_traverse(): internal path traversal failed
     major: Symbol table
     minor: Object not found
-  #007: (file name) line (number) in H5G__traverse_real(): special link traversal failed
+  #008: (file name) line (number) in H5G__traverse_real(): special link traversal failed
     major: Links
     minor: Link traversal failure
-  #008: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
+  #009: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
     major: Links
     minor: Link traversal failure
-  #009: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
+  #010: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
     major: Symbol table
     minor: Unable to find atom information (already closed?)
-  #010: (file name) line (number) in H5L__extern_traverse(): unable to open object
+  #011: (file name) line (number) in H5L__extern_traverse(): unable to open object
     major: Links
     minor: Can't open object
-  #011: (file name) line (number) in H5O_open_name(): object not found
+  #012: (file name) line (number) in H5O_open_name(): object not found
     major: Object header
     minor: Object not found
-  #012: (file name) line (number) in H5G_loc_find(): can't find object
+  #013: (file name) line (number) in H5G_loc_find(): can't find object
     major: Symbol table
     minor: Object not found
-  #013: (file name) line (number) in H5G_traverse(): internal path traversal failed
+  #014: (file name) line (number) in H5G_traverse(): internal path traversal failed
     major: Symbol table
     minor: Object not found
-  #014: (file name) line (number) in H5G__traverse_real(): special link traversal failed
+  #015: (file name) line (number) in H5G__traverse_real(): special link traversal failed
     major: Links
     minor: Link traversal failure
-  #015: (file name) line (number) in H5G__traverse_special(): symbolic link traversal failed
+  #016: (file name) line (number) in H5G__traverse_special(): symbolic link traversal failed
     major: Links
     minor: Link traversal failure
-  #016: (file name) line (number) in H5G__traverse_slink(): unable to follow symbolic link
+  #017: (file name) line (number) in H5G__traverse_slink(): unable to follow symbolic link
     major: Symbol table
     minor: Object not found
-  #017: (file name) line (number) in H5G__traverse_real(): traversal operator failed
+  #018: (file name) line (number) in H5G__traverse_real(): traversal operator failed
     major: Symbol table
     minor: Callback failed
-  #018: (file name) line (number) in H5G__traverse_slink_cb(): component not found
+  #019: (file name) line (number) in H5G__traverse_slink_cb(): component not found
     major: Symbol table
     minor: Object not found
 HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):

--- a/tools/test/h5dump/errfiles/textlinksrc.err
+++ b/tools/test/h5dump/errfiles/textlinksrc.err
@@ -1,59 +1,62 @@
 HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
-  #000: (file name) line (number) in H5Oopen(): unable to open object
+  #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object
-  #001: (file name) line (number) in H5VL_object_open(): object open failed
+  #001: (file name) line (number) in H5O__open_api_common(): unable to open object
+    major: Object header
+    minor: Can't open object
+  #002: (file name) line (number) in H5VL_object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #002: (file name) line (number) in H5VL__object_open(): object open failed
+  #003: (file name) line (number) in H5VL__object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #003: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
+  #004: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
     major: Object header
     minor: Can't open object
-  #004: (file name) line (number) in H5O_open_name(): object not found
+  #005: (file name) line (number) in H5O_open_name(): object not found
     major: Object header
     minor: Object not found
-  #005: (file name) line (number) in H5G_loc_find(): can't find object
+  #006: (file name) line (number) in H5G_loc_find(): can't find object
     major: Symbol table
     minor: Object not found
-  #006: (file name) line (number) in H5G_traverse(): internal path traversal failed
+  #007: (file name) line (number) in H5G_traverse(): internal path traversal failed
     major: Symbol table
     minor: Object not found
-  #007: (file name) line (number) in H5G__traverse_real(): special link traversal failed
+  #008: (file name) line (number) in H5G__traverse_real(): special link traversal failed
     major: Links
     minor: Link traversal failure
-  #008: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
+  #009: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
     major: Links
     minor: Link traversal failure
-  #009: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
+  #010: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
     major: Symbol table
     minor: Unable to find atom information (already closed?)
-  #010: (file name) line (number) in H5L__extern_traverse(): unable to open object
+  #011: (file name) line (number) in H5L__extern_traverse(): unable to open object
     major: Links
     minor: Can't open object
-  #011: (file name) line (number) in H5O_open_name(): object not found
+  #012: (file name) line (number) in H5O_open_name(): object not found
     major: Object header
     minor: Object not found
-  #012: (file name) line (number) in H5G_loc_find(): can't find object
+  #013: (file name) line (number) in H5G_loc_find(): can't find object
     major: Symbol table
     minor: Object not found
-  #013: (file name) line (number) in H5G_traverse(): internal path traversal failed
+  #014: (file name) line (number) in H5G_traverse(): internal path traversal failed
     major: Symbol table
     minor: Object not found
-  #014: (file name) line (number) in H5G__traverse_real(): special link traversal failed
+  #015: (file name) line (number) in H5G__traverse_real(): special link traversal failed
     major: Links
     minor: Link traversal failure
-  #015: (file name) line (number) in H5G__traverse_special(): symbolic link traversal failed
+  #016: (file name) line (number) in H5G__traverse_special(): symbolic link traversal failed
     major: Links
     minor: Link traversal failure
-  #016: (file name) line (number) in H5G__traverse_slink(): unable to follow symbolic link
+  #017: (file name) line (number) in H5G__traverse_slink(): unable to follow symbolic link
     major: Symbol table
     minor: Object not found
-  #017: (file name) line (number) in H5G__traverse_real(): traversal operator failed
+  #018: (file name) line (number) in H5G__traverse_real(): traversal operator failed
     major: Symbol table
     minor: Callback failed
-  #018: (file name) line (number) in H5G__traverse_slink_cb(): component not found
+  #019: (file name) line (number) in H5G__traverse_slink_cb(): component not found
     major: Symbol table
     minor: Object not found
 HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):

--- a/tools/test/h5dump/errfiles/torderlinks1.err
+++ b/tools/test/h5dump/errfiles/torderlinks1.err
@@ -1,34 +1,37 @@
 HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
-  #000: (file name) line (number) in H5Oopen(): unable to open object
+  #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object
-  #001: (file name) line (number) in H5VL_object_open(): object open failed
+  #001: (file name) line (number) in H5O__open_api_common(): unable to open object
+    major: Object header
+    minor: Can't open object
+  #002: (file name) line (number) in H5VL_object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #002: (file name) line (number) in H5VL__object_open(): object open failed
+  #003: (file name) line (number) in H5VL__object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #003: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
+  #004: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
     major: Object header
     minor: Can't open object
-  #004: (file name) line (number) in H5O_open_name(): object not found
+  #005: (file name) line (number) in H5O_open_name(): object not found
     major: Object header
     minor: Object not found
-  #005: (file name) line (number) in H5G_loc_find(): can't find object
+  #006: (file name) line (number) in H5G_loc_find(): can't find object
     major: Symbol table
     minor: Object not found
-  #006: (file name) line (number) in H5G_traverse(): internal path traversal failed
+  #007: (file name) line (number) in H5G_traverse(): internal path traversal failed
     major: Symbol table
     minor: Object not found
-  #007: (file name) line (number) in H5G__traverse_real(): special link traversal failed
+  #008: (file name) line (number) in H5G__traverse_real(): special link traversal failed
     major: Links
     minor: Link traversal failure
-  #008: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
+  #009: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
     major: Links
     minor: Link traversal failure
-  #009: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
+  #010: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
     major: Symbol table
     minor: Unable to find atom information (already closed?)
-  #010: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'fname'
+  #011: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'fname'
     major: Links
     minor: Unable to open file

--- a/tools/test/h5dump/errfiles/torderlinks2.err
+++ b/tools/test/h5dump/errfiles/torderlinks2.err
@@ -1,34 +1,37 @@
 HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
-  #000: (file name) line (number) in H5Oopen(): unable to open object
+  #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object
-  #001: (file name) line (number) in H5VL_object_open(): object open failed
+  #001: (file name) line (number) in H5O__open_api_common(): unable to open object
+    major: Object header
+    minor: Can't open object
+  #002: (file name) line (number) in H5VL_object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #002: (file name) line (number) in H5VL__object_open(): object open failed
+  #003: (file name) line (number) in H5VL__object_open(): object open failed
     major: Virtual Object Layer
     minor: Can't open object
-  #003: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
+  #004: (file name) line (number) in H5VL__native_object_open(): unable to open object by name
     major: Object header
     minor: Can't open object
-  #004: (file name) line (number) in H5O_open_name(): object not found
+  #005: (file name) line (number) in H5O_open_name(): object not found
     major: Object header
     minor: Object not found
-  #005: (file name) line (number) in H5G_loc_find(): can't find object
+  #006: (file name) line (number) in H5G_loc_find(): can't find object
     major: Symbol table
     minor: Object not found
-  #006: (file name) line (number) in H5G_traverse(): internal path traversal failed
+  #007: (file name) line (number) in H5G_traverse(): internal path traversal failed
     major: Symbol table
     minor: Object not found
-  #007: (file name) line (number) in H5G__traverse_real(): special link traversal failed
+  #008: (file name) line (number) in H5G__traverse_real(): special link traversal failed
     major: Links
     minor: Link traversal failure
-  #008: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
+  #009: (file name) line (number) in H5G__traverse_special(): user-defined link traversal failed
     major: Links
     minor: Link traversal failure
-  #009: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
+  #010: (file name) line (number) in H5G__traverse_ud(): traversal callback returned invalid ID
     major: Symbol table
     minor: Unable to find atom information (already closed?)
-  #010: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'fname'
+  #011: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'fname'
     major: Links
     minor: Unable to open file


### PR DESCRIPTION
(b) Remove verification of name parameter in async related routines for H55A and H5L modules
    because it is checked in H5VL_setup* routine.
(c) Modify h5dump expected output due to the async changes.