### PR TITLE
Corrects use of uninitialized bytes in the chunk_info test

### DIFF
--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -542,7 +542,7 @@ test_get_chunk_info_highest_v18(hid_t fapl)
 
 #ifdef H5_HAVE_FILTER_DEFLATE
     /* Allocate input (compressed) buffer */
-    inbuf = HDmalloc(z_dst_nbytes);
+    inbuf = HDcalloc(1, z_dst_nbytes);
 
     /* Set chunk size to the compressed chunk size and the chunk point
        to the compressed data chunk */
@@ -567,7 +567,7 @@ test_get_chunk_info_highest_v18(hid_t fapl)
     }
 #else
     /* Allocate input (non-compressed) buffer */
-    inbuf = HDmalloc(CHK_SIZE);
+    inbuf = HDcalloc(1, CHK_SIZE);
     HDmemcpy(inbuf, direct_buf, CHK_SIZE);
 #endif /* end H5_HAVE_FILTER_DEFLATE */
 


### PR DESCRIPTION
Found while debugging other memory issues

==700979== Syscall param pwrite64(buf) points to uninitialised byte(s)
==700979==    at 0x4F4938A: pwrite (pwrite64.c:29)
==700979==    by 0x4A0C7F5: H5FD__sec2_write (H5FDsec2.c:850)
==700979==    by 0x4A03AB1: H5FD_write (H5FDint.c:239)
==700979==    by 0x49CA2D2: H5F__accum_write (H5Faccum.c:830)
==700979==    by 0x4B7D731: H5PB_write (H5PB.c:1020)
==700979==    by 0x49DA6BE: H5F_shared_block_write (H5Fio.c:190)
==700979==    by 0x49548CD: H5D__chunk_direct_write (H5Dchunk.c:459)
==700979==    by 0x4CDC9B7: H5VL__native_dataset_optional (H5VLnative_dataset.c:563)
==700979==    by 0x4CB4C3B: H5VL__dataset_optional (H5VLcallback.c:2384)
==700979==    by 0x4CC09F7: H5VL_dataset_optional (H5VLcallback.c:2420)
==700979==    by 0x497DD43: H5Dwrite_chunk (H5Dio.c:342)
==700979==    by 0x11207D: test_get_chunk_info_highest_v18 (chunk_info.c:581)
==700979==  Address 0x53d6141 is 49 bytes inside a block of size 109 alloc'd
==700979==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==700979==    by 0x111D8F: test_get_chunk_info_highest_v18 (chunk_info.c:545)
==700979==    by 0x114C40: main (chunk_info.c:2092)
==700979== 
