### PR TITLE
Enhance API tracing

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -950,6 +950,7 @@
 ./src/H5Rprivate.h
 ./src/H5Rpublic.h
 ./src/H5RS.c
+./src/H5RSmodule.h
 ./src/H5RSprivate.h
 ./src/H5S.c
 ./src/H5Sall.c

--- a/bin/trace
+++ b/bin/trace
@@ -28,61 +28,99 @@ $Source = "";
 # usually the same as the package name.
 #
 %TypeString = ("haddr_t"                    => "a",
+               "H5A_info_t"                 => "Ai",
+               "H5A_operator1_t"            => "Ao",
+               "H5A_operator2_t"            => "AO",
                "hbool_t"                    => "b",
+               "H5AC_cache_config_t"        => "Cc",
+               "H5AC_cache_image_config_t"  => "CC",
                "double"                     => "d",
                "H5D_alloc_time_t"           => "Da",
+               "H5D_append_cb_t"            => "DA",
                "H5FD_mpio_collective_opt_t" => "Dc",
                "H5D_fill_time_t"            => "Df",
                "H5D_fill_value_t"           => "DF",
+               "H5D_gather_func_t"          => "Dg",
                "H5FD_mpio_chunk_opt_t"      => "Dh",
                "H5D_mpio_actual_io_mode_t"  => "Di",
+               "H5FD_file_image_callbacks_t" => "DI",
                "H5D_chunk_index_t"          => "Dk",
                "H5D_layout_t"               => "Dl",
                "H5D_mpio_no_collective_cause_t" => "Dn",
                "H5D_mpio_actual_chunk_opt_mode_t" => "Do",
+               "H5D_operator_t"             => "DO",
                "H5D_space_status_t"         => "Ds",
-               "H5D_vds_view_t"             => "Dv",
+               "H5D_scatter_func_t"         => "DS",
                "H5FD_mpio_xfer_t"           => "Dt",
-               "H5FD_splitter_vfd_config_t" => "Dr",
+               "H5D_vds_view_t"             => "Dv",
                "herr_t"                     => "e",
+               "H5E_auto1_t"                => "Ea",
+               "H5E_auto2_t"                => "EA",
                "H5E_direction_t"            => "Ed",
                "H5E_error_t"                => "Ee",
-               "H5E_type_t"                 => "Et",
                "H5ES_status_t"              => "Es",
+               "H5E_type_t"                 => "Et",
+               "H5FD_class_t"               => "FC",
                "H5F_close_degree_t"         => "Fd",
                "H5F_fspace_strategy_t"      => "Ff",
-               "H5F_file_space_type_t"      => "Ff",
+               "H5F_flush_cb_t"             => "FF",
+               "H5F_info2_t"                => "FI",
                "H5F_mem_t"                  => "Fm",
                "H5F_scope_t"                => "Fs",
-               "H5F_fspace_type_t"          => "Ft",
+               "H5F_file_space_type_t"      => "Ft",
                "H5F_libver_t"               => "Fv",
+               "H5G_iterate_t"              => "Gi",
                "H5G_obj_t"                  => "Go",
                "H5G_stat_t"                 => "Gs",
                "hsize_t"                    => "h",
+               "H5_alloc_stats_t"           => "Ha",
+               "H5_atclose_func_t"          => "Hc",
                "hssize_t"                   => "Hs",
-               "H5E_major_t"                => "i",
-               "H5E_minor_t"                => "i",
-               "H5_iter_order_t"            => "Io",
-               "H5_index_t"                 => "Ii",
+               "H5E_major_t"                => "i",     # H5E_major_t is typedef'd to hid_t
+               "H5E_minor_t"                => "i",     # H5E_minor_t is typedef'd to hid_t
                "hid_t"                      => "i",
+               "H5I_free_t"                 => "If",
+               "H5_index_t"                 => "Ii",
+               "H5I_iterate_func_t"         => "II",
+               "H5_iter_order_t"            => "Io",
                "int"                        => "Is",
                "int32_t"                    => "Is",
+               "H5I_search_func_t"          => "IS",
+               "H5I_type_t"                 => "It",
                "unsigned"                   => "Iu",
                "unsigned int"               => "Iu",
                "uint32_t"                   => "Iu",
-               "uint64_t"                   => "UL",
-               "H5I_type_t"                 => "It",
                "H5O_token_t"                => "k",
+               "H5L_iterate1_t"             => "Li",
+               "H5L_iterate2_t"             => "LI",
                "H5G_link_t"                 => "Ll", #Same as H5L_type_t now
                "H5L_type_t"                 => "Ll",
+               "H5L_elink_traverse_t"       => "Lt",
+               "H5MM_allocate_t"            => "Ma",
                "MPI_Comm"                   => "Mc",
+               "H5MM_free_t"                => "Mf",
                "MPI_Info"                   => "Mi",
+               "H5M_iterate_t"              => 'MI',
                "H5FD_mem_t"                 => "Mt",
                "off_t"                      => "o",
+               "H5O_iterate1_t"             => "Oi",
+               "H5O_iterate2_t"             => "OI",
+               "H5O_mcdt_search_cb_t"       => "Os",
                "H5O_type_t"                 => "Ot",
                "H5P_class_t"                => "p",
-               "hobj_ref_t"                 => "Ro",
+               "H5P_cls_create_func_t"      => "Pc",
+               "H5P_prp_create_func_t"      => "PC",
+               "H5P_prp_delete_func_t"      => "PD",
+               "H5P_prp_get_func_t"         => "PG",
+               "H5P_iterate_t"              => "Pi",
+               "H5P_cls_close_func_t"       => "Pl",
+               "H5P_prp_close_func_t"       => "PL",
+               "H5P_prp_compare_func_t"     => "PM",
+               "H5P_cls_copy_func_t"        => "Po",
+               "H5P_prp_copy_func_t"        => "PO",
+               "H5P_prp_set_func_t"         => "PS",
                "hdset_reg_ref_t"            => "Rd",
+               "hobj_ref_t"                 => "Ro",
                "H5R_ref_t"                  => "Rr",
                "H5R_type_t"                 => "Rt",
                "char"                       => "s",
@@ -92,122 +130,74 @@ $Source = "";
                "H5S_sel_type"               => "St",
                "htri_t"                     => "t",
                "H5T_cset_t",                => "Tc",
+               "H5T_conv_t"                 => "TC",
                "H5T_direction_t",           => "Td",
+               "H5T_pers_t"                 => "Te",
+               "H5T_conv_except_func_t"     => "TE",
                "H5T_norm_t"                 => "Tn",
                "H5T_order_t"                => "To",
                "H5T_pad_t"                  => "Tp",
-               "H5T_pers_t"                 => "Te",
                "H5T_sign_t"                 => "Ts",
                "H5T_class_t"                => "Tt",
                "H5T_str_t"                  => "Tz",
                "unsigned long"              => "Ul",
                "unsigned long long"         => "UL",
-               "H5VL_subclass_t"            => "VS",
-               "H5VL_get_conn_lvl_t"        => "VL",
+               "uint64_t"                   => "UL",
                "H5VL_attr_get_t"            => "Va",
-               "H5VL_attr_optional_t"       => "Vs",
+               "H5VL_blob_optional_t"       => "VA",
                "H5VL_attr_specific_t"       => "Vb",
                "H5VL_blob_specific_t"       => "VB",
-               "H5VL_class_value_t"         => "VC",
                "H5VL_dataset_get_t"         => "Vc",
+               "H5VL_class_value_t"         => "VC",
                "H5VL_dataset_specific_t"    => "Vd",
-               "H5VL_dataset_optional_t"    => "Vt",
                "H5VL_datatype_get_t"        => "Ve",
                "H5VL_datatype_specific_t"   => "Vf",
-               "H5VL_datatype_optional_t"   => "Vu",
                "H5VL_file_get_t"            => "Vg",
                "H5VL_file_specific_t"       => "Vh",
-               "H5VL_file_optional_t"       => "Vv",
                "H5VL_group_get_t"           => "Vi",
                "H5VL_group_specific_t"      => "Vj",
-               "H5VL_group_optional_t"      => "Vw",
                "H5VL_link_create_type_t"    => "Vk",
                "H5VL_link_get_t"            => "Vl",
+               "H5VL_get_conn_lvl_t"        => "VL",
                "H5VL_link_specific_t"       => "Vm",
-               "H5VL_link_optional_t"       => "Vx",
                "H5VL_object_get_t"          => "Vn",
+               "H5VL_request_notify_t"      => "VN",
                "H5VL_object_specific_t"     => "Vo",
-               "H5VL_object_optional_t"     => "Vy",
                "H5VL_request_specific_t"    => "Vr",
+               "H5VL_attr_optional_t"       => "Vs",
+               "H5VL_subclass_t"            => "VS",
+               "H5VL_dataset_optional_t"    => "Vt",
+               "H5VL_datatype_optional_t"   => "Vu",
+               "H5VL_file_optional_t"       => "Vv",
+               "H5VL_group_optional_t"      => "Vw",
+               "H5VL_link_optional_t"       => "Vx",
+               "H5VL_object_optional_t"     => "Vy",
                "H5VL_request_optional_t"    => "Vz",
-               "H5VL_blob_optional_t"       => "VA",
-               "void"                       => "x",
-               "FILE"                       => "x",
-               "H5_alloc_stats_t"           => "x",
-               "H5A_operator_t"             => "x",
-               "H5A_operator1_t"            => "x",
-               "H5A_operator2_t"            => "x",
-               "H5A_info_t"                 => "x",
-               "H5AC_cache_config_t"        => "x",
-               "H5AC_cache_image_config_t"  => "x",
-               "H5D_append_cb_t"            => "x",
-               "H5D_gather_func_t"          => "x",
-               "H5D_operator_t"             => "x",
-               "H5D_scatter_func_t"         => "x",
-               "H5E_auto_t"                 => "x",
-               "H5E_auto1_t"                => "x",
-               "H5E_auto2_t"                => "x",
-               "H5E_walk_t"                 => "x",
-               "H5E_walk1_t"                => "x",
-               "H5E_walk2_t"                => "x",
-               "H5F_flush_cb_t"             => "x",
-               "H5F_info1_t"                => "x",
-               "H5F_info2_t"                => "x",
-               "H5F_retry_info_t"           => "x",
-               "H5FD_t"                     => "x",
-               "H5FD_class_t"               => "x",
-               "H5FD_stream_fapl_t"         => "x",
-               "H5FD_ros3_fapl_t"           => "x",
-               "H5FD_hdfs_fapl_t"           => "x",
-               "H5FD_file_image_callbacks_t" => "x",
-               "H5FD_mirror_fapl_t"         => "x",
-               "H5G_iterate_t"              => "x",
-               "H5G_info_t"                 => "x",
-               "H5I_free_t"                 => "x",
-               "H5I_iterate_func_t"         => "x",
-               "H5I_search_func_t"          => "x",
-               "H5L_class_t"                => "x",
-               "H5L_elink_traverse_t"       => "x",
-               "H5L_info1_t"                => "x",
-               "H5L_info2_t"                => "x",
-               "H5L_iterate1_t"             => "x",
-               "H5L_iterate2_t"             => "x",
-               "H5M_iterate_t"              => 'x',
-               "H5MM_allocate_t"            => "x",
-               "H5MM_free_t"                => "x",
-               "H5O_info1_t"                => "x",
-               "H5O_info2_t"                => "x",
-               "H5O_native_info_t"          => "x",
-               "H5O_iterate1_t"             => "x",
-               "H5O_iterate2_t"             => "x",
-               "H5O_mcdt_search_cb_t"       => "x",
-               "H5P_cls_create_func_t"      => "x",
-               "H5P_cls_copy_func_t"        => "x",
-               "H5P_cls_close_func_t"       => "x",
-               "H5P_iterate_t"              => "x",
-               "H5P_prp_create_func_t"      => "x",
-               "H5P_prp_copy_func_t"        => "x",
-               "H5P_prp_close_func_t"       => "x",
-               "H5P_prp_delete_func_t"      => "x",
-               "H5P_prp_get_func_t"         => "x",
-               "H5P_prp_set_func_t"         => "x",
-               "H5P_prp_compare_func_t"     => "x",
-               "H5T_cdata_t"                => "x",
-               "H5T_conv_t"                 => "x",
-               "H5T_conv_except_func_t"     => "x",
-               "H5VL_t"                     => "x",
-               "H5VL_class_t"               => "x",
-               "H5VL_loc_params_t"          => "x",
-               "H5VL_request_notify_t"      => "x",
-               "H5Z_func_t"                 => "x",
-               "H5Z_filter_func_t"          => "x",
                "va_list"                    => "x",
+               "void"                       => "x",
                "size_t"                     => "z",
                "H5Z_SO_scale_type_t"        => "Za",
                "H5Z_class_t"                => "Zc",
                "H5Z_EDC_t"                  => "Ze",
                "H5Z_filter_t"               => "Zf",
+               "H5Z_filter_func_t"          => "ZF",
                "ssize_t"                    => "Zs",
+# Types below must be defined here, as they appear in function arguments,
+# but they are not yet supported in the H5_trace_args() routine yet.  If
+# they are used as an actual parameter type (and not just as a pointer to
+# to the type), they must have a "real" abbreviation added (like the ones
+# above), moved to the section of entries above, and support for displaying
+# the type must be added to H5_trace_args().
+               "H5ES_err_info_t"            => "#",
+               "H5FD_t"                     => "#",
+               "H5FD_hdfs_fapl_t"           => "#",
+               "H5FD_mirror_fapl_t"         => "#",
+               "H5FD_ros3_fapl_t"           => "#",
+               "H5FD_splitter_vfd_config_t" => "#",
+               "H5L_class_t"                => "#",
+               "H5VL_class_t"               => "#",
+               "H5VL_loc_params_t"          => "#",
+               "H5VL_request_status_t"      => "#",
               );
 
 
@@ -248,7 +238,9 @@ sub argstring ($$$) {
 
   # Normalize the data type by removing redundant white space,
   # certain type qualifiers, and indirection.
-  $atype =~ s/^\bconst\b//;
+  $atype =~ s/^\bconst\b//;     # Leading const
+  $atype =~ s/\s*const\s*//;    # const after type, possibly in the middle of '*'s
+  $atype =~ s/^\bstatic\b//;
   $atype =~ s/\bH5_ATTR_UNUSED\b//g;
   $atype =~ s/\bH5_ATTR_DEPRECATED_USED\b//g;
   $atype =~ s/\bH5_ATTR_NDEBUG_UNUSED\b//g;
@@ -272,53 +264,65 @@ sub argstring ($$$) {
     --$ptr;
     $tstr = $TypeString{"$atype*"};
   } elsif (!exists $TypeString{$atype}) {
-    errmesg $file, $func, "untraceable type \`$atype", '*'x$ptr, "\'";
+# Defer throwing error until type is actually used
+#    errmesg $file, $func, "untraceable type \`$atype", '*'x$ptr, "\'";
   } else {
     $tstr = $TypeString{$atype};
   }
-  return ("*" x $ptr) . ($array?"[$array]":"") . $tstr;
+  return ("*" x $ptr) . ($array ? "[$array]" : "") . $tstr;
 }
 
 ##############################################################################
 # Given information about an API function, rewrite that function with
 # updated tracing information.
 #
-sub rewrite_func ($$$$$) {
-  my ($file, $type, $name, $args, $body) = @_;
-  my ($arg,$trace);
-  my (@arg_name, @arg_str);
+my $file_api = 0;
+my $file_args = 0;
+my $total_api = 0;
+my $total_args = 0;
+sub rewrite_func ($$$$$$$$) {
+  my ($file, $begin, $type, $aftertype, $name, $args, $close, $body) = @_;
+  my ($arg, $trace, $argtrace);
+  my (@arg_name, @arg_str, @arg_type);
   local $_;
+
+  # Keep copy of original arguments
+  my $orig_args = $args;
 
   # Parse return value
   my $rettype = argstring $file, $name, $type;
-  goto error if $rettype =~ /!/;
 
   # Parse arguments
   if ($args eq "void") {
     $trace = "H5TRACE0(\"$rettype\", \"\");\n";
+    $argtrace = "H5ARG_TRACE0(\"\")";
   } else {
     # Split arguments.  First convert `/*in,out*/' to get rid of the
-    # comma, then split the arguments on commas.
-    $args =~ s/(\/\*\s*in),\s*(out\s*\*\/)/$1_$2/g;
+    # comma and remove lines beginning with a '#', then split the arguments
+    # on commas.
+    $args =~ s/(\/\*\s*in),\s*(out\s*\*\/)/$1_$2/g;     # Get rid of comma in 'in,out'
+    $args =~ s/H5FL_TRACK_PARAMS//g; # Remove free list macro
+    $args =~ s/\n#.*?\n/\n/g;        # Remove lines beginning with '#'
     my @args = split /,[\s\n]*/, $args;
     my $argno = 0;
     my %names;
 
     for $arg (@args) {
-      if($arg=~/\w*\.{3}\w*/){
+      if($arg=~/\w*\.{3}\w*/){  # Skip "..." for varargs parameter
         next;
       }
-      unless ($arg=~/^(([a-z_A-Z]\w*\s+)+\**)
+      unless ($arg=~/^((\s*[a-z_A-Z](\w|\*)*\s+)+(\s*\*\s*|\s*const\s*|\s*volatile\s*)*)
               ([a-z_A-Z]\w*)(\[.*?\])?
               (\s*\/\*\s*(in|out|in_out)\s*\*\/)?\s*$/x) {
         errmesg $file, $name, "unable to parse \`$arg\'";
         goto error;
       } else {
-        my ($atype, $aname, $array, $adir) = ($1, $3, $4, $6);
+        my ($atype, $aname, $array, $adir) = ($1, $5, $6, $8);
         $names{$aname} = $argno++;
         $adir ||= "in";
         $atype =~ s/\s+$//;
         push @arg_name, $aname;
+        push @arg_type, $atype;
 
         if ($adir eq "out") {
           push @arg_str, "x";
@@ -342,7 +346,9 @@ sub rewrite_func ($$$$$) {
 
     # Compose the trace macro
     $trace = "H5TRACE" . scalar(@arg_str) . "(\"$rettype\", \"";
+    $argtrace = "H5ARG_TRACE" . scalar(@arg_str) . "(FUNC, \"";
     $trace .= join("", @arg_str) . "\"";
+    $argtrace .= join("", @arg_str) . "\"";
     my $len = 4 + length $trace;        # Add 4, for indenting the line
     for (@arg_name) {
       # Wrap lines that will be longer than the limit, after ');' is added
@@ -363,63 +369,147 @@ sub rewrite_func ($$$$$) {
 
       # Append argument
       $trace .= "$_";
+      $argtrace .= ", $_";
       $len += length;     # Add length of appended argument name
     }
 
     # Append final ');' for macro
     $trace .= ");\n";
-  }
-  goto error if grep {/!/} @arg_str;
-
-  # The H5TRACE() statement
-  if ($body =~ /\/\*[ \t]*NO[ \t]*TRACE[ \t]*\*\//) {
-    # Ignored due to NO TRACE comment.
-  } elsif ($body =~ s/((\n[ \t]*)H5TRACE\d+\s*\(.*?\);)\n/"$2$trace"/es) {
-    # Replaced an H5TRACE macro.
-  } elsif ($body=~s/((\n[ \t]*)FUNC_ENTER\w*[ \t]*(\(.*?\))?;??)\n/"$1$2$trace"/es) {
-    # Added an H5TRACE macro after a FUNC_ENTER macro.
-  } else {
-    errmesg $file, $name, "unable to insert tracing information";
-    print "body = ", $body, "\n";
-    goto error;
+    $argtrace .= ")";
   }
 
-  
+  # Check for API / non-API routine name
+  if( $name =~ /H5[A-Z]{0,2}[a-z].*/) {
+      # The H5TRACE() statement, for API routines
+      if ($body =~ /\/\*[ \t]*NO[ \t]*TRACE[ \t]*\*\//) {
+        # Ignored due to NO TRACE comment.
+      } else {
+          # Check for known, but unsupported type
+          if ( $trace =~ /(^#)|([^*]#)/ ) {
+            # Check for unsupported return type
+            if ( $type =~ /(^#)|([^*]#)/ ) {
+              errmesg $file, $name, "unsupported type in return type\nAdd to TypeString hash in trace script and update H5_trace_args()";
+              print "type = '$type'\n";
+            }
+
+            # Check for unsupported argument type
+            $index = 0;
+            for (@arg_str) {
+              if ( $_ =~ /(^#)|([^*]#)/ ) {
+                errmesg $file, $name, "unsupported type in args\nAdd to TypeString hash in trace script and update H5_trace_args()";
+                print "type = $arg_type[$index]\n";
+              }
+              $index++;
+            }
+            goto error;
+          }
+
+          # Check for unknown (and therefore unsupported) type
+          if ( $trace =~ /(^!)|([^*]!)/ ) {
+            # Check for unsupported return type
+            if ( $type =~ /(^!)|([^*]!)/ ) {
+              errmesg $file, $name, "unknown type in return type\nAdd to TypeString hash in trace script and also update H5_trace_args() if used by value";
+              print "type = '$type'\n";
+            }
+
+            # Check for unsupported argument type
+            $index = 0;
+            for (@arg_str) {
+              if ( $_ =~ /(^!)|([^*]!)/ ) {
+                errmesg $file, $name, "unknown type in args\nAdd to TypeString hash in trace script and also update H5_trace_args() if used by value";
+                print "type = $arg_type[$index]\n";
+              }
+              $index++;
+            }
+            goto error;
+          }
+
+          if ($body =~ s/((\n[ \t]*)H5TRACE\d+\s*\(.*?\);)\n/"$2$trace"/es) {
+            # Replaced an H5TRACE macro.
+          } elsif ($body=~s/((\n[ \t]*)FUNC_ENTER\w*[ \t]*(\(.*?\))?;??)\n/"$1$2$trace"/es) {
+            # Added an H5TRACE macro after a FUNC_ENTER macro.
+          } else {
+            errmesg $file, $name, "unable to insert tracing information";
+            print "body = ", $body, "\n";
+            goto error;
+          }
+      }
+
+    #Increment # of API routines modified
+    $file_api++;
+  }
+
+  # Check for H5ARG_TRACE macros in non-API routines
+  if ( $body =~ /H5ARG_TRACE/ ) {
+      # Check for untraceable type (deferred until $argtrace used)
+      if ( $argtrace =~ /(^!)|([^*]!)/ ) {
+        errmesg $file, $name, "untraceable type in args";
+        print "args = '$orig_args'\n";
+        goto error;
+      }
+
+      # Replace / update H5ARG_TRACE macro.
+      $body =~ s/(H5ARG_TRACE(\d+\s*\(.*?\))?)/"$argtrace"/esg;
+
+    #Increment # of non-API routines modified
+    $file_args++;
+  }
+
  error:
-  return "\n$type\n$name($args)\n$body";
+  return "\n$begin$type$aftertype$name($orig_args)$close$body";
 }
 
 ##############################################################################
 # Process each source file, rewriting API functions with updated
 # tracing information.
 #
-my $total_api = 0;
 for $file (@ARGV) {
+  $file_api = 0;
+  $file_args = 0;
+
   # Ignore some files that do not need tracing macros
   unless ($file eq "H5FDmulti.c" or $file eq "src/H5FDmulti.c" or $file eq "H5FDstdio.c" or $file eq "src/H5FDstdio.c") {
-  
+
     # Snarf up the entire file
     open SOURCE, $file or die "$file: $!\n";
     $Source = join "", <SOURCE>;
     close SOURCE;
 
-    # Make modifications
+    # Make a copy of the original data
     my $original = $Source;
-    my $napi = $Source =~ s/\n([A-Za-z]\w*(\s+[A-Za-z]\w*)*\s*\**)\n #type
-                              (H5[A-Z]{0,2}[^_A-Z0-9]\w*)      #name
-                              \s*\((.*?)\)\s*               #args
-                              (\{.*?\n\}[^\n]*)             #body
-                           /rewrite_func($file,$1,$3,$4,$5)/segx;
-    $total_api += $napi;
+
+    # Check which style of function declaration is used in this file
+    if ( $Source =~ /BEGIN_FUNC/ ) {
+        # Make modifications
+        $Source =~ s/\n(BEGIN_FUNC.*?\n)                      #begin
+                        ([A-Za-z]\w*(\s+[A-Za-z]\w*)*\s*\**)  #type
+                        (.*?\n)                               #aftertype
+                         (H5[A-Z]{0,2}_?[a-zA-Z0-9_]\w*)      #name
+                         \s*\((.*?)\)\s*                      #args
+                         (\))                                 #close
+                         (\n.*?\nEND_FUNC\([^\n]*)            #body
+                         /rewrite_func($file,$1,$2,$4,$5,$6,$7,$8)/segx;
+    } else {
+        # Make modifications
+        $Source =~ s/\n([A-Za-z]\w*(\s+[A-Za-z]\w*)*\s*\**)\n #type
+                         (H5[A-Z]{0,2}_?[a-zA-Z0-9_]\w*)      #name
+                         \s*\((.*?)\)\s*                      #args
+                         (\{.*?\n\}[^\n]*)                    #body
+                         /rewrite_func($file,"",$1,"\n",$3,$4,"\n",$5)/segx;
+    }
 
 # If the source changed then print out the new version
     if ($original ne $Source) {
-      printf "%s: instrumented %d API function%s\n", 
-             $file, $napi, 1==$napi?"":"s";
+      printf "%s: instrumented %d API function%s and %d argument list%s\n",
+             $file, $file_api, (1 == $file_api ? "" : "s"),
+             $file_args, (1 == $file_args ? "" : "s");
       rename $file, "$file~" or die "unable to make backup";
       open SOURCE, ">$file" or die "unable to modify source";
       print SOURCE $Source;
       close SOURCE;
+
+      $total_api += $file_api;
+      $total_args += $file_args;
     }
   }
 }
@@ -431,6 +521,9 @@ if ($found_errors eq 1) {
     printf "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
     exit 1;
 } else {
-    printf "Finished processing HDF5 API calls\n";
+    printf "Finished processing HDF5 API calls:\n";
+    printf "\tinstrumented %d API function%s and %d argument list%s\n",
+             $total_api, (1 == $total_api ? "" : "s"),
+             $total_args, (1 == $total_args ? "" : "s");
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -746,6 +746,7 @@ set (H5_MODULE_HEADERS
     ${HDF5_SRC_DIR}/H5PBmodule.h
     ${HDF5_SRC_DIR}/H5PLmodule.h
     ${HDF5_SRC_DIR}/H5Rmodule.h
+    ${HDF5_SRC_DIR}/H5RSmodule.h
     ${HDF5_SRC_DIR}/H5Smodule.h
     ${HDF5_SRC_DIR}/H5SLmodule.h
     ${HDF5_SRC_DIR}/H5SMmodule.h

--- a/src/H5.c
+++ b/src/H5.c
@@ -597,12 +597,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5get_free_list_sizes(size_t *reg_size, size_t *arr_size, size_t *blk_size, size_t *fac_size)
+H5get_free_list_sizes(size_t *reg_size /*out*/, size_t *arr_size /*out*/, size_t *blk_size /*out*/,
+                      size_t *fac_size /*out*/)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "*z*z*z*z", reg_size, arr_size, blk_size, fac_size);
+    H5TRACE4("e", "xxxx", reg_size, arr_size, blk_size, fac_size);
 
     /* Call the free list function to actually get the sizes */
     if (H5FL_get_free_list_sizes(reg_size, arr_size, blk_size, fac_size) < 0)
@@ -637,12 +638,12 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5get_alloc_stats(H5_alloc_stats_t *stats)
+H5get_alloc_stats(H5_alloc_stats_t *stats /*out*/)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE1("e", "*x", stats);
+    H5TRACE1("e", "x", stats);
 
     /* Call the internal allocation stat routine to get the values */
     if (H5MM_get_alloc_stats(stats) < 0)
@@ -800,12 +801,12 @@ H5__mpi_delete_cb(MPI_Comm H5_ATTR_UNUSED comm, int H5_ATTR_UNUSED keyval, void 
  *-------------------------------------------------------------------------
  */
 herr_t
-H5get_libversion(unsigned *majnum, unsigned *minnum, unsigned *relnum)
+H5get_libversion(unsigned *majnum /*out*/, unsigned *minnum /*out*/, unsigned *relnum /*out*/)
 {
     herr_t ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "*Iu*Iu*Iu", majnum, minnum, relnum);
+    H5TRACE3("e", "xxx", majnum, minnum, relnum);
 
     /* Set the version information */
     if (majnum)

--- a/src/H5A.c
+++ b/src/H5A.c
@@ -685,13 +685,13 @@ done:
         This function reads a complete attribute from disk.
 --------------------------------------------------------------------------*/
 herr_t
-H5Aread(hid_t attr_id, hid_t dtype_id, void *buf)
+H5Aread(hid_t attr_id, hid_t dtype_id, void *buf /*out*/)
 {
     H5VL_object_t *vol_obj;   /* Attribute object for ID */
     herr_t         ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ii*x", attr_id, dtype_id, buf);
+    H5TRACE3("e", "iix", attr_id, dtype_id, buf);
 
     /* Check arguments */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(attr_id, H5I_ATTR)))
@@ -849,14 +849,14 @@ done:
     properly terminate the string.
 --------------------------------------------------------------------------*/
 ssize_t
-H5Aget_name(hid_t attr_id, size_t buf_size, char *buf)
+H5Aget_name(hid_t attr_id, size_t buf_size, char *buf /*out*/)
 {
     H5VL_object_t *   vol_obj = NULL; /* Attribute object for ID */
     H5VL_loc_params_t loc_params;
     ssize_t           ret_value = -1;
 
     FUNC_ENTER_API((-1))
-    H5TRACE3("Zs", "iz*s", attr_id, buf_size, buf);
+    H5TRACE3("Zs", "izx", attr_id, buf_size, buf);
 
     /* check arguments */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(attr_id, H5I_ATTR)))
@@ -995,14 +995,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Aget_info(hid_t attr_id, H5A_info_t *ainfo)
+H5Aget_info(hid_t attr_id, H5A_info_t *ainfo /*out*/)
 {
     H5VL_object_t *   vol_obj;
     H5VL_loc_params_t loc_params;
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", attr_id, ainfo);
+    H5TRACE2("e", "ix", attr_id, ainfo);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(attr_id, H5I_ATTR)))
@@ -1036,7 +1036,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Aget_info_by_name(hid_t loc_id, const char *obj_name, const char *attr_name, H5A_info_t *ainfo,
+H5Aget_info_by_name(hid_t loc_id, const char *obj_name, const char *attr_name, H5A_info_t *ainfo /*out*/,
                     hid_t lapl_id)
 {
     H5VL_object_t *   vol_obj;
@@ -1044,7 +1044,7 @@ H5Aget_info_by_name(hid_t loc_id, const char *obj_name, const char *attr_name, H
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*s*s*xi", loc_id, obj_name, attr_name, ainfo, lapl_id);
+    H5TRACE5("e", "i*s*sxi", loc_id, obj_name, attr_name, ainfo, lapl_id);
 
     /* Check args */
     if (H5I_ATTR == H5I_get_type(loc_id))
@@ -1094,14 +1094,14 @@ done:
  */
 herr_t
 H5Aget_info_by_idx(hid_t loc_id, const char *obj_name, H5_index_t idx_type, H5_iter_order_t order, hsize_t n,
-                   H5A_info_t *ainfo, hid_t lapl_id)
+                   H5A_info_t *ainfo /*out*/, hid_t lapl_id)
 {
     H5VL_object_t *   vol_obj;
     H5VL_loc_params_t loc_params;
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "i*sIiIoh*xi", loc_id, obj_name, idx_type, order, n, ainfo, lapl_id);
+    H5TRACE7("e", "i*sIiIohxi", loc_id, obj_name, idx_type, order, n, ainfo, lapl_id);
 
     /* Check args */
     if (H5I_ATTR == H5I_get_type(loc_id))
@@ -1300,7 +1300,7 @@ done:
             attribute.
 --------------------------------------------------------------------------*/
 herr_t
-H5Aiterate2(hid_t loc_id, H5_index_t idx_type, H5_iter_order_t order, hsize_t *idx, H5A_operator2_t op,
+H5Aiterate2(hid_t loc_id, H5_index_t idx_type, H5_iter_order_t order, hsize_t *idx /*in,out */, H5A_operator2_t op,
             void *op_data)
 {
     H5VL_object_t *   vol_obj = NULL; /* object of loc_id */
@@ -1308,7 +1308,7 @@ H5Aiterate2(hid_t loc_id, H5_index_t idx_type, H5_iter_order_t order, hsize_t *i
     herr_t            ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "iIiIo*hx*x", loc_id, idx_type, order, idx, op, op_data);
+    H5TRACE6("e", "iIiIo*hAO*x", loc_id, idx_type, order, idx, op, op_data);
 
     /* check arguments */
     if (H5I_ATTR == H5I_get_type(loc_id))
@@ -1379,14 +1379,14 @@ done:
 --------------------------------------------------------------------------*/
 herr_t
 H5Aiterate_by_name(hid_t loc_id, const char *obj_name, H5_index_t idx_type, H5_iter_order_t order,
-                   hsize_t *idx, H5A_operator2_t op, void *op_data, hid_t lapl_id)
+                   hsize_t *idx /*in,out */, H5A_operator2_t op, void *op_data, hid_t lapl_id)
 {
     H5VL_object_t *   vol_obj = NULL; /* Object location */
     H5VL_loc_params_t loc_params;
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "i*sIiIo*hx*xi", loc_id, obj_name, idx_type, order, idx, op, op_data, lapl_id);
+    H5TRACE8("e", "i*sIiIo*hAO*xi", loc_id, obj_name, idx_type, order, idx, op, op_data, lapl_id);
 
     /* Check arguments */
     if (H5I_ATTR == H5I_get_type(loc_id))

--- a/src/H5ACmpio.c
+++ b/src/H5ACmpio.c
@@ -137,8 +137,7 @@ H5FL_DEFINE_STATIC(H5AC_slist_entry_t);
  *-------------------------------------------------------------------------
  */
 herr_t
-H5AC__set_sync_point_done_callback(H5C_t *cache_ptr,
-                                   void (*sync_point_done)(unsigned num_writes, haddr_t *written_entries_tbl))
+H5AC__set_sync_point_done_callback(H5C_t *cache_ptr, H5AC_sync_point_done_cb_t sync_point_done)
 {
     H5AC_aux_t *aux_ptr;
 
@@ -170,7 +169,7 @@ H5AC__set_sync_point_done_callback(H5C_t *cache_ptr,
  *-------------------------------------------------------------------------
  */
 herr_t
-H5AC__set_write_done_callback(H5C_t *cache_ptr, void (*write_done)(void))
+H5AC__set_write_done_callback(H5C_t *cache_ptr, H5AC_write_done_cb_t write_done)
 {
     H5AC_aux_t *aux_ptr;
 

--- a/src/H5ACpkg.h
+++ b/src/H5ACpkg.h
@@ -401,7 +401,12 @@ typedef struct H5AC_aux_t {
     unsigned p0_image_len;
 
 } H5AC_aux_t; /* struct H5AC_aux_t */
-#endif        /* H5_HAVE_PARALLEL */
+
+/* Typedefs for debugging function pointers */
+typedef void (*H5AC_sync_point_done_cb_t)(unsigned num_writes, haddr_t *written_entries_tbl);
+typedef void (*H5AC_write_done_cb_t)(void);
+
+#endif /* H5_HAVE_PARALLEL */
 
 /******************************/
 /* Package Private Prototypes */
@@ -417,10 +422,8 @@ H5_DLL herr_t H5AC__log_inserted_entry(const H5AC_info_t *entry_ptr);
 H5_DLL herr_t H5AC__log_moved_entry(const H5F_t *f, haddr_t old_addr, haddr_t new_addr);
 H5_DLL herr_t H5AC__flush_entries(H5F_t *f);
 H5_DLL herr_t H5AC__run_sync_point(H5F_t *f, int sync_point_op);
-H5_DLL herr_t H5AC__set_sync_point_done_callback(H5C_t *cache_ptr,
-                                                 void (*sync_point_done)(unsigned num_writes,
-                                                                         haddr_t *written_entries_tbl));
-H5_DLL herr_t H5AC__set_write_done_callback(H5C_t *cache_ptr, void (*write_done)(void));
+H5_DLL herr_t H5AC__set_sync_point_done_callback(H5C_t *cache_ptr, H5AC_sync_point_done_cb_t sync_point_done);
+H5_DLL herr_t H5AC__set_write_done_callback(H5C_t *cache_ptr, H5AC_write_done_cb_t write_done);
 #endif /* H5_HAVE_PARALLEL */
 
 #endif /* _H5ACpkg_H */

--- a/src/H5Adeprec.c
+++ b/src/H5Adeprec.c
@@ -373,13 +373,13 @@ done:
     Deprecated in favor of H5Aiterate2
 --------------------------------------------------------------------------*/
 herr_t
-H5Aiterate1(hid_t loc_id, unsigned *attr_num, H5A_operator1_t op, void *op_data)
+H5Aiterate1(hid_t loc_id, unsigned *attr_num /*in,out*/, H5A_operator1_t op, void *op_data)
 {
     H5VL_object_t *vol_obj = NULL; /* Object of loc_id */
     herr_t         ret_value;      /* Return value */
 
     FUNC_ENTER_API(H5_ITER_ERROR)
-    H5TRACE4("e", "i*Iux*x", loc_id, attr_num, op, op_data);
+    H5TRACE4("e", "i*IuAo*x", loc_id, attr_num, op, op_data);
 
     /* check arguments */
     if (H5I_ATTR == H5I_get_type(loc_id))

--- a/src/H5C.c
+++ b/src/H5C.c
@@ -4138,13 +4138,13 @@ done:
  *
  *-------------------------------------------------------------------------
  */
-#if H5C_COLLECT_CACHE_STATS
 static herr_t
-H5C__pin_entry_from_client(H5C_t *cache_ptr, H5C_cache_entry_t *entry_ptr)
-#else
-static herr_t
-H5C__pin_entry_from_client(H5C_t H5_ATTR_UNUSED *cache_ptr, H5C_cache_entry_t *entry_ptr)
+H5C__pin_entry_from_client(H5C_t
+#if !H5C_COLLECT_CACHE_STATS
+                               H5_ATTR_UNUSED
 #endif
+                                   *          cache_ptr,
+                           H5C_cache_entry_t *entry_ptr)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -374,13 +374,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Dget_space_status(hid_t dset_id, H5D_space_status_t *allocation)
+H5Dget_space_status(hid_t dset_id, H5D_space_status_t *allocation /*out*/)
 {
     H5VL_object_t *vol_obj   = NULL;    /* Dataset structure    */
     herr_t         ret_value = SUCCEED; /* Return value         */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*Ds", dset_id, allocation);
+    H5TRACE2("e", "ix", dset_id, allocation);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(dset_id, H5I_DATASET)))
@@ -661,7 +661,7 @@ H5Diterate(void *buf, hid_t type_id, hid_t space_id, H5D_operator_t op, void *op
     herr_t            ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "*xiix*x", buf, type_id, space_id, op, operator_data);
+    H5TRACE5("e", "*xiiDO*x", buf, type_id, space_id, op, operator_data);
 
     /* Check args */
     if (NULL == op)
@@ -704,14 +704,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Dvlen_get_buf_size(hid_t dataset_id, hid_t type_id, hid_t space_id, hsize_t *size)
+H5Dvlen_get_buf_size(hid_t dataset_id, hid_t type_id, hid_t space_id, hsize_t *size /*out*/)
 {
     H5VL_object_t *vol_obj;   /* Dataset for this operation */
     hbool_t        supported; /* Whether 'get vlen buf size' operation is supported by VOL connector */
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "iii*h", dataset_id, type_id, space_id, size);
+    H5TRACE4("e", "iiix", dataset_id, type_id, space_id, size);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(dataset_id)))
@@ -911,13 +911,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Dget_chunk_index_type(hid_t dset_id, H5D_chunk_index_t *idx_type)
+H5Dget_chunk_index_type(hid_t dset_id, H5D_chunk_index_t *idx_type /*out*/)
 {
     H5VL_object_t *vol_obj;             /* Dataset for this operation   */
     herr_t         ret_value = SUCCEED; /* Return value                 */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*Dk", dset_id, idx_type);
+    H5TRACE2("e", "ix", dset_id, idx_type);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(dset_id, H5I_DATASET)))
@@ -950,13 +950,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Dget_chunk_storage_size(hid_t dset_id, const hsize_t *offset, hsize_t *chunk_nbytes)
+H5Dget_chunk_storage_size(hid_t dset_id, const hsize_t *offset, hsize_t *chunk_nbytes /*out*/)
 {
     H5VL_object_t *vol_obj;             /* Dataset for this operation   */
     herr_t         ret_value = SUCCEED; /* Return value                 */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*h*h", dset_id, offset, chunk_nbytes);
+    H5TRACE3("e", "i*hx", dset_id, offset, chunk_nbytes);
 
     /* Check arguments */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(dset_id, H5I_DATASET)))
@@ -997,13 +997,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Dget_num_chunks(hid_t dset_id, hid_t fspace_id, hsize_t *nchunks)
+H5Dget_num_chunks(hid_t dset_id, hid_t fspace_id, hsize_t *nchunks /*out*/)
 {
     H5VL_object_t *vol_obj   = NULL; /* Dataset for this operation */
     herr_t         ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ii*h", dset_id, fspace_id, nchunks);
+    H5TRACE3("e", "iix", dset_id, fspace_id, nchunks);
 
     /* Check arguments */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(dset_id, H5I_DATASET)))
@@ -1043,15 +1043,15 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Dget_chunk_info(hid_t dset_id, hid_t fspace_id, hsize_t chk_index, hsize_t *offset, unsigned *filter_mask,
-                  haddr_t *addr, hsize_t *size)
+H5Dget_chunk_info(hid_t dset_id, hid_t fspace_id, hsize_t chk_index, hsize_t *offset /*out*/,
+                  unsigned *filter_mask /*out*/, haddr_t *addr /*out*/, hsize_t *size /*out*/)
 {
     H5VL_object_t *vol_obj   = NULL; /* Dataset for this operation */
     hsize_t        nchunks   = 0;
     herr_t         ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "iih*h*Iu*a*h", dset_id, fspace_id, chk_index, offset, filter_mask, addr, size);
+    H5TRACE7("e", "iihxxxx", dset_id, fspace_id, chk_index, offset, filter_mask, addr, size);
 
     /* Check arguments */
     if (NULL == offset && NULL == filter_mask && NULL == addr && NULL == size)
@@ -1100,14 +1100,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Dget_chunk_info_by_coord(hid_t dset_id, const hsize_t *offset, unsigned *filter_mask, haddr_t *addr,
-                           hsize_t *size)
+H5Dget_chunk_info_by_coord(hid_t dset_id, const hsize_t *offset, unsigned *filter_mask /*out*/,
+                           haddr_t *addr /*out*/, hsize_t *size /*out*/)
 {
     H5VL_object_t *vol_obj   = NULL; /* Dataset for this operation */
     herr_t         ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*h*Iu*a*h", dset_id, offset, filter_mask, addr, size);
+    H5TRACE5("e", "i*hxxx", dset_id, offset, filter_mask, addr, size);
 
     /* Check arguments */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(dset_id, H5I_DATASET)))

--- a/src/H5Dmpio.c
+++ b/src/H5Dmpio.c
@@ -207,6 +207,9 @@ typedef struct H5D_filtered_collective_io_info_t {
     } async_info;
 } H5D_filtered_collective_io_info_t;
 
+/* Function pointer typedef for sort function */
+typedef int (*H5D_mpio_sort_func_cb_t)(const void *, const void *);
+
 /********************/
 /* Local Prototypes */
 /********************/
@@ -527,7 +530,7 @@ done:
 static herr_t
 H5D__mpio_array_gatherv(void *local_array, size_t local_array_num_entries, size_t array_entry_size,
                         void **_gathered_array, size_t *_gathered_array_num_entries, hbool_t allgather,
-                        int root, MPI_Comm comm, int (*sort_func)(const void *, const void *))
+                        int root, MPI_Comm comm, H5D_mpio_sort_func_cb_t sort_func)
 {
     size_t gathered_array_num_entries = 0;    /* The size of the newly-constructed array */
     void * gathered_array             = NULL; /* The newly-constructed array returned to the caller */

--- a/src/H5Dscatgath.c
+++ b/src/H5Dscatgath.c
@@ -916,7 +916,7 @@ H5D__compound_opt_write(size_t nelmts, const H5D_type_info_t *type_info)
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Dscatter(H5D_scatter_func_t op, void *op_data, hid_t type_id, hid_t dst_space_id, void *dst_buf)
+H5Dscatter(H5D_scatter_func_t op, void *op_data, hid_t type_id, hid_t dst_space_id, void *dst_buf /*out*/)
 {
     H5T_t *         type;                     /* Datatype */
     H5S_t *         dst_space;                /* Dataspace */
@@ -930,7 +930,7 @@ H5Dscatter(H5D_scatter_func_t op, void *op_data, hid_t type_id, hid_t dst_space_
     herr_t          ret_value      = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "x*xii*x", op, op_data, type_id, dst_space_id, dst_buf);
+    H5TRACE5("e", "DS*xiix", op, op_data, type_id, dst_space_id, dst_buf);
 
     /* Check args */
     if (op == NULL)
@@ -1012,7 +1012,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Dgather(hid_t src_space_id, const void *src_buf, hid_t type_id, size_t dst_buf_size, void *dst_buf,
+H5Dgather(hid_t src_space_id, const void *src_buf, hid_t type_id, size_t dst_buf_size, void *dst_buf /*out*/,
           H5D_gather_func_t op, void *op_data)
 {
     H5T_t *         type;                /* Datatype */
@@ -1026,7 +1026,7 @@ H5Dgather(hid_t src_space_id, const void *src_buf, hid_t type_id, size_t dst_buf
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "i*xiz*xx*x", src_space_id, src_buf, type_id, dst_buf_size, dst_buf, op, op_data);
+    H5TRACE7("e", "i*xizxDg*x", src_space_id, src_buf, type_id, dst_buf_size, dst_buf, op, op_data);
 
     /* Check args */
     if (NULL == (src_space = (H5S_t *)H5I_object_verify(src_space_id, H5I_DATASPACE)))

--- a/src/H5E.c
+++ b/src/H5E.c
@@ -575,13 +575,13 @@ done:
  *-------------------------------------------------------------------------
  */
 ssize_t
-H5Eget_class_name(hid_t class_id, char *name, size_t size)
+H5Eget_class_name(hid_t class_id, char *name /*out*/, size_t size)
 {
     H5E_cls_t *cls;            /* Pointer to error class */
     ssize_t    ret_value = -1; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE3("Zs", "i*sz", class_id, name, size);
+    H5TRACE3("Zs", "ixz", class_id, name, size);
 
     /* Get the error class */
     if (NULL == (cls = (H5E_cls_t *)H5I_object_verify(class_id, H5I_ERROR_CLASS)))
@@ -836,13 +836,13 @@ done:
  *-------------------------------------------------------------------------
  */
 ssize_t
-H5Eget_msg(hid_t msg_id, H5E_type_t *type, char *msg_str, size_t size)
+H5Eget_msg(hid_t msg_id, H5E_type_t *type /*out*/, char *msg_str /*out*/, size_t size)
 {
     H5E_msg_t *msg;            /* Pointer to error message */
     ssize_t    ret_value = -1; /* Return value */
 
     FUNC_ENTER_API_NOCLEAR((-1))
-    H5TRACE4("Zs", "i*Et*sz", msg_id, type, msg_str, size);
+    H5TRACE4("Zs", "ixxz", msg_id, type, msg_str, size);
 
     /* Get the message object */
     if (NULL == (msg = (H5E_msg_t *)H5I_object_verify(msg_id, H5I_ERROR_MSG)))
@@ -1525,14 +1525,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Eget_auto2(hid_t estack_id, H5E_auto2_t *func, void **client_data)
+H5Eget_auto2(hid_t estack_id, H5E_auto2_t *func /*out*/, void **client_data /*out*/)
 {
     H5E_t *       estack;              /* Error stack to operate on */
     H5E_auto_op_t op;                  /* Error stack function */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*x**x", estack_id, func, client_data);
+    H5TRACE3("e", "ixx", estack_id, func, client_data);
 
     if (estack_id == H5E_DEFAULT) {
         if (NULL == (estack = H5E__get_my_stack())) /*lint !e506 !e774 Make lint 'constant value Boolean' in
@@ -1590,7 +1590,7 @@ H5Eset_auto2(hid_t estack_id, H5E_auto2_t func, void *client_data)
 
     /* Don't clear the error stack! :-) */
     FUNC_ENTER_API_NOCLEAR(FAIL)
-    H5TRACE3("e", "ix*x", estack_id, func, client_data);
+    H5TRACE3("e", "iEA*x", estack_id, func, client_data);
 
     if (estack_id == H5E_DEFAULT) {
         if (NULL == (estack = H5E__get_my_stack())) /*lint !e506 !e774 Make lint 'constant value Boolean' in

--- a/src/H5Edeprec.c
+++ b/src/H5Edeprec.c
@@ -334,14 +334,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Eget_auto1(H5E_auto1_t *func, void **client_data)
+H5Eget_auto1(H5E_auto1_t *func /*out*/, void **client_data /*out*/)
 {
     H5E_t *       estack;              /* Error stack to operate on */
     H5E_auto_op_t auto_op;             /* Error stack operator */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "*x**x", func, client_data);
+    H5TRACE2("e", "xx", func, client_data);
 
     /* Retrieve default error stack */
     if (NULL == (estack = H5E__get_my_stack())) /*lint !e506 !e774 Make lint 'constant value Boolean' in
@@ -395,7 +395,7 @@ H5Eset_auto1(H5E_auto1_t func, void *client_data)
 
     /* Don't clear the error stack! :-) */
     FUNC_ENTER_API_NOCLEAR(FAIL)
-    H5TRACE2("e", "x*x", func, client_data);
+    H5TRACE2("e", "Ea*x", func, client_data);
 
     if (NULL == (estack = H5E__get_my_stack())) /*lint !e506 !e774 Make lint 'constant value Boolean' in
                                                    non-threaded case */

--- a/src/H5F.c
+++ b/src/H5F.c
@@ -305,12 +305,12 @@ done:
  *-------------------------------------------------------------------------
  */
 ssize_t
-H5Fget_obj_ids(hid_t file_id, unsigned types, size_t max_objs, hid_t *oid_list)
+H5Fget_obj_ids(hid_t file_id, unsigned types, size_t max_objs, hid_t *oid_list /*out*/)
 {
     ssize_t ret_value = 0; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE4("Zs", "iIuz*i", file_id, types, max_objs, oid_list);
+    H5TRACE4("Zs", "iIuzx", file_id, types, max_objs, oid_list);
 
     /* Check arguments */
     if (0 == (types & H5F_OBJ_ALL))
@@ -384,13 +384,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Fget_vfd_handle(hid_t file_id, hid_t fapl_id, void **file_handle)
+H5Fget_vfd_handle(hid_t file_id, hid_t fapl_id, void **file_handle /*out*/)
 {
     H5VL_object_t *vol_obj;             /* File info */
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ii**x", file_id, fapl_id, file_handle);
+    H5TRACE3("e", "iix", file_id, fapl_id, file_handle);
 
     /* Check args */
     if (!file_handle)
@@ -840,12 +840,12 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Fget_intent(hid_t file_id, unsigned *intent_flags)
+H5Fget_intent(hid_t file_id, unsigned *intent_flags /*out*/)
 {
     herr_t ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*Iu", file_id, intent_flags);
+    H5TRACE2("e", "ix", file_id, intent_flags);
 
     /* If no intent flags were passed in, exit quietly */
     if (intent_flags) {
@@ -876,12 +876,12 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Fget_fileno(hid_t file_id, unsigned long *fnumber)
+H5Fget_fileno(hid_t file_id, unsigned long *fnumber /*out*/)
 {
     herr_t ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*Ul", file_id, fnumber);
+    H5TRACE2("e", "ix", file_id, fnumber);
 
     /* If no fnumber pointer was passed in, exit quietly */
     if (fnumber) {
@@ -944,13 +944,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Fget_filesize(hid_t file_id, hsize_t *size)
+H5Fget_filesize(hid_t file_id, hsize_t *size /*out*/)
 {
     H5VL_object_t *vol_obj;             /* File info */
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*h", file_id, size);
+    H5TRACE2("e", "ix", file_id, size);
 
     /* Check args */
     if (!size)
@@ -1005,13 +1005,13 @@ done:
  *-------------------------------------------------------------------------
  */
 ssize_t
-H5Fget_file_image(hid_t file_id, void *buf, size_t buf_len)
+H5Fget_file_image(hid_t file_id, void *buf /*out*/, size_t buf_len)
 {
     H5VL_object_t *vol_obj;   /* File object for file ID  */
     ssize_t        ret_value; /* Return value             */
 
     FUNC_ENTER_API((-1))
-    H5TRACE3("Zs", "i*xz", file_id, buf, buf_len);
+    H5TRACE3("Zs", "ixz", file_id, buf, buf_len);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
@@ -1041,13 +1041,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Fget_mdc_config(hid_t file_id, H5AC_cache_config_t *config)
+H5Fget_mdc_config(hid_t file_id, H5AC_cache_config_t *config /*out*/)
 {
     H5VL_object_t *vol_obj   = NULL;
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", file_id, config);
+    H5TRACE2("e", "ix", file_id, config);
 
     /* Check args */
     if ((NULL == config) || (config->version != H5AC__CURR_CACHE_CONFIG_VERSION))
@@ -1084,7 +1084,7 @@ H5Fset_mdc_config(hid_t file_id, H5AC_cache_config_t *config_ptr)
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", file_id, config_ptr);
+    H5TRACE2("e", "i*Cc", file_id, config_ptr);
 
     /* Get the file object */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(file_id)))
@@ -1112,13 +1112,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Fget_mdc_hit_rate(hid_t file_id, double *hit_rate)
+H5Fget_mdc_hit_rate(hid_t file_id, double *hit_rate /*out*/)
 {
     H5VL_object_t *vol_obj;
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*d", file_id, hit_rate);
+    H5TRACE2("e", "ix", file_id, hit_rate);
 
     /* Check args */
     if (NULL == hit_rate)
@@ -1149,14 +1149,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Fget_mdc_size(hid_t file_id, size_t *max_size, size_t *min_clean_size, size_t *cur_size,
-                int *cur_num_entries)
+H5Fget_mdc_size(hid_t file_id, size_t *max_size /*out*/, size_t *min_clean_size /*out*/,
+                size_t *cur_size /*out*/, int *cur_num_entries /*out*/)
 {
     H5VL_object_t *vol_obj;
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*z*z*z*Is", file_id, max_size, min_clean_size, cur_size, cur_num_entries);
+    H5TRACE5("e", "ixxxx", file_id, max_size, min_clean_size, cur_size, cur_num_entries);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
@@ -1271,14 +1271,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Fget_info2(hid_t obj_id, H5F_info2_t *finfo)
+H5Fget_info2(hid_t obj_id, H5F_info2_t *finfo /*out*/)
 {
     H5VL_object_t *vol_obj = NULL;
     H5I_type_t     type;
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", obj_id, finfo);
+    H5TRACE2("e", "ix", obj_id, finfo);
 
     /* Check args */
     if (!finfo)
@@ -1314,13 +1314,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Fget_metadata_read_retry_info(hid_t file_id, H5F_retry_info_t *info)
+H5Fget_metadata_read_retry_info(hid_t file_id, H5F_retry_info_t *info /*out*/)
 {
     H5VL_object_t *vol_obj   = NULL;    /* File object for file ID */
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", file_id, info);
+    H5TRACE2("e", "ix", file_id, info);
 
     /* Check args */
     if (!info)
@@ -1545,13 +1545,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Fget_mdc_logging_status(hid_t file_id, hbool_t *is_enabled, hbool_t *is_currently_logging)
+H5Fget_mdc_logging_status(hid_t file_id, hbool_t *is_enabled /*out*/, hbool_t *is_currently_logging /*out*/)
 {
     H5VL_object_t *vol_obj;             /* File info */
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*b*b", file_id, is_enabled, is_currently_logging);
+    H5TRACE3("e", "ixx", file_id, is_enabled, is_currently_logging);
 
     /* Sanity check */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
@@ -1682,14 +1682,15 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Fget_page_buffering_stats(hid_t file_id, unsigned accesses[2], unsigned hits[2], unsigned misses[2],
-                            unsigned evictions[2], unsigned bypasses[2])
+H5Fget_page_buffering_stats(hid_t file_id, unsigned accesses[2] /*out*/, unsigned hits[2] /*out*/,
+                            unsigned misses[2] /*out*/, unsigned evictions[2] /*out*/,
+                            unsigned bypasses[2] /*out*/)
 {
     H5VL_object_t *vol_obj;             /* File object */
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "i*Iu*Iu*Iu*Iu*Iu", file_id, accesses, hits, misses, evictions, bypasses);
+    H5TRACE6("e", "ixxxxx", file_id, accesses, hits, misses, evictions, bypasses);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
@@ -1720,13 +1721,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Fget_mdc_image_info(hid_t file_id, haddr_t *image_addr, hsize_t *image_len)
+H5Fget_mdc_image_info(hid_t file_id, haddr_t *image_addr /*out*/, hsize_t *image_len /*out*/)
 {
     H5VL_object_t *vol_obj;             /* File info */
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*a*h", file_id, image_addr, image_len);
+    H5TRACE3("e", "ixx", file_id, image_addr, image_len);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
@@ -1753,13 +1754,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Fget_eoa(hid_t file_id, haddr_t *eoa)
+H5Fget_eoa(hid_t file_id, haddr_t *eoa /*out*/)
 {
     H5VL_object_t *vol_obj;             /* File info */
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*a", file_id, eoa);
+    H5TRACE2("e", "ix", file_id, eoa);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
@@ -1819,13 +1820,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Fget_dset_no_attrs_hint(hid_t file_id, hbool_t *minimize)
+H5Fget_dset_no_attrs_hint(hid_t file_id, hbool_t *minimize /*out*/)
 {
     H5VL_object_t *vol_obj   = NULL;
     herr_t         ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*b", file_id, minimize);
+    H5TRACE2("e", "ix", file_id, minimize);
 
     if (NULL == minimize)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "out pointer 'minimize' cannot be NULL")

--- a/src/H5FD.c
+++ b/src/H5FD.c
@@ -218,7 +218,7 @@ H5FDregister(const H5FD_class_t *cls)
     hid_t      ret_value = H5I_INVALID_HID;
 
     FUNC_ENTER_API(H5I_INVALID_HID)
-    H5TRACE1("i", "*x", cls);
+    H5TRACE1("i", "*FC", cls);
 
     /* Check arguments */
     if (!cls)
@@ -644,7 +644,7 @@ H5FDopen(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr)
     H5FD_t *ret_value = NULL;
 
     FUNC_ENTER_API(NULL)
-    H5TRACE4("*x", "*sIuia", name, flags, fapl_id, maxaddr);
+    H5TRACE4("*#", "*sIuia", name, flags, fapl_id, maxaddr);
 
     /* Check arguments */
     if (H5P_DEFAULT == fapl_id)
@@ -780,7 +780,7 @@ H5FDclose(H5FD_t *file)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE1("e", "*x", file);
+    H5TRACE1("e", "*#", file);
 
     /* Check arguments */
     if (!file)
@@ -858,7 +858,7 @@ H5FDcmp(const H5FD_t *f1, const H5FD_t *f2)
     int ret_value = -1;
 
     FUNC_ENTER_API(-1) /* return value is arbitrary */
-    H5TRACE2("Is", "*x*x", f1, f2);
+    H5TRACE2("Is", "*#*#", f1, f2);
 
     /* Call private function */
     ret_value = H5FD_cmp(f1, f2);
@@ -928,7 +928,7 @@ H5FDquery(const H5FD_t *file, unsigned long *flags /*out*/)
     int ret_value = 0;
 
     FUNC_ENTER_API((-1))
-    H5TRACE2("Is", "*xx", file, flags);
+    H5TRACE2("Is", "*#x", file, flags);
 
     /* Check arguments */
     if (!file)
@@ -1021,7 +1021,7 @@ H5FDalloc(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, hsize_t size)
     haddr_t ret_value = HADDR_UNDEF;
 
     FUNC_ENTER_API(HADDR_UNDEF)
-    H5TRACE4("a", "*xMtih", file, type, dxpl_id, size);
+    H5TRACE4("a", "*#Mtih", file, type, dxpl_id, size);
 
     /* Check arguments */
     if (!file)
@@ -1071,7 +1071,7 @@ H5FDfree(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, hsize_t siz
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "*xMtiah", file, type, dxpl_id, addr, size);
+    H5TRACE5("e", "*#Mtiah", file, type, dxpl_id, addr, size);
 
     /* Check arguments */
     if (!file)
@@ -1114,7 +1114,7 @@ H5FDget_eoa(H5FD_t *file, H5FD_mem_t type)
     haddr_t ret_value;
 
     FUNC_ENTER_API(HADDR_UNDEF)
-    H5TRACE2("a", "*xMt", file, type);
+    H5TRACE2("a", "*#Mt", file, type);
 
     /* Check arguments */
     if (!file)
@@ -1162,7 +1162,7 @@ H5FDset_eoa(H5FD_t *file, H5FD_mem_t type, haddr_t addr)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "*xMta", file, type, addr);
+    H5TRACE3("e", "*#Mta", file, type, addr);
 
     /* Check arguments */
     if (!file)
@@ -1210,7 +1210,7 @@ H5FDget_eof(H5FD_t *file, H5FD_mem_t type)
     haddr_t ret_value;
 
     FUNC_ENTER_API(HADDR_UNDEF)
-    H5TRACE2("a", "*xMt", file, type);
+    H5TRACE2("a", "*#Mt", file, type);
 
     /* Check arguments */
     if (!file)
@@ -1361,7 +1361,7 @@ H5FDread(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, size_t size
     herr_t ret_value = SUCCEED; /* Return value             */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "*xMtiazx", file, type, dxpl_id, addr, size, buf);
+    H5TRACE6("e", "*#Mtiazx", file, type, dxpl_id, addr, size, buf);
 
     /* Check arguments */
     if (!file)
@@ -1407,7 +1407,7 @@ H5FDwrite(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, size_t siz
     herr_t ret_value = SUCCEED; /* Return value             */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "*xMtiaz*x", file, type, dxpl_id, addr, size, buf);
+    H5TRACE6("e", "*#Mtiaz*x", file, type, dxpl_id, addr, size, buf);
 
     /* Check arguments */
     if (!file)
@@ -1451,7 +1451,7 @@ H5FDflush(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "*xib", file, dxpl_id, closing);
+    H5TRACE3("e", "*#ib", file, dxpl_id, closing);
 
     /* Check arguments */
     if (!file)
@@ -1518,7 +1518,7 @@ H5FDtruncate(H5FD_t *file, hid_t dxpl_id, hbool_t closing)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "*xib", file, dxpl_id, closing);
+    H5TRACE3("e", "*#ib", file, dxpl_id, closing);
 
     /* Check arguments */
     if (!file)
@@ -1584,7 +1584,7 @@ H5FDlock(H5FD_t *file, hbool_t rw)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "*xb", file, rw);
+    H5TRACE2("e", "*#b", file, rw);
 
     /* Check arguments */
     if (!file)
@@ -1643,7 +1643,7 @@ H5FDunlock(H5FD_t *file)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE1("e", "*x", file);
+    H5TRACE1("e", "*#", file);
 
     /* Check arguments */
     if (!file)
@@ -1724,12 +1724,12 @@ H5FD_get_fileno(const H5FD_t *file, unsigned long *filenum)
  *--------------------------------------------------------------------------
  */
 herr_t
-H5FDget_vfd_handle(H5FD_t *file, hid_t fapl_id, void **file_handle)
+H5FDget_vfd_handle(H5FD_t *file, hid_t fapl_id, void **file_handle /*out*/)
 {
     herr_t ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "*xi**x", file, fapl_id, file_handle);
+    H5TRACE3("e", "*#ix", file, fapl_id, file_handle);
 
     /* Check arguments */
     if (!file)

--- a/src/H5FDcore.c
+++ b/src/H5FDcore.c
@@ -557,14 +557,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_core_write_tracking(hid_t plist_id, hbool_t *is_enabled, size_t *page_size)
+H5Pget_core_write_tracking(hid_t plist_id, hbool_t *is_enabled /*out*/, size_t *page_size /*out*/)
 {
     H5P_genplist_t *        plist;               /* Property list pointer */
     const H5FD_core_fapl_t *fa;                  /* Core VFD info */
     herr_t                  ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*b*z", plist_id, is_enabled, page_size);
+    H5TRACE3("e", "ixx", plist_id, is_enabled, page_size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))

--- a/src/H5FDhdfs.c
+++ b/src/H5FDhdfs.c
@@ -610,7 +610,7 @@ H5Pset_fapl_hdfs(hid_t fapl_id, H5FD_hdfs_fapl_t *fa)
     herr_t          ret_value = FAIL;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", fapl_id, fa);
+    H5TRACE2("e", "i*#", fapl_id, fa);
 
     HDassert(fa != NULL);
 
@@ -646,14 +646,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_fapl_hdfs(hid_t fapl_id, H5FD_hdfs_fapl_t *fa_dst)
+H5Pget_fapl_hdfs(hid_t fapl_id, H5FD_hdfs_fapl_t *fa_dst /*out*/)
 {
     const H5FD_hdfs_fapl_t *fa_src    = NULL;
     H5P_genplist_t *        plist     = NULL;
     herr_t                  ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", fapl_id, fa_dst);
+    H5TRACE2("e", "ix", fapl_id, fa_dst);
 
 #if HDFS_DEBUG
     HDfprintf(stdout, "called %s.\n", FUNC);

--- a/src/H5FDmirror.c
+++ b/src/H5FDmirror.c
@@ -1272,14 +1272,14 @@ H5FD__mirror_fapl_free(void *_fa)
  * -------------------------------------------------------------------------
  */
 herr_t
-H5Pget_fapl_mirror(hid_t fapl_id, H5FD_mirror_fapl_t *fa_dst)
+H5Pget_fapl_mirror(hid_t fapl_id, H5FD_mirror_fapl_t *fa_dst /*out*/)
 {
     const H5FD_mirror_fapl_t *fa_src    = NULL;
     H5P_genplist_t *          plist     = NULL;
     herr_t                    ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", fapl_id, fa_dst);
+    H5TRACE2("e", "ix", fapl_id, fa_dst);
 
     LOG_OP_CALL(FUNC);
 
@@ -1320,7 +1320,7 @@ H5Pset_fapl_mirror(hid_t fapl_id, H5FD_mirror_fapl_t *fa)
     herr_t          ret_value = FAIL;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", fapl_id, fa);
+    H5TRACE2("e", "i*#", fapl_id, fa);
 
     LOG_OP_CALL(FUNC);
 

--- a/src/H5FDros3.c
+++ b/src/H5FDros3.c
@@ -394,7 +394,7 @@ H5Pset_fapl_ros3(hid_t fapl_id, H5FD_ros3_fapl_t *fa)
     herr_t          ret_value = FAIL;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", fapl_id, fa);
+    H5TRACE2("e", "i*#", fapl_id, fa);
 
     HDassert(fa != NULL);
 
@@ -472,14 +472,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_fapl_ros3(hid_t fapl_id, H5FD_ros3_fapl_t *fa_dst)
+H5Pget_fapl_ros3(hid_t fapl_id, H5FD_ros3_fapl_t *fa_dst /*out*/)
 {
     const H5FD_ros3_fapl_t *fa_src    = NULL;
     H5P_genplist_t *        plist     = NULL;
     herr_t                  ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", fapl_id, fa_dst);
+    H5TRACE2("e", "ix", fapl_id, fa_dst);
 
 #if ROS3_DEBUG
     HDfprintf(stdout, "H5Pget_fapl_ros3() called.\n");

--- a/src/H5FDsplitter.c
+++ b/src/H5FDsplitter.c
@@ -297,7 +297,7 @@ H5Pset_fapl_splitter(hid_t fapl_id, H5FD_splitter_vfd_config_t *vfd_config)
     herr_t                ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*Dr", fapl_id, vfd_config);
+    H5TRACE2("e", "i*#", fapl_id, vfd_config);
 
     H5FD_SPLITTER_LOG_CALL(FUNC);
 
@@ -378,14 +378,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_fapl_splitter(hid_t fapl_id, H5FD_splitter_vfd_config_t *config)
+H5Pget_fapl_splitter(hid_t fapl_id, H5FD_splitter_vfd_config_t *config /*out*/)
 {
     const H5FD_splitter_fapl_t *fapl_ptr  = NULL;
     H5P_genplist_t *            plist_ptr = NULL;
     herr_t                      ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*Dr", fapl_id, config);
+    H5TRACE2("e", "ix", fapl_id, config);
 
     H5FD_SPLITTER_LOG_CALL(FUNC);
 

--- a/src/H5Fdeprec.c
+++ b/src/H5Fdeprec.c
@@ -87,7 +87,7 @@
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Fget_info1(hid_t obj_id, H5F_info1_t *finfo)
+H5Fget_info1(hid_t obj_id, H5F_info1_t *finfo /*out*/)
 {
     H5VL_object_t *vol_obj = NULL;
     H5I_type_t     type;
@@ -95,7 +95,7 @@ H5Fget_info1(hid_t obj_id, H5F_info1_t *finfo)
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", obj_id, finfo);
+    H5TRACE2("e", "ix", obj_id, finfo);
 
     /* Check args */
     if (!finfo)

--- a/src/H5Fmpi.c
+++ b/src/H5Fmpi.c
@@ -336,13 +336,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Fget_mpi_atomicity(hid_t file_id, hbool_t *flag)
+H5Fget_mpi_atomicity(hid_t file_id, hbool_t *flag /*out*/)
 {
     H5VL_object_t *vol_obj   = NULL;
     herr_t         ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL);
-    H5TRACE2("e", "i*b", file_id, flag);
+    H5TRACE2("e", "ix", file_id, flag);
 
     /* Get the file object */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))

--- a/src/H5G.c
+++ b/src/H5G.c
@@ -566,7 +566,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Gget_info(hid_t loc_id, H5G_info_t *group_info)
+H5Gget_info(hid_t loc_id, H5G_info_t *group_info /*out*/)
 {
     H5VL_object_t *   vol_obj;
     H5I_type_t        id_type; /* Type of ID */
@@ -574,7 +574,7 @@ H5Gget_info(hid_t loc_id, H5G_info_t *group_info)
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", loc_id, group_info);
+    H5TRACE2("e", "ix", loc_id, group_info);
 
     /* Check args */
     id_type = H5I_get_type(loc_id);
@@ -609,14 +609,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Gget_info_by_name(hid_t loc_id, const char *name, H5G_info_t *group_info, hid_t lapl_id)
+H5Gget_info_by_name(hid_t loc_id, const char *name, H5G_info_t *group_info /*out*/, hid_t lapl_id)
 {
     H5VL_object_t *   vol_obj;
     H5VL_loc_params_t loc_params;
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "i*s*xi", loc_id, name, group_info, lapl_id);
+    H5TRACE4("e", "i*sxi", loc_id, name, group_info, lapl_id);
 
     /* Check args */
     if (!name)
@@ -661,14 +661,14 @@ done:
  */
 herr_t
 H5Gget_info_by_idx(hid_t loc_id, const char *group_name, H5_index_t idx_type, H5_iter_order_t order,
-                   hsize_t n, H5G_info_t *group_info, hid_t lapl_id)
+                   hsize_t n, H5G_info_t *group_info /*out*/, hid_t lapl_id)
 {
     H5VL_object_t *   vol_obj;
     H5VL_loc_params_t loc_params;
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "i*sIiIoh*xi", loc_id, group_name, idx_type, order, n, group_info, lapl_id);
+    H5TRACE7("e", "i*sIiIohxi", loc_id, group_name, idx_type, order, n, group_info, lapl_id);
 
     /* Check args */
     if (!group_name)

--- a/src/H5Gdeprec.c
+++ b/src/H5Gdeprec.c
@@ -724,7 +724,7 @@ done:
  *-------------------------------------------------------------------------
  */
 int
-H5Gget_comment(hid_t loc_id, const char *name, size_t bufsize, char *buf)
+H5Gget_comment(hid_t loc_id, const char *name, size_t bufsize, char *buf /*out*/)
 {
     H5VL_object_t *   vol_obj; /* Object of loc_id */
     H5VL_loc_params_t loc_params;
@@ -732,7 +732,7 @@ H5Gget_comment(hid_t loc_id, const char *name, size_t bufsize, char *buf)
     int               ret_value; /* Return value */
 
     FUNC_ENTER_API(-1)
-    H5TRACE4("Is", "i*sz*s", loc_id, name, bufsize, buf);
+    H5TRACE4("Is", "i*szx", loc_id, name, bufsize, buf);
 
     if (!name || !*name)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, -1, "no name specified")
@@ -800,7 +800,7 @@ H5Giterate(hid_t loc_id, const char *name, int *idx_p, H5G_iterate_t op, void *o
     herr_t             ret_value; /* Return value                     */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*s*Isx*x", loc_id, name, idx_p, op, op_data);
+    H5TRACE5("e", "i*s*IsGi*x", loc_id, name, idx_p, op, op_data);
 
     /* Check args */
     if (!name || !*name)
@@ -858,7 +858,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Gget_num_objs(hid_t loc_id, hsize_t *num_objs)
+H5Gget_num_objs(hid_t loc_id, hsize_t *num_objs /*out*/)
 {
     H5VL_object_t *   vol_obj; /* Object of loc_id */
     H5I_type_t        id_type; /* Type of ID */
@@ -867,7 +867,7 @@ H5Gget_num_objs(hid_t loc_id, hsize_t *num_objs)
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*h", loc_id, num_objs);
+    H5TRACE2("e", "ix", loc_id, num_objs);
 
     /* Check args */
     id_type = H5I_get_type(loc_id);
@@ -1131,14 +1131,14 @@ done:
  *-------------------------------------------------------------------------
  */
 ssize_t
-H5Gget_objname_by_idx(hid_t loc_id, hsize_t idx, char *name, size_t size)
+H5Gget_objname_by_idx(hid_t loc_id, hsize_t idx, char *name /*out*/, size_t size)
 {
     H5VL_object_t *   vol_obj; /* Object of loc_id */
     H5VL_loc_params_t loc_params;
     ssize_t           ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("Zs", "ih*sz", loc_id, idx, name, size);
+    H5TRACE4("Zs", "ihxz", loc_id, idx, name, size);
 
     /* Set up collective metadata if appropriate */
     if (H5CX_set_loc(loc_id) < 0)

--- a/src/H5Gname.c
+++ b/src/H5Gname.c
@@ -87,9 +87,6 @@ static int         H5G__name_replace_cb(void *obj_ptr, hid_t obj_id, void *key);
 /* Package Variables */
 /*********************/
 
-/* Declare extern the PQ free list for the wrapped strings */
-H5FL_BLK_EXTERN(str_buf);
-
 /*****************************/
 /* Library Private Variables */
 /*****************************/
@@ -274,11 +271,6 @@ done:
 static H5RS_str_t *
 H5G__build_fullpath(const char *prefix, const char *name)
 {
-    char *      full_path;        /* Full user path built */
-    size_t      orig_path_len;    /* Original length of the path */
-    size_t      path_len;         /* Length of the path */
-    size_t      name_len;         /* Length of the name */
-    unsigned    need_sep;         /* Flag to indicate if separator is needed */
     H5RS_str_t *ret_value = NULL; /* Return value */
 
     FUNC_ENTER_STATIC
@@ -287,32 +279,12 @@ H5G__build_fullpath(const char *prefix, const char *name)
     HDassert(prefix);
     HDassert(name);
 
-    /* Get the length of the prefix */
-    orig_path_len = path_len = HDstrlen(prefix);
-
-    /* Determine if there is a trailing separator in the name */
-    if (prefix[path_len - 1] == '/')
-        need_sep = 0;
-    else
-        need_sep = 1;
-
-    /* Add in the length needed for the '/' separator and the relative path */
-    name_len = HDstrlen(name);
-    path_len += name_len + need_sep;
-
-    /* Allocate space for the path */
-    if (NULL == (full_path = (char *)H5FL_BLK_MALLOC(str_buf, path_len + 1)))
-        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed")
-
-    /* Build full path */
-    HDstrncpy(full_path, prefix, orig_path_len + 1);
-    if (need_sep)
-        HDstrncat(full_path, "/", (size_t)1);
-    HDstrncat(full_path, name, name_len);
-
-    /* Create reference counted string for path */
-    if (NULL == (ret_value = H5RS_own(full_path)))
-        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed")
+    /* Create full path */
+    if (NULL == (ret_value = H5RS_create(prefix)))
+        HGOTO_ERROR(H5E_SYM, H5E_CANTCREATE, NULL, "can't create ref-counted string")
+    if (prefix[HDstrlen(prefix) - 1] != '/')
+        H5RS_aputc(ret_value, '/'); /* Add separator, if the prefix doesn't end in one */
+    H5RS_acat(ret_value, name);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -640,27 +612,23 @@ H5G__name_move_path(H5RS_str_t **path_r_ptr, const char *full_suffix, const char
     path_len        = HDstrlen(path);
     if (full_suffix_len < path_len) {
         const char *dst_suffix;        /* Destination suffix that changes */
-        size_t      dst_suffix_len;    /* Length of destination suffix */
         const char *src_suffix;        /* Source suffix that changes */
         size_t      path_prefix_len;   /* Length of path prefix */
         const char *path_prefix2;      /* 2nd prefix for path */
         size_t      path_prefix2_len;  /* Length of 2nd path prefix */
-        const char *common_prefix;     /* Common prefix for src & dst paths */
         size_t      common_prefix_len; /* Length of common prefix */
-        char *      new_path;          /* Pointer to new path */
-        size_t      new_path_len;      /* Length of new path */
+        H5RS_str_t *rs;                /* Ref-counted string for new path */
 
-        /* Compute path prefix before full suffix*/
+        /* Compute path prefix before full suffix */
         path_prefix_len = path_len - full_suffix_len;
 
         /* Determine the common prefix for src & dst paths */
-        common_prefix     = src_path;
         common_prefix_len = 0;
         /* Find first character that is different */
         while (*(src_path + common_prefix_len) == *(dst_path + common_prefix_len))
             common_prefix_len++;
         /* Back up to previous '/' */
-        while (*(common_prefix + common_prefix_len) != '/')
+        while (*(src_path + common_prefix_len) != '/')
             common_prefix_len--;
         /* Include '/' */
         common_prefix_len++;
@@ -669,33 +637,28 @@ H5G__name_move_path(H5RS_str_t **path_r_ptr, const char *full_suffix, const char
         src_suffix = src_path + (common_prefix_len - 1);
 
         /* Determine destination suffix */
-        dst_suffix     = dst_path + (common_prefix_len - 1);
-        dst_suffix_len = HDstrlen(dst_suffix);
+        dst_suffix = dst_path + (common_prefix_len - 1);
 
-        /* Compute path prefix before src suffix*/
+        /* Compute path prefix before src suffix */
         path_prefix2     = path;
         path_prefix2_len = path_prefix_len - HDstrlen(src_suffix);
 
-        /* Allocate space for the new path */
-        new_path_len = path_prefix2_len + dst_suffix_len + full_suffix_len;
-        if (NULL == (new_path = (char *)H5FL_BLK_MALLOC(str_buf, new_path_len + 1)))
-            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed")
+        /* Allocate new ref-counted string */
+        if (NULL == (rs = H5RS_create(NULL)))
+            HGOTO_ERROR(H5E_SYM, H5E_CANTCREATE, FAIL, "can't create ref-counted string")
 
         /* Create the new path */
-        if (path_prefix2_len > 0) {
-            HDstrncpy(new_path, path_prefix2, path_prefix2_len + 1);
-            HDstrncpy(new_path + path_prefix2_len, dst_suffix, dst_suffix_len + 1);
-        } /* end if */
-        else
-            HDstrncpy(new_path, dst_suffix, dst_suffix_len + 1);
+        if (path_prefix2_len > 0)
+            H5RS_ancat(rs, path_prefix2, path_prefix2_len);
+        H5RS_acat(rs, dst_suffix);
         if (full_suffix_len > 0)
-            HDstrncat(new_path, full_suffix, full_suffix_len);
+            H5RS_acat(rs, full_suffix);
 
         /* Release previous path */
         H5RS_decr(*path_r_ptr);
 
         /* Take ownership of the new full path */
-        *path_r_ptr = H5RS_own(new_path);
+        *path_r_ptr = rs;
     } /* end if */
 
 done:
@@ -812,33 +775,24 @@ H5G__name_replace_cb(void *obj_ptr, hid_t obj_id, void *key)
         case H5G_NAME_MOUNT:
             /* Check if object is in child mount hier. */
             if (obj_in_child) {
-                const char *full_path;     /* Full path of current object */
-                const char *src_path;      /* Full path of source object */
-                size_t      src_path_len;  /* Length of source full path */
-                char *      new_full_path; /* New full path of object */
-                size_t      new_full_len;  /* Length of new full path */
+                const char *full_path; /* Full path of current object */
+                const char *src_path;  /* Full path of source object */
+                H5RS_str_t *rs;        /* Ref-counted string for new path */
 
                 /* Get pointers to paths of interest */
-                full_path    = H5RS_get_str(obj_path->full_path_r);
-                src_path     = H5RS_get_str(names->src_full_path_r);
-                src_path_len = HDstrlen(src_path);
+                full_path = H5RS_get_str(obj_path->full_path_r);
+                src_path  = H5RS_get_str(names->src_full_path_r);
 
-                /* Build new full path */
-
-                /* Allocate space for the new full path */
-                new_full_len = src_path_len + HDstrlen(full_path);
-                if (NULL == (new_full_path = (char *)H5FL_BLK_MALLOC(str_buf, new_full_len + 1)))
-                    HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed")
-
-                /* Create the new full path */
-                HDstrncpy(new_full_path, src_path, src_path_len + 1);
-                HDstrncat(new_full_path, full_path, new_full_len);
+                /* Create new full path */
+                if (NULL == (rs = H5RS_create(src_path)))
+                    HGOTO_ERROR(H5E_SYM, H5E_CANTCREATE, FAIL, "can't create ref-counted string")
+                H5RS_acat(rs, full_path);
 
                 /* Release previous full path */
                 H5RS_decr(obj_path->full_path_r);
 
                 /* Take ownership of the new full path */
-                obj_path->full_path_r = H5RS_own(new_full_path);
+                obj_path->full_path_r = rs;
             } /* end if */
             /* Object must be in parent mount file hier. */
             else {
@@ -858,36 +812,30 @@ H5G__name_replace_cb(void *obj_ptr, hid_t obj_id, void *key)
          */
         case H5G_NAME_UNMOUNT:
             if (obj_in_child) {
-                const char *full_path;       /* Full path of current object */
-                const char *full_suffix;     /* Full path after source path */
-                size_t      full_suffix_len; /* Length of full path after source path */
-                const char *src_path;        /* Full path of source object */
-                char *      new_full_path;   /* New full path of object */
+                const char *full_path;   /* Full path of current object */
+                const char *full_suffix; /* Full path after source path */
+                const char *src_path;    /* Full path of source object */
+                H5RS_str_t *rs;          /* Ref-counted string for new path */
 
                 /* Get pointers to paths of interest */
                 full_path = H5RS_get_str(obj_path->full_path_r);
                 src_path  = H5RS_get_str(names->src_full_path_r);
 
                 /* Construct full path suffix */
-                full_suffix     = full_path + HDstrlen(src_path);
-                full_suffix_len = HDstrlen(full_suffix);
+                full_suffix = full_path + HDstrlen(src_path);
 
-                /* Build new full path */
-
-                /* Create the new full path */
-                if (NULL == (new_full_path = (char *)H5FL_BLK_MALLOC(str_buf, full_suffix_len + 1)))
-                    HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed")
-                HDstrncpy(new_full_path, full_suffix, full_suffix_len + 1);
+                /* Create new full path suffix */
+                if (NULL == (rs = H5RS_create(full_suffix)))
+                    HGOTO_ERROR(H5E_SYM, H5E_CANTCREATE, FAIL, "can't create ref-counted string")
 
                 /* Release previous full path */
                 H5RS_decr(obj_path->full_path_r);
 
                 /* Take ownership of the new full path */
-                obj_path->full_path_r = H5RS_own(new_full_path);
+                obj_path->full_path_r = rs;
 
                 /* Check if the object's user path should be invalidated */
-                if (obj_path->user_path_r &&
-                    HDstrlen(new_full_path) < (size_t)H5RS_len(obj_path->user_path_r)) {
+                if (obj_path->user_path_r && H5RS_len(rs) < H5RS_len(obj_path->user_path_r)) {
                     /* Free user path */
                     H5RS_decr(obj_path->user_path_r);
                     obj_path->user_path_r = NULL;
@@ -922,53 +870,42 @@ H5G__name_replace_cb(void *obj_ptr, hid_t obj_id, void *key)
         case H5G_NAME_MOVE: /* Link move case, check for relative names case */
             /* Check if the src object moved is in the current object's path */
             if (H5G__common_path(obj_path->full_path_r, names->src_full_path_r)) {
-                const char *full_path;       /* Full path of current object */
-                const char *full_suffix;     /* Suffix of full path, after src_path */
-                size_t      full_suffix_len; /* Length of suffix of full path after src_path*/
-                char *      new_full_path;   /* New full path of object */
-                size_t      new_full_len;    /* Length of new full path */
-                const char *src_path;        /* Full path of source object */
-                const char *dst_path;        /* Full path of destination object */
-                size_t      dst_path_len;    /* Length of destination's full path */
+                const char *full_path;   /* Full path of current object */
+                const char *full_suffix; /* Suffix of full path, after src_path */
+                const char *src_path;    /* Full path of source object */
+                const char *dst_path;    /* Full path of destination object */
+                H5RS_str_t *rs;          /* Ref-counted string for new path */
 
                 /* Sanity check */
                 HDassert(names->dst_full_path_r);
 
                 /* Get pointers to paths of interest */
-                full_path    = H5RS_get_str(obj_path->full_path_r);
-                src_path     = H5RS_get_str(names->src_full_path_r);
-                dst_path     = H5RS_get_str(names->dst_full_path_r);
-                dst_path_len = HDstrlen(dst_path);
+                full_path = H5RS_get_str(obj_path->full_path_r);
+                src_path  = H5RS_get_str(names->src_full_path_r);
+                dst_path  = H5RS_get_str(names->dst_full_path_r);
 
                 /* Make certain that the source and destination names are full (not relative) paths */
                 HDassert(*src_path == '/');
                 HDassert(*dst_path == '/');
 
                 /* Get pointer to "full suffix" */
-                full_suffix     = full_path + HDstrlen(src_path);
-                full_suffix_len = HDstrlen(full_suffix);
+                full_suffix = full_path + HDstrlen(src_path);
 
                 /* Update the user path, if one exists */
                 if (obj_path->user_path_r)
                     if (H5G__name_move_path(&(obj_path->user_path_r), full_suffix, src_path, dst_path) < 0)
                         HGOTO_ERROR(H5E_SYM, H5E_PATH, FAIL, "can't build user path name")
 
-                /* Build new full path */
-
-                /* Allocate space for the new full path */
-                new_full_len = dst_path_len + full_suffix_len;
-                if (NULL == (new_full_path = (char *)H5FL_BLK_MALLOC(str_buf, new_full_len + 1)))
-                    HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed")
-
-                /* Create the new full path */
-                HDstrncpy(new_full_path, dst_path, dst_path_len + 1);
-                HDstrncat(new_full_path, full_suffix, full_suffix_len);
+                /* Create new full path */
+                if (NULL == (rs = H5RS_create(dst_path)))
+                    HGOTO_ERROR(H5E_SYM, H5E_CANTCREATE, FAIL, "can't create ref-counted string")
+                H5RS_acat(rs, full_suffix);
 
                 /* Release previous full path */
                 H5RS_decr(obj_path->full_path_r);
 
                 /* Take ownership of the new full path */
-                obj_path->full_path_r = H5RS_own(new_full_path);
+                obj_path->full_path_r = rs;
             } /* end if */
             break;
 

--- a/src/H5I.c
+++ b/src/H5I.c
@@ -98,7 +98,7 @@ H5Iregister_type(size_t H5_ATTR_DEBUG_API_USED hash_size, unsigned reserved, H5I
     H5I_type_t   ret_value = H5I_BADID; /* Return value */
 
     FUNC_ENTER_API(H5I_BADID)
-    H5TRACE3("It", "zIux", hash_size, reserved, free_func);
+    H5TRACE3("It", "zIuIf", hash_size, reserved, free_func);
 
     /* Generate a new H5I_type_t value */
 
@@ -714,7 +714,7 @@ H5Isearch(H5I_type_t type, H5I_search_func_t func, void *key)
     void *          ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API(NULL)
-    H5TRACE3("*x", "Itx*x", type, func, key);
+    H5TRACE3("*x", "ItIS*x", type, func, key);
 
     /* Check arguments */
     if (H5I_IS_LIB_TYPE(type))
@@ -806,7 +806,7 @@ H5Iiterate(H5I_type_t type, H5I_iterate_func_t op, void *op_data)
     herr_t               ret_value = FAIL; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "Itx*x", type, op, op_data);
+    H5TRACE3("e", "ItII*x", type, op, op_data);
 
     /* Set up udata struct */
     int_udata.op      = op;

--- a/src/H5L.c
+++ b/src/H5L.c
@@ -1078,7 +1078,7 @@ H5Lregister(const H5L_class_t *cls)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE1("e", "*x", cls);
+    H5TRACE1("e", "*#", cls);
 
     /* Check args */
     if (cls == NULL)
@@ -1279,7 +1279,7 @@ H5Literate2(hid_t group_id, H5_index_t idx_type, H5_iter_order_t order, hsize_t 
     herr_t            ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "iIiIo*hx*x", group_id, idx_type, order, idx_p, op, op_data);
+    H5TRACE6("e", "iIiIo*hLI*x", group_id, idx_type, order, idx_p, op, op_data);
 
     /* Check arguments */
     id_type = H5I_get_type(group_id);
@@ -1341,7 +1341,7 @@ H5Literate_by_name2(hid_t loc_id, const char *group_name, H5_index_t idx_type, H
     herr_t            ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "i*sIiIo*hx*xi", loc_id, group_name, idx_type, order, idx_p, op, op_data, lapl_id);
+    H5TRACE8("e", "i*sIiIo*hLI*xi", loc_id, group_name, idx_type, order, idx_p, op, op_data, lapl_id);
 
     /* Check arguments */
     if (!group_name)
@@ -1415,7 +1415,7 @@ H5Lvisit2(hid_t group_id, H5_index_t idx_type, H5_iter_order_t order, H5L_iterat
     herr_t            ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "iIiIox*x", group_id, idx_type, order, op, op_data);
+    H5TRACE5("e", "iIiIoLI*x", group_id, idx_type, order, op, op_data);
 
     /* Check args */
     id_type = H5I_get_type(group_id);
@@ -1482,7 +1482,7 @@ H5Lvisit_by_name2(hid_t loc_id, const char *group_name, H5_index_t idx_type, H5_
     herr_t            ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "i*sIiIox*xi", loc_id, group_name, idx_type, order, op, op_data, lapl_id);
+    H5TRACE7("e", "i*sIiIoLI*xi", loc_id, group_name, idx_type, order, op, op_data, lapl_id);
 
     /* Check args */
     if (!group_name)

--- a/src/H5Ldeprec.c
+++ b/src/H5Ldeprec.c
@@ -149,7 +149,7 @@ H5Literate1(hid_t group_id, H5_index_t idx_type, H5_iter_order_t order, hsize_t 
     herr_t            ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "iIiIo*hx*x", group_id, idx_type, order, idx_p, op, op_data);
+    H5TRACE6("e", "iIiIo*hLi*x", group_id, idx_type, order, idx_p, op, op_data);
 
     /* Check arguments */
     id_type = H5I_get_type(group_id);
@@ -226,7 +226,7 @@ H5Literate_by_name1(hid_t loc_id, const char *group_name, H5_index_t idx_type, H
     herr_t            ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "i*sIiIo*hx*xi", loc_id, group_name, idx_type, order, idx_p, op, op_data, lapl_id);
+    H5TRACE8("e", "i*sIiIo*hLi*xi", loc_id, group_name, idx_type, order, idx_p, op, op_data, lapl_id);
 
     /* Check arguments */
     if (!group_name)
@@ -487,7 +487,7 @@ H5Lvisit1(hid_t group_id, H5_index_t idx_type, H5_iter_order_t order, H5L_iterat
     herr_t            ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "iIiIox*x", group_id, idx_type, order, op, op_data);
+    H5TRACE5("e", "iIiIoLi*x", group_id, idx_type, order, op, op_data);
 
     /* Check args */
     id_type = H5I_get_type(group_id);
@@ -570,7 +570,7 @@ H5Lvisit_by_name1(hid_t loc_id, const char *group_name, H5_index_t idx_type, H5_
     herr_t            ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "i*sIiIox*xi", loc_id, group_name, idx_type, order, op, op_data, lapl_id);
+    H5TRACE7("e", "i*sIiIoLi*xi", loc_id, group_name, idx_type, order, op, op_data, lapl_id);
 
     /* Check args */
     if (!group_name)

--- a/src/H5M.c
+++ b/src/H5M.c
@@ -617,13 +617,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Mget_count(hid_t map_id, hsize_t *count, hid_t dxpl_id)
+H5Mget_count(hid_t map_id, hsize_t *count /*out*/, hid_t dxpl_id)
 {
     H5VL_object_t *vol_obj;             /* Map structure    */
     herr_t         ret_value = SUCCEED; /* Return value         */
 
     FUNC_ENTER_API(H5I_INVALID_HID)
-    H5TRACE3("e", "i*hi", map_id, count, dxpl_id);
+    H5TRACE3("e", "ixi", map_id, count, dxpl_id);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(map_id, H5I_MAP)))
@@ -844,7 +844,7 @@ H5Miterate(hid_t map_id, hsize_t *idx, hid_t key_mem_type_id, H5M_iterate_t op, 
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "i*hix*xi", map_id, idx, key_mem_type_id, op, op_data, dxpl_id);
+    H5TRACE6("e", "i*hiMI*xi", map_id, idx, key_mem_type_id, op, op_data, dxpl_id);
 
     /* Check arguments */
     if (key_mem_type_id < 0)
@@ -918,7 +918,7 @@ H5Miterate_by_name(hid_t loc_id, const char *map_name, hsize_t *idx, hid_t key_m
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "i*s*hix*xii", loc_id, map_name, idx, key_mem_type_id, op, op_data, dxpl_id, lapl_id);
+    H5TRACE8("e", "i*s*hiMI*xii", loc_id, map_name, idx, key_mem_type_id, op, op_data, dxpl_id, lapl_id);
 
     /* Check arguments */
     if (!map_name)

--- a/src/H5O.c
+++ b/src/H5O.c
@@ -522,14 +522,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Oget_info3(hid_t loc_id, H5O_info2_t *oinfo, unsigned fields)
+H5Oget_info3(hid_t loc_id, H5O_info2_t *oinfo /*out*/, unsigned fields)
 {
     H5VL_object_t *   vol_obj; /* Object of loc_id */
     H5VL_loc_params_t loc_params;
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*xIu", loc_id, oinfo, fields);
+    H5TRACE3("e", "ixIu", loc_id, oinfo, fields);
 
     /* Check args */
     if (!oinfo)
@@ -567,14 +567,15 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Oget_info_by_name3(hid_t loc_id, const char *name, H5O_info2_t *oinfo, unsigned fields, hid_t lapl_id)
+H5Oget_info_by_name3(hid_t loc_id, const char *name, H5O_info2_t *oinfo /*out*/, unsigned fields,
+                     hid_t lapl_id)
 {
     H5VL_object_t *   vol_obj; /* Object of loc_id */
     H5VL_loc_params_t loc_params;
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*s*xIui", loc_id, name, oinfo, fields, lapl_id);
+    H5TRACE5("e", "i*sxIui", loc_id, name, oinfo, fields, lapl_id);
 
     /* Check args */
     if (!name)
@@ -625,14 +626,14 @@ done:
  */
 herr_t
 H5Oget_info_by_idx3(hid_t loc_id, const char *group_name, H5_index_t idx_type, H5_iter_order_t order,
-                    hsize_t n, H5O_info2_t *oinfo, unsigned fields, hid_t lapl_id)
+                    hsize_t n, H5O_info2_t *oinfo /*out*/, unsigned fields, hid_t lapl_id)
 {
     H5VL_object_t *   vol_obj; /* Object of loc_id */
     H5VL_loc_params_t loc_params;
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "i*sIiIoh*xIui", loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id);
+    H5TRACE8("e", "i*sIiIohxIui", loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id);
 
     /* Check args */
     if (!group_name || !*group_name)
@@ -684,14 +685,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Oget_native_info(hid_t loc_id, H5O_native_info_t *oinfo, unsigned fields)
+H5Oget_native_info(hid_t loc_id, H5O_native_info_t *oinfo /*out*/, unsigned fields)
 {
     H5VL_object_t *   vol_obj; /* Object of loc_id */
     H5VL_loc_params_t loc_params;
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*xIu", loc_id, oinfo, fields);
+    H5TRACE3("e", "ixIu", loc_id, oinfo, fields);
 
     /* Check args */
     if (!oinfo)
@@ -729,7 +730,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Oget_native_info_by_name(hid_t loc_id, const char *name, H5O_native_info_t *oinfo, unsigned fields,
+H5Oget_native_info_by_name(hid_t loc_id, const char *name, H5O_native_info_t *oinfo /*out*/, unsigned fields,
                            hid_t lapl_id)
 {
     H5VL_object_t *   vol_obj; /* Object of loc_id */
@@ -737,7 +738,7 @@ H5Oget_native_info_by_name(hid_t loc_id, const char *name, H5O_native_info_t *oi
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*s*xIui", loc_id, name, oinfo, fields, lapl_id);
+    H5TRACE5("e", "i*sxIui", loc_id, name, oinfo, fields, lapl_id);
 
     /* Check args */
     if (!name)
@@ -788,14 +789,14 @@ done:
  */
 herr_t
 H5Oget_native_info_by_idx(hid_t loc_id, const char *group_name, H5_index_t idx_type, H5_iter_order_t order,
-                          hsize_t n, H5O_native_info_t *oinfo, unsigned fields, hid_t lapl_id)
+                          hsize_t n, H5O_native_info_t *oinfo /*out*/, unsigned fields, hid_t lapl_id)
 {
     H5VL_object_t *   vol_obj; /* Object of loc_id */
     H5VL_loc_params_t loc_params;
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "i*sIiIoh*xIui", loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id);
+    H5TRACE8("e", "i*sIiIohxIui", loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id);
 
     /* Check args */
     if (!group_name || !*group_name)
@@ -953,14 +954,14 @@ done:
  *-------------------------------------------------------------------------
  */
 ssize_t
-H5Oget_comment(hid_t obj_id, char *comment, size_t bufsize)
+H5Oget_comment(hid_t obj_id, char *comment /*out*/, size_t bufsize)
 {
     H5VL_object_t *   vol_obj; /* Object of loc_id */
     H5VL_loc_params_t loc_params;
     ssize_t           ret_value = -1; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE3("Zs", "i*sz", obj_id, comment, bufsize);
+    H5TRACE3("Zs", "ixz", obj_id, comment, bufsize);
 
     /* Get the object */
     if (NULL == (vol_obj = H5VL_vol_object(obj_id)))
@@ -996,14 +997,14 @@ done:
  *-------------------------------------------------------------------------
  */
 ssize_t
-H5Oget_comment_by_name(hid_t loc_id, const char *name, char *comment, size_t bufsize, hid_t lapl_id)
+H5Oget_comment_by_name(hid_t loc_id, const char *name, char *comment /*out*/, size_t bufsize, hid_t lapl_id)
 {
     H5VL_object_t *   vol_obj; /* Object of loc_id */
     H5VL_loc_params_t loc_params;
     ssize_t           ret_value = -1; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE5("Zs", "i*s*szi", loc_id, name, comment, bufsize, lapl_id);
+    H5TRACE5("Zs", "i*sxzi", loc_id, name, comment, bufsize, lapl_id);
 
     /* Check args */
     if (!name || !*name)
@@ -1076,7 +1077,7 @@ H5Ovisit3(hid_t obj_id, H5_index_t idx_type, H5_iter_order_t order, H5O_iterate2
     herr_t            ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "iIiIox*xIu", obj_id, idx_type, order, op, op_data, fields);
+    H5TRACE6("e", "iIiIoOI*xIu", obj_id, idx_type, order, op, op_data, fields);
 
     /* Check args */
     if (idx_type <= H5_INDEX_UNKNOWN || idx_type >= H5_INDEX_N)
@@ -1150,7 +1151,7 @@ H5Ovisit_by_name3(hid_t loc_id, const char *obj_name, H5_index_t idx_type, H5_it
     herr_t            ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "i*sIiIox*xIui", loc_id, obj_name, idx_type, order, op, op_data, fields, lapl_id);
+    H5TRACE8("e", "i*sIiIoOI*xIui", loc_id, obj_name, idx_type, order, op, op_data, fields, lapl_id);
 
     /* Check args */
     if (!obj_name)

--- a/src/H5Odeprec.c
+++ b/src/H5Odeprec.c
@@ -385,14 +385,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Oget_info1(hid_t loc_id, H5O_info1_t *oinfo)
+H5Oget_info1(hid_t loc_id, H5O_info1_t *oinfo /*out*/)
 {
     H5VL_object_t *   vol_obj = NULL; /* Object of loc_id */
     H5VL_loc_params_t loc_params;
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", loc_id, oinfo);
+    H5TRACE2("e", "ix", loc_id, oinfo);
 
     /* Check args */
     if (!oinfo)
@@ -425,14 +425,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Oget_info_by_name1(hid_t loc_id, const char *name, H5O_info1_t *oinfo, hid_t lapl_id)
+H5Oget_info_by_name1(hid_t loc_id, const char *name, H5O_info1_t *oinfo /*out*/, hid_t lapl_id)
 {
     H5VL_object_t *   vol_obj = NULL; /* object of loc_id */
     H5VL_loc_params_t loc_params;
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "i*s*xi", loc_id, name, oinfo, lapl_id);
+    H5TRACE4("e", "i*sxi", loc_id, name, oinfo, lapl_id);
 
     /* Check args */
     if (!name)
@@ -480,14 +480,14 @@ done:
  */
 herr_t
 H5Oget_info_by_idx1(hid_t loc_id, const char *group_name, H5_index_t idx_type, H5_iter_order_t order,
-                    hsize_t n, H5O_info1_t *oinfo, hid_t lapl_id)
+                    hsize_t n, H5O_info1_t *oinfo /*out*/, hid_t lapl_id)
 {
     H5VL_object_t *   vol_obj = NULL; /* object of loc_id */
     H5VL_loc_params_t loc_params;
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "i*sIiIoh*xi", loc_id, group_name, idx_type, order, n, oinfo, lapl_id);
+    H5TRACE7("e", "i*sIiIohxi", loc_id, group_name, idx_type, order, n, oinfo, lapl_id);
 
     /* Check args */
     if (!group_name || !*group_name)
@@ -538,7 +538,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Oget_info2(hid_t loc_id, H5O_info1_t *oinfo, unsigned fields)
+H5Oget_info2(hid_t loc_id, H5O_info1_t *oinfo /*out*/, unsigned fields)
 {
     H5VL_object_t *   vol_obj; /* Object of loc_id */
     H5VL_loc_params_t loc_params;
@@ -546,7 +546,7 @@ H5Oget_info2(hid_t loc_id, H5O_info1_t *oinfo, unsigned fields)
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*xIu", loc_id, oinfo, fields);
+    H5TRACE3("e", "ixIu", loc_id, oinfo, fields);
 
     /* Check args */
     if (!oinfo)
@@ -593,7 +593,8 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Oget_info_by_name2(hid_t loc_id, const char *name, H5O_info1_t *oinfo, unsigned fields, hid_t lapl_id)
+H5Oget_info_by_name2(hid_t loc_id, const char *name, H5O_info1_t *oinfo /*out*/, unsigned fields,
+                     hid_t lapl_id)
 {
     H5VL_object_t *   vol_obj; /* Object of loc_id */
     H5VL_loc_params_t loc_params;
@@ -601,7 +602,7 @@ H5Oget_info_by_name2(hid_t loc_id, const char *name, H5O_info1_t *oinfo, unsigne
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*s*xIui", loc_id, name, oinfo, fields, lapl_id);
+    H5TRACE5("e", "i*sxIui", loc_id, name, oinfo, fields, lapl_id);
 
     /* Check args */
     if (!name)
@@ -661,7 +662,7 @@ done:
  */
 herr_t
 H5Oget_info_by_idx2(hid_t loc_id, const char *group_name, H5_index_t idx_type, H5_iter_order_t order,
-                    hsize_t n, H5O_info1_t *oinfo, unsigned fields, hid_t lapl_id)
+                    hsize_t n, H5O_info1_t *oinfo /*out*/, unsigned fields, hid_t lapl_id)
 {
     H5VL_object_t *   vol_obj; /* Object of loc_id */
     H5VL_loc_params_t loc_params;
@@ -669,7 +670,7 @@ H5Oget_info_by_idx2(hid_t loc_id, const char *group_name, H5_index_t idx_type, H
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "i*sIiIoh*xIui", loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id);
+    H5TRACE8("e", "i*sIiIohxIui", loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id);
 
     /* Check args */
     if (!group_name || !*group_name)
@@ -756,7 +757,7 @@ H5Ovisit1(hid_t obj_id, H5_index_t idx_type, H5_iter_order_t order, H5O_iterate1
     herr_t               ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "iIiIox*x", obj_id, idx_type, order, op, op_data);
+    H5TRACE5("e", "iIiIoOi*x", obj_id, idx_type, order, op, op_data);
 
     /* Check args */
     if (idx_type <= H5_INDEX_UNKNOWN || idx_type >= H5_INDEX_N)
@@ -831,7 +832,7 @@ H5Ovisit_by_name1(hid_t loc_id, const char *obj_name, H5_index_t idx_type, H5_it
     herr_t               ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "i*sIiIox*xi", loc_id, obj_name, idx_type, order, op, op_data, lapl_id);
+    H5TRACE7("e", "i*sIiIoOi*xi", loc_id, obj_name, idx_type, order, op, op_data, lapl_id);
 
     /* Check args */
     if (!obj_name)
@@ -920,7 +921,7 @@ H5Ovisit2(hid_t obj_id, H5_index_t idx_type, H5_iter_order_t order, H5O_iterate1
     herr_t               ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "iIiIox*xIu", obj_id, idx_type, order, op, op_data, fields);
+    H5TRACE6("e", "iIiIoOi*xIu", obj_id, idx_type, order, op, op_data, fields);
 
     /* Check args */
     if (idx_type <= H5_INDEX_UNKNOWN || idx_type >= H5_INDEX_N)
@@ -1009,7 +1010,7 @@ H5Ovisit_by_name2(hid_t loc_id, const char *obj_name, H5_index_t idx_type, H5_it
     herr_t               ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "i*sIiIox*xIui", loc_id, obj_name, idx_type, order, op, op_data, fields, lapl_id);
+    H5TRACE8("e", "i*sIiIoOi*xIui", loc_id, obj_name, idx_type, order, op, op_data, fields, lapl_id);
 
     /* Check args */
     if (!obj_name)

--- a/src/H5P.c
+++ b/src/H5P.c
@@ -173,7 +173,7 @@ H5Pcreate_class(hid_t parent, const char *name, H5P_cls_create_func_t cls_create
     hid_t           ret_value = H5I_INVALID_HID; /* Return value		   */
 
     FUNC_ENTER_API(H5I_INVALID_HID)
-    H5TRACE8("i", "i*sx*xx*xx*x", parent, name, cls_create, create_data, cls_copy, copy_data, cls_close,
+    H5TRACE8("i", "i*sPc*xPo*xPl*x", parent, name, cls_create, create_data, cls_copy, copy_data, cls_close,
              close_data);
 
     /* Check arguments. */
@@ -414,8 +414,8 @@ H5Pregister2(hid_t cls_id, const char *name, size_t size, void *def_value, H5P_p
     herr_t          ret_value;   /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE11("e", "i*sz*xxxxxxxx", cls_id, name, size, def_value, prp_create, prp_set, prp_get, prp_delete,
-              prp_copy, prp_cmp, prp_close);
+    H5TRACE11("e", "i*sz*xPCPSPGPDPOPMPL", cls_id, name, size, def_value, prp_create, prp_set, prp_get,
+              prp_delete, prp_copy, prp_cmp, prp_close);
 
     /* Check arguments. */
     if (NULL == (pclass = (H5P_genclass_t *)H5I_object_verify(cls_id, H5I_GENPROP_CLS)))
@@ -598,7 +598,7 @@ H5Pinsert2(hid_t plist_id, const char *name, size_t size, void *value, H5P_prp_s
     herr_t          ret_value; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE10("e", "i*sz*xxxxxxx", plist_id, name, size, value, prp_set, prp_get, prp_delete, prp_copy,
+    H5TRACE10("e", "i*sz*xPSPGPDPOPMPL", plist_id, name, size, value, prp_set, prp_get, prp_delete, prp_copy,
               prp_cmp, prp_close);
 
     /* Check arguments. */
@@ -756,14 +756,14 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 herr_t
-H5Pget_size(hid_t id, const char *name, size_t *size)
+H5Pget_size(hid_t id, const char *name, size_t *size /*out*/)
 {
     H5P_genclass_t *pclass;    /* Property class to query */
     H5P_genplist_t *plist;     /* Property list to query */
     herr_t          ret_value; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*s*z", id, name, size);
+    H5TRACE3("e", "i*sx", id, name, size);
 
     /* Check arguments. */
     if (H5I_GENPROP_LST != H5I_get_type(id) && H5I_GENPROP_CLS != H5I_get_type(id))
@@ -961,14 +961,14 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 herr_t
-H5Pget_nprops(hid_t id, size_t *nprops)
+H5Pget_nprops(hid_t id, size_t *nprops /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list to query */
     H5P_genclass_t *pclass;              /* Property class to query */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*z", id, nprops);
+    H5TRACE2("e", "ix", id, nprops);
 
     /* Check arguments. */
     if (H5I_GENPROP_LST != H5I_get_type(id) && H5I_GENPROP_CLS != H5I_get_type(id))
@@ -1199,7 +1199,7 @@ H5Piterate(hid_t id, int *idx, H5P_iterate_t iter_func, void *iter_data)
     int           ret_value;    /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("Is", "i*Isx*x", id, idx, iter_func, iter_data);
+    H5TRACE4("Is", "i*IsPi*x", id, idx, iter_func, iter_data);
 
     /* Check arguments. */
     if (H5I_GENPROP_LST != H5I_get_type(id) && H5I_GENPROP_CLS != H5I_get_type(id))
@@ -1262,13 +1262,13 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 herr_t
-H5Pget(hid_t plist_id, const char *name, void *value)
+H5Pget(hid_t plist_id, const char *name, void *value /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*s*x", plist_id, name, value);
+    H5TRACE3("e", "i*sx", plist_id, name, value);
 
     /* Check arguments. */
     if (NULL == (plist = (H5P_genplist_t *)H5I_object_verify(plist_id, H5I_GENPROP_LST)))

--- a/src/H5PL.c
+++ b/src/H5PL.c
@@ -104,12 +104,12 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5PLget_loading_state(unsigned int *plugin_control_mask)
+H5PLget_loading_state(unsigned *plugin_control_mask /*out*/)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE1("e", "*Iu", plugin_control_mask);
+    H5TRACE1("e", "x", plugin_control_mask);
 
     if (NULL == plugin_control_mask)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "plugin_control_mask parameter cannot be NULL")

--- a/src/H5Pdapl.c
+++ b/src/H5Pdapl.c
@@ -804,14 +804,15 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_chunk_cache(hid_t dapl_id, size_t *rdcc_nslots, size_t *rdcc_nbytes, double *rdcc_w0)
+H5Pget_chunk_cache(hid_t dapl_id, size_t *rdcc_nslots /*out*/, size_t *rdcc_nbytes /*out*/,
+                   double *rdcc_w0 /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     H5P_genplist_t *def_plist;           /* Default file access property list */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "i*z*z*d", dapl_id, rdcc_nslots, rdcc_nbytes, rdcc_w0);
+    H5TRACE4("e", "ixxx", dapl_id, rdcc_nslots, rdcc_nbytes, rdcc_w0);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(dapl_id, H5P_DATASET_ACCESS)))
@@ -1103,13 +1104,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_virtual_view(hid_t plist_id, H5D_vds_view_t *view)
+H5Pget_virtual_view(hid_t plist_id, H5D_vds_view_t *view /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*Dv", plist_id, view);
+    H5TRACE2("e", "ix", plist_id, view);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_ACCESS)))
@@ -1246,13 +1247,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_virtual_printf_gap(hid_t plist_id, hsize_t *gap_size)
+H5Pget_virtual_printf_gap(hid_t plist_id, hsize_t *gap_size /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*h", plist_id, gap_size);
+    H5TRACE2("e", "ix", plist_id, gap_size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_ACCESS)))
@@ -1292,7 +1293,7 @@ H5Pset_append_flush(hid_t plist_id, unsigned ndims, const hsize_t *boundary, H5D
     herr_t             ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "iIu*hx*x", plist_id, ndims, boundary, func, udata);
+    H5TRACE5("e", "iIu*hDA*x", plist_id, ndims, boundary, func, udata);
 
     /* Check arguments */
     if (0 == ndims)
@@ -1345,7 +1346,8 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_append_flush(hid_t plist_id, unsigned ndims, hsize_t boundary[], H5D_append_cb_t *func, void **udata)
+H5Pget_append_flush(hid_t plist_id, unsigned ndims, hsize_t boundary[], H5D_append_cb_t *func /*out*/,
+                    void **udata /*out*/)
 {
     H5P_genplist_t *   plist; /* property list pointer */
     H5D_append_flush_t info;
@@ -1353,7 +1355,7 @@ H5Pget_append_flush(hid_t plist_id, unsigned ndims, hsize_t boundary[], H5D_appe
     herr_t             ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "iIu*h*x**x", plist_id, ndims, boundary, func, udata);
+    H5TRACE5("e", "iIu*hxx", plist_id, ndims, boundary, func, udata);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_ACCESS)))
@@ -1428,7 +1430,7 @@ done:
  *-------------------------------------------------------------------------
  */
 ssize_t
-H5Pget_efile_prefix(hid_t plist_id, char *prefix, size_t size)
+H5Pget_efile_prefix(hid_t plist_id, char *prefix /*out*/, size_t size)
 {
     H5P_genplist_t *plist;     /* Property list pointer */
     char *          my_prefix; /* Library's copy of the prefix */
@@ -1436,7 +1438,7 @@ H5Pget_efile_prefix(hid_t plist_id, char *prefix, size_t size)
     ssize_t         ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("Zs", "i*sz", plist_id, prefix, size);
+    H5TRACE3("Zs", "ixz", plist_id, prefix, size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_ACCESS)))
@@ -1518,7 +1520,7 @@ done:
  *-------------------------------------------------------------------------
  */
 ssize_t
-H5Pget_virtual_prefix(hid_t plist_id, char *prefix, size_t size)
+H5Pget_virtual_prefix(hid_t plist_id, char *prefix /*out*/, size_t size)
 {
     H5P_genplist_t *plist;     /* Property list pointer */
     char *          my_prefix; /* Library's copy of the prefix */
@@ -1526,7 +1528,7 @@ H5Pget_virtual_prefix(hid_t plist_id, char *prefix, size_t size)
     ssize_t         ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("Zs", "i*sz", plist_id, prefix, size);
+    H5TRACE3("Zs", "ixz", plist_id, prefix, size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_ACCESS)))

--- a/src/H5Pdcpl.c
+++ b/src/H5Pdcpl.c
@@ -2773,14 +2773,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_chunk_opts(hid_t plist_id, unsigned *options)
+H5Pget_chunk_opts(hid_t plist_id, unsigned *options /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     H5O_layout_t    layout;              /* Layout information for setting chunk info */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*Iu", plist_id, options);
+    H5TRACE2("e", "ix", plist_id, options);
 
 #ifndef H5_HAVE_C99_DESIGNATED_INITIALIZER
     /* If the compiler doesn't support C99 designated initializers, check if
@@ -3800,14 +3800,14 @@ done:
  *-----------------------------------------------------------------------------
  */
 herr_t
-H5Pget_dset_no_attrs_hint(hid_t dcpl_id, hbool_t *minimize)
+H5Pget_dset_no_attrs_hint(hid_t dcpl_id, hbool_t *minimize /*out*/)
 {
     hbool_t         setting   = FALSE;
     H5P_genplist_t *plist     = NULL;
     herr_t          ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*b", dcpl_id, minimize);
+    H5TRACE2("e", "ix", dcpl_id, minimize);
 
     if (NULL == minimize)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "receiving pointer cannot be NULL")

--- a/src/H5Pdeprec.c
+++ b/src/H5Pdeprec.c
@@ -220,8 +220,8 @@ H5Pregister1(hid_t cls_id, const char *name, size_t size, void *def_value, H5P_p
     herr_t          ret_value;   /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE10("e", "i*sz*xxxxxxx", cls_id, name, size, def_value, prp_create, prp_set, prp_get, prp_delete,
-              prp_copy, prp_close);
+    H5TRACE10("e", "i*sz*xPCPSPGPDPOPL", cls_id, name, size, def_value, prp_create, prp_set, prp_get,
+              prp_delete, prp_copy, prp_close);
 
     /* Check arguments. */
     if (NULL == (pclass = (H5P_genclass_t *)H5I_object_verify(cls_id, H5I_GENPROP_CLS)))
@@ -404,7 +404,7 @@ H5Pinsert1(hid_t plist_id, const char *name, size_t size, void *value, H5P_prp_s
     herr_t          ret_value; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE9("e", "i*sz*xxxxxx", plist_id, name, size, value, prp_set, prp_get, prp_delete, prp_copy,
+    H5TRACE9("e", "i*sz*xPSPGPDPOPL", plist_id, name, size, value, prp_set, prp_get, prp_delete, prp_copy,
              prp_close);
 
     /* Check arguments. */
@@ -545,7 +545,7 @@ H5Pset_file_space(hid_t plist_id, H5F_file_space_type_t strategy, hsize_t thresh
     herr_t                ret_value     = SUCCEED;                      /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "iFfh", plist_id, strategy, threshold);
+    H5TRACE3("e", "iFth", plist_id, strategy, threshold);
 
     if ((unsigned)in_strategy >= H5F_FILE_SPACE_NTYPES)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid strategy")
@@ -606,7 +606,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_file_space(hid_t plist_id, H5F_file_space_type_t *strategy, hsize_t *threshold)
+H5Pget_file_space(hid_t plist_id, H5F_file_space_type_t *strategy /*out*/, hsize_t *threshold /*out*/)
 {
     H5F_fspace_strategy_t new_strategy;        /* File space strategy type */
     hbool_t               new_persist;         /* Persisting free-space or not */
@@ -614,7 +614,7 @@ H5Pget_file_space(hid_t plist_id, H5F_file_space_type_t *strategy, hsize_t *thre
     herr_t                ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*Ff*h", plist_id, strategy, threshold);
+    H5TRACE3("e", "ixx", plist_id, strategy, threshold);
 
     /* Get current file space info */
     if (H5Pget_file_space_strategy(plist_id, &new_strategy, &new_persist, &new_threshold) < 0)

--- a/src/H5Pdxpl.c
+++ b/src/H5Pdxpl.c
@@ -1314,7 +1314,7 @@ H5Pset_filter_callback(hid_t plist_id, H5Z_filter_func_t func, void *op_data)
     H5Z_cb_t        cb_struct;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ix*x", plist_id, func, op_data);
+    H5TRACE3("e", "iZF*x", plist_id, func, op_data);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -1353,7 +1353,7 @@ H5Pset_type_conv_cb(hid_t plist_id, H5T_conv_except_func_t op, void *operate_dat
     H5T_conv_cb_t   cb_struct;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ix*x", plist_id, op, operate_data);
+    H5TRACE3("e", "iTE*x", plist_id, op, operate_data);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -1385,14 +1385,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_type_conv_cb(hid_t plist_id, H5T_conv_except_func_t *op, void **operate_data)
+H5Pget_type_conv_cb(hid_t plist_id, H5T_conv_except_func_t *op /*out*/, void **operate_data /*out*/)
 {
     H5P_genplist_t *plist; /* Property list pointer */
     H5T_conv_cb_t   cb_struct;
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*x**x", plist_id, op, operate_data);
+    H5TRACE3("e", "ixx", plist_id, op, operate_data);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -1577,7 +1577,7 @@ H5Pset_vlen_mem_manager(hid_t plist_id, H5MM_allocate_t alloc_func, void *alloc_
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "ix*xx*x", plist_id, alloc_func, alloc_info, free_func, free_info);
+    H5TRACE5("e", "iMa*xMf*x", plist_id, alloc_func, alloc_info, free_func, free_info);
 
     /* Check arguments */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -1945,13 +1945,14 @@ H5P__dxfr_mpio_chunk_opt_hard_dec(const void **_pp, void *_value)
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_mpio_actual_chunk_opt_mode(hid_t plist_id, H5D_mpio_actual_chunk_opt_mode_t *actual_chunk_opt_mode)
+H5Pget_mpio_actual_chunk_opt_mode(hid_t                             plist_id,
+                                  H5D_mpio_actual_chunk_opt_mode_t *actual_chunk_opt_mode /*out*/)
 {
     H5P_genplist_t *plist;
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*Do", plist_id, actual_chunk_opt_mode);
+    H5TRACE2("e", "ix", plist_id, actual_chunk_opt_mode);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -1980,13 +1981,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_mpio_actual_io_mode(hid_t plist_id, H5D_mpio_actual_io_mode_t *actual_io_mode)
+H5Pget_mpio_actual_io_mode(hid_t plist_id, H5D_mpio_actual_io_mode_t *actual_io_mode /*out*/)
 {
     H5P_genplist_t *plist;
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*Di", plist_id, actual_io_mode);
+    H5TRACE2("e", "ix", plist_id, actual_io_mode);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -2013,14 +2014,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_mpio_no_collective_cause(hid_t plist_id, uint32_t *local_no_collective_cause,
-                                uint32_t *global_no_collective_cause)
+H5Pget_mpio_no_collective_cause(hid_t plist_id, uint32_t *local_no_collective_cause /*out*/,
+                                uint32_t *global_no_collective_cause /*out*/)
 {
     H5P_genplist_t *plist;
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*Iu*Iu", plist_id, local_no_collective_cause, global_no_collective_cause);
+    H5TRACE3("e", "ixx", plist_id, local_no_collective_cause, global_no_collective_cause);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))

--- a/src/H5Pfapl.c
+++ b/src/H5Pfapl.c
@@ -1551,13 +1551,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_family_offset(hid_t fapl_id, hsize_t *offset)
+H5Pget_family_offset(hid_t fapl_id, hsize_t *offset /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*h", fapl_id, offset);
+    H5TRACE2("e", "ix", fapl_id, offset);
 
     /* Get the plist structure */
     if (H5P_DEFAULT == fapl_id)
@@ -1629,13 +1629,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_multi_type(hid_t fapl_id, H5FD_mem_t *type)
+H5Pget_multi_type(hid_t fapl_id, H5FD_mem_t *type /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*Mt", fapl_id, type);
+    H5TRACE2("e", "ix", fapl_id, type);
 
     /* Get the plist structure */
     if (H5P_DEFAULT == fapl_id)
@@ -1723,13 +1723,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_cache(hid_t plist_id, int *mdc_nelmts, size_t *rdcc_nslots, size_t *rdcc_nbytes, double *rdcc_w0)
+H5Pget_cache(hid_t plist_id, int *mdc_nelmts, size_t *rdcc_nslots /*out*/, size_t *rdcc_nbytes /*out*/,
+             double *rdcc_w0 /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*Is*z*z*d", plist_id, mdc_nelmts, rdcc_nslots, rdcc_nbytes, rdcc_w0);
+    H5TRACE5("e", "i*Isxxx", plist_id, mdc_nelmts, rdcc_nslots, rdcc_nbytes, rdcc_w0);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -1775,7 +1776,7 @@ H5Pset_mdc_image_config(hid_t plist_id, H5AC_cache_image_config_t *config_ptr)
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", plist_id, config_ptr);
+    H5TRACE2("e", "i*CC", plist_id, config_ptr);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -1816,13 +1817,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_mdc_image_config(hid_t plist_id, H5AC_cache_image_config_t *config)
+H5Pget_mdc_image_config(hid_t plist_id, H5AC_cache_image_config_t *config /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", plist_id, config);
+    H5TRACE2("e", "ix", plist_id, config);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -1867,7 +1868,7 @@ H5Pset_mdc_config(hid_t plist_id, H5AC_cache_config_t *config_ptr)
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", plist_id, config_ptr);
+    H5TRACE2("e", "i*Cc", plist_id, config_ptr);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -1908,13 +1909,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_mdc_config(hid_t plist_id, H5AC_cache_config_t *config)
+H5Pget_mdc_config(hid_t plist_id, H5AC_cache_config_t *config /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", plist_id, config);
+    H5TRACE2("e", "ix", plist_id, config);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -2065,13 +2066,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_fclose_degree(hid_t plist_id, H5F_close_degree_t *degree)
+H5Pget_fclose_degree(hid_t plist_id, H5F_close_degree_t *degree /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*Fd", plist_id, degree);
+    H5TRACE2("e", "ix", plist_id, degree);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -2553,13 +2554,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_elink_file_cache_size(hid_t plist_id, unsigned *efc_size)
+H5Pget_elink_file_cache_size(hid_t plist_id, unsigned *efc_size /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*Iu", plist_id, efc_size);
+    H5TRACE2("e", "ix", plist_id, efc_size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -2685,14 +2686,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_file_image(hid_t fapl_id, void **buf, size_t *buf_len)
+H5Pget_file_image(hid_t fapl_id, void **buf /*out*/, size_t *buf_len /*out*/)
 {
     H5P_genplist_t *       fapl;                /* Property list pointer */
     H5FD_file_image_info_t image_info;          /* File image info */
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i**x*z", fapl_id, buf, buf_len);
+    H5TRACE3("e", "ixx", fapl_id, buf, buf_len);
 
     /* Get the plist structure */
     if (NULL == (fapl = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
@@ -2767,7 +2768,7 @@ H5Pset_file_image_callbacks(hid_t fapl_id, H5FD_file_image_callbacks_t *callback
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", fapl_id, callbacks_ptr);
+    H5TRACE2("e", "i*DI", fapl_id, callbacks_ptr);
 
     /* Get the plist structure */
     if (NULL == (fapl = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
@@ -2836,14 +2837,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_file_image_callbacks(hid_t fapl_id, H5FD_file_image_callbacks_t *callbacks)
+H5Pget_file_image_callbacks(hid_t fapl_id, H5FD_file_image_callbacks_t *callbacks /*out*/)
 {
     H5P_genplist_t *       fapl;                /* Property list pointer */
     H5FD_file_image_info_t info;                /* File image info */
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*x", fapl_id, callbacks);
+    H5TRACE2("e", "ix", fapl_id, callbacks);
 
     /* Get the plist structure */
     if (NULL == (fapl = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
@@ -4144,7 +4145,7 @@ H5Pset_object_flush_cb(hid_t plist_id, H5F_flush_cb_t func, void *udata)
     herr_t             ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ix*x", plist_id, func, udata);
+    H5TRACE3("e", "iFF*x", plist_id, func, udata);
 
     /* Check if the callback function is NULL and the user data is non-NULL.
      * This is almost certainly an error as the user data will not be used. */
@@ -4180,14 +4181,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_object_flush_cb(hid_t plist_id, H5F_flush_cb_t *func, void **udata)
+H5Pget_object_flush_cb(hid_t plist_id, H5F_flush_cb_t *func /*out*/, void **udata /*out*/)
 {
     H5P_genplist_t *   plist; /* Property list pointer */
     H5F_object_flush_t flush_info;
     herr_t             ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*x**x", plist_id, func, udata);
+    H5TRACE3("e", "ixx", plist_id, func, udata);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -4267,15 +4268,15 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_mdc_log_options(hid_t plist_id, hbool_t *is_enabled, char *location, size_t *location_size,
-                       hbool_t *start_on_access)
+H5Pget_mdc_log_options(hid_t plist_id, hbool_t *is_enabled /*out*/, char *location /*out*/,
+                       size_t *location_size /*out*/, hbool_t *start_on_access /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     char *          location_ptr;        /* Pointer to location string */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*b*s*z*b", plist_id, is_enabled, location, location_size, start_on_access);
+    H5TRACE5("e", "ixxxx", plist_id, is_enabled, location, location_size, start_on_access);
 
     /* Get the property list structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -4578,13 +4579,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_evict_on_close(hid_t fapl_id, hbool_t *evict_on_close)
+H5Pget_evict_on_close(hid_t fapl_id, hbool_t *evict_on_close /*out*/)
 {
     H5P_genplist_t *plist;               /* property list pointer */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*b", fapl_id, evict_on_close);
+    H5TRACE2("e", "ix", fapl_id, evict_on_close);
 
     /* Compare the property list's class against the other class */
     if (TRUE != H5P_isa_class(fapl_id, H5P_FILE_ACCESS))
@@ -4665,13 +4666,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_file_locking(hid_t fapl_id, hbool_t *use_file_locking, hbool_t *ignore_when_disabled)
+H5Pget_file_locking(hid_t fapl_id, hbool_t *use_file_locking /*out*/, hbool_t *ignore_when_disabled /*out*/)
 {
     H5P_genplist_t *plist;               /* property list pointer */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*b*b", fapl_id, use_file_locking, ignore_when_disabled);
+    H5TRACE3("e", "ixx", fapl_id, use_file_locking, ignore_when_disabled);
 
     /* Make sure this is a fapl */
     if (TRUE != H5P_isa_class(fapl_id, H5P_FILE_ACCESS))
@@ -4839,12 +4840,12 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_all_coll_metadata_ops(hid_t plist_id, hbool_t *is_collective)
+H5Pget_all_coll_metadata_ops(hid_t plist_id, hbool_t *is_collective /*out*/)
 {
     herr_t ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*b", plist_id, is_collective);
+    H5TRACE2("e", "ix", plist_id, is_collective);
 
     /* Compare the property list's class against the other class */
     /* (Dataset, group, attribute, and named datype  access property lists
@@ -4928,13 +4929,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_mpi_params(hid_t plist_id, MPI_Comm *comm, MPI_Info *info)
+H5Pget_mpi_params(hid_t plist_id, MPI_Comm *comm /*out*/, MPI_Info *info /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*Mc*Mi", plist_id, comm, info);
+    H5TRACE3("e", "ixx", plist_id, comm, info);
 
     /* Make sure that the property list is a fapl */
     if (TRUE != H5P_isa_class(plist_id, H5P_FILE_ACCESS))
@@ -5378,13 +5379,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_coll_metadata_write(hid_t plist_id, hbool_t *is_collective)
+H5Pget_coll_metadata_write(hid_t plist_id, hbool_t *is_collective /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*b", plist_id, is_collective);
+    H5TRACE2("e", "ix", plist_id, is_collective);
 
     /* Compare the property list's class against the other class */
     if (TRUE != H5P_isa_class(plist_id, H5P_FILE_ACCESS))
@@ -5465,13 +5466,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_page_buffer_size(hid_t plist_id, size_t *buf_size, unsigned *min_meta_perc, unsigned *min_raw_perc)
+H5Pget_page_buffer_size(hid_t plist_id, size_t *buf_size /*out*/, unsigned *min_meta_perc /*out*/,
+                        unsigned *min_raw_perc /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "i*z*Iu*Iu", plist_id, buf_size, min_meta_perc, min_raw_perc);
+    H5TRACE4("e", "ixxx", plist_id, buf_size, min_meta_perc, min_raw_perc);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -5615,13 +5617,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_vol_id(hid_t plist_id, hid_t *vol_id)
+H5Pget_vol_id(hid_t plist_id, hid_t *vol_id /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*i", plist_id, vol_id);
+    H5TRACE2("e", "ix", plist_id, vol_id);
 
     /* Get property list for ID */
     if (NULL == (plist = (H5P_genplist_t *)H5I_object_verify(plist_id, H5I_GENPROP_LST)))
@@ -5661,13 +5663,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_vol_info(hid_t plist_id, void **vol_info)
+H5Pget_vol_info(hid_t plist_id, void **vol_info /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i**x", plist_id, vol_info);
+    H5TRACE2("e", "ix", plist_id, vol_info);
 
     /* Get property list for ID */
     if (NULL == (plist = (H5P_genplist_t *)H5I_object_verify(plist_id, H5I_GENPROP_LST)))

--- a/src/H5Pfcpl.c
+++ b/src/H5Pfcpl.c
@@ -366,13 +366,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_userblock(hid_t plist_id, hsize_t *size)
+H5Pget_userblock(hid_t plist_id, hsize_t *size /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*h", plist_id, size);
+    H5TRACE2("e", "ix", plist_id, size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))
@@ -458,13 +458,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_sizes(hid_t plist_id, size_t *sizeof_addr, size_t *sizeof_size)
+H5Pget_sizes(hid_t plist_id, size_t *sizeof_addr /*out*/, size_t *sizeof_size /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*z*z", plist_id, sizeof_addr, sizeof_size);
+    H5TRACE3("e", "ixx", plist_id, sizeof_addr, sizeof_size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))
@@ -825,13 +825,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_shared_mesg_nindexes(hid_t plist_id, unsigned *nindexes)
+H5Pget_shared_mesg_nindexes(hid_t plist_id, unsigned *nindexes /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*Iu", plist_id, nindexes);
+    H5TRACE2("e", "ix", plist_id, nindexes);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))
@@ -924,8 +924,8 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_shared_mesg_index(hid_t plist_id, unsigned index_num, unsigned *mesg_type_flags,
-                         unsigned *min_mesg_size)
+H5Pget_shared_mesg_index(hid_t plist_id, unsigned index_num, unsigned *mesg_type_flags /*out*/,
+                         unsigned *min_mesg_size /*out*/)
 {
     H5P_genplist_t *plist;                               /* Property list pointer */
     unsigned        nindexes;                            /* Number of SOHM indexes */
@@ -934,7 +934,7 @@ H5Pget_shared_mesg_index(hid_t plist_id, unsigned index_num, unsigned *mesg_type
     herr_t          ret_value = SUCCEED;                 /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "iIu*Iu*Iu", plist_id, index_num, mesg_type_flags, min_mesg_size);
+    H5TRACE4("e", "iIuxx", plist_id, index_num, mesg_type_flags, min_mesg_size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))
@@ -1219,13 +1219,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_shared_mesg_phase_change(hid_t plist_id, unsigned *max_list, unsigned *min_btree)
+H5Pget_shared_mesg_phase_change(hid_t plist_id, unsigned *max_list /*out*/, unsigned *min_btree /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*Iu*Iu", plist_id, max_list, min_btree);
+    H5TRACE3("e", "ixx", plist_id, max_list, min_btree);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))
@@ -1304,14 +1304,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_file_space_strategy(hid_t plist_id, H5F_fspace_strategy_t *strategy, hbool_t *persist,
-                           hsize_t *threshold)
+H5Pget_file_space_strategy(hid_t plist_id, H5F_fspace_strategy_t *strategy /*out*/, hbool_t *persist /*out*/,
+                           hsize_t *threshold /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "i*Ff*b*h", plist_id, strategy, persist, threshold);
+    H5TRACE4("e", "ixxx", plist_id, strategy, persist, threshold);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))
@@ -1455,13 +1455,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_file_space_page_size(hid_t plist_id, hsize_t *fsp_size)
+H5Pget_file_space_page_size(hid_t plist_id, hsize_t *fsp_size /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*h", plist_id, fsp_size);
+    H5TRACE2("e", "ix", plist_id, fsp_size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))

--- a/src/H5Plapl.c
+++ b/src/H5Plapl.c
@@ -946,13 +946,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_nlinks(hid_t plist_id, size_t *nlinks)
+H5Pget_nlinks(hid_t plist_id, size_t *nlinks /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*z", plist_id, nlinks);
+    H5TRACE2("e", "ix", plist_id, nlinks);
 
     if (!nlinks)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid pointer passed in");
@@ -1021,7 +1021,7 @@ done:
  *-------------------------------------------------------------------------
  */
 ssize_t
-H5Pget_elink_prefix(hid_t plist_id, char *prefix, size_t size)
+H5Pget_elink_prefix(hid_t plist_id, char *prefix /*out*/, size_t size)
 {
     H5P_genplist_t *plist;     /* Property list pointer */
     char *          my_prefix; /* Library's copy of the prefix */
@@ -1029,7 +1029,7 @@ H5Pget_elink_prefix(hid_t plist_id, char *prefix, size_t size)
     ssize_t         ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("Zs", "i*sz", plist_id, prefix, size);
+    H5TRACE3("Zs", "ixz", plist_id, prefix, size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_LINK_ACCESS)))
@@ -1180,13 +1180,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_elink_acc_flags(hid_t lapl_id, unsigned *flags)
+H5Pget_elink_acc_flags(hid_t lapl_id, unsigned *flags /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*Iu", lapl_id, flags);
+    H5TRACE2("e", "ix", lapl_id, flags);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(lapl_id, H5P_LINK_ACCESS)))
@@ -1223,7 +1223,7 @@ H5Pset_elink_cb(hid_t lapl_id, H5L_elink_traverse_t func, void *op_data)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ix*x", lapl_id, func, op_data);
+    H5TRACE3("e", "iLt*x", lapl_id, func, op_data);
 
     /* Check if the callback function is NULL and the user data is non-NULL.
      * This is almost certainly an error as the user data will not be used. */
@@ -1260,14 +1260,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_elink_cb(hid_t lapl_id, H5L_elink_traverse_t *func, void **op_data)
+H5Pget_elink_cb(hid_t lapl_id, H5L_elink_traverse_t *func /*out*/, void **op_data /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     H5L_elink_cb_t  cb_info;             /* Callback info struct */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*x**x", lapl_id, func, op_data);
+    H5TRACE3("e", "ixx", lapl_id, func, op_data);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(lapl_id, H5P_LINK_ACCESS)))

--- a/src/H5Pmapl.c
+++ b/src/H5Pmapl.c
@@ -182,13 +182,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_map_iterate_hints(hid_t mapl_id, size_t *key_prefetch_size, size_t *key_alloc_size)
+H5Pget_map_iterate_hints(hid_t mapl_id, size_t *key_prefetch_size /*out*/, size_t *key_alloc_size /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*z*z", mapl_id, key_prefetch_size, key_alloc_size);
+    H5TRACE3("e", "ixx", mapl_id, key_prefetch_size, key_alloc_size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(mapl_id, H5P_MAP_ACCESS)))

--- a/src/H5Pocpl.c
+++ b/src/H5Pocpl.c
@@ -251,13 +251,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_attr_phase_change(hid_t plist_id, unsigned *max_compact, unsigned *min_dense)
+H5Pget_attr_phase_change(hid_t plist_id, unsigned *max_compact /*out*/, unsigned *min_dense /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*Iu*Iu", plist_id, max_compact, min_dense);
+    H5TRACE3("e", "ixx", plist_id, max_compact, min_dense);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_OBJECT_CREATE)))
@@ -342,12 +342,12 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_attr_creation_order(hid_t plist_id, unsigned *crt_order_flags)
+H5Pget_attr_creation_order(hid_t plist_id, unsigned *crt_order_flags /*out*/)
 {
     herr_t ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*Iu", plist_id, crt_order_flags);
+    H5TRACE2("e", "ix", plist_id, crt_order_flags);
 
     /* Get values */
     if (crt_order_flags) {
@@ -445,12 +445,12 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_obj_track_times(hid_t plist_id, hbool_t *track_times)
+H5Pget_obj_track_times(hid_t plist_id, hbool_t *track_times /*out*/)
 {
     herr_t ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*b", plist_id, track_times);
+    H5TRACE2("e", "ix", plist_id, track_times);
 
     /* Get values */
     if (track_times) {
@@ -931,13 +931,13 @@ done:
 herr_t
 H5Pget_filter_by_id2(hid_t plist_id, H5Z_filter_t id, unsigned int *flags /*out*/,
                      size_t *cd_nelmts /*in_out*/, unsigned cd_values[] /*out*/, size_t namelen,
-                     char name[] /*out*/, unsigned *filter_config)
+                     char name[] /*out*/, unsigned *filter_config /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "iZfx*zxzx*Iu", plist_id, id, flags, cd_nelmts, cd_values, namelen, name, filter_config);
+    H5TRACE8("e", "iZfx*zxzxx", plist_id, id, flags, cd_nelmts, cd_values, namelen, name, filter_config);
 
     /* Check args */
     if (cd_nelmts || cd_values) {

--- a/src/H5Pocpypl.c
+++ b/src/H5Pocpypl.c
@@ -837,7 +837,7 @@ H5Pset_mcdt_search_cb(hid_t plist_id, H5O_mcdt_search_cb_t func, void *op_data)
     herr_t             ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ix*x", plist_id, func, op_data);
+    H5TRACE3("e", "iOs*x", plist_id, func, op_data);
 
     /* Check if the callback function is NULL and the user data is non-NULL.
      * This is almost certainly an error as the user data will not be used. */
@@ -878,14 +878,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_mcdt_search_cb(hid_t plist_id, H5O_mcdt_search_cb_t *func, void **op_data)
+H5Pget_mcdt_search_cb(hid_t plist_id, H5O_mcdt_search_cb_t *func /*out*/, void **op_data /*out*/)
 {
     H5P_genplist_t *   plist;               /* Property list pointer */
     H5O_mcdt_cb_info_t cb_info;             /* Callback info struct */
     herr_t             ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*x**x", plist_id, func, op_data);
+    H5TRACE3("e", "ixx", plist_id, func, op_data);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_OBJECT_COPY)))

--- a/src/H5R.c
+++ b/src/H5R.c
@@ -724,7 +724,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Rget_obj_type3(H5R_ref_t *ref_ptr, hid_t rapl_id, H5O_type_t *obj_type)
+H5Rget_obj_type3(H5R_ref_t *ref_ptr, hid_t rapl_id, H5O_type_t *obj_type /*out*/)
 {
     hid_t             loc_id;              /* Reference location ID */
     H5VL_object_t *   vol_obj = NULL;      /* Object of loc_id */
@@ -733,7 +733,7 @@ H5Rget_obj_type3(H5R_ref_t *ref_ptr, hid_t rapl_id, H5O_type_t *obj_type)
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "*Rri*Ot", ref_ptr, rapl_id, obj_type);
+    H5TRACE3("e", "*Rrix", ref_ptr, rapl_id, obj_type);
 
     /* Check args */
     if (ref_ptr == NULL)
@@ -784,13 +784,13 @@ done:
  *-------------------------------------------------------------------------
  */
 ssize_t
-H5Rget_file_name(const H5R_ref_t *ref_ptr, char *buf, size_t size)
+H5Rget_file_name(const H5R_ref_t *ref_ptr, char *buf /*out*/, size_t size)
 {
     hid_t   loc_id;    /* Reference location ID */
     ssize_t ret_value; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE3("Zs", "*Rr*sz", ref_ptr, buf, size);
+    H5TRACE3("Zs", "*Rrxz", ref_ptr, buf, size);
 
     /* Check args */
     if (ref_ptr == NULL)
@@ -833,7 +833,7 @@ done:
  *-------------------------------------------------------------------------
  */
 ssize_t
-H5Rget_obj_name(H5R_ref_t *ref_ptr, hid_t rapl_id, char *buf, size_t size)
+H5Rget_obj_name(H5R_ref_t *ref_ptr, hid_t rapl_id, char *buf /*out*/, size_t size)
 {
     hid_t             loc_id;          /* Reference location ID */
     H5VL_object_t *   vol_obj = NULL;  /* Object of loc_id */
@@ -842,7 +842,7 @@ H5Rget_obj_name(H5R_ref_t *ref_ptr, hid_t rapl_id, char *buf, size_t size)
     ssize_t           ret_value = 0;   /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE4("Zs", "*Rri*sz", ref_ptr, rapl_id, buf, size);
+    H5TRACE4("Zs", "*Rrixz", ref_ptr, rapl_id, buf, size);
 
     /* Check args */
     if (ref_ptr == NULL)
@@ -892,12 +892,12 @@ done:
  *-------------------------------------------------------------------------
  */
 ssize_t
-H5Rget_attr_name(const H5R_ref_t *ref_ptr, char *buf, size_t size)
+H5Rget_attr_name(const H5R_ref_t *ref_ptr, char *buf /*out*/, size_t size)
 {
     ssize_t ret_value; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE3("Zs", "*Rr*sz", ref_ptr, buf, size);
+    H5TRACE3("Zs", "*Rrxz", ref_ptr, buf, size);
 
     /* Check args */
     if (ref_ptr == NULL)

--- a/src/H5RS.c
+++ b/src/H5RS.c
@@ -349,7 +349,7 @@ done:
  *      format_templ in the code below, but early (4.4.7, at least) gcc only
  *      allows diagnostic pragmas to be toggled outside of functions.
  */
-H5_GCC_DIAG_OFF(format - nonliteral)
+H5_GCC_DIAG_OFF("format-nonliteral")
 H5_ATTR_FORMAT(printf, 2, 3)
 herr_t
 H5RS_asprintf_cat(H5RS_str_t *rs, const char *fmt, ...)
@@ -392,7 +392,7 @@ H5RS_asprintf_cat(H5RS_str_t *rs, const char *fmt, ...)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5RS_asprintf_cat() */
-H5_GCC_DIAG_ON(format - nonliteral)
+H5_GCC_DIAG_ON("format-nonliteral")
 
 /*-------------------------------------------------------------------------
  * Function:    H5RS_acat

--- a/src/H5RS.c
+++ b/src/H5RS.c
@@ -15,8 +15,15 @@
  * Reference counted string algorithms.
  *
  * These are used for various internal strings which get copied multiple times.
+ * They also efficiently handle dynamically allocations and appends.
  *
  */
+
+/****************/
+/* Module Setup */
+/****************/
+
+#include "H5RSmodule.h" /* This source code file is part of the H5RS module */
 
 /***********/
 /* Headers */
@@ -30,6 +37,9 @@
 /* Local Macros */
 /****************/
 
+/* Initial buffer size to allocate */
+#define H5RS_ALLOC_SIZE 256
+
 /******************/
 /* Local Typedefs */
 /******************/
@@ -37,7 +47,10 @@
 /* Private typedefs & structs */
 struct H5RS_str_t {
     char *   s;       /* String to be reference counted */
-    unsigned wrapped; /* Indicates that the string to be ref-counted is not copied */
+    char *   end;     /* Pointer to terminating NUL character at the end of the string */
+    size_t   len;     /* Current length of the string */
+    size_t   max;     /* Size of allocated buffer */
+    hbool_t  wrapped; /* Indicates that the string to be ref-counted is not copied */
     unsigned n;       /* Reference count of number of pointers sharing string */
 };
 
@@ -48,9 +61,16 @@ struct H5RS_str_t {
 /********************/
 /* Local Prototypes */
 /********************/
+static herr_t H5RS__xstrdup(H5RS_str_t *rs, const char *s);
+static herr_t H5RS__prepare_for_append(H5RS_str_t *rs);
+static herr_t H5RS__resize_for_append(H5RS_str_t *rs, size_t len);
+
 /*********************/
 /* Package Variables */
 /*********************/
+
+/* Package initialization variable */
+hbool_t H5_PKG_INIT_VAR = FALSE;
 
 /*****************************/
 /* Library Private Variables */
@@ -64,7 +84,7 @@ struct H5RS_str_t {
 H5FL_DEFINE_STATIC(H5RS_str_t);
 
 /* Declare the PQ free list for the wrapped strings */
-H5FL_BLK_DEFINE(str_buf);
+H5FL_BLK_DEFINE_STATIC(str_buf);
 
 /*--------------------------------------------------------------------------
  NAME
@@ -72,11 +92,12 @@ H5FL_BLK_DEFINE(str_buf);
  PURPOSE
     Duplicate the string being reference counted
  USAGE
-    char *H5RS__xstrdup(s)
+    herr_t H5RS__xstrdup(rs, s)
+        H5RS_str_t *rs;         IN/OUT: Ref-counted string to hold duplicated string
         const char *s;          IN: String to duplicate
 
  RETURNS
-    Returns a pointer to a new string on success, NULL on failure.
+    Non-negative on success/Negative on failure
  DESCRIPTION
     Duplicate a string buffer being reference counted.  Use this instead of
     [H5MM_][x]strdup, in order to use the free-list memory routines.
@@ -85,25 +106,145 @@ H5FL_BLK_DEFINE(str_buf);
  EXAMPLES
  REVISION LOG
 --------------------------------------------------------------------------*/
-static char *
-H5RS__xstrdup(const char *s)
+static herr_t
+H5RS__xstrdup(H5RS_str_t *rs, const char *s)
 {
-    char *ret_value; /* Return value */
+    herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_STATIC
+
+    /* Sanity check */
+    HDassert(rs);
 
     if (s) {
-        size_t len = HDstrlen(s) + 1;
+        size_t len = HDstrlen(s);
 
-        ret_value = (char *)H5FL_BLK_MALLOC(str_buf, len);
-        HDassert(ret_value);
-        HDstrncpy(ret_value, s, len);
+        /* Determine size of buffer to allocate */
+        rs->max = H5RS_ALLOC_SIZE;
+        while ((len + 1) > rs->max)
+            rs->max *= 2;
+
+        /* Allocate the underlying string */
+        if (NULL == (rs->s = (char *)H5FL_BLK_MALLOC(str_buf, rs->max)))
+            HGOTO_ERROR(H5E_RS, H5E_CANTALLOC, FAIL, "memory allocation failed")
+        if (len)
+            HDmemcpy(rs->s, s, len);
+        rs->end  = rs->s + len;
+        *rs->end = '\0';
+        rs->len  = len;
     } /* end if */
-    else
-        ret_value = NULL;
+    else {
+        /* Free previous string, if one */
+        if (rs->s) {
+            H5FL_BLK_FREE(str_buf, rs->s);
+            rs->s = rs->end = NULL;
+            rs->max = rs->len = 0;
+        } /* end if */
+        else {
+            /* Sanity checks */
+            HDassert(NULL == rs->end);
+            HDassert(0 == rs->max);
+            HDassert(0 == rs->len);
+        } /* end else */
+    }     /* end else */
 
+done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5RS__xstrdup() */
+
+/*--------------------------------------------------------------------------
+ NAME
+    H5RS__prepare_for_append
+ PURPOSE
+    Prepare a ref-counted string for an append
+ USAGE
+    herr_t H5RS__prepare_for_append(rs)
+        H5RS_str_t *rs;         IN/OUT: Ref-counted string to hold duplicated string
+ RETURNS
+    Non-negative on success/Negative on failure
+ DESCRIPTION
+    Allocate space for a string, or duplicate a wrapped string, in preparation
+    for appending another string.
+ GLOBAL VARIABLES
+ COMMENTS, BUGS, ASSUMPTIONS
+ EXAMPLES
+ REVISION LOG
+--------------------------------------------------------------------------*/
+static herr_t
+H5RS__prepare_for_append(H5RS_str_t *rs)
+{
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_STATIC
+
+    /* Sanity check */
+    HDassert(rs);
+
+    if (NULL == rs->s) {
+        rs->max = H5RS_ALLOC_SIZE;
+        if (NULL == (rs->s = (char *)H5FL_BLK_MALLOC(str_buf, rs->max)))
+            HGOTO_ERROR(H5E_RS, H5E_CANTALLOC, FAIL, "memory allocation failed")
+        rs->end = rs->s;
+        *rs->s  = '\0';
+        rs->len = 0;
+    } /* end if */
+    else {
+        /* If the ref-counted string started life as a wrapper around an
+         * existing string, duplicate the string now, so we can modify it.
+         */
+        if (rs->wrapped) {
+            if (H5RS__xstrdup(rs, rs->s) < 0)
+                HGOTO_ERROR(H5E_RS, H5E_CANTCOPY, FAIL, "can't copy string")
+            rs->wrapped = FALSE;
+        } /* end if */
+    }     /* end else */
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5RS__prepare_for_append() */
+
+/*--------------------------------------------------------------------------
+ NAME
+    H5RS__resize_for_append
+ PURPOSE
+    Resize ref-counted string buffer to accommodate appending another string
+ USAGE
+    herr_t H5RS__resize_for_append(rs, len)
+        H5RS_str_t *rs;         IN/OUT: Ref-counted string to hold duplicated string
+        size_t len;             IN: Additional length to accommodate
+ RETURNS
+    Non-negative on success/Negative on failure
+ DESCRIPTION
+    Resize a ref-counted string buffer to be large enough to accommodate
+    another string of a specified length.
+ GLOBAL VARIABLES
+ COMMENTS, BUGS, ASSUMPTIONS
+ EXAMPLES
+ REVISION LOG
+--------------------------------------------------------------------------*/
+static herr_t
+H5RS__resize_for_append(H5RS_str_t *rs, size_t len)
+{
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_STATIC
+
+    /* Sanity check */
+    HDassert(rs);
+
+    /* Check if buffer should be re-allocated */
+    if (len >= (rs->max - rs->len)) {
+        /* Allocate a large enough buffer */
+        while (len >= (rs->max - rs->len))
+            rs->max *= 2;
+        if (NULL == (rs->s = (char *)H5FL_BLK_REALLOC(str_buf, rs->s, rs->max)))
+            HGOTO_ERROR(H5E_RS, H5E_CANTALLOC, FAIL, "memory allocation failed")
+        rs->end = rs->s + rs->len;
+    } /* end if */
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5RS__resize() */
 
 /*--------------------------------------------------------------------------
  NAME
@@ -127,18 +268,19 @@ H5RS__xstrdup(const char *s)
 H5RS_str_t *
 H5RS_create(const char *s)
 {
-    H5RS_str_t *ret_value; /* Return value */
+    H5RS_str_t *ret_value = NULL; /* Return value */
 
     FUNC_ENTER_NOAPI(NULL)
 
     /* Allocate ref-counted string structure */
-    if (NULL == (ret_value = H5FL_MALLOC(H5RS_str_t)))
-        HGOTO_ERROR(H5E_RS, H5E_NOSPACE, NULL, "memory allocation failed")
+    if (NULL == (ret_value = H5FL_CALLOC(H5RS_str_t)))
+        HGOTO_ERROR(H5E_RS, H5E_CANTALLOC, NULL, "memory allocation failed")
 
     /* Set the internal fields */
-    ret_value->s       = H5RS__xstrdup(s);
-    ret_value->wrapped = 0;
-    ret_value->n       = 1;
+    if (s)
+        if (H5RS__xstrdup(ret_value, s) < 0)
+            HGOTO_ERROR(H5E_RS, H5E_CANTCOPY, NULL, "can't copy string")
+    ret_value->n = 1;
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -175,54 +317,224 @@ H5RS_wrap(const char *s)
         HGOTO_ERROR(H5E_RS, H5E_CANTALLOC, NULL, "memory allocation failed")
 
     /* Set the internal fields */
-    ret_value->s       = (char *)s;
-    ret_value->wrapped = 1;
+    ret_value->s   = (char *)s;
+    ret_value->len = HDstrlen(s);
+    ret_value->end = ret_value->s + ret_value->len;
+
+    ret_value->wrapped = TRUE;
+    ret_value->max     = 0; /* Wrapped, not allocated */
     ret_value->n       = 1;
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5RS_wrap() */
 
-/*--------------------------------------------------------------------------
- NAME
-    H5RS_own
- PURPOSE
-    Transfer ownership of a regular string to a reference counted string
- USAGE
-    H5RS_str_t *H5RS_own(s)
-        const char *s;          IN: String to transfer ownership of
-
- RETURNS
-    Returns a pointer to a new ref-counted string on success, NULL on failure.
- DESCRIPTION
-    Transfer ownership of a dynamically allocated string to a reference counted
-    string.  The routine which passed in the string should not attempt to free
-    it, the reference counting string routines will do that when the reference
-    count drops to zero.
- GLOBAL VARIABLES
- COMMENTS, BUGS, ASSUMPTIONS
- EXAMPLES
- REVISION LOG
---------------------------------------------------------------------------*/
-H5RS_str_t *
-H5RS_own(char *s)
+/*-------------------------------------------------------------------------
+ * Function:    H5RS_asprintf_cat
+ *
+ * Purpose:     This function appends formatted output to a ref-counted string,
+ *              allocating the managed string if necessary.  The formatting
+ *              string is printf() compatible.
+ *
+ * Return:      SUCCEED / FAIL
+ *
+ * Programmer:	Quincey Koziol
+ *	        Friday, September 18, 2020
+ *
+ *-------------------------------------------------------------------------
+ */
+/* Disable warning for "format not a string literal" here -QAK */
+/*
+ *      This pragma only needs to surround the sprintf() calls with
+ *      format_templ in the code below, but early (4.4.7, at least) gcc only
+ *      allows diagnostic pragmas to be toggled outside of functions.
+ */
+H5_GCC_DIAG_OFF(format - nonliteral)
+H5_ATTR_FORMAT(printf, 2, 3)
+herr_t
+H5RS_asprintf_cat(H5RS_str_t *rs, const char *fmt, ...)
 {
-    H5RS_str_t *ret_value; /* Return value */
+    va_list args1, args2;
+    size_t  out_len;
+    herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_NOAPI(NULL)
+    FUNC_ENTER_NOAPI(FAIL)
 
-    /* Allocate ref-counted string structure */
-    if (NULL == (ret_value = H5FL_MALLOC(H5RS_str_t)))
-        HGOTO_ERROR(H5E_RS, H5E_NOSPACE, NULL, "memory allocation failed")
+    /* Sanity checks */
+    HDassert(rs);
+    HDassert(fmt);
 
-    /* Set the internal fields */
-    ret_value->s       = s;
-    ret_value->wrapped = 0;
-    ret_value->n       = 1;
+    /* Prepare the [possibly wrapped or empty] ref-counted string for an append */
+    if (H5RS__prepare_for_append(rs) < 0)
+        HGOTO_ERROR(H5E_RS, H5E_CANTINIT, FAIL, "can't initialize ref-counted string")
+
+    /* Attempt to write formatted output into the managed string */
+    HDva_start(args1, fmt);
+    HDva_copy(args2, args1);
+    while ((out_len = (size_t)HDvsnprintf(rs->end, (rs->max - rs->len), fmt, args1)) >= (rs->max - rs->len)) {
+        /* Allocate a large enough buffer */
+        if (H5RS__resize_for_append(rs, out_len) < 0)
+            HGOTO_ERROR(H5E_RS, H5E_CANTRESIZE, FAIL, "can't resize ref-counted string buffer")
+
+        /* Restart the va_list */
+        HDva_end(args1);
+        HDva_copy(args1, args2);
+    } /* end while */
+
+    /* Increment the size & end of the string */
+    rs->len += out_len;
+    rs->end += out_len;
+
+    /* Finish access to varargs */
+    HDva_end(args1);
+    HDva_end(args2);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
-} /* end H5RS_own() */
+} /* end H5RS_asprintf_cat() */
+H5_GCC_DIAG_ON(format - nonliteral)
+
+/*-------------------------------------------------------------------------
+ * Function:    H5RS_acat
+ *
+ * Purpose:     This function appends a character string to a ref-counted string,
+ *              allocating the managed string if necessary.
+ *
+ * Return:      SUCCEED / FAIL
+ *
+ * Programmer:	Quincey Koziol
+ *	        Friday, September 18, 2020
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5RS_acat(H5RS_str_t *rs, const char *s)
+{
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    /* Sanity checks */
+    HDassert(rs);
+    HDassert(s);
+
+    /* Concatenate the provided string on to the managed string */
+    if (*s) {
+        size_t len = HDstrlen(s);
+
+        /* Allocate the underlying string, if necessary */
+        if (H5RS__prepare_for_append(rs) < 0)
+            HGOTO_ERROR(H5E_RS, H5E_CANTINIT, FAIL, "can't initialize ref-counted string")
+
+        /* Increase the managed string's buffer size if necessary */
+        if ((rs->len + len) >= rs->max)
+            if (H5RS__resize_for_append(rs, len) < 0)
+                HGOTO_ERROR(H5E_RS, H5E_CANTRESIZE, FAIL, "can't resize ref-counted string buffer")
+
+        /* Append the string */
+        HDmemcpy(rs->end, s, len);
+        rs->end += len;
+        *rs->end = '\0';
+        rs->len += len;
+    } /* end if */
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5RS_acat() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5RS_ancat
+ *
+ * Purpose:     This function appends at most 'n' characters from a string
+ *              to a ref-counted string, allocating the managed string if
+ *              necessary.
+ *
+ * Return:      SUCCEED / FAIL
+ *
+ * Programmer:	Quincey Koziol
+ *	        Friday, September 18, 2020
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5RS_ancat(H5RS_str_t *rs, const char *s, size_t n)
+{
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    /* Sanity checks */
+    HDassert(rs);
+    HDassert(s);
+
+    /* Concatenate the provided string on to the managed string */
+    if (n && *s) {
+        size_t len = HDstrlen(s);
+
+        /* Limit characters to copy to the minimum of 'n' and 'len' */
+        n = MIN(len, n);
+
+        /* Allocate the underlying string, if necessary */
+        if (H5RS__prepare_for_append(rs) < 0)
+            HGOTO_ERROR(H5E_RS, H5E_CANTINIT, FAIL, "can't initialize ref-counted string")
+
+        /* Increase the managed string's buffer size if necessary */
+        if ((rs->len + n) >= rs->max)
+            if (H5RS__resize_for_append(rs, n) < 0)
+                HGOTO_ERROR(H5E_RS, H5E_CANTRESIZE, FAIL, "can't resize ref-counted string buffer")
+
+        /* Append the string */
+        HDmemcpy(rs->end, s, n);
+        rs->end += n;
+        *rs->end = '\0';
+        rs->len += n;
+    } /* end if */
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5RS_ancat() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5RS_aputc
+ *
+ * Purpose:     This function appends a character to a ref-counted string,
+ *              allocating the managed string if necessary.
+ *
+ * Return:      SUCCEED / FAIL
+ *
+ * Programmer:	Quincey Koziol
+ *	        Friday, September 18, 2020
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5RS_aputc(H5RS_str_t *rs, int c)
+{
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    /* Sanity checks */
+    HDassert(rs);
+    HDassert(c);
+
+    /* Allocate the underlying string, if necessary */
+    if (H5RS__prepare_for_append(rs) < 0)
+        HGOTO_ERROR(H5E_RS, H5E_CANTINIT, FAIL, "can't initialize ref-counted string")
+
+    /* Increase the managed string's buffer size if necessary */
+    if ((rs->len + 1) >= rs->max)
+        if (H5RS__resize_for_append(rs, 1) < 0)
+            HGOTO_ERROR(H5E_RS, H5E_CANTRESIZE, FAIL, "can't resize ref-counted string buffer")
+
+    /* Append the current character */
+    *rs->end++ = (char)c;
+    rs->len++;
+    *rs->end = '\0';
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5RS_aputc() */
 
 /*--------------------------------------------------------------------------
  NAME
@@ -283,7 +595,9 @@ H5RS_decr(H5RS_str_t *rs)
 herr_t
 H5RS_incr(H5RS_str_t *rs)
 {
-    FUNC_ENTER_NOAPI_NOINIT_NOERR
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
 
     /* Sanity check */
     HDassert(rs);
@@ -294,14 +608,16 @@ H5RS_incr(H5RS_str_t *rs)
      * scope appropriately.
      */
     if (rs->wrapped) {
-        rs->s       = H5RS__xstrdup(rs->s);
-        rs->wrapped = 0;
+        if (H5RS__xstrdup(rs, rs->s) < 0)
+            HGOTO_ERROR(H5E_RS, H5E_CANTCOPY, FAIL, "can't copy string")
+        rs->wrapped = FALSE;
     } /* end if */
 
     /* Increment reference count for string */
     rs->n++;
 
-    FUNC_LEAVE_NOAPI(SUCCEED)
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5RS_incr() */
 
 /*--------------------------------------------------------------------------
@@ -335,53 +651,6 @@ H5RS_dup(H5RS_str_t *ret_value)
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5RS_dup() */
-
-/*--------------------------------------------------------------------------
- NAME
-    H5RS_dup_str
- PURPOSE
-    "Duplicate" a regular string into a ref-counted string
- USAGE
-    H5RS_str_t H5RS_dup_str(s)
-        const char *s;     IN: Regular string to duplicate
-
- RETURNS
-    Returns a pointer to ref-counted string on success, NULL on failure.
- DESCRIPTION
-    Duplicate a regular string into a ref-counted string.
- GLOBAL VARIABLES
- COMMENTS, BUGS, ASSUMPTIONS
- EXAMPLES
- REVISION LOG
---------------------------------------------------------------------------*/
-H5RS_str_t *
-H5RS_dup_str(const char *s)
-{
-    char *      new_str;  /* Duplicate of string */
-    size_t      path_len; /* Length of the path */
-    H5RS_str_t *ret_value;
-
-    FUNC_ENTER_NOAPI(NULL)
-
-    /* Sanity check */
-    HDassert(s);
-
-    /* Get the length of the string */
-    path_len = HDstrlen(s);
-
-    /* Allocate space for the string */
-    if (NULL == (new_str = (char *)H5FL_BLK_MALLOC(str_buf, path_len + 1)))
-        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed")
-
-    /* Copy name for full path */
-    HDstrncpy(new_str, s, (path_len + 1));
-
-    /* Create reference counted string for path */
-    ret_value = H5RS_own(new_str);
-
-done:
-    FUNC_LEAVE_NOAPI(ret_value)
-} /* end H5RS_dup_str() */
 
 /*--------------------------------------------------------------------------
  NAME

--- a/src/H5RSmodule.h
+++ b/src/H5RSmodule.h
@@ -1,0 +1,32 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by The HDF Group.                                               *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the root of the source code       *
+ * distribution tree, or in https://support.hdfgroup.org/ftp/HDF5/releases.  *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/*
+ * Programmer:	Quincey Koziol
+ *		Saturday, October 10, 2020
+ *
+ * Purpose:	This file contains declarations which define macros for the
+ *		H5RS package.  Including this header means that the source file
+ *		is part of the H5RS package.
+ */
+#ifndef _H5RSmodule_H
+#define _H5RSmodule_H
+
+/* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
+ *      reporting macros.
+ */
+#define H5RS_MODULE
+#define H5_MY_PKG      H5RS
+#define H5_MY_PKG_ERR  H5E_RS
+#define H5_MY_PKG_INIT NO
+
+#endif /* _H5RSmodule_H */

--- a/src/H5RSprivate.h
+++ b/src/H5RSprivate.h
@@ -45,11 +45,13 @@ typedef struct H5RS_str_t H5RS_str_t;
 /********************/
 H5_DLL H5RS_str_t *H5RS_create(const char *s);
 H5_DLL H5RS_str_t *H5RS_wrap(const char *s);
-H5_DLL H5RS_str_t *H5RS_own(char *s);
 H5_DLL herr_t      H5RS_decr(H5RS_str_t *rs);
 H5_DLL herr_t      H5RS_incr(H5RS_str_t *rs);
 H5_DLL H5RS_str_t *H5RS_dup(H5RS_str_t *s);
-H5_DLL H5RS_str_t *H5RS_dup_str(const char *s);
+H5_DLL herr_t      H5RS_asprintf_cat(H5RS_str_t *rs, const char *fmt, ...) H5_ATTR_FORMAT(printf, 2, 3);
+H5_DLL herr_t      H5RS_acat(H5RS_str_t *rs, const char *s);
+H5_DLL herr_t      H5RS_ancat(H5RS_str_t *rs, const char *s, size_t len);
+H5_DLL herr_t      H5RS_aputc(H5RS_str_t *rs, int c);
 H5_DLL int         H5RS_cmp(const H5RS_str_t *rs1, const H5RS_str_t *rs2);
 H5_DLL ssize_t     H5RS_len(const H5RS_str_t *rs);
 H5_DLL char *      H5RS_get_str(const H5RS_str_t *rs);

--- a/src/H5Rdeprec.c
+++ b/src/H5Rdeprec.c
@@ -481,7 +481,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Rget_obj_type2(hid_t id, H5R_type_t ref_type, const void *ref, H5O_type_t *obj_type)
+H5Rget_obj_type2(hid_t id, H5R_type_t ref_type, const void *ref, H5O_type_t *obj_type /*out*/)
 {
     H5VL_object_t *      vol_obj      = NULL;                    /* Object of loc_id */
     H5I_type_t           vol_obj_type = H5I_BADID;               /* Object type of loc_id */
@@ -491,7 +491,7 @@ H5Rget_obj_type2(hid_t id, H5R_type_t ref_type, const void *ref, H5O_type_t *obj
     herr_t               ret_value = SUCCEED;                    /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "iRt*x*Ot", id, ref_type, ref, obj_type);
+    H5TRACE4("e", "iRt*xx", id, ref_type, ref, obj_type);
 
     /* Check args */
     if (buf == NULL)
@@ -693,7 +693,7 @@ done:
  *-------------------------------------------------------------------------
  */
 ssize_t
-H5Rget_name(hid_t id, H5R_type_t ref_type, const void *ref, char *name, size_t size)
+H5Rget_name(hid_t id, H5R_type_t ref_type, const void *ref, char *name /*out*/, size_t size)
 {
     H5VL_object_t *      vol_obj      = NULL;                    /* Object of loc_id */
     H5I_type_t           vol_obj_type = H5I_BADID;               /* Object type of loc_id */
@@ -703,7 +703,7 @@ H5Rget_name(hid_t id, H5R_type_t ref_type, const void *ref, char *name, size_t s
     ssize_t              ret_value = -1;                         /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE5("Zs", "iRt*x*sz", id, ref_type, ref, name, size);
+    H5TRACE5("Zs", "iRt*xxz", id, ref_type, ref, name, size);
 
     /* Check args */
     if (buf == NULL)

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -4773,13 +4773,13 @@ H5S__get_select_hyper_blocklist(H5S_t *space, hsize_t startblock, hsize_t numblo
 --------------------------------------------------------------------------*/
 herr_t
 H5Sget_select_hyper_blocklist(hid_t spaceid, hsize_t startblock, hsize_t numblocks,
-                              hsize_t buf[/*numblocks*/])
+                              hsize_t buf[/*numblocks*/] /*out*/)
 {
     H5S_t *space;     /* Dataspace to modify selection of */
     herr_t ret_value; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "ihh*[a2]h", spaceid, startblock, numblocks, buf);
+    H5TRACE4("e", "ihhx", spaceid, startblock, numblocks, buf);
 
     /* Check args */
     if (buf == NULL)
@@ -12358,14 +12358,15 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 herr_t
-H5Sget_regular_hyperslab(hid_t spaceid, hsize_t start[], hsize_t stride[], hsize_t count[], hsize_t block[])
+H5Sget_regular_hyperslab(hid_t spaceid, hsize_t start[] /*out*/, hsize_t stride[] /*out*/,
+                         hsize_t count[] /*out*/, hsize_t block[] /*out*/)
 {
     H5S_t *  space;               /* Dataspace to query */
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*h*h*h*h", spaceid, start, stride, count, block);
+    H5TRACE5("e", "ixxxx", spaceid, start, stride, count, block);
 
     /* Check args */
     if (NULL == (space = (H5S_t *)H5I_object_verify(spaceid, H5I_DATASPACE)))

--- a/src/H5Spoint.c
+++ b/src/H5Spoint.c
@@ -1572,13 +1572,14 @@ H5S__get_select_elem_pointlist(const H5S_t *space, hsize_t startpoint, hsize_t n
  REVISION LOG
 --------------------------------------------------------------------------*/
 herr_t
-H5Sget_select_elem_pointlist(hid_t spaceid, hsize_t startpoint, hsize_t numpoints, hsize_t buf[/*numpoints*/])
+H5Sget_select_elem_pointlist(hid_t spaceid, hsize_t startpoint, hsize_t numpoints,
+                             hsize_t buf[/*numpoints*/] /*out*/)
 {
     H5S_t *space;     /* Dataspace to modify selection of */
     herr_t ret_value; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "ihh*[a2]h", spaceid, startpoint, numpoints, buf);
+    H5TRACE4("e", "ihhx", spaceid, startpoint, numpoints, buf);
 
     /* Check args */
     if (NULL == buf)

--- a/src/H5Sselect.c
+++ b/src/H5Sselect.c
@@ -602,13 +602,13 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 herr_t
-H5Sget_select_bounds(hid_t spaceid, hsize_t start[], hsize_t end[])
+H5Sget_select_bounds(hid_t spaceid, hsize_t start[] /*out*/, hsize_t end[] /*out*/)
 {
     H5S_t *space;     /* Dataspace to modify selection of */
     herr_t ret_value; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*h*h", spaceid, start, end);
+    H5TRACE3("e", "ixx", spaceid, start, end);
 
     /* Check args */
     if (start == NULL || end == NULL)
@@ -3056,14 +3056,14 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 herr_t
-H5Ssel_iter_get_seq_list(hid_t sel_iter_id, size_t maxseq, size_t maxbytes, size_t *nseq, size_t *nbytes,
-                         hsize_t *off, size_t *len)
+H5Ssel_iter_get_seq_list(hid_t sel_iter_id, size_t maxseq, size_t maxbytes, size_t *nseq /*out*/,
+                         size_t *nbytes /*out*/, hsize_t *off /*out*/, size_t *len /*out*/)
 {
     H5S_sel_iter_t *sel_iter;            /* Dataspace selection iterator to operate on */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "izz*z*z*h*z", sel_iter_id, maxseq, maxbytes, nseq, nbytes, off, len);
+    H5TRACE7("e", "izzxxxx", sel_iter_id, maxseq, maxbytes, nseq, nbytes, off, len);
 
     /* Check args */
     if (NULL == (sel_iter = (H5S_sel_iter_t *)H5I_object_verify(sel_iter_id, H5I_SPACE_SEL_ITER)))

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -2714,7 +2714,7 @@ H5Tregister(H5T_pers_t pers, const char *name, hid_t src_id, hid_t dst_id, H5T_c
     herr_t          ret_value = SUCCEED; /*return value                   */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "Te*siix", pers, name, src_id, dst_id, func);
+    H5TRACE5("e", "Te*siiTC", pers, name, src_id, dst_id, func);
 
     /* Check args */
     if (H5T_PERS_HARD != pers && H5T_PERS_SOFT != pers)
@@ -2867,7 +2867,7 @@ H5Tunregister(H5T_pers_t pers, const char *name, hid_t src_id, hid_t dst_id, H5T
     herr_t ret_value = SUCCEED;     /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "Te*siix", pers, name, src_id, dst_id, func);
+    H5TRACE5("e", "Te*siiTC", pers, name, src_id, dst_id, func);
 
     /* Check arguments */
     if (src_id > 0 && (NULL == (src = (H5T_t *)H5I_object_verify(src_id, H5I_DATATYPE))))
@@ -2901,14 +2901,14 @@ done:
  *-------------------------------------------------------------------------
  */
 H5T_conv_t
-H5Tfind(hid_t src_id, hid_t dst_id, H5T_cdata_t **pcdata)
+H5Tfind(hid_t src_id, hid_t dst_id, H5T_cdata_t **pcdata /*out*/)
 {
     H5T_t *     src, *dst;
     H5T_path_t *path;
     H5T_conv_t  ret_value; /* Return value */
 
     FUNC_ENTER_API(NULL)
-    H5TRACE3("x", "ii**x", src_id, dst_id, pcdata);
+    H5TRACE3("TC", "iix", src_id, dst_id, pcdata);
 
     /* Check args */
     if (NULL == (src = (H5T_t *)H5I_object_verify(src_id, H5I_DATATYPE)) ||

--- a/src/H5TS.c
+++ b/src/H5TS.c
@@ -49,6 +49,9 @@ typedef struct H5TS_cancel_struct {
     unsigned int cancel_count;
 } H5TS_cancel_t;
 
+/* Function pointer typedef for thread callback function */
+typedef void *(*H5TS_thread_cb_t)(void *);
+
 /********************/
 /* Local Prototypes */
 /********************/
@@ -703,7 +706,7 @@ H5TS_win32_thread_exit(void)
  *--------------------------------------------------------------------------
  */
 H5TS_thread_t
-H5TS_create_thread(void *(*func)(void *), H5TS_attr_t *attr, void *udata)
+H5TS_create_thread(H5TS_thread_cb_t func, H5TS_attr_t *attr, void *udata)
 {
     H5TS_thread_t ret_value;
 

--- a/src/H5Tarray.c
+++ b/src/H5Tarray.c
@@ -255,13 +255,13 @@ H5T__get_array_ndims(const H5T_t *dt)
  *-------------------------------------------------------------------------
  */
 int
-H5Tget_array_dims2(hid_t type_id, hsize_t dims[])
+H5Tget_array_dims2(hid_t type_id, hsize_t dims[] /*out*/)
 {
     H5T_t *dt;        /* pointer to array data type	*/
     int    ret_value; /* return value			*/
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("Is", "i*h", type_id, dims);
+    H5TRACE2("Is", "ix", type_id, dims);
 
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
@@ -383,13 +383,13 @@ done:
  *-------------------------------------------------------------------------
  */
 int
-H5Tget_array_dims1(hid_t type_id, hsize_t dims[], int H5_ATTR_UNUSED perm[])
+H5Tget_array_dims1(hid_t type_id, hsize_t dims[] /*out*/, int H5_ATTR_UNUSED perm[] /*out*/)
 {
     H5T_t *dt;        /* Array datatype to query	*/
     int    ret_value; /* return value			*/
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("Is", "i*h*Is", type_id, dims, perm);
+    H5TRACE3("Is", "ixx", type_id, dims, perm);
 
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))

--- a/src/H5VL.c
+++ b/src/H5VL.c
@@ -85,7 +85,7 @@ H5VLregister_connector(const H5VL_class_t *cls, hid_t vipl_id)
     hid_t ret_value = H5I_INVALID_HID; /* Return value */
 
     FUNC_ENTER_API(H5I_INVALID_HID)
-    H5TRACE2("i", "*xi", cls, vipl_id);
+    H5TRACE2("i", "*#i", cls, vipl_id);
 
     /* Check arguments */
     if (!cls)
@@ -757,13 +757,13 @@ done:
  *---------------------------------------------------------------------------
  */
 herr_t
-H5VLretrieve_lib_state(void **state)
+H5VLretrieve_lib_state(void **state /*out*/)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
     /* Must use this, to avoid modifying the API context stack in FUNC_ENTER */
     FUNC_ENTER_API_NOINIT
-    H5TRACE1("e", "**x", state);
+    H5TRACE1("e", "x", state);
 
     /* Check args */
     if (NULL == state)

--- a/src/H5VLcallback.c
+++ b/src/H5VLcallback.c
@@ -263,13 +263,13 @@ done:
  *---------------------------------------------------------------------------
  */
 herr_t
-H5VLget_cap_flags(hid_t connector_id, unsigned *cap_flags)
+H5VLget_cap_flags(hid_t connector_id, unsigned *cap_flags /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE2("e", "i*Iu", connector_id, cap_flags);
+    H5TRACE2("e", "ix", connector_id, cap_flags);
 
     /* Check args */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -294,13 +294,13 @@ done:
  *---------------------------------------------------------------------------
  */
 herr_t
-H5VLget_value(hid_t connector_id, H5VL_class_value_t *value)
+H5VLget_value(hid_t connector_id, H5VL_class_value_t *value /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE2("e", "i*VC", connector_id, value);
+    H5TRACE2("e", "ix", connector_id, value);
 
     /* Check args */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -599,12 +599,12 @@ done:
  *---------------------------------------------------------------------------
  */
 herr_t
-H5VLconnector_str_to_info(const char *str, hid_t connector_id, void **info)
+H5VLconnector_str_to_info(const char *str, hid_t connector_id, void **info /*out*/)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE3("e", "*si**x", str, connector_id, info);
+    H5TRACE3("e", "*six", str, connector_id, info);
 
     /* Call internal routine */
     if (H5VL__connector_str_to_info(str, connector_id, info) < 0)
@@ -698,13 +698,13 @@ done:
  *---------------------------------------------------------------------------
  */
 herr_t
-H5VLget_wrap_ctx(void *obj, hid_t connector_id, void **wrap_ctx)
+H5VLget_wrap_ctx(void *obj, hid_t connector_id, void **wrap_ctx /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE3("e", "*xi**x", obj, connector_id, wrap_ctx);
+    H5TRACE3("e", "*xix", obj, connector_id, wrap_ctx);
 
     /* Check args and get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -994,14 +994,15 @@ done:
  */
 void *
 H5VLattr_create(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id, const char *name,
-                hid_t type_id, hid_t space_id, hid_t acpl_id, hid_t aapl_id, hid_t dxpl_id, void **req)
+                hid_t type_id, hid_t space_id, hid_t acpl_id, hid_t aapl_id, hid_t dxpl_id,
+                void **req /*out*/)
 {
     H5VL_class_t *cls;              /* VOL connector's class struct */
     void *        ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE10("*x", "*x*xi*siiiii**x", obj, loc_params, connector_id, name, type_id, space_id, acpl_id,
-              aapl_id, dxpl_id, req);
+    H5TRACE10("*x", "*x*#i*siiiiix", obj, loc_params, connector_id, name, type_id, space_id, acpl_id, aapl_id,
+              dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -1097,13 +1098,13 @@ done:
  */
 void *
 H5VLattr_open(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id, const char *name,
-              hid_t aapl_id, hid_t dxpl_id, void **req)
+              hid_t aapl_id, hid_t dxpl_id, void **req /*out*/)
 {
     H5VL_class_t *cls;              /* VOL connector's class struct */
     void *        ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE7("*x", "*x*xi*sii**x", obj, loc_params, connector_id, name, aapl_id, dxpl_id, req);
+    H5TRACE7("*x", "*x*#i*siix", obj, loc_params, connector_id, name, aapl_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -1194,13 +1195,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLattr_read(void *obj, hid_t connector_id, hid_t mem_type_id, void *buf, hid_t dxpl_id, void **req)
+H5VLattr_read(void *obj, hid_t connector_id, hid_t mem_type_id, void *buf, hid_t dxpl_id, void **req /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xii*xi**x", obj, connector_id, mem_type_id, buf, dxpl_id, req);
+    H5TRACE6("e", "*xii*xix", obj, connector_id, mem_type_id, buf, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -1292,13 +1293,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLattr_write(void *obj, hid_t connector_id, hid_t mem_type_id, const void *buf, hid_t dxpl_id, void **req)
+H5VLattr_write(void *obj, hid_t connector_id, hid_t mem_type_id, const void *buf, hid_t dxpl_id,
+               void **req /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xii*xi**x", obj, connector_id, mem_type_id, buf, dxpl_id, req);
+    H5TRACE6("e", "*xii*xix", obj, connector_id, mem_type_id, buf, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -1398,14 +1400,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLattr_get(void *obj, hid_t connector_id, H5VL_attr_get_t get_type, hid_t dxpl_id, void **req,
+H5VLattr_get(void *obj, hid_t connector_id, H5VL_attr_get_t get_type, hid_t dxpl_id, void **req /*out*/,
              va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiVai**xx", obj, connector_id, get_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiVaixx", obj, connector_id, get_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -1508,13 +1510,13 @@ done:
  */
 herr_t
 H5VLattr_specific(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id,
-                  H5VL_attr_specific_t specific_type, hid_t dxpl_id, void **req, va_list arguments)
+                  H5VL_attr_specific_t specific_type, hid_t dxpl_id, void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE7("e", "*x*xiVbi**xx", obj, loc_params, connector_id, specific_type, dxpl_id, req, arguments);
+    H5TRACE7("e", "*x*#iVbixx", obj, loc_params, connector_id, specific_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -1616,14 +1618,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLattr_optional(void *obj, hid_t connector_id, H5VL_attr_optional_t opt_type, hid_t dxpl_id, void **req,
-                  va_list arguments)
+H5VLattr_optional(void *obj, hid_t connector_id, H5VL_attr_optional_t opt_type, hid_t dxpl_id,
+                  void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiVsi**xx", obj, connector_id, opt_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiVsixx", obj, connector_id, opt_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -1707,13 +1709,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLattr_close(void *obj, hid_t connector_id, hid_t dxpl_id, void **req)
+H5VLattr_close(void *obj, hid_t connector_id, hid_t dxpl_id, void **req /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE4("e", "*xii**x", obj, connector_id, dxpl_id, req);
+    H5TRACE4("e", "*xiix", obj, connector_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -1813,13 +1815,13 @@ done:
 void *
 H5VLdataset_create(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id, const char *name,
                    hid_t lcpl_id, hid_t type_id, hid_t space_id, hid_t dcpl_id, hid_t dapl_id, hid_t dxpl_id,
-                   void **req)
+                   void **req /*out*/)
 {
     H5VL_class_t *cls;              /* VOL connector's class struct */
     void *        ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE11("*x", "*x*xi*siiiiii**x", obj, loc_params, connector_id, name, lcpl_id, type_id, space_id,
+    H5TRACE11("*x", "*x*#i*siiiiiix", obj, loc_params, connector_id, name, lcpl_id, type_id, space_id,
               dcpl_id, dapl_id, dxpl_id, req);
 
     /* Check args and get class pointer */
@@ -1916,13 +1918,13 @@ done:
  */
 void *
 H5VLdataset_open(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id, const char *name,
-                 hid_t dapl_id, hid_t dxpl_id, void **req)
+                 hid_t dapl_id, hid_t dxpl_id, void **req /*out*/)
 {
     H5VL_class_t *cls;              /* VOL connector's class struct */
     void *        ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE7("*x", "*x*xi*sii**x", obj, loc_params, connector_id, name, dapl_id, dxpl_id, req);
+    H5TRACE7("*x", "*x*#i*siix", obj, loc_params, connector_id, name, dapl_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -2017,13 +2019,13 @@ done:
  */
 herr_t
 H5VLdataset_read(void *obj, hid_t connector_id, hid_t mem_type_id, hid_t mem_space_id, hid_t file_space_id,
-                 hid_t dxpl_id, void *buf, void **req)
+                 hid_t dxpl_id, void *buf, void **req /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE8("e", "*xiiiii*x**x", obj, connector_id, mem_type_id, mem_space_id, file_space_id, dxpl_id, buf,
+    H5TRACE8("e", "*xiiiii*xx", obj, connector_id, mem_type_id, mem_space_id, file_space_id, dxpl_id, buf,
              req);
 
     /* Check args and get class pointer */
@@ -2119,13 +2121,13 @@ done:
  */
 herr_t
 H5VLdataset_write(void *obj, hid_t connector_id, hid_t mem_type_id, hid_t mem_space_id, hid_t file_space_id,
-                  hid_t dxpl_id, const void *buf, void **req)
+                  hid_t dxpl_id, const void *buf, void **req /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE8("e", "*xiiiii*x**x", obj, connector_id, mem_type_id, mem_space_id, file_space_id, dxpl_id, buf,
+    H5TRACE8("e", "*xiiiii*xx", obj, connector_id, mem_type_id, mem_space_id, file_space_id, dxpl_id, buf,
              req);
 
     /* Check args and get class pointer */
@@ -2226,14 +2228,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLdataset_get(void *obj, hid_t connector_id, H5VL_dataset_get_t get_type, hid_t dxpl_id, void **req,
+H5VLdataset_get(void *obj, hid_t connector_id, H5VL_dataset_get_t get_type, hid_t dxpl_id, void **req /*out*/,
                 va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiVci**xx", obj, connector_id, get_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiVcixx", obj, connector_id, get_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -2336,13 +2338,13 @@ done:
  */
 herr_t
 H5VLdataset_specific(void *obj, hid_t connector_id, H5VL_dataset_specific_t specific_type, hid_t dxpl_id,
-                     void **req, va_list arguments)
+                     void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiVdi**xx", obj, connector_id, specific_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiVdixx", obj, connector_id, specific_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -2444,13 +2446,13 @@ done:
  */
 herr_t
 H5VLdataset_optional(void *obj, hid_t connector_id, H5VL_dataset_optional_t opt_type, hid_t dxpl_id,
-                     void **req, va_list arguments)
+                     void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiVti**xx", obj, connector_id, opt_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiVtixx", obj, connector_id, opt_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -2551,13 +2553,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLdataset_close(void *obj, hid_t connector_id, hid_t dxpl_id, void **req)
+H5VLdataset_close(void *obj, hid_t connector_id, hid_t dxpl_id, void **req /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE4("e", "*xii**x", obj, connector_id, dxpl_id, req);
+    H5TRACE4("e", "*xiix", obj, connector_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -2654,14 +2656,15 @@ done:
  */
 void *
 H5VLdatatype_commit(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id, const char *name,
-                    hid_t type_id, hid_t lcpl_id, hid_t tcpl_id, hid_t tapl_id, hid_t dxpl_id, void **req)
+                    hid_t type_id, hid_t lcpl_id, hid_t tcpl_id, hid_t tapl_id, hid_t dxpl_id,
+                    void **req /*out*/)
 {
     H5VL_class_t *cls;              /* VOL connector's class struct */
     void *        ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE10("*x", "*x*xi*siiiii**x", obj, loc_params, connector_id, name, type_id, lcpl_id, tcpl_id,
-              tapl_id, dxpl_id, req);
+    H5TRACE10("*x", "*x*#i*siiiiix", obj, loc_params, connector_id, name, type_id, lcpl_id, tcpl_id, tapl_id,
+              dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -2757,13 +2760,13 @@ done:
  */
 void *
 H5VLdatatype_open(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id, const char *name,
-                  hid_t tapl_id, hid_t dxpl_id, void **req)
+                  hid_t tapl_id, hid_t dxpl_id, void **req /*out*/)
 {
     H5VL_class_t *cls;              /* VOL connector's class struct */
     void *        ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE7("*x", "*x*xi*sii**x", obj, loc_params, connector_id, name, tapl_id, dxpl_id, req);
+    H5TRACE7("*x", "*x*#i*siix", obj, loc_params, connector_id, name, tapl_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -2863,14 +2866,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLdatatype_get(void *obj, hid_t connector_id, H5VL_datatype_get_t get_type, hid_t dxpl_id, void **req,
-                 va_list arguments)
+H5VLdatatype_get(void *obj, hid_t connector_id, H5VL_datatype_get_t get_type, hid_t dxpl_id,
+                 void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiVei**xx", obj, connector_id, get_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiVeixx", obj, connector_id, get_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -2977,13 +2980,13 @@ done:
  */
 herr_t
 H5VLdatatype_specific(void *obj, hid_t connector_id, H5VL_datatype_specific_t specific_type, hid_t dxpl_id,
-                      void **req, va_list arguments)
+                      void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiVfi**xx", obj, connector_id, specific_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiVfixx", obj, connector_id, specific_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -3086,13 +3089,13 @@ done:
  */
 herr_t
 H5VLdatatype_optional(void *obj, hid_t connector_id, H5VL_datatype_optional_t opt_type, hid_t dxpl_id,
-                      void **req, va_list arguments)
+                      void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiVui**xx", obj, connector_id, opt_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiVuixx", obj, connector_id, opt_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -3183,13 +3186,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLdatatype_close(void *obj, hid_t connector_id, hid_t dxpl_id, void **req)
+H5VLdatatype_close(void *obj, hid_t connector_id, hid_t dxpl_id, void **req /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE4("e", "*xii**x", obj, connector_id, dxpl_id, req);
+    H5TRACE4("e", "*xiix", obj, connector_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -3283,7 +3286,8 @@ done:
  *-------------------------------------------------------------------------
  */
 void *
-H5VLfile_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id, void **req)
+H5VLfile_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id,
+                void **req /*out*/)
 {
     H5P_genplist_t *      plist;            /* Property list pointer */
     H5VL_connector_prop_t connector_prop;   /* Property for VOL connector ID & info */
@@ -3291,7 +3295,7 @@ H5VLfile_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, 
     void *                ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("*x", "*sIuiii**x", name, flags, fcpl_id, fapl_id, dxpl_id, req);
+    H5TRACE6("*x", "*sIuiiix", name, flags, fcpl_id, fapl_id, dxpl_id, req);
 
     /* Get the VOL info from the fapl */
     if (NULL == (plist = (H5P_genplist_t *)H5I_object(fapl_id)))
@@ -3386,7 +3390,7 @@ done:
  *-------------------------------------------------------------------------
  */
 void *
-H5VLfile_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, void **req)
+H5VLfile_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, void **req /*out*/)
 {
     H5P_genplist_t *      plist;            /* Property list pointer */
     H5VL_connector_prop_t connector_prop;   /* Property for VOL connector ID & info */
@@ -3394,7 +3398,7 @@ H5VLfile_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, vo
     void *                ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("*x", "*sIuii**x", name, flags, fapl_id, dxpl_id, req);
+    H5TRACE5("*x", "*sIuiix", name, flags, fapl_id, dxpl_id, req);
 
     /* Get the VOL info from the fapl */
     if (NULL == (plist = (H5P_genplist_t *)H5I_object(fapl_id)))
@@ -3498,14 +3502,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLfile_get(void *obj, hid_t connector_id, H5VL_file_get_t get_type, hid_t dxpl_id, void **req,
+H5VLfile_get(void *obj, hid_t connector_id, H5VL_file_get_t get_type, hid_t dxpl_id, void **req /*out*/,
              va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiVgi**xx", obj, connector_id, get_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiVgixx", obj, connector_id, get_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -3643,13 +3647,13 @@ done:
  */
 herr_t
 H5VLfile_specific(void *obj, hid_t connector_id, H5VL_file_specific_t specific_type, hid_t dxpl_id,
-                  void **req, va_list arguments)
+                  void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiVhi**xx", obj, connector_id, specific_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiVhixx", obj, connector_id, specific_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -3748,14 +3752,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLfile_optional(void *obj, hid_t connector_id, H5VL_file_optional_t opt_type, hid_t dxpl_id, void **req,
-                  va_list arguments)
+H5VLfile_optional(void *obj, hid_t connector_id, H5VL_file_optional_t opt_type, hid_t dxpl_id,
+                  void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiVvi**xx", obj, connector_id, opt_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiVvixx", obj, connector_id, opt_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -3850,13 +3854,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLfile_close(void *obj, hid_t connector_id, hid_t dxpl_id, void **req)
+H5VLfile_close(void *obj, hid_t connector_id, hid_t dxpl_id, void **req /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE4("e", "*xii**x", obj, connector_id, dxpl_id, req);
+    H5TRACE4("e", "*xiix", obj, connector_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -3952,13 +3956,13 @@ done:
  */
 void *
 H5VLgroup_create(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id, const char *name,
-                 hid_t lcpl_id, hid_t gcpl_id, hid_t gapl_id, hid_t dxpl_id, void **req)
+                 hid_t lcpl_id, hid_t gcpl_id, hid_t gapl_id, hid_t dxpl_id, void **req /*out*/)
 {
     H5VL_class_t *cls;              /* VOL connector's class struct */
     void *        ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE9("*x", "*x*xi*siiii**x", obj, loc_params, connector_id, name, lcpl_id, gcpl_id, gapl_id, dxpl_id,
+    H5TRACE9("*x", "*x*#i*siiiix", obj, loc_params, connector_id, name, lcpl_id, gcpl_id, gapl_id, dxpl_id,
              req);
 
     /* Check args and get class pointer */
@@ -4055,13 +4059,13 @@ done:
  */
 void *
 H5VLgroup_open(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id, const char *name,
-               hid_t gapl_id, hid_t dxpl_id, void **req)
+               hid_t gapl_id, hid_t dxpl_id, void **req /*out*/)
 {
     H5VL_class_t *cls;              /* VOL connector's class struct */
     void *        ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE7("*x", "*x*xi*sii**x", obj, loc_params, connector_id, name, gapl_id, dxpl_id, req);
+    H5TRACE7("*x", "*x*#i*siix", obj, loc_params, connector_id, name, gapl_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -4161,14 +4165,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLgroup_get(void *obj, hid_t connector_id, H5VL_group_get_t get_type, hid_t dxpl_id, void **req,
+H5VLgroup_get(void *obj, hid_t connector_id, H5VL_group_get_t get_type, hid_t dxpl_id, void **req /*out*/,
               va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiVii**xx", obj, connector_id, get_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiViixx", obj, connector_id, get_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -4271,13 +4275,13 @@ done:
  */
 herr_t
 H5VLgroup_specific(void *obj, hid_t connector_id, H5VL_group_specific_t specific_type, hid_t dxpl_id,
-                   void **req, va_list arguments)
+                   void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiVji**xx", obj, connector_id, specific_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiVjixx", obj, connector_id, specific_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -4379,14 +4383,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLgroup_optional(void *obj, hid_t connector_id, H5VL_group_optional_t opt_type, hid_t dxpl_id, void **req,
-                   va_list arguments)
+H5VLgroup_optional(void *obj, hid_t connector_id, H5VL_group_optional_t opt_type, hid_t dxpl_id,
+                   void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiVwi**xx", obj, connector_id, opt_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiVwixx", obj, connector_id, opt_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -4481,13 +4485,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLgroup_close(void *obj, hid_t connector_id, hid_t dxpl_id, void **req)
+H5VLgroup_close(void *obj, hid_t connector_id, hid_t dxpl_id, void **req /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE4("e", "*xii**x", obj, connector_id, dxpl_id, req);
+    H5TRACE4("e", "*xiix", obj, connector_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -4613,15 +4617,15 @@ done:
  */
 herr_t
 H5VLlink_create(H5VL_link_create_type_t create_type, void *obj, const H5VL_loc_params_t *loc_params,
-                hid_t connector_id, hid_t lcpl_id, hid_t lapl_id, hid_t dxpl_id, void **req,
+                hid_t connector_id, hid_t lcpl_id, hid_t lapl_id, hid_t dxpl_id, void **req /*out*/,
                 va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE9("e", "Vk*x*xiiii**xx", create_type, obj, loc_params, connector_id, lcpl_id, lapl_id, dxpl_id,
-             req, arguments);
+    H5TRACE9("e", "Vk*x*#iiiixx", create_type, obj, loc_params, connector_id, lcpl_id, lapl_id, dxpl_id, req,
+             arguments);
 
     /* Get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -4721,14 +4725,14 @@ done:
 herr_t
 H5VLlink_copy(void *src_obj, const H5VL_loc_params_t *loc_params1, void *dst_obj,
               const H5VL_loc_params_t *loc_params2, hid_t connector_id, hid_t lcpl_id, hid_t lapl_id,
-              hid_t dxpl_id, void **req)
+              hid_t dxpl_id, void **req /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE9("e", "*x*x*x*xiiii**x", src_obj, loc_params1, dst_obj, loc_params2, connector_id, lcpl_id,
-             lapl_id, dxpl_id, req);
+    H5TRACE9("e", "*x*#*x*#iiiix", src_obj, loc_params1, dst_obj, loc_params2, connector_id, lcpl_id, lapl_id,
+             dxpl_id, req);
 
     /* Get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -4828,14 +4832,14 @@ done:
 herr_t
 H5VLlink_move(void *src_obj, const H5VL_loc_params_t *loc_params1, void *dst_obj,
               const H5VL_loc_params_t *loc_params2, hid_t connector_id, hid_t lcpl_id, hid_t lapl_id,
-              hid_t dxpl_id, void **req)
+              hid_t dxpl_id, void **req /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE9("e", "*x*x*x*xiiii**x", src_obj, loc_params1, dst_obj, loc_params2, connector_id, lcpl_id,
-             lapl_id, dxpl_id, req);
+    H5TRACE9("e", "*x*#*x*#iiiix", src_obj, loc_params1, dst_obj, loc_params2, connector_id, lcpl_id, lapl_id,
+             dxpl_id, req);
 
     /* Get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -4936,13 +4940,13 @@ done:
  */
 herr_t
 H5VLlink_get(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id, H5VL_link_get_t get_type,
-             hid_t dxpl_id, void **req, va_list arguments)
+             hid_t dxpl_id, void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE7("e", "*x*xiVli**xx", obj, loc_params, connector_id, get_type, dxpl_id, req, arguments);
+    H5TRACE7("e", "*x*#iVlixx", obj, loc_params, connector_id, get_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -5045,13 +5049,13 @@ done:
  */
 herr_t
 H5VLlink_specific(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id,
-                  H5VL_link_specific_t specific_type, hid_t dxpl_id, void **req, va_list arguments)
+                  H5VL_link_specific_t specific_type, hid_t dxpl_id, void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE7("e", "*x*xiVmi**xx", obj, loc_params, connector_id, specific_type, dxpl_id, req, arguments);
+    H5TRACE7("e", "*x*#iVmixx", obj, loc_params, connector_id, specific_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -5152,14 +5156,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLlink_optional(void *obj, hid_t connector_id, H5VL_link_optional_t opt_type, hid_t dxpl_id, void **req,
-                  va_list arguments)
+H5VLlink_optional(void *obj, hid_t connector_id, H5VL_link_optional_t opt_type, hid_t dxpl_id,
+                  void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiVxi**xx", obj, connector_id, opt_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiVxixx", obj, connector_id, opt_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -5254,13 +5258,13 @@ done:
  */
 void *
 H5VLobject_open(void *obj, const H5VL_loc_params_t *params, hid_t connector_id, H5I_type_t *opened_type,
-                hid_t dxpl_id, void **req)
+                hid_t dxpl_id, void **req /*out*/)
 {
     H5VL_class_t *cls;              /* VOL connector's class struct */
     void *        ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("*x", "*x*xi*Iti**x", obj, params, connector_id, opened_type, dxpl_id, req);
+    H5TRACE6("*x", "*x*#i*Itix", obj, params, connector_id, opened_type, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -5364,14 +5368,14 @@ done:
 herr_t
 H5VLobject_copy(void *src_obj, const H5VL_loc_params_t *src_loc_params, const char *src_name, void *dst_obj,
                 const H5VL_loc_params_t *dst_loc_params, const char *dst_name, hid_t connector_id,
-                hid_t ocpypl_id, hid_t lcpl_id, hid_t dxpl_id, void **req)
+                hid_t ocpypl_id, hid_t lcpl_id, hid_t dxpl_id, void **req /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE11("e", "*x*x*s*x*x*siiii**x", src_obj, src_loc_params, src_name, dst_obj, dst_loc_params,
-              dst_name, connector_id, ocpypl_id, lcpl_id, dxpl_id, req);
+    H5TRACE11("e", "*x*#*s*x*#*siiiix", src_obj, src_loc_params, src_name, dst_obj, dst_loc_params, dst_name,
+              connector_id, ocpypl_id, lcpl_id, dxpl_id, req);
 
     /* Check args and get class pointers */
     if (NULL == src_obj || NULL == dst_obj)
@@ -5475,13 +5479,13 @@ done:
  */
 herr_t
 H5VLobject_get(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id, H5VL_object_get_t get_type,
-               hid_t dxpl_id, void **req, va_list arguments)
+               hid_t dxpl_id, void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE7("e", "*x*xiVni**xx", obj, loc_params, connector_id, get_type, dxpl_id, req, arguments);
+    H5TRACE7("e", "*x*#iVnixx", obj, loc_params, connector_id, get_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -5584,13 +5588,14 @@ done:
  */
 herr_t
 H5VLobject_specific(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id,
-                    H5VL_object_specific_t specific_type, hid_t dxpl_id, void **req, va_list arguments)
+                    H5VL_object_specific_t specific_type, hid_t dxpl_id, void **req /*out*/,
+                    va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE7("e", "*x*xiVoi**xx", obj, loc_params, connector_id, specific_type, dxpl_id, req, arguments);
+    H5TRACE7("e", "*x*#iVoixx", obj, loc_params, connector_id, specific_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -5695,14 +5700,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLobject_optional(void *obj, hid_t connector_id, H5VL_object_optional_t opt_type, hid_t dxpl_id, void **req,
-                    va_list arguments)
+H5VLobject_optional(void *obj, hid_t connector_id, H5VL_object_optional_t opt_type, hid_t dxpl_id,
+                    void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiVyi**xx", obj, connector_id, opt_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiVyixx", obj, connector_id, opt_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -5805,13 +5810,13 @@ done:
  */
 herr_t
 H5VLintrospect_get_conn_cls(void *obj, hid_t connector_id, H5VL_get_conn_lvl_t lvl,
-                            const H5VL_class_t **conn_cls)
+                            const H5VL_class_t **conn_cls /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE4("e", "*xiVL**x", obj, connector_id, lvl, conn_cls);
+    H5TRACE4("e", "*xiVLx", obj, connector_id, lvl, conn_cls);
 
     /* Check args */
     if (NULL == obj)
@@ -5912,13 +5917,13 @@ done:
  */
 herr_t
 H5VLintrospect_opt_query(void *obj, hid_t connector_id, H5VL_subclass_t subcls, int opt_type,
-                         hbool_t *supported)
+                         hbool_t *supported /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xiVSIs*b", obj, connector_id, subcls, opt_type, supported);
+    H5TRACE5("e", "*xiVSIsx", obj, connector_id, subcls, opt_type, supported);
 
     /* Get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -6024,13 +6029,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLrequest_wait(void *req, hid_t connector_id, uint64_t timeout, H5ES_status_t *status)
+H5VLrequest_wait(void *req, hid_t connector_id, uint64_t timeout, H5ES_status_t *status /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE4("e", "*xiUL*Es", req, connector_id, timeout, status);
+    H5TRACE4("e", "*xiULx", req, connector_id, timeout, status);
 
     /* Get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -6141,7 +6146,7 @@ H5VLrequest_notify(void *req, hid_t connector_id, H5VL_request_notify_t cb, void
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE4("e", "*xix*x", req, connector_id, cb, ctx);
+    H5TRACE4("e", "*xiVN*x", req, connector_id, cb, ctx);
 
     /* Get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -6783,13 +6788,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLblob_get(void *obj, hid_t connector_id, const void *blob_id, void *buf, size_t size, void *ctx)
+H5VLblob_get(void *obj, hid_t connector_id, const void *blob_id, void *buf /*out*/, size_t size, void *ctx)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xi*x*xz*x", obj, connector_id, blob_id, buf, size, ctx);
+    H5TRACE6("e", "*xi*xxz*x", obj, connector_id, blob_id, buf, size, ctx);
 
     /* Get class pointer */
     if (NULL == obj)
@@ -7495,13 +7500,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLoptional(void *obj, hid_t connector_id, int op_type, hid_t dxpl_id, void **req, va_list arguments)
+H5VLoptional(void *obj, hid_t connector_id, int op_type, hid_t dxpl_id, void **req /*out*/, va_list arguments)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xiIsi**xx", obj, connector_id, op_type, dxpl_id, req, arguments);
+    H5TRACE6("e", "*xiIsixx", obj, connector_id, op_type, dxpl_id, req, arguments);
 
     /* Check args and get class pointer */
     if (NULL == obj)

--- a/src/H5Z.c
+++ b/src/H5Z.c
@@ -1665,12 +1665,12 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Zget_filter_info(H5Z_filter_t filter, unsigned int *filter_config_flags)
+H5Zget_filter_info(H5Z_filter_t filter, unsigned *filter_config_flags /*out*/)
 {
     herr_t ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "Zf*Iu", filter, filter_config_flags);
+    H5TRACE2("e", "Zfx", filter, filter_config_flags);
 
     /* Get the filter info */
     if (H5Z_get_filter_info(filter, filter_config_flags) < 0)

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -1943,7 +1943,31 @@ extern char H5libhdf5_settings[]; /* embedded library information */
 #define H5TRACE_RETURN(V)                                                 /*void*/
 #endif /* H5_DEBUG_API */
 
+/* Argument tracing macros (defined all the time) */
+#define H5ARG_TRACE0(C, T)                         C, T
+#define H5ARG_TRACE1(C, T, A0)                     C, T, #A0, A0
+#define H5ARG_TRACE2(C, T, A0, A1)                 C, T, #A0, A0, #A1, A1
+#define H5ARG_TRACE3(C, T, A0, A1, A2)             C, T, #A0, A0, #A1, A1, #A2, A2
+#define H5ARG_TRACE4(C, T, A0, A1, A2, A3)         C, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3
+#define H5ARG_TRACE5(C, T, A0, A1, A2, A3, A4)     C, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4
+#define H5ARG_TRACE6(C, T, A0, A1, A2, A3, A4, A5) C, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5
+#define H5ARG_TRACE7(C, T, A0, A1, A2, A3, A4, A5, A6)                                                       \
+    C, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6
+#define H5ARG_TRACE8(C, T, A0, A1, A2, A3, A4, A5, A6, A7)                                                   \
+    C, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6, #A7, A7
+#define H5ARG_TRACE9(C, T, A0, A1, A2, A3, A4, A5, A6, A7, A8)                                               \
+    C, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6, #A7, A7, #A8, A8
+#define H5ARG_TRACE10(C, T, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9)                                          \
+    C, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6, #A7, A7, #A8, A8, #A9, A9
+#define H5ARG_TRACE11(C, T, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)                                     \
+    C, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6, #A7, A7, #A8, A8, #A9, A9, #A10, A10
+#define H5ARG_TRACE12(C, T, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)                                \
+    C, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6, #A7, A7, #A8, A8, #A9, A9, #A10,    \
+        A10, #A11, A11
+
+struct H5RS_str_t;
 H5_DLL double H5_trace(const double *calltime, const char *func, const char *type, ...);
+H5_DLL herr_t H5_trace_args(struct H5RS_str_t *rs, const char *type, va_list ap);
 
 /*-------------------------------------------------------------------------
  * Purpose:  Register function entry for library initialization and code

--- a/src/H5trace.c
+++ b/src/H5trace.c
@@ -37,7 +37,9 @@
 #include "H5FDprivate.h" /* File drivers                             */
 #include "H5Rprivate.h"  /* References                               */
 #include "H5Ipkg.h"      /* IDs                                      */
+#include "H5Mpublic.h"   /* Maps                                     */
 #include "H5MMprivate.h" /* Memory management                        */
+#include "H5RSprivate.h" /* Reference-counted strings                */
 #include "H5VLprivate.h" /* Virtual Object Layer                     */
 
 #ifdef H5_HAVE_PARALLEL
@@ -60,6 +62,9 @@
 /********************/
 /* Local Prototypes */
 /********************/
+static herr_t H5_trace_args_bool(H5RS_str_t *rs, hbool_t val);
+static herr_t H5_trace_args_cset(H5RS_str_t *rs, H5T_cset_t cset);
+static herr_t H5_trace_args_close_degree(H5RS_str_t *rs, H5F_close_degree_t degree);
 
 /*********************/
 /* Package Variables */
@@ -72,6 +77,3734 @@
 /*******************/
 /* Local Variables */
 /*******************/
+
+/*-------------------------------------------------------------------------
+ * Function:    H5_trace_args_bool
+ *
+ * Purpose:     This routine formats an hbool_t and adds the output to
+ *		the refcounted string (RS) argument.
+ *
+ * Return:      SUCCEED / FAIL
+ *
+ * Programmer:	Quincey Koziol
+ *	        Monday, September 21, 2020
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5_trace_args_bool(H5RS_str_t *rs, hbool_t val)
+{
+    /* FUNC_ENTER() should not be called */
+
+    if (TRUE == val)
+        H5RS_acat(rs, "TRUE");
+    else if (!val)
+        H5RS_acat(rs, "FALSE");
+    else
+        H5RS_asprintf_cat(rs, "TRUE(%u)", (unsigned)val);
+
+    return SUCCEED;
+} /* end H5_trace_args_bool() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5_trace_args_cset
+ *
+ * Purpose:     This routine formats an H5T_cset_t and adds the output to
+ *		the refcounted string (RS) argument.
+ *
+ * Return:      SUCCEED / FAIL
+ *
+ * Programmer:	Quincey Koziol
+ *	        Sunday, September 20, 2020
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5_trace_args_cset(H5RS_str_t *rs, H5T_cset_t cset)
+{
+    /* FUNC_ENTER() should not be called */
+
+    switch (cset) {
+        case H5T_CSET_ERROR:
+            H5RS_acat(rs, "H5T_CSET_ERROR");
+            break;
+
+        case H5T_CSET_ASCII:
+            H5RS_acat(rs, "H5T_CSET_ASCII");
+            break;
+
+        case H5T_CSET_UTF8:
+            H5RS_acat(rs, "H5T_CSET_UTF8");
+            break;
+
+        case H5T_CSET_RESERVED_2:
+        case H5T_CSET_RESERVED_3:
+        case H5T_CSET_RESERVED_4:
+        case H5T_CSET_RESERVED_5:
+        case H5T_CSET_RESERVED_6:
+        case H5T_CSET_RESERVED_7:
+        case H5T_CSET_RESERVED_8:
+        case H5T_CSET_RESERVED_9:
+        case H5T_CSET_RESERVED_10:
+        case H5T_CSET_RESERVED_11:
+        case H5T_CSET_RESERVED_12:
+        case H5T_CSET_RESERVED_13:
+        case H5T_CSET_RESERVED_14:
+        case H5T_CSET_RESERVED_15:
+            H5RS_asprintf_cat(rs, "H5T_CSET_RESERVED_%ld", (long)cset);
+            break;
+
+        default:
+            H5RS_asprintf_cat(rs, "%ld", (long)cset);
+            break;
+    } /* end switch */
+
+    return SUCCEED;
+} /* end H5_trace_args_cset() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5_trace_args_close_degree
+ *
+ * Purpose:     This routine formats an H5F_close_degree_t and adds the output to
+ *		the refcounted string (RS) argument.
+ *
+ * Return:      SUCCEED / FAIL
+ *
+ * Programmer:	Quincey Koziol
+ *	        Monday, September 21, 2020
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5_trace_args_close_degree(H5RS_str_t *rs, H5F_close_degree_t degree)
+{
+    /* FUNC_ENTER() should not be called */
+
+    switch (degree) {
+        case H5F_CLOSE_DEFAULT:
+            H5RS_acat(rs, "H5F_CLOSE_DEFAULT");
+            break;
+
+        case H5F_CLOSE_WEAK:
+            H5RS_acat(rs, "H5F_CLOSE_WEAK");
+            break;
+
+        case H5F_CLOSE_SEMI:
+            H5RS_acat(rs, "H5F_CLOSE_SEMI");
+            break;
+
+        case H5F_CLOSE_STRONG:
+            H5RS_acat(rs, "H5F_CLOSE_STRONG");
+            break;
+
+        default:
+            H5RS_asprintf_cat(rs, "%ld", (long)degree);
+            break;
+    } /* end switch */
+
+    return SUCCEED;
+} /* end H5_trace_args_cset() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5_trace_args
+ *
+ * Purpose:     This routine formats a set of function arguments, placing the
+ *		resulting string in the refcounted string (RS) argument.
+ *
+ *		The TYPE argument is a string which gives the type of each of
+ *              the following argument pairs.  Each type begins with zero or
+ *		more asterisks (one for each level of indirection, although
+ *		some types have one level of indirection already implied)
+ *		followed by either one letter (lower case) or two letters
+ *		(first one uppercase).
+ *
+ *              The variable argument list consists of pairs of values. Each
+ *              pair is a string which is the formal argument name in the
+ *              calling function, followed by the argument value.  The type
+ *              of the argument value is given by the TYPE string.
+ *
+ * Note:        The TYPE string is meant to be terse and is generated by a
+ *              separate perl script.
+ *
+ * Return:      SUCCEED / FAIL
+ *
+ * Programmer:	Quincey Koziol
+ *	        Saturday, September 19, 2020
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5_trace_args(H5RS_str_t *rs, const char *type, va_list ap)
+{
+    const char *argname;
+    int         argno = 0, ptr, asize_idx;
+    hssize_t    asize[16];
+    hssize_t    i;
+    void *      vp = NULL;
+
+    /* FUNC_ENTER() should not be called */
+
+    /* Clear array sizes */
+    for (i = 0; i < (hssize_t)NELMTS(asize); i++)
+        asize[i] = -1;
+
+    /* Parse the argument types */
+    for (argno = 0; *type; argno++, type += (HDisupper(*type) ? 2 : 1)) {
+        /* Count levels of indirection */
+        for (ptr = 0; '*' == *type; type++)
+            ptr++;
+
+        /* Array parameter, possibly with another argument as the array size */
+        if ('[' == *type) {
+            char *rest;
+
+            if ('a' == type[1]) {
+                asize_idx = (int)HDstrtol(type + 2, &rest, 10);
+                HDassert(0 <= asize_idx && asize_idx < (int)NELMTS(asize));
+                HDassert(']' == *rest);
+                type = rest + 1;
+            }
+            else {
+                rest = (char *)HDstrchr(type, ']');
+                HDassert(rest);
+                type      = rest + 1;
+                asize_idx = -1;
+            }
+        } /* end if */
+        else
+            asize_idx = -1;
+
+        /*
+         * The argument name.  If the argument name is the null pointer then
+         * don't print the argument or the following `=' (this is used for
+         * return values).
+         */
+        argname = HDva_arg(ap, char *);
+        if (argname)
+            H5RS_asprintf_cat(rs, "%s%s=", argno ? ", " : "", argname);
+        else
+            argname = "";
+
+        /* A pointer/array */
+        if (ptr) {
+            vp = HDva_arg(ap, void *);
+            if (vp) {
+                switch (type[0]) {
+                    case 'h': /* hsize_t */
+                        H5RS_asprintf_cat(rs, "%p", vp);
+                        if (asize_idx >= 0 && asize[asize_idx] >= 0) {
+                            hsize_t *p = (hsize_t *)vp;
+
+                            H5RS_acat(rs, " {");
+                            for (i = 0; i < asize[asize_idx]; i++) {
+                                if (H5S_UNLIMITED == p[i])
+                                    H5RS_asprintf_cat(rs, "%sH5S_UNLIMITED", (i ? ", " : ""));
+                                else
+                                    H5RS_asprintf_cat(rs, "%s%" PRIuHSIZE, (i ? ", " : ""), p[i]);
+                            } /* end for */
+                            H5RS_acat(rs, "}");
+                        } /* end if */
+                        break;
+
+                    case 'H':
+                        if ('s' == type[1]) { /* hssize_t */
+                            H5RS_asprintf_cat(rs, "%p", vp);
+                            if (asize_idx >= 0 && asize[asize_idx] >= 0) {
+                                hssize_t *p = (hssize_t *)vp;
+
+                                H5RS_acat(rs, " {");
+                                for (i = 0; i < asize[asize_idx]; i++)
+                                    H5RS_asprintf_cat(rs, "%s%" PRIdHSIZE, (i ? ", " : ""), p[i]);
+                                H5RS_acat(rs, "}");
+                            } /* end if */
+                        }     /* end if */
+                        else
+                            H5RS_asprintf_cat(rs, "%p", vp);
+                        break;
+
+                    case 'I':
+                        if ('s' == type[1]) { /* int / int32_t */
+                            H5RS_asprintf_cat(rs, "%p", vp);
+                            if (asize_idx >= 0 && asize[asize_idx] >= 0) {
+                                int *p = (int *)vp;
+
+                                H5RS_acat(rs, " {");
+                                for (i = 0; i < asize[asize_idx]; i++)
+                                    H5RS_asprintf_cat(rs, "%s%d", (i ? ", " : ""), p[i]);
+                                H5RS_acat(rs, "}");
+                            }                      /* end if */
+                        }                          /* end if */
+                        else if ('u' == type[1]) { /* unsigned / uint32_t */
+                            H5RS_asprintf_cat(rs, "%p", vp);
+                            if (asize_idx >= 0 && asize[asize_idx] >= 0) {
+                                unsigned *p = (unsigned *)vp;
+
+                                H5RS_acat(rs, " {");
+                                for (i = 0; i < asize[asize_idx]; i++)
+                                    H5RS_asprintf_cat(rs, "%s%u", i ? ", " : "", p[i]);
+                                H5RS_acat(rs, "}");
+                            } /* end if */
+                        }     /* end else-if */
+                        else
+                            H5RS_asprintf_cat(rs, "%p", vp);
+                        break;
+
+                    case 's': /* char* */
+                        /* Strings have one level of indirection by default, pointers
+                         *      to strings have 2 or more.
+                         */
+                        if (ptr > 1)
+                            H5RS_asprintf_cat(rs, "%p", vp);
+                        else
+                            H5RS_asprintf_cat(rs, "\"%s\"", (const char *)vp);
+                        break;
+
+                    case 'U':
+                        if ('l' == type[1]) { /* unsigned long */
+                            H5RS_asprintf_cat(rs, "%p", vp);
+                            if (asize_idx >= 0 && asize[asize_idx] >= 0) {
+                                unsigned long *p = (unsigned long *)vp;
+
+                                H5RS_acat(rs, " {");
+                                for (i = 0; i < asize[asize_idx]; i++)
+                                    H5RS_asprintf_cat(rs, "%s%lu", i ? ", " : "", p[i]);
+                                H5RS_acat(rs, "}");
+                            }                      /* end if */
+                        }                          /* end if */
+                        else if ('L' == type[1]) { /* unsigned long long / uint64_t */
+                            H5RS_asprintf_cat(rs, "%p", vp);
+                            if (asize_idx >= 0 && asize[asize_idx] >= 0) {
+                                unsigned long long *p = (unsigned long long *)vp;
+
+                                H5RS_acat(rs, " {");
+                                for (i = 0; i < asize[asize_idx]; i++)
+                                    H5RS_asprintf_cat(rs, "%s%llu", i ? ", " : "", p[i]);
+                                H5RS_acat(rs, "}");
+                            } /* end if */
+                        }     /* end else-if */
+                        else
+                            H5RS_asprintf_cat(rs, "%p", vp);
+                        break;
+
+                    case 'x': /* void */
+                        H5RS_asprintf_cat(rs, "%p", vp);
+                        if (asize_idx >= 0 && asize[asize_idx] >= 0) {
+                            void **p = (void **)vp;
+
+                            H5RS_acat(rs, " {");
+                            for (i = 0; i < asize[asize_idx]; i++) {
+                                if (p[i])
+                                    H5RS_asprintf_cat(rs, "%s%p", (i ? ", " : ""), p[i]);
+                                else
+                                    H5RS_asprintf_cat(rs, "%sNULL", (i ? ", " : ""));
+                            } /* end for */
+                            H5RS_acat(rs, "}");
+                        } /* end if */
+                        break;
+
+                    case 'z': /* size_t */
+                        H5RS_asprintf_cat(rs, "%p", vp);
+                        if (asize_idx >= 0 && asize[asize_idx] >= 0) {
+                            size_t *p = (size_t *)vp;
+
+                            H5RS_acat(rs, " {");
+                            for (i = 0; i < asize[asize_idx]; i++)
+                                H5RS_asprintf_cat(rs, "%s%zu", (i ? ", " : ""), p[i]);
+                            H5RS_acat(rs, "}");
+                        } /* end if */
+                        break;
+
+                    case 'Z':
+                        if ('s' == type[1]) { /* ssize_t */
+                            H5RS_asprintf_cat(rs, "%p", vp);
+                            if (asize_idx >= 0 && asize[asize_idx] >= 0) {
+                                ssize_t *p = (ssize_t *)vp;
+
+                                H5RS_acat(rs, " {");
+                                for (i = 0; i < asize[asize_idx]; i++)
+                                    H5RS_asprintf_cat(rs, "%s%zd", (i ? ", " : ""), p[i]);
+                                H5RS_acat(rs, "}");
+                            } /* end if */
+                        }     /* end if */
+                        else
+                            H5RS_asprintf_cat(rs, "%p", vp);
+                        break;
+
+                    default:
+                        H5RS_asprintf_cat(rs, "%p", vp);
+                } /* end switch */
+            }     /* end if */
+            else
+                H5RS_acat(rs, "NULL");
+        } /* end if */
+        /* A value */
+        else {
+            switch (type[0]) {
+                case 'a': /* haddr_t */
+                {
+                    haddr_t addr = HDva_arg(ap, haddr_t);
+
+                    if (H5F_addr_defined(addr))
+                        H5RS_asprintf_cat(rs, "%" PRIuHADDR, addr);
+                    else
+                        H5RS_acat(rs, "UNDEF");
+                } /* end block */
+                break;
+
+                case 'A':
+                    switch (type[1]) {
+                        case 'i': /* H5A_info_t */
+                        {
+                            H5A_info_t ainfo = HDva_arg(ap, H5A_info_t);
+
+                            H5RS_acat(rs, "{");
+                            H5_trace_args_bool(rs, ainfo.corder_valid);
+                            H5RS_asprintf_cat(rs, ", %u, ", ainfo.corder);
+                            H5_trace_args_cset(rs, ainfo.cset);
+                            H5RS_asprintf_cat(rs, "%" PRIuHSIZE "}", ainfo.data_size);
+                        } /* end block */
+                        break;
+
+#ifndef H5_NO_DEPRECATED_SYMBOLS
+                        case 'o': /* H5A_operator1_t */
+                        {
+                            H5A_operator1_t aop1 = (H5A_operator1_t)HDva_arg(ap, H5A_operator1_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)aop1);
+                        } /* end block */
+                        break;
+#endif /* H5_NO_DEPRECATED_SYMBOLS */
+
+                        case 'O': /* H5A_operator2_t */
+                        {
+                            H5A_operator2_t aop2 = (H5A_operator2_t)HDva_arg(ap, H5A_operator2_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)aop2);
+                        } /* end block */
+                        break;
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(A%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 'b': /* hbool_t */
+                {
+                    /* Can't pass hbool_t to HDva_arg() */
+                    hbool_t bool_var = (hbool_t)HDva_arg(ap, int);
+
+                    H5_trace_args_bool(rs, bool_var);
+                } /* end block */
+                break;
+
+                case 'C':
+                    switch (type[1]) {
+                        case 'c': /* H5AC_cache_config_t */
+                        {
+                            H5AC_cache_config_t cc = HDva_arg(ap, H5AC_cache_config_t);
+
+                            H5RS_asprintf_cat(rs, "{%d, ", cc.version);
+                            H5_trace_args_bool(rs, cc.rpt_fcn_enabled);
+                            H5RS_acat(rs, ", ");
+                            H5_trace_args_bool(rs, cc.open_trace_file);
+                            H5RS_acat(rs, ", ");
+                            H5_trace_args_bool(rs, cc.close_trace_file);
+                            H5RS_asprintf_cat(rs, ", '%s', ", cc.trace_file_name);
+                            H5RS_acat(rs, ", ");
+                            H5_trace_args_bool(rs, cc.evictions_enabled);
+                            H5RS_acat(rs, ", ");
+                            H5_trace_args_bool(rs, cc.set_initial_size);
+                            H5RS_asprintf_cat(rs, ", %zu, ", cc.initial_size);
+                            H5RS_asprintf_cat(rs, "%f, ", cc.min_clean_fraction);
+                            H5RS_asprintf_cat(rs, "%zu, ", cc.max_size);
+                            H5RS_asprintf_cat(rs, "%zu, ", cc.min_size);
+                            H5RS_asprintf_cat(rs, "%ld, ", cc.epoch_length);
+                            switch (cc.incr_mode) {
+                                case H5C_incr__off:
+                                    H5RS_acat(rs, "H5C_incr__off");
+                                    break;
+
+                                case H5C_incr__threshold:
+                                    H5RS_acat(rs, "H5C_incr__threshold");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)cc.incr_mode);
+                                    break;
+                            } /* end switch */
+                            H5RS_asprintf_cat(rs, ", %f, ", cc.lower_hr_threshold);
+                            H5RS_asprintf_cat(rs, "%f, ", cc.increment);
+                            H5_trace_args_bool(rs, cc.apply_max_increment);
+                            H5RS_asprintf_cat(rs, ", %zu, ", cc.max_increment);
+                            switch (cc.flash_incr_mode) {
+                                case H5C_flash_incr__off:
+                                    H5RS_acat(rs, "H5C_flash_incr__off");
+                                    break;
+
+                                case H5C_flash_incr__add_space:
+                                    H5RS_acat(rs, "H5C_flash_incr__add_space");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)cc.flash_incr_mode);
+                                    break;
+                            } /* end switch */
+                            H5RS_asprintf_cat(rs, ", %f, ", cc.flash_multiple);
+                            H5RS_asprintf_cat(rs, "%f, ", cc.flash_threshold);
+                            switch (cc.decr_mode) {
+                                case H5C_decr__off:
+                                    H5RS_acat(rs, "H5C_decr__off");
+                                    break;
+
+                                case H5C_decr__threshold:
+                                    H5RS_acat(rs, "H5C_decr__threshold");
+                                    break;
+
+                                case H5C_decr__age_out:
+                                    H5RS_acat(rs, "H5C_decr__age_out");
+                                    break;
+
+                                case H5C_decr__age_out_with_threshold:
+                                    H5RS_acat(rs, "H5C_decr__age_out_with_threshold");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)cc.decr_mode);
+                                    break;
+                            } /* end switch */
+                            H5RS_asprintf_cat(rs, ", %f, ", cc.upper_hr_threshold);
+                            H5RS_asprintf_cat(rs, "%f, ", cc.decrement);
+                            H5_trace_args_bool(rs, cc.apply_max_decrement);
+                            H5RS_asprintf_cat(rs, ", %zu, ", cc.max_decrement);
+                            H5RS_asprintf_cat(rs, "%d, ", cc.epochs_before_eviction);
+                            H5_trace_args_bool(rs, cc.apply_empty_reserve);
+                            H5RS_asprintf_cat(rs, ", %f, ", cc.empty_reserve);
+                            H5RS_asprintf_cat(rs, "%zu, ", cc.dirty_bytes_threshold);
+                            H5RS_asprintf_cat(rs, "%d}", cc.metadata_write_strategy);
+                        } /* end block */
+                        break;
+
+                        case 'C': /* H5AC_cache_image_config_t */
+                        {
+                            H5AC_cache_image_config_t cic = HDva_arg(ap, H5AC_cache_image_config_t);
+
+                            H5RS_asprintf_cat(rs, "{%d, ", cic.version);
+                            H5_trace_args_bool(rs, cic.generate_image);
+                            H5RS_acat(rs, ", ");
+                            H5_trace_args_bool(rs, cic.save_resize_status);
+                            H5RS_acat(rs, ", ");
+                            H5RS_asprintf_cat(rs, "%d}", cic.entry_ageout);
+                        } /* end block */
+                        break;
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(C%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 'd': /* double */
+                {
+                    double dbl = HDva_arg(ap, double);
+
+                    H5RS_asprintf_cat(rs, "%g", dbl);
+                } /* end block */
+                break;
+
+                case 'D':
+                    switch (type[1]) {
+                        case 'a': /* H5D_alloc_time_t */
+                        {
+                            H5D_alloc_time_t alloc_time = (H5D_alloc_time_t)HDva_arg(ap, int);
+
+                            switch (alloc_time) {
+                                case H5D_ALLOC_TIME_ERROR:
+                                    H5RS_acat(rs, "H5D_ALLOC_TIME_ERROR");
+                                    break;
+
+                                case H5D_ALLOC_TIME_DEFAULT:
+                                    H5RS_acat(rs, "H5D_ALLOC_TIME_DEFAULT");
+                                    break;
+
+                                case H5D_ALLOC_TIME_EARLY:
+                                    H5RS_acat(rs, "H5D_ALLOC_TIME_EARLY");
+                                    break;
+
+                                case H5D_ALLOC_TIME_LATE:
+                                    H5RS_acat(rs, "H5D_ALLOC_TIME_LATE");
+                                    break;
+
+                                case H5D_ALLOC_TIME_INCR:
+                                    H5RS_acat(rs, "H5D_ALLOC_TIME_INCR");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)alloc_time);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'A': /* H5D_append_cb_t */
+                        {
+                            H5D_append_cb_t dapp = (H5D_append_cb_t)HDva_arg(ap, H5D_append_cb_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)dapp);
+                        } /* end block */
+                        break;
+
+                        case 'c': /* H5FD_mpio_collective_opt_t */
+                        {
+                            H5FD_mpio_collective_opt_t opt = (H5FD_mpio_collective_opt_t)HDva_arg(ap, int);
+
+                            switch (opt) {
+                                case H5FD_MPIO_COLLECTIVE_IO:
+                                    H5RS_acat(rs, "H5FD_MPIO_COLLECTIVE_IO");
+                                    break;
+
+                                case H5FD_MPIO_INDIVIDUAL_IO:
+                                    H5RS_acat(rs, "H5FD_MPIO_INDIVIDUAL_IO");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)opt);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'f': /* H5D_fill_time_t */
+                        {
+                            H5D_fill_time_t fill_time = (H5D_fill_time_t)HDva_arg(ap, int);
+
+                            switch (fill_time) {
+                                case H5D_FILL_TIME_ERROR:
+                                    H5RS_acat(rs, "H5D_FILL_TIME_ERROR");
+                                    break;
+
+                                case H5D_FILL_TIME_ALLOC:
+                                    H5RS_acat(rs, "H5D_FILL_TIME_ALLOC");
+                                    break;
+
+                                case H5D_FILL_TIME_NEVER:
+                                    H5RS_acat(rs, "H5D_FILL_TIME_NEVER");
+                                    break;
+
+                                case H5D_FILL_TIME_IFSET:
+                                    H5RS_acat(rs, "H5D_FILL_TIME_IFSET");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)fill_time);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'F': /* H5D_fill_value_t */
+                        {
+                            H5D_fill_value_t fill_value = (H5D_fill_value_t)HDva_arg(ap, int);
+
+                            switch (fill_value) {
+                                case H5D_FILL_VALUE_ERROR:
+                                    H5RS_acat(rs, "H5D_FILL_VALUE_ERROR");
+                                    break;
+
+                                case H5D_FILL_VALUE_UNDEFINED:
+                                    H5RS_acat(rs, "H5D_FILL_VALUE_UNDEFINED");
+                                    break;
+
+                                case H5D_FILL_VALUE_DEFAULT:
+                                    H5RS_acat(rs, "H5D_FILL_VALUE_DEFAULT");
+                                    break;
+
+                                case H5D_FILL_VALUE_USER_DEFINED:
+                                    H5RS_acat(rs, "H5D_FILL_VALUE_USER_DEFINED");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)fill_value);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'g': /* H5D_gather_func_t */
+                        {
+                            H5D_gather_func_t gop = (H5D_gather_func_t)HDva_arg(ap, H5D_gather_func_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)gop);
+                        } /* end block */
+                        break;
+
+                        case 'h': /* H5FD_mpio_chunk_opt_t */
+                        {
+                            H5FD_mpio_chunk_opt_t opt = (H5FD_mpio_chunk_opt_t)HDva_arg(ap, int);
+
+                            switch (opt) {
+                                case H5FD_MPIO_CHUNK_DEFAULT:
+                                    H5RS_acat(rs, "H5FD_MPIO_CHUNK_DEFAULT");
+                                    break;
+
+                                case H5FD_MPIO_CHUNK_ONE_IO:
+                                    H5RS_acat(rs, "H5FD_MPIO_CHUNK_ONE_IO");
+                                    break;
+
+                                case H5FD_MPIO_CHUNK_MULTI_IO:
+                                    H5RS_acat(rs, "H5FD_MPIO_CHUNK_MULTI_IO");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)opt);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'i': /* H5D_mpio_actual_io_mode_t */
+                        {
+                            H5D_mpio_actual_io_mode_t actual_io_mode =
+                                (H5D_mpio_actual_io_mode_t)HDva_arg(ap, int);
+
+                            switch (actual_io_mode) {
+                                case H5D_MPIO_NO_COLLECTIVE:
+                                    H5RS_acat(rs, "H5D_MPIO_NO_COLLECTIVE");
+                                    break;
+
+                                case H5D_MPIO_CHUNK_INDEPENDENT:
+                                    H5RS_acat(rs, "H5D_MPIO_CHUNK_INDEPENDENT");
+                                    break;
+
+                                case H5D_MPIO_CHUNK_COLLECTIVE:
+                                    H5RS_acat(rs, "H5D_MPIO_CHUNK_COLLECTIVE");
+                                    break;
+
+                                case H5D_MPIO_CHUNK_MIXED:
+                                    H5RS_acat(rs, "H5D_MPIO_CHUNK_MIXED");
+                                    break;
+
+                                case H5D_MPIO_CONTIGUOUS_COLLECTIVE:
+                                    H5RS_acat(rs, "H5D_MPIO_CONTIGUOUS_COLLECTIVE");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)actual_io_mode);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'I': /* H5FD_file_image_callbacks_t */
+                        {
+                            H5FD_file_image_callbacks_t ficb = HDva_arg(ap, H5FD_file_image_callbacks_t);
+
+                            H5RS_asprintf_cat(rs, "{%p, ", (void *)(uintptr_t)ficb.image_malloc);
+                            H5RS_asprintf_cat(rs, "%p, ", (void *)(uintptr_t)ficb.image_memcpy);
+                            H5RS_asprintf_cat(rs, "%p, ", (void *)(uintptr_t)ficb.image_realloc);
+                            H5RS_asprintf_cat(rs, "%p, ", (void *)(uintptr_t)ficb.image_free);
+                            H5RS_asprintf_cat(rs, "%p, ", (void *)(uintptr_t)ficb.udata_copy);
+                            H5RS_asprintf_cat(rs, "%p, ", (void *)(uintptr_t)ficb.udata_free);
+                            H5RS_asprintf_cat(rs, "%p}", ficb.udata);
+                        } /* end block */
+                        break;
+
+                        case 'k': /* H5D_chunk_index_t */
+                        {
+                            H5D_chunk_index_t idx = (H5D_chunk_index_t)HDva_arg(ap, int);
+
+                            switch (idx) {
+                                case H5D_CHUNK_IDX_BTREE:
+                                    H5RS_acat(rs, "H5D_CHUNK_IDX_BTREE");
+                                    break;
+
+                                case H5D_CHUNK_IDX_NONE:
+                                    H5RS_acat(rs, "H5D_CHUNK_IDX_NONE");
+                                    break;
+
+                                case H5D_CHUNK_IDX_FARRAY:
+                                    H5RS_acat(rs, "H5D_CHUNK_IDX_FARRAY");
+                                    break;
+
+                                case H5D_CHUNK_IDX_EARRAY:
+                                    H5RS_acat(rs, "H5D_CHUNK_IDX_EARRAY");
+                                    break;
+
+                                case H5D_CHUNK_IDX_BT2:
+                                    H5RS_acat(rs, "H5D_CHUNK_IDX_BT2");
+                                    break;
+
+                                case H5D_CHUNK_IDX_SINGLE:
+                                    H5RS_acat(rs, "H5D_CHUNK_IDX_SINGLE");
+                                    break;
+
+                                case H5D_CHUNK_IDX_NTYPES:
+                                    H5RS_acat(rs, "ERROR: H5D_CHUNK_IDX_NTYPES (invalid value)");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "UNKNOWN VALUE: %ld", (long)idx);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'l': /* H5D_layout_t */
+                        {
+                            H5D_layout_t layout = (H5D_layout_t)HDva_arg(ap, int);
+
+                            switch (layout) {
+                                case H5D_LAYOUT_ERROR:
+                                    H5RS_acat(rs, "H5D_LAYOUT_ERROR");
+                                    break;
+
+                                case H5D_COMPACT:
+                                    H5RS_acat(rs, "H5D_COMPACT");
+                                    break;
+
+                                case H5D_CONTIGUOUS:
+                                    H5RS_acat(rs, "H5D_CONTIGUOUS");
+                                    break;
+
+                                case H5D_CHUNKED:
+                                    H5RS_acat(rs, "H5D_CHUNKED");
+                                    break;
+
+                                case H5D_VIRTUAL:
+                                    H5RS_acat(rs, "H5D_VIRTUAL");
+                                    break;
+
+                                case H5D_NLAYOUTS:
+                                    H5RS_acat(rs, "H5D_NLAYOUTS");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)layout);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'n': /* H5D_mpio_no_collective_cause_t */
+                        {
+                            H5D_mpio_no_collective_cause_t nocol_cause_mode =
+                                (H5D_mpio_no_collective_cause_t)HDva_arg(ap, int);
+                            hbool_t flag_already_displayed = FALSE;
+
+                            /* Check for all bit-flags which might be set */
+                            if (nocol_cause_mode & H5D_MPIO_COLLECTIVE) {
+                                H5RS_acat(rs, "H5D_MPIO_COLLECTIVE");
+                                flag_already_displayed = TRUE;
+                            } /* end if */
+                            if (nocol_cause_mode & H5D_MPIO_SET_INDEPENDENT) {
+                                H5RS_asprintf_cat(rs, "%sH5D_MPIO_SET_INDEPENDENT",
+                                                  flag_already_displayed ? " | " : "");
+                                flag_already_displayed = TRUE;
+                            } /* end if */
+                            if (nocol_cause_mode & H5D_MPIO_DATATYPE_CONVERSION) {
+                                H5RS_asprintf_cat(rs, "%sH5D_MPIO_DATATYPE_CONVERSION",
+                                                  flag_already_displayed ? " | " : "");
+                                flag_already_displayed = TRUE;
+                            } /* end if */
+                            if (nocol_cause_mode & H5D_MPIO_DATA_TRANSFORMS) {
+                                H5RS_asprintf_cat(rs, "%sH5D_MPIO_DATA_TRANSFORMS",
+                                                  flag_already_displayed ? " | " : "");
+                                flag_already_displayed = TRUE;
+                            } /* end if */
+                            if (nocol_cause_mode & H5D_MPIO_MPI_OPT_TYPES_ENV_VAR_DISABLED) {
+                                H5RS_asprintf_cat(rs, "%sH5D_MPIO_MPI_OPT_TYPES_ENV_VAR_DISABLED",
+                                                  flag_already_displayed ? " | " : "");
+                                flag_already_displayed = TRUE;
+                            } /* end if */
+                            if (nocol_cause_mode & H5D_MPIO_NOT_SIMPLE_OR_SCALAR_DATASPACES) {
+                                H5RS_asprintf_cat(rs, "%sH5D_MPIO_NOT_SIMPLE_OR_SCALAR_DATASPACES",
+                                                  flag_already_displayed ? " | " : "");
+                                flag_already_displayed = TRUE;
+                            } /* end if */
+                            if (nocol_cause_mode & H5D_MPIO_NOT_CONTIGUOUS_OR_CHUNKED_DATASET) {
+                                H5RS_asprintf_cat(rs, "%sH5D_MPIO_NOT_CONTIGUOUS_OR_CHUNKED_DATASET",
+                                                  flag_already_displayed ? " | " : "");
+                                flag_already_displayed = TRUE;
+                            } /* end if */
+
+                            /* Display '<none>' if there's no flags set */
+                            if (!flag_already_displayed)
+                                H5RS_acat(rs, "<none>");
+                        } /* end block */
+                        break;
+
+                        case 'o': /* H5D_mpio_actual_chunk_opt_mode_t */
+                        {
+                            H5D_mpio_actual_chunk_opt_mode_t chunk_opt_mode =
+                                (H5D_mpio_actual_chunk_opt_mode_t)HDva_arg(ap, int);
+
+                            switch (chunk_opt_mode) {
+                                case H5D_MPIO_NO_CHUNK_OPTIMIZATION:
+                                    H5RS_acat(rs, "H5D_MPIO_NO_CHUNK_OPTIMIZATION");
+                                    break;
+
+                                case H5D_MPIO_LINK_CHUNK:
+                                    H5RS_acat(rs, "H5D_MPIO_LINK_CHUNK");
+                                    break;
+
+                                case H5D_MPIO_MULTI_CHUNK:
+                                    H5RS_acat(rs, "H5D_MPIO_MULTI_CHUNK");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)chunk_opt_mode);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'O': /* H5D_operator_t */
+                        {
+                            H5D_operator_t dop = (H5D_operator_t)HDva_arg(ap, H5D_operator_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)dop);
+                        } /* end block */
+                        break;
+
+                        case 's': /* H5D_space_status_t */
+                        {
+                            H5D_space_status_t space_status = (H5D_space_status_t)HDva_arg(ap, int);
+
+                            switch (space_status) {
+                                case H5D_SPACE_STATUS_NOT_ALLOCATED:
+                                    H5RS_acat(rs, "H5D_SPACE_STATUS_NOT_ALLOCATED");
+                                    break;
+
+                                case H5D_SPACE_STATUS_PART_ALLOCATED:
+                                    H5RS_acat(rs, "H5D_SPACE_STATUS_PART_ALLOCATED");
+                                    break;
+
+                                case H5D_SPACE_STATUS_ALLOCATED:
+                                    H5RS_acat(rs, "H5D_SPACE_STATUS_ALLOCATED");
+                                    break;
+
+                                case H5D_SPACE_STATUS_ERROR:
+                                    H5RS_acat(rs, "H5D_SPACE_STATUS_ERROR");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)space_status);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'S': /* H5D_scatter_func_t */
+                        {
+                            H5D_scatter_func_t sop = (H5D_scatter_func_t)HDva_arg(ap, H5D_scatter_func_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)sop);
+                        } /* end block */
+                        break;
+
+                        case 't': /* H5FD_mpio_xfer_t */
+                        {
+                            H5FD_mpio_xfer_t transfer = (H5FD_mpio_xfer_t)HDva_arg(ap, int);
+
+                            switch (transfer) {
+                                case H5FD_MPIO_INDEPENDENT:
+                                    H5RS_acat(rs, "H5FD_MPIO_INDEPENDENT");
+                                    break;
+
+                                case H5FD_MPIO_COLLECTIVE:
+                                    H5RS_acat(rs, "H5FD_MPIO_COLLECTIVE");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)transfer);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'v': /* H5D_vds_view_t */
+                        {
+                            H5D_vds_view_t view = (H5D_vds_view_t)HDva_arg(ap, int);
+
+                            switch (view) {
+                                case H5D_VDS_ERROR:
+                                    H5RS_acat(rs, "H5D_VDS_ERROR");
+                                    break;
+
+                                case H5D_VDS_FIRST_MISSING:
+                                    H5RS_acat(rs, "H5D_VDS_FIRST_MISSING");
+                                    break;
+
+                                case H5D_VDS_LAST_AVAILABLE:
+                                    H5RS_acat(rs, "H5D_VDS_LAST_AVAILABLE");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)view);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(D%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 'e': /* herr_t */
+                {
+                    herr_t status = HDva_arg(ap, herr_t);
+
+                    if (status >= 0)
+                        H5RS_acat(rs, "SUCCEED");
+                    else
+                        H5RS_acat(rs, "FAIL");
+                } /* end block */
+                break;
+
+                case 'E':
+                    switch (type[1]) {
+#ifndef H5_NO_DEPRECATED_SYMBOLS
+                        case 'a': /* H5E_auto1_t */
+                        {
+                            H5E_auto1_t eauto1 = (H5E_auto1_t)HDva_arg(ap, H5E_auto1_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)eauto1);
+                        } /* end block */
+                        break;
+#endif /* H5_NO_DEPRECATED_SYMBOLS */
+
+                        case 'A': /* H5E_auto2_t */
+                        {
+                            H5E_auto2_t eauto2 = (H5E_auto2_t)HDva_arg(ap, H5E_auto2_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)eauto2);
+                        } /* end block */
+                        break;
+
+                        case 'd': /* H5E_direction_t */
+                        {
+                            H5E_direction_t direction = (H5E_direction_t)HDva_arg(ap, int);
+
+                            switch (direction) {
+                                case H5E_WALK_UPWARD:
+                                    H5RS_acat(rs, "H5E_WALK_UPWARD");
+                                    break;
+
+                                case H5E_WALK_DOWNWARD:
+                                    H5RS_acat(rs, "H5E_WALK_DOWNWARD");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)direction);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'e': /* H5E_error_t */
+                        {
+                            H5E_error2_t *error = HDva_arg(ap, H5E_error2_t *);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)error);
+                        } /* end block */
+                        break;
+
+                        case 's': /* H5ES_status_t */
+                        {
+                            H5ES_status_t status = (H5ES_status_t)HDva_arg(ap, int);
+
+                            switch (status) {
+                                case H5ES_STATUS_IN_PROGRESS:
+                                    H5RS_acat(rs, "H5ES_STATUS_IN_PROGRESS");
+                                    break;
+
+                                case H5ES_STATUS_SUCCEED:
+                                    H5RS_acat(rs, "H5ES_STATUS_SUCCEED");
+                                    break;
+
+                                case H5ES_STATUS_FAIL:
+                                    H5RS_acat(rs, "H5ES_STATUS_FAIL");
+                                    break;
+
+                                case H5ES_STATUS_CANCELED:
+                                    H5RS_acat(rs, "H5ES_STATUS_CANCELED");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)status);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 't': /* H5E_type_t */
+                        {
+                            H5E_type_t etype = (H5E_type_t)HDva_arg(ap, int);
+
+                            switch (etype) {
+                                case H5E_MAJOR:
+                                    H5RS_acat(rs, "H5E_MAJOR");
+                                    break;
+
+                                case H5E_MINOR:
+                                    H5RS_acat(rs, "H5E_MINOR");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)etype);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(E%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 'F':
+                    switch (type[1]) {
+                        case 'C': /* H5FD_class_t */
+                        {
+                            H5FD_class_t cls = HDva_arg(ap, H5FD_class_t);
+
+                            H5RS_asprintf_cat(rs, "{'%s', " H5_PRINTF_HADDR_FMT ", ", cls.name, cls.maxaddr);
+                            H5_trace_args_close_degree(rs, cls.fc_degree);
+                            H5RS_acat(rs, ", ...}");
+                        } /* end block */
+                        break;
+
+                        case 'd': /* H5F_close_degree_t */
+                        {
+                            H5F_close_degree_t degree = (H5F_close_degree_t)HDva_arg(ap, int);
+
+                            H5_trace_args_close_degree(rs, degree);
+                        } /* end block */
+                        break;
+
+                        case 'f': /* H5F_fspace_strategy_t */
+                        {
+                            H5F_fspace_strategy_t fs_strategy = (H5F_fspace_strategy_t)HDva_arg(ap, int);
+
+                            switch (fs_strategy) {
+                                case H5F_FSPACE_STRATEGY_FSM_AGGR:
+                                    H5RS_acat(rs, "H5F_FSPACE_STRATEGY_FSM_AGGR");
+                                    break;
+
+                                case H5F_FSPACE_STRATEGY_PAGE:
+                                    H5RS_acat(rs, "H5F_FSPACE_STRATEGY_PAGE");
+                                    break;
+
+                                case H5F_FSPACE_STRATEGY_AGGR:
+                                    H5RS_acat(rs, "H5F_FSPACE_STRATEGY_AGGR");
+                                    break;
+
+                                case H5F_FSPACE_STRATEGY_NONE:
+                                    H5RS_acat(rs, "H5F_FSPACE_STRATEGY_NONE");
+                                    break;
+
+                                case H5F_FSPACE_STRATEGY_NTYPES:
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)fs_strategy);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'F': /* H5F_flush_cb_t */
+                        {
+                            H5F_flush_cb_t fflsh = (H5F_flush_cb_t)HDva_arg(ap, H5F_flush_cb_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)fflsh);
+                        } /* end block */
+                        break;
+
+                        case 'I': /* H5F_info2_t */
+                        {
+                            H5F_info2_t fi2 = HDva_arg(ap, H5F_info2_t);
+
+                            H5RS_asprintf_cat(rs, "{{%u, %" PRIuHSIZE ", %" PRIuHSIZE "}, ",
+                                              fi2.super.version, fi2.super.super_size,
+                                              fi2.super.super_ext_size);
+                            H5RS_asprintf_cat(rs, "{%u, %" PRIuHSIZE ", %" PRIuHSIZE "}, ", fi2.free.version,
+                                              fi2.free.meta_size, fi2.free.tot_space);
+                            H5RS_asprintf_cat(rs, "{%u, %" PRIuHSIZE ", {%" PRIuHSIZE ", %" PRIuHSIZE "}}}",
+                                              fi2.sohm.version, fi2.sohm.hdr_size,
+                                              fi2.sohm.msgs_info.index_size, fi2.sohm.msgs_info.heap_size);
+                        } /* end block */
+                        break;
+
+                        case 'm': /* H5F_mem_t */
+                        {
+                            H5F_mem_t mem_type = (H5F_mem_t)HDva_arg(ap, int);
+
+                            switch (mem_type) {
+                                case H5FD_MEM_NOLIST:
+                                    H5RS_acat(rs, "H5FD_MEM_NOLIST");
+                                    break;
+
+                                case H5FD_MEM_DEFAULT:
+                                    H5RS_acat(rs, "H5FD_MEM_DEFAULT");
+                                    break;
+
+                                case H5FD_MEM_SUPER:
+                                    H5RS_acat(rs, "H5FD_MEM_SUPER");
+                                    break;
+
+                                case H5FD_MEM_BTREE:
+                                    H5RS_acat(rs, "H5FD_MEM_BTREE");
+                                    break;
+
+                                case H5FD_MEM_DRAW:
+                                    H5RS_acat(rs, "H5FD_MEM_DRAW");
+                                    break;
+
+                                case H5FD_MEM_GHEAP:
+                                    H5RS_acat(rs, "H5FD_MEM_GHEAP");
+                                    break;
+
+                                case H5FD_MEM_LHEAP:
+                                    H5RS_acat(rs, "H5FD_MEM_LHEAP");
+                                    break;
+
+                                case H5FD_MEM_OHDR:
+                                    H5RS_acat(rs, "H5FD_MEM_OHDR");
+                                    break;
+
+                                case H5FD_MEM_NTYPES:
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)mem_type);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 's': /* H5F_scope_t */
+                        {
+                            H5F_scope_t scope = (H5F_scope_t)HDva_arg(ap, int);
+
+                            switch (scope) {
+                                case H5F_SCOPE_LOCAL:
+                                    H5RS_acat(rs, "H5F_SCOPE_LOCAL");
+                                    break;
+
+                                case H5F_SCOPE_GLOBAL:
+                                    H5RS_acat(rs, "H5F_SCOPE_GLOBAL");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)scope);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 't': /* H5F_file_space_type_t */
+                        {
+                            H5F_file_space_type_t fspace_type = (H5F_file_space_type_t)HDva_arg(ap, int);
+
+                            switch (fspace_type) {
+                                case H5F_FILE_SPACE_DEFAULT:
+                                    H5RS_acat(rs, "H5F_FILE_SPACE_DEFAULT");
+                                    break;
+
+                                case H5F_FILE_SPACE_ALL_PERSIST:
+                                    H5RS_acat(rs, "H5F_FILE_SPACE_ALL_PERSIST");
+                                    break;
+
+                                case H5F_FILE_SPACE_ALL:
+                                    H5RS_acat(rs, "H5F_FILE_SPACE_ALL");
+                                    break;
+
+                                case H5F_FILE_SPACE_AGGR_VFD:
+                                    H5RS_acat(rs, "H5F_FILE_SPACE_AGGR_VFD");
+                                    break;
+
+                                case H5F_FILE_SPACE_VFD:
+                                    H5RS_acat(rs, "H5F_FILE_SPACE_VFD");
+                                    break;
+
+                                case H5F_FILE_SPACE_NTYPES:
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)fspace_type);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'v': /* H5F_libver_t */
+                        {
+                            H5F_libver_t libver_vers = (H5F_libver_t)HDva_arg(ap, int);
+
+                            switch (libver_vers) {
+                                case H5F_LIBVER_EARLIEST:
+                                    H5RS_acat(rs, "H5F_LIBVER_EARLIEST");
+                                    break;
+
+                                case H5F_LIBVER_V18:
+                                    H5RS_acat(rs, "H5F_LIBVER_V18");
+                                    break;
+
+                                case H5F_LIBVER_V110:
+                                    H5RS_acat(rs, "H5F_LIBVER_V110");
+                                    break;
+
+                                case H5F_LIBVER_V112:
+                                    H5RS_acat(rs, "H5F_LIBVER_V112");
+                                    break;
+
+                                case H5F_LIBVER_V114:
+                                    HDcompile_assert(H5F_LIBVER_LATEST == H5F_LIBVER_V114);
+                                    H5RS_acat(rs, "H5F_LIBVER_LATEST");
+                                    break;
+
+                                case H5F_LIBVER_ERROR:
+                                case H5F_LIBVER_NBOUNDS:
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)libver_vers);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(F%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 'G':
+                    switch (type[1]) {
+#ifndef H5_NO_DEPRECATED_SYMBOLS
+                        case 'i': /* H5G_iterate_t */
+                        {
+                            H5G_iterate_t git = (H5G_iterate_t)HDva_arg(ap, H5G_iterate_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)git);
+                        } /* end block */
+                        break;
+
+                        case 'o': /* H5G_obj_t */
+                        {
+                            H5G_obj_t obj_type = (H5G_obj_t)HDva_arg(ap, int);
+
+                            switch (obj_type) {
+                                case H5G_UNKNOWN:
+                                    H5RS_acat(rs, "H5G_UNKNOWN");
+                                    break;
+
+                                case H5G_GROUP:
+                                    H5RS_acat(rs, "H5G_GROUP");
+                                    break;
+
+                                case H5G_DATASET:
+                                    H5RS_acat(rs, "H5G_DATASET");
+                                    break;
+
+                                case H5G_TYPE:
+                                    H5RS_acat(rs, "H5G_TYPE");
+                                    break;
+
+                                case H5G_LINK:
+                                    H5RS_acat(rs, "H5G_LINK");
+                                    break;
+
+                                case H5G_UDLINK:
+                                    H5RS_acat(rs, "H5G_UDLINK");
+                                    break;
+
+                                case H5G_RESERVED_5:
+                                case H5G_RESERVED_6:
+                                case H5G_RESERVED_7:
+                                    H5RS_asprintf_cat(rs, "H5G_RESERVED(%ld)", (long)obj_type);
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)obj_type);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 's': /* H5G_stat_t */
+                        {
+                            H5G_stat_t *statbuf = HDva_arg(ap, H5G_stat_t *);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)statbuf);
+                        } /* end block */
+                        break;
+#endif /* H5_NO_DEPRECATED_SYMBOLS */
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(G%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 'h': /* hsize_t */
+                {
+                    hsize_t hsize = HDva_arg(ap, hsize_t);
+
+                    if (H5S_UNLIMITED == hsize)
+                        H5RS_acat(rs, "H5S_UNLIMITED");
+                    else {
+                        H5RS_asprintf_cat(rs, "%" PRIuHSIZE, hsize);
+                        asize[argno] = (hssize_t)hsize;
+                    } /* end else */
+                }     /* end block */
+                break;
+
+                case 'H':
+                    switch (type[1]) {
+                        case 'a': /* H5_alloc_stats_t */
+                        {
+                            H5_alloc_stats_t stats = HDva_arg(ap, H5_alloc_stats_t);
+
+                            H5RS_asprintf_cat(rs, "{%llu, %zu, %zu, %zu, %zu, %zu, %zu}",
+                                              stats.total_alloc_bytes, stats.curr_alloc_bytes,
+                                              stats.peak_alloc_bytes, stats.max_block_size,
+                                              stats.total_alloc_blocks_count, stats.curr_alloc_blocks_count,
+                                              stats.peak_alloc_blocks_count);
+                        } /* end block */
+                        break;
+
+                        case 's': /* hssize_t */
+                        {
+                            hssize_t hssize = HDva_arg(ap, hssize_t);
+
+                            H5RS_asprintf_cat(rs, "%" PRIdHSIZE, hssize);
+                            asize[argno] = (hssize_t)hssize;
+                        } /* end block */
+                        break;
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(H%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 'i': /* hid_t (and H5E_major_t / H5E_minor_t) */
+                {
+                    hid_t obj = HDva_arg(ap, hid_t);
+
+                    if (H5P_DEFAULT == obj)
+                        H5RS_acat(rs, "H5P_DEFAULT");
+                    else if (obj < 0)
+                        H5RS_acat(rs, "FAIL");
+                    else {
+                        switch (H5I_TYPE(obj)) { /* Use internal H5I macro instead of function call */
+                            case H5I_UNINIT:
+                                H5RS_asprintf_cat(rs, "0x%0llx (uninit - error)", (unsigned long long)obj);
+                                break;
+
+                            case H5I_BADID:
+                                H5RS_asprintf_cat(rs, "0x%0llx (badid - error)", (unsigned long long)obj);
+                                break;
+
+                            case H5I_FILE:
+                                H5RS_asprintf_cat(rs, "0x%0llx (file)", (unsigned long long)obj);
+                                break;
+
+                            case H5I_GROUP:
+                                H5RS_asprintf_cat(rs, "0x%0llx (group)", (unsigned long long)obj);
+                                break;
+
+                            case H5I_DATATYPE:
+                                if (obj == H5T_NATIVE_SCHAR_g)
+                                    H5RS_acat(rs, "H5T_NATIVE_SCHAR");
+                                else if (obj == H5T_NATIVE_UCHAR_g)
+                                    H5RS_acat(rs, "H5T_NATIVE_UCHAR");
+                                else if (obj == H5T_NATIVE_SHORT_g)
+                                    H5RS_acat(rs, "H5T_NATIVE_SHORT");
+                                else if (obj == H5T_NATIVE_USHORT_g)
+                                    H5RS_acat(rs, "H5T_NATIVE_USHORT");
+                                else if (obj == H5T_NATIVE_INT_g)
+                                    H5RS_acat(rs, "H5T_NATIVE_INT");
+                                else if (obj == H5T_NATIVE_UINT_g)
+                                    H5RS_acat(rs, "H5T_NATIVE_UINT");
+                                else if (obj == H5T_NATIVE_LONG_g)
+                                    H5RS_acat(rs, "H5T_NATIVE_LONG");
+                                else if (obj == H5T_NATIVE_ULONG_g)
+                                    H5RS_acat(rs, "H5T_NATIVE_ULONG");
+                                else if (obj == H5T_NATIVE_LLONG_g)
+                                    H5RS_acat(rs, "H5T_NATIVE_LLONG");
+                                else if (obj == H5T_NATIVE_ULLONG_g)
+                                    H5RS_acat(rs, "H5T_NATIVE_ULLONG");
+                                else if (obj == H5T_NATIVE_FLOAT_g)
+                                    H5RS_acat(rs, "H5T_NATIVE_FLOAT");
+                                else if (obj == H5T_NATIVE_DOUBLE_g)
+                                    H5RS_acat(rs, "H5T_NATIVE_DOUBLE");
+#if H5_SIZEOF_LONG_DOUBLE != 0
+                                else if (obj == H5T_NATIVE_LDOUBLE_g)
+                                    H5RS_acat(rs, "H5T_NATIVE_LDOUBLE");
+#endif
+                                else if (obj == H5T_IEEE_F32BE_g)
+                                    H5RS_acat(rs, "H5T_IEEE_F32BE");
+                                else if (obj == H5T_IEEE_F32LE_g)
+                                    H5RS_acat(rs, "H5T_IEEE_F32LE");
+                                else if (obj == H5T_IEEE_F64BE_g)
+                                    H5RS_acat(rs, "H5T_IEEE_F64BE");
+                                else if (obj == H5T_IEEE_F64LE_g)
+                                    H5RS_acat(rs, "H5T_IEEE_F64LE");
+                                else if (obj == H5T_STD_I8BE_g)
+                                    H5RS_acat(rs, "H5T_STD_I8BE");
+                                else if (obj == H5T_STD_I8LE_g)
+                                    H5RS_acat(rs, "H5T_STD_I8LE");
+                                else if (obj == H5T_STD_I16BE_g)
+                                    H5RS_acat(rs, "H5T_STD_I16BE");
+                                else if (obj == H5T_STD_I16LE_g)
+                                    H5RS_acat(rs, "H5T_STD_I16LE");
+                                else if (obj == H5T_STD_I32BE_g)
+                                    H5RS_acat(rs, "H5T_STD_I32BE");
+                                else if (obj == H5T_STD_I32LE_g)
+                                    H5RS_acat(rs, "H5T_STD_I32LE");
+                                else if (obj == H5T_STD_I64BE_g)
+                                    H5RS_acat(rs, "H5T_STD_I64BE");
+                                else if (obj == H5T_STD_I64LE_g)
+                                    H5RS_acat(rs, "H5T_STD_I64LE");
+                                else if (obj == H5T_STD_U8BE_g)
+                                    H5RS_acat(rs, "H5T_STD_U8BE");
+                                else if (obj == H5T_STD_U8LE_g)
+                                    H5RS_acat(rs, "H5T_STD_U8LE");
+                                else if (obj == H5T_STD_U16BE_g)
+                                    H5RS_acat(rs, "H5T_STD_U16BE");
+                                else if (obj == H5T_STD_U16LE_g)
+                                    H5RS_acat(rs, "H5T_STD_U16LE");
+                                else if (obj == H5T_STD_U32BE_g)
+                                    H5RS_acat(rs, "H5T_STD_U32BE");
+                                else if (obj == H5T_STD_U32LE_g)
+                                    H5RS_acat(rs, "H5T_STD_U32LE");
+                                else if (obj == H5T_STD_U64BE_g)
+                                    H5RS_acat(rs, "H5T_STD_U64BE");
+                                else if (obj == H5T_STD_U64LE_g)
+                                    H5RS_acat(rs, "H5T_STD_U64LE");
+                                else if (obj == H5T_STD_B8BE_g)
+                                    H5RS_acat(rs, "H5T_STD_B8BE");
+                                else if (obj == H5T_STD_B8LE_g)
+                                    H5RS_acat(rs, "H5T_STD_B8LE");
+                                else if (obj == H5T_STD_B16BE_g)
+                                    H5RS_acat(rs, "H5T_STD_B16BE");
+                                else if (obj == H5T_STD_B16LE_g)
+                                    H5RS_acat(rs, "H5T_STD_B16LE");
+                                else if (obj == H5T_STD_B32BE_g)
+                                    H5RS_acat(rs, "H5T_STD_B32BE");
+                                else if (obj == H5T_STD_B32LE_g)
+                                    H5RS_acat(rs, "H5T_STD_B32LE");
+                                else if (obj == H5T_STD_B64BE_g)
+                                    H5RS_acat(rs, "H5T_STD_B64BE");
+                                else if (obj == H5T_STD_B64LE_g)
+                                    H5RS_acat(rs, "H5T_STD_B64LE");
+                                else if (obj == H5T_C_S1_g)
+                                    H5RS_acat(rs, "H5T_C_S1");
+                                else if (obj == H5T_FORTRAN_S1_g)
+                                    H5RS_acat(rs, "H5T_FORTRAN_S1");
+                                else
+                                    H5RS_asprintf_cat(rs, "0x%0llx (dtype)", (unsigned long long)obj);
+                                break;
+
+                            case H5I_DATASPACE:
+                                H5RS_asprintf_cat(rs, "0x%0llx (dspace)", (unsigned long long)obj);
+                                /* Save the rank of simple dataspaces for arrays */
+                                /* This may generate recursive call to the library... -QAK */
+                                {
+                                    H5S_t *space;
+
+                                    if (NULL != (space = (H5S_t *)H5I_object(obj)))
+                                        if (H5S_SIMPLE == H5S_GET_EXTENT_TYPE(space))
+                                            asize[argno] = H5S_GET_EXTENT_NDIMS(space);
+                                }
+                                break;
+
+                            case H5I_DATASET:
+                                H5RS_asprintf_cat(rs, "0x%0llx (dset)", (unsigned long long)obj);
+                                break;
+
+                            case H5I_ATTR:
+                                H5RS_asprintf_cat(rs, "0x%0llx (attr)", (unsigned long long)obj);
+                                break;
+
+                            case H5I_MAP:
+                                H5RS_asprintf_cat(rs, "0x%0llx (map)", (unsigned long long)obj);
+                                break;
+
+                            case H5I_VFL:
+                                H5RS_asprintf_cat(rs, "0x%0llx (file driver)", (unsigned long long)obj);
+                                break;
+
+                            case H5I_VOL:
+                                H5RS_asprintf_cat(rs, "0x%0llx (VOL plugin)", (unsigned long long)obj);
+                                break;
+
+                            case H5I_GENPROP_CLS:
+                                H5RS_asprintf_cat(rs, "0x%0llx (genprop class)", (unsigned long long)obj);
+                                break;
+
+                            case H5I_GENPROP_LST:
+                                H5RS_asprintf_cat(rs, "0x%0llx (genprop list)", (unsigned long long)obj);
+                                break;
+
+                            case H5I_ERROR_CLASS:
+                                H5RS_asprintf_cat(rs, "0x%0llx (err class)", (unsigned long long)obj);
+                                break;
+
+                            case H5I_ERROR_MSG:
+                                H5RS_asprintf_cat(rs, "0x%0llx (err msg)", (unsigned long long)obj);
+                                break;
+
+                            case H5I_ERROR_STACK:
+                                H5RS_asprintf_cat(rs, "0x%0llx (err stack)", (unsigned long long)obj);
+                                break;
+
+                            case H5I_SPACE_SEL_ITER:
+                                H5RS_asprintf_cat(rs, "0x%0llx (dataspace selection iterator)",
+                                                  (unsigned long long)obj);
+                                break;
+
+                            case H5I_NTYPES:
+                                H5RS_asprintf_cat(rs, "0x%0llx (ntypes - error)", (unsigned long long)obj);
+                                break;
+
+                            default:
+                                H5RS_asprintf_cat(rs, "0x%0llx (unknown class)", (unsigned long long)obj);
+                                break;
+                        } /* end switch */
+                    }     /* end else */
+                }         /* end block */
+                break;
+
+                case 'I':
+                    switch (type[1]) {
+                        case 'f': /* H5I_free_t */
+                        {
+                            H5I_free_t ifree = (H5I_free_t)HDva_arg(ap, H5I_free_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)ifree);
+                        } /* end block */
+                        break;
+
+                        case 'i': /* H5_index_t */
+                        {
+                            H5_index_t idx_type = (H5_index_t)HDva_arg(ap, int);
+
+                            switch (idx_type) {
+                                case H5_INDEX_UNKNOWN:
+                                    H5RS_acat(rs, "H5_INDEX_UNKNOWN");
+                                    break;
+
+                                case H5_INDEX_NAME:
+                                    H5RS_acat(rs, "H5_INDEX_NAME");
+                                    break;
+
+                                case H5_INDEX_CRT_ORDER:
+                                    H5RS_acat(rs, "H5_INDEX_CRT_ORDER");
+                                    break;
+
+                                case H5_INDEX_N:
+                                    H5RS_acat(rs, "H5_INDEX_N");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)idx_type);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'I': /* H5I_iterate_func_t */
+                        {
+                            H5I_iterate_func_t iiter = (H5I_iterate_func_t)HDva_arg(ap, H5I_iterate_func_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)iiter);
+                        } /* end block */
+                        break;
+
+                        case 'o': /* H5_iter_order_t */
+                        {
+                            H5_iter_order_t order = (H5_iter_order_t)HDva_arg(ap, int);
+
+                            switch (order) {
+                                case H5_ITER_UNKNOWN:
+                                    H5RS_acat(rs, "H5_ITER_UNKNOWN");
+                                    break;
+
+                                case H5_ITER_INC:
+                                    H5RS_acat(rs, "H5_ITER_INC");
+                                    break;
+
+                                case H5_ITER_DEC:
+                                    H5RS_acat(rs, "H5_ITER_DEC");
+                                    break;
+
+                                case H5_ITER_NATIVE:
+                                    H5RS_acat(rs, "H5_ITER_NATIVE");
+                                    break;
+
+                                case H5_ITER_N:
+                                    H5RS_acat(rs, "H5_ITER_N");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)order);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 's': /* int / int32_t */
+                        {
+                            int is = HDva_arg(ap, int);
+
+                            H5RS_asprintf_cat(rs, "%d", is);
+                            asize[argno] = is;
+                        } /* end block */
+                        break;
+
+                        case 'S': /* H5I_search_func_t */
+                        {
+                            H5I_search_func_t isearch = (H5I_search_func_t)HDva_arg(ap, H5I_search_func_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)isearch);
+                        } /* end block */
+                        break;
+
+                        case 't': /* H5I_type_t */
+                        {
+                            H5I_type_t id_type = (H5I_type_t)HDva_arg(ap, int);
+
+                            switch (id_type) {
+                                case H5I_UNINIT:
+                                    H5RS_acat(rs, "H5I_UNINIT");
+                                    break;
+
+                                case H5I_BADID:
+                                    H5RS_acat(rs, "H5I_BADID");
+                                    break;
+
+                                case H5I_FILE:
+                                    H5RS_acat(rs, "H5I_FILE");
+                                    break;
+
+                                case H5I_GROUP:
+                                    H5RS_acat(rs, "H5I_GROUP");
+                                    break;
+
+                                case H5I_DATATYPE:
+                                    H5RS_acat(rs, "H5I_DATATYPE");
+                                    break;
+
+                                case H5I_DATASPACE:
+                                    H5RS_acat(rs, "H5I_DATASPACE");
+                                    break;
+
+                                case H5I_DATASET:
+                                    H5RS_acat(rs, "H5I_DATASET");
+                                    break;
+
+                                case H5I_ATTR:
+                                    H5RS_acat(rs, "H5I_ATTR");
+                                    break;
+
+                                case H5I_MAP:
+                                    H5RS_acat(rs, "H5I_MAP");
+                                    break;
+
+                                case H5I_VFL:
+                                    H5RS_acat(rs, "H5I_VFL");
+                                    break;
+
+                                case H5I_VOL:
+                                    H5RS_acat(rs, "H5I_VOL");
+                                    break;
+
+                                case H5I_GENPROP_CLS:
+                                    H5RS_acat(rs, "H5I_GENPROP_CLS");
+                                    break;
+
+                                case H5I_GENPROP_LST:
+                                    H5RS_acat(rs, "H5I_GENPROP_LST");
+                                    break;
+
+                                case H5I_ERROR_CLASS:
+                                    H5RS_acat(rs, "H5I_ERROR_CLASS");
+                                    break;
+
+                                case H5I_ERROR_MSG:
+                                    H5RS_acat(rs, "H5I_ERROR_MSG");
+                                    break;
+
+                                case H5I_ERROR_STACK:
+                                    H5RS_acat(rs, "H5I_ERROR_STACK");
+                                    break;
+
+                                case H5I_SPACE_SEL_ITER:
+                                    H5RS_acat(rs, "H5I_SPACE_SEL_ITER");
+                                    break;
+
+                                case H5I_NTYPES:
+                                    H5RS_acat(rs, "H5I_NTYPES");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)id_type);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'u': /* unsigned / uint32_t */
+                        {
+                            unsigned iu = HDva_arg(ap, unsigned);
+
+                            H5RS_asprintf_cat(rs, "%u", iu);
+                            asize[argno] = iu;
+                        } /* end block */
+                        break;
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(I%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 'k': /* H5O_token_t */
+                {
+                    H5O_token_t token = HDva_arg(ap, H5O_token_t);
+                    int         j;
+
+                    for (j = 0; j < H5O_MAX_TOKEN_SIZE; j++)
+                        H5RS_asprintf_cat(rs, "%02x", token.__data[j]);
+                } /* end block */
+                break;
+
+                case 'L':
+                    switch (type[1]) {
+#ifndef H5_NO_DEPRECATED_SYMBOLS
+                        case 'i': /* H5L_iterate1_t */
+                        {
+                            H5L_iterate1_t liter = (H5L_iterate1_t)HDva_arg(ap, H5L_iterate1_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)liter);
+                        } /* end block */
+                        break;
+#endif /* H5_NO_DEPRECATED_SYMBOLS */
+
+                        case 'I': /* H5L_iterate2_t */
+                        {
+                            H5L_iterate2_t liter = (H5L_iterate2_t)HDva_arg(ap, H5L_iterate2_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)liter);
+                        } /* end block */
+                        break;
+
+                        case 'l': /* H5L_type_t (or H5G_link_t) */
+                        {
+                            H5L_type_t link_type = (H5L_type_t)HDva_arg(ap, int);
+
+                            switch (link_type) {
+                                case H5L_TYPE_ERROR:
+                                    H5RS_acat(rs, "H5L_TYPE_ERROR");
+                                    break;
+
+                                case H5L_TYPE_HARD:
+                                    H5RS_acat(rs, "H5L_TYPE_HARD");
+                                    break;
+
+                                case H5L_TYPE_SOFT:
+                                    H5RS_acat(rs, "H5L_TYPE_SOFT");
+                                    break;
+
+                                case H5L_TYPE_EXTERNAL:
+                                    H5RS_acat(rs, "H5L_TYPE_EXTERNAL");
+                                    break;
+
+                                case H5L_TYPE_MAX:
+                                    H5RS_acat(rs, "H5L_TYPE_MAX");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)link_type);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 't': /* H5L_elink_traverse_t */
+                        {
+                            H5L_elink_traverse_t elt =
+                                (H5L_elink_traverse_t)HDva_arg(ap, H5L_elink_traverse_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)elt);
+                        } /* end block */
+                        break;
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(G%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 'M':
+                    switch (type[1]) {
+                        case 'a': /* H5MM_allocate_t */
+                        {
+                            H5MM_allocate_t afunc = (H5MM_allocate_t)HDva_arg(ap, H5MM_allocate_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)afunc);
+                        } /* end block */
+                        break;
+
+#ifdef H5_HAVE_PARALLEL
+                        case 'c': /* MPI_Comm */
+                        {
+                            MPI_Comm comm = HDva_arg(ap, MPI_Comm);
+
+                            H5RS_asprintf_cat(rs, "%ld", (long)comm);
+                        } /* end block */
+                        break;
+#endif /* H5_HAVE_PARALLEL */
+
+                        case 'f': /* H5MM_free_t */
+                        {
+                            H5MM_free_t ffunc = (H5MM_free_t)HDva_arg(ap, H5MM_free_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)ffunc);
+                        } /* end block */
+                        break;
+
+#ifdef H5_HAVE_PARALLEL
+                        case 'i': /* MPI_Info */
+                        {
+                            MPI_Info info = HDva_arg(ap, MPI_Info);
+
+                            H5RS_asprintf_cat(rs, "%ld", (long)info);
+                        } /* end block */
+                        break;
+#endif /* H5_HAVE_PARALLEL */
+
+#ifdef H5_HAVE_MAP_API
+                        case 'I': /* H5M_iterate_t */
+                        {
+                            H5M_iterate_t miter = (H5M_iterate_t)HDva_arg(ap, H5M_iterate_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)miter);
+                        } /* end block */
+                        break;
+#endif /* H5_HAVE_MAP_API */
+
+                        case 't': /* H5FD_mem_t */
+                        {
+                            H5FD_mem_t mt = (H5FD_mem_t)HDva_arg(ap, int);
+
+                            switch (mt) {
+                                case H5FD_MEM_NOLIST:
+                                    H5RS_acat(rs, "H5FD_MEM_NOLIST");
+                                    break;
+
+                                case H5FD_MEM_DEFAULT:
+                                    H5RS_acat(rs, "H5FD_MEM_DEFAULT");
+                                    break;
+
+                                case H5FD_MEM_SUPER:
+                                    H5RS_acat(rs, "H5FD_MEM_SUPER");
+                                    break;
+
+                                case H5FD_MEM_BTREE:
+                                    H5RS_acat(rs, "H5FD_MEM_BTREE");
+                                    break;
+
+                                case H5FD_MEM_DRAW:
+                                    H5RS_acat(rs, "H5FD_MEM_DRAW");
+                                    break;
+
+                                case H5FD_MEM_GHEAP:
+                                    H5RS_acat(rs, "H5FD_MEM_GHEAP");
+                                    break;
+
+                                case H5FD_MEM_LHEAP:
+                                    H5RS_acat(rs, "H5FD_MEM_LHEAP");
+                                    break;
+
+                                case H5FD_MEM_OHDR:
+                                    H5RS_acat(rs, "H5FD_MEM_OHDR");
+                                    break;
+
+                                case H5FD_MEM_NTYPES:
+                                    H5RS_acat(rs, "H5FD_MEM_NTYPES");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)mt);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        default:
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 'o': /* off_t */
+                {
+                    off_t offset = HDva_arg(ap, off_t);
+
+                    H5RS_asprintf_cat(rs, "%ld", (long)offset);
+                } /* end block */
+                break;
+
+                case 'O':
+                    switch (type[1]) {
+#ifndef H5_NO_DEPRECATED_SYMBOLS
+                        case 'i': /* H5O_iterate1_t */
+                        {
+                            H5O_iterate1_t oiter = (H5O_iterate1_t)HDva_arg(ap, H5O_iterate1_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)oiter);
+                        } /* end block */
+                        break;
+#endif /* H5_NO_DEPRECATED_SYMBOLS */
+
+                        case 'I': /* H5O_iterate2_t */
+                        {
+                            H5O_iterate2_t oiter2 = (H5O_iterate2_t)HDva_arg(ap, H5O_iterate2_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)oiter2);
+                        } /* end block */
+                        break;
+
+                        case 's': /* H5O_mcdt_search_cb_t */
+                        {
+                            H5O_mcdt_search_cb_t osrch =
+                                (H5O_mcdt_search_cb_t)HDva_arg(ap, H5O_mcdt_search_cb_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)osrch);
+                        } /* end block */
+                        break;
+
+                        case 't': /* H5O_type_t */
+                        {
+                            H5O_type_t objtype = (H5O_type_t)HDva_arg(ap, int);
+
+                            switch (objtype) {
+                                case H5O_TYPE_UNKNOWN:
+                                    H5RS_acat(rs, "H5O_TYPE_UNKNOWN");
+                                    break;
+
+                                case H5O_TYPE_GROUP:
+                                    H5RS_acat(rs, "H5O_TYPE_GROUP");
+                                    break;
+
+                                case H5O_TYPE_DATASET:
+                                    H5RS_acat(rs, "H5O_TYPE_DATASET");
+                                    break;
+
+                                case H5O_TYPE_NAMED_DATATYPE:
+                                    H5RS_acat(rs, "H5O_TYPE_NAMED_DATATYPE");
+                                    break;
+
+                                case H5O_TYPE_MAP:
+                                    H5RS_acat(rs, "H5O_TYPE_MAP");
+                                    break;
+
+                                case H5O_TYPE_NTYPES:
+                                    H5RS_acat(rs, "H5O_TYPE_NTYPES");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "BADTYPE(%ld)", (long)objtype);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(S%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 'p': /* H5P_class_t */
+                {
+                    hid_t           pclass_id  = HDva_arg(ap, hid_t);
+                    char *          class_name = NULL;
+                    H5P_genclass_t *pclass;
+
+                    /* Get the class name and print it */
+                    /* (This may generate recursive call to the library... -QAK) */
+                    if (NULL != (pclass = (H5P_genclass_t *)H5I_object(pclass_id)) &&
+                        NULL != (class_name = H5P_get_class_name(pclass))) {
+                        H5RS_asprintf_cat(rs, "%s", class_name);
+                        H5MM_xfree(class_name);
+                    } /* end if */
+                    else
+                        H5RS_asprintf_cat(rs, "%ld", (long)pclass_id);
+                } /* end block */
+                break;
+
+                case 'P':
+                    switch (type[1]) {
+                        case 'c': /* H5P_cls_create_func_t */
+                        {
+                            H5P_cls_create_func_t pcls_crt =
+                                (H5P_cls_create_func_t)HDva_arg(ap, H5P_cls_create_func_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)pcls_crt);
+                        } /* end block */
+                        break;
+
+                        case 'C': /* H5P_prp_create_func_t */
+                        {
+                            H5P_prp_create_func_t prp_crt =
+                                (H5P_prp_create_func_t)HDva_arg(ap, H5P_prp_create_func_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)prp_crt);
+                        } /* end block */
+                        break;
+
+                        case 'D': /* H5P_prp_delete_func_t */
+                        {
+                            H5P_prp_delete_func_t prp_del =
+                                (H5P_prp_delete_func_t)HDva_arg(ap, H5P_prp_delete_func_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)prp_del);
+                        } /* end block */
+                        break;
+
+                        case 'G': /* H5P_prp_get_func_t */
+                        {
+                            H5P_prp_get_func_t prp_get = (H5P_prp_get_func_t)HDva_arg(ap, H5P_prp_get_func_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)prp_get);
+                        } /* end block */
+                        break;
+
+                        case 'i': /* H5P_iterate_t */
+                        {
+                            H5P_iterate_t piter = (H5P_iterate_t)HDva_arg(ap, H5P_iterate_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)piter);
+                        } /* end block */
+                        break;
+
+                        case 'l': /* H5P_cls_close_func_t */
+                        {
+                            H5P_cls_close_func_t pcls_cls =
+                                (H5P_cls_close_func_t)HDva_arg(ap, H5P_cls_close_func_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)pcls_cls);
+                        } /* end block */
+                        break;
+
+                        case 'L': /* H5P_prp_close_func_t */
+                        {
+                            H5P_prp_close_func_t prp_cls =
+                                (H5P_prp_close_func_t)HDva_arg(ap, H5P_prp_close_func_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)prp_cls);
+                        } /* end block */
+                        break;
+
+                        case 'M': /* H5P_prp_compare_func_t */
+                        {
+                            H5P_prp_compare_func_t prp_cmp =
+                                (H5P_prp_compare_func_t)HDva_arg(ap, H5P_prp_compare_func_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)prp_cmp);
+                        } /* end block */
+                        break;
+
+                        case 'o': /* H5P_cls_copy_func_t */
+                        {
+                            H5P_cls_copy_func_t pcls_cpy =
+                                (H5P_cls_copy_func_t)HDva_arg(ap, H5P_cls_copy_func_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)pcls_cpy);
+                        } /* end block */
+                        break;
+
+                        case 'O': /* H5P_prp_copy_func_t */
+                        {
+                            H5P_prp_copy_func_t prp_cpy =
+                                (H5P_prp_copy_func_t)HDva_arg(ap, H5P_prp_copy_func_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)prp_cpy);
+                        } /* end block */
+                        break;
+
+                        case 'S': /* H5P_prp_set_func_t */
+                        {
+                            H5P_prp_set_func_t prp_set = (H5P_prp_set_func_t)HDva_arg(ap, H5P_prp_set_func_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)prp_set);
+                        } /* end block */
+                        break;
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(P%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 'R':
+                    switch (type[1]) {
+                        case 'd': /* hdset_reg_ref_t */
+                        {
+                            /* Note! region references are array types */
+                            H5RS_acat(rs, "Reference Region");
+                            goto error;
+                        } /* end block */
+                        break;
+
+                        case 'o': /* hobj_ref_t */
+                        {
+                            hobj_ref_t ref = HDva_arg(ap, hobj_ref_t);
+
+                            H5RS_asprintf_cat(rs, "Reference Object=%" PRIuHADDR, ref);
+                        } /* end block */
+                        break;
+
+                        case 'r': /* H5R_ref_t */
+                        {
+                            /* Note! reference types are opaque types */
+                            H5RS_acat(rs, "Reference Opaque");
+                            goto error;
+                        } /* end block */
+                        break;
+
+                        case 't': /* H5R_type_t */
+                        {
+                            H5R_type_t reftype = (H5R_type_t)HDva_arg(ap, int);
+
+                            switch (reftype) {
+                                case H5R_BADTYPE:
+                                    H5RS_acat(rs, "H5R_BADTYPE");
+                                    break;
+
+                                case H5R_OBJECT1:
+                                    H5RS_acat(rs, "H5R_OBJECT1");
+                                    break;
+
+                                case H5R_DATASET_REGION1:
+                                    H5RS_acat(rs, "H5R_DATASET_REGION1");
+                                    break;
+
+                                case H5R_OBJECT2:
+                                    H5RS_acat(rs, "H5R_OBJECT2");
+                                    break;
+
+                                case H5R_DATASET_REGION2:
+                                    H5RS_acat(rs, "H5R_DATASET_REGION2");
+                                    break;
+
+                                case H5R_ATTR:
+                                    H5RS_acat(rs, "H5R_ATTR");
+                                    break;
+
+                                case H5R_MAXTYPE:
+                                    H5RS_acat(rs, "H5R_MAXTYPE");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "BADTYPE(%ld)", (long)reftype);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(S%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 'S':
+                    switch (type[1]) {
+                        case 'c': /* H5S_class_t */
+                        {
+                            H5S_class_t cls = (H5S_class_t)HDva_arg(ap, int);
+
+                            switch (cls) {
+                                case H5S_NO_CLASS:
+                                    H5RS_acat(rs, "H5S_NO_CLASS");
+                                    break;
+
+                                case H5S_SCALAR:
+                                    H5RS_acat(rs, "H5S_SCALAR");
+                                    break;
+
+                                case H5S_SIMPLE:
+                                    H5RS_acat(rs, "H5S_SIMPLE");
+                                    break;
+
+                                case H5S_NULL:
+                                    H5RS_acat(rs, "H5S_NULL");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)cls);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 's': /* H5S_seloper_t */
+                        {
+                            H5S_seloper_t so = (H5S_seloper_t)HDva_arg(ap, int);
+
+                            switch (so) {
+                                case H5S_SELECT_NOOP:
+                                    H5RS_acat(rs, "H5S_NOOP");
+                                    break;
+
+                                case H5S_SELECT_SET:
+                                    H5RS_acat(rs, "H5S_SELECT_SET");
+                                    break;
+
+                                case H5S_SELECT_OR:
+                                    H5RS_acat(rs, "H5S_SELECT_OR");
+                                    break;
+
+                                case H5S_SELECT_AND:
+                                    H5RS_acat(rs, "H5S_SELECT_AND");
+                                    break;
+
+                                case H5S_SELECT_XOR:
+                                    H5RS_acat(rs, "H5S_SELECT_XOR");
+                                    break;
+
+                                case H5S_SELECT_NOTB:
+                                    H5RS_acat(rs, "H5S_SELECT_NOTB");
+                                    break;
+
+                                case H5S_SELECT_NOTA:
+                                    H5RS_acat(rs, "H5S_SELECT_NOTA");
+                                    break;
+
+                                case H5S_SELECT_APPEND:
+                                    H5RS_acat(rs, "H5S_SELECT_APPEND");
+                                    break;
+
+                                case H5S_SELECT_PREPEND:
+                                    H5RS_acat(rs, "H5S_SELECT_PREPEND");
+                                    break;
+
+                                case H5S_SELECT_INVALID:
+                                    H5RS_acat(rs, "H5S_SELECT_INVALID");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)so);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 't': /* H5S_sel_type */
+                        {
+                            H5S_sel_type st = (H5S_sel_type)HDva_arg(ap, int);
+
+                            switch (st) {
+                                case H5S_SEL_ERROR:
+                                    H5RS_acat(rs, "H5S_SEL_ERROR");
+                                    break;
+
+                                case H5S_SEL_NONE:
+                                    H5RS_acat(rs, "H5S_SEL_NONE");
+                                    break;
+
+                                case H5S_SEL_POINTS:
+                                    H5RS_acat(rs, "H5S_SEL_POINTS");
+                                    break;
+
+                                case H5S_SEL_HYPERSLABS:
+                                    H5RS_acat(rs, "H5S_SEL_HYPERSLABS");
+                                    break;
+
+                                case H5S_SEL_ALL:
+                                    H5RS_acat(rs, "H5S_SEL_ALL");
+                                    break;
+
+                                case H5S_SEL_N:
+                                    H5RS_acat(rs, "H5S_SEL_N");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)st);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(S%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 't': /* htri_t */
+                {
+                    htri_t tri_var = HDva_arg(ap, htri_t);
+
+                    if (tri_var > 0)
+                        H5RS_acat(rs, "TRUE");
+                    else if (!tri_var)
+                        H5RS_acat(rs, "FALSE");
+                    else
+                        H5RS_asprintf_cat(rs, "FAIL(%d)", (int)tri_var);
+                } /* end block */
+                break;
+
+                case 'T':
+                    switch (type[1]) {
+                        case 'c': /* H5T_cset_t */
+                        {
+                            H5T_cset_t cset = (H5T_cset_t)HDva_arg(ap, int);
+
+                            H5_trace_args_cset(rs, cset);
+                        } /* end block */
+                        break;
+
+                        case 'C': /* H5T_conv_t */
+                        {
+                            H5T_conv_t tconv = (H5T_conv_t)HDva_arg(ap, H5T_conv_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)tconv);
+                        } /* end block */
+                        break;
+
+                        case 'd': /* H5T_direction_t */
+                        {
+                            H5T_direction_t direct = (H5T_direction_t)HDva_arg(ap, int);
+
+                            switch (direct) {
+                                case H5T_DIR_DEFAULT:
+                                    H5RS_acat(rs, "H5T_DIR_DEFAULT");
+                                    break;
+
+                                case H5T_DIR_ASCEND:
+                                    H5RS_acat(rs, "H5T_DIR_ASCEND");
+                                    break;
+
+                                case H5T_DIR_DESCEND:
+                                    H5RS_acat(rs, "H5T_DIR_DESCEND");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)direct);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'e': /* H5T_pers_t */
+                        {
+                            H5T_pers_t pers = (H5T_pers_t)HDva_arg(ap, int);
+
+                            switch (pers) {
+                                case H5T_PERS_DONTCARE:
+                                    H5RS_acat(rs, "H5T_PERS_DONTCARE");
+                                    break;
+
+                                case H5T_PERS_SOFT:
+                                    H5RS_acat(rs, "H5T_PERS_SOFT");
+                                    break;
+
+                                case H5T_PERS_HARD:
+                                    H5RS_acat(rs, "H5T_PERS_HARD");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)pers);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'E': /* H5T_conv_except_func_t */
+                        {
+                            H5T_conv_except_func_t conv_ex =
+                                (H5T_conv_except_func_t)HDva_arg(ap, H5T_conv_except_func_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)conv_ex);
+                        } /* end block */
+                        break;
+
+                        case 'n': /* H5T_norm_t */
+                        {
+                            H5T_norm_t norm = (H5T_norm_t)HDva_arg(ap, int);
+
+                            switch (norm) {
+                                case H5T_NORM_ERROR:
+                                    H5RS_acat(rs, "H5T_NORM_ERROR");
+                                    break;
+
+                                case H5T_NORM_IMPLIED:
+                                    H5RS_acat(rs, "H5T_NORM_IMPLIED");
+                                    break;
+
+                                case H5T_NORM_MSBSET:
+                                    H5RS_acat(rs, "H5T_NORM_MSBSET");
+                                    break;
+
+                                case H5T_NORM_NONE:
+                                    H5RS_acat(rs, "H5T_NORM_NONE");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)norm);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'o': /* H5T_order_t */
+                        {
+                            H5T_order_t order = (H5T_order_t)HDva_arg(ap, int);
+
+                            switch (order) {
+                                case H5T_ORDER_ERROR:
+                                    H5RS_acat(rs, "H5T_ORDER_ERROR");
+                                    break;
+
+                                case H5T_ORDER_LE:
+                                    H5RS_acat(rs, "H5T_ORDER_LE");
+                                    break;
+
+                                case H5T_ORDER_BE:
+                                    H5RS_acat(rs, "H5T_ORDER_BE");
+                                    break;
+
+                                case H5T_ORDER_VAX:
+                                    H5RS_acat(rs, "H5T_ORDER_VAX");
+                                    break;
+
+                                case H5T_ORDER_MIXED:
+                                    H5RS_acat(rs, "H5T_ORDER_MIXED");
+                                    break;
+
+                                case H5T_ORDER_NONE:
+                                    H5RS_acat(rs, "H5T_ORDER_NONE");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)order);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'p': /* H5T_pad_t */
+                        {
+                            H5T_pad_t pad = (H5T_pad_t)HDva_arg(ap, int);
+
+                            switch (pad) {
+                                case H5T_PAD_ERROR:
+                                    H5RS_acat(rs, "H5T_PAD_ERROR");
+                                    break;
+
+                                case H5T_PAD_ZERO:
+                                    H5RS_acat(rs, "H5T_PAD_ZERO");
+                                    break;
+
+                                case H5T_PAD_ONE:
+                                    H5RS_acat(rs, "H5T_PAD_ONE");
+                                    break;
+
+                                case H5T_PAD_BACKGROUND:
+                                    H5RS_acat(rs, "H5T_PAD_BACKGROUND");
+                                    break;
+
+                                case H5T_NPAD:
+                                    H5RS_acat(rs, "H5T_NPAD");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)pad);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 's': /* H5T_sign_t */
+                        {
+                            H5T_sign_t sign = (H5T_sign_t)HDva_arg(ap, int);
+
+                            switch (sign) {
+                                case H5T_SGN_ERROR:
+                                    H5RS_acat(rs, "H5T_SGN_ERROR");
+                                    break;
+
+                                case H5T_SGN_NONE:
+                                    H5RS_acat(rs, "H5T_SGN_NONE");
+                                    break;
+
+                                case H5T_SGN_2:
+                                    H5RS_acat(rs, "H5T_SGN_2");
+                                    break;
+
+                                case H5T_NSGN:
+                                    H5RS_acat(rs, "H5T_NSGN");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)sign);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 't': /* H5T_class_t */
+                        {
+                            H5T_class_t type_class = (H5T_class_t)HDva_arg(ap, int);
+
+                            switch (type_class) {
+                                case H5T_NO_CLASS:
+                                    H5RS_acat(rs, "H5T_NO_CLASS");
+                                    break;
+
+                                case H5T_INTEGER:
+                                    H5RS_acat(rs, "H5T_INTEGER");
+                                    break;
+
+                                case H5T_FLOAT:
+                                    H5RS_acat(rs, "H5T_FLOAT");
+                                    break;
+
+                                case H5T_TIME:
+                                    H5RS_acat(rs, "H5T_TIME");
+                                    break;
+
+                                case H5T_STRING:
+                                    H5RS_acat(rs, "H5T_STRING");
+                                    break;
+
+                                case H5T_BITFIELD:
+                                    H5RS_acat(rs, "H5T_BITFIELD");
+                                    break;
+
+                                case H5T_OPAQUE:
+                                    H5RS_acat(rs, "H5T_OPAQUE");
+                                    break;
+
+                                case H5T_COMPOUND:
+                                    H5RS_acat(rs, "H5T_COMPOUND");
+                                    break;
+
+                                case H5T_REFERENCE:
+                                    H5RS_acat(rs, "H5T_REFERENCE");
+                                    break;
+
+                                case H5T_ENUM:
+                                    H5RS_acat(rs, "H5T_ENUM");
+                                    break;
+
+                                case H5T_VLEN:
+                                    H5RS_acat(rs, "H5T_VLEN");
+                                    break;
+
+                                case H5T_ARRAY:
+                                    H5RS_acat(rs, "H5T_ARRAY");
+                                    break;
+
+                                case H5T_NCLASSES:
+                                    H5RS_acat(rs, "H5T_NCLASSES");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)type_class);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'z': /* H5T_str_t */
+                        {
+                            H5T_str_t str = (H5T_str_t)HDva_arg(ap, int);
+
+                            switch (str) {
+                                case H5T_STR_ERROR:
+                                    H5RS_acat(rs, "H5T_STR_ERROR");
+                                    break;
+
+                                case H5T_STR_NULLTERM:
+                                    H5RS_acat(rs, "H5T_STR_NULLTERM");
+                                    break;
+
+                                case H5T_STR_NULLPAD:
+                                    H5RS_acat(rs, "H5T_STR_NULLPAD");
+                                    break;
+
+                                case H5T_STR_SPACEPAD:
+                                    H5RS_acat(rs, "H5T_STR_SPACEPAD");
+                                    break;
+
+                                case H5T_STR_RESERVED_3:
+                                case H5T_STR_RESERVED_4:
+                                case H5T_STR_RESERVED_5:
+                                case H5T_STR_RESERVED_6:
+                                case H5T_STR_RESERVED_7:
+                                case H5T_STR_RESERVED_8:
+                                case H5T_STR_RESERVED_9:
+                                case H5T_STR_RESERVED_10:
+                                case H5T_STR_RESERVED_11:
+                                case H5T_STR_RESERVED_12:
+                                case H5T_STR_RESERVED_13:
+                                case H5T_STR_RESERVED_14:
+                                case H5T_STR_RESERVED_15:
+                                    H5RS_asprintf_cat(rs, "H5T_STR_RESERVED(%ld)", (long)str);
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)str);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(T%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 'U':
+                    switch (type[1]) {
+                        case 'l': /* unsigned long */
+                        {
+                            unsigned long iul = HDva_arg(ap, unsigned long);
+
+                            H5RS_asprintf_cat(rs, "%lu", iul);
+                            asize[argno] = (hssize_t)iul;
+                        } /* end block */
+                        break;
+
+                        case 'L': /* unsigned long long / uint64_t */
+                        {
+                            unsigned long long iull = HDva_arg(ap, unsigned long long);
+
+                            H5RS_asprintf_cat(rs, "%llu", iull);
+                            asize[argno] = (hssize_t)iull;
+                        } /* end block */
+                        break;
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(U%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 'V':
+                    switch (type[1]) {
+                        case 'a': /* H5VL_attr_get_t */
+                        {
+                            H5VL_attr_get_t get = (H5VL_attr_get_t)HDva_arg(ap, int);
+
+                            switch (get) {
+                                case H5VL_ATTR_GET_SPACE:
+                                    H5RS_acat(rs, "H5VL_ATTR_GET_SPACE");
+                                    break;
+
+                                case H5VL_ATTR_GET_TYPE:
+                                    H5RS_acat(rs, "H5VL_ATTR_GET_TYPE");
+                                    break;
+
+                                case H5VL_ATTR_GET_ACPL:
+                                    H5RS_acat(rs, "H5VL_ATTR_GET_ACPL");
+                                    break;
+
+                                case H5VL_ATTR_GET_NAME:
+                                    H5RS_acat(rs, "H5VL_ATTR_GET_NAME");
+                                    break;
+
+                                case H5VL_ATTR_GET_STORAGE_SIZE:
+                                    H5RS_acat(rs, "H5VL_ATTR_GET_STORAGE_SIZE");
+                                    break;
+
+                                case H5VL_ATTR_GET_INFO:
+                                    H5RS_acat(rs, "H5VL_ATTR_GET_INFO");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)get);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'A': /* H5VL_blob_optional_t */
+                        {
+                            H5VL_blob_optional_t optional = (H5VL_blob_optional_t)HDva_arg(ap, int);
+
+                            H5RS_asprintf_cat(rs, "%ld", (long)optional);
+                        } /* end block */
+                        break;
+
+                        case 'b': /* H5VL_attr_specific_t */
+                        {
+                            H5VL_attr_specific_t specific = (H5VL_attr_specific_t)HDva_arg(ap, int);
+
+                            switch (specific) {
+                                case H5VL_ATTR_DELETE:
+                                    H5RS_acat(rs, "H5VL_ATTR_DELETE");
+                                    break;
+
+                                case H5VL_ATTR_EXISTS:
+                                    H5RS_acat(rs, "H5VL_ATTR_EXISTS");
+                                    break;
+
+                                case H5VL_ATTR_ITER:
+                                    H5RS_acat(rs, "H5VL_ATTR_ITER");
+                                    break;
+
+                                case H5VL_ATTR_RENAME:
+                                    H5RS_acat(rs, "H5VL_ATTR_RENAME");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)specific);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'B': /* H5VL_blob_specific_t */
+                        {
+                            H5VL_blob_specific_t specific = (H5VL_blob_specific_t)HDva_arg(ap, int);
+
+                            switch (specific) {
+                                case H5VL_BLOB_DELETE:
+                                    H5RS_acat(rs, "H5VL_BLOB_DELETE");
+                                    break;
+
+                                case H5VL_BLOB_GETSIZE:
+                                    H5RS_acat(rs, "H5VL_BLOB_GETSIZE");
+                                    break;
+
+                                case H5VL_BLOB_ISNULL:
+                                    H5RS_acat(rs, "H5VL_BLOB_ISNULL");
+                                    break;
+
+                                case H5VL_BLOB_SETNULL:
+                                    H5RS_acat(rs, "H5VL_BLOB_SETNULL");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)specific);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'c': /* H5VL_dataset_get_t */
+                        {
+                            H5VL_dataset_get_t get = (H5VL_dataset_get_t)HDva_arg(ap, int);
+
+                            switch (get) {
+                                case H5VL_DATASET_GET_SPACE:
+                                    H5RS_acat(rs, "H5VL_DATASET_GET_SPACE");
+                                    break;
+
+                                case H5VL_DATASET_GET_SPACE_STATUS:
+                                    H5RS_acat(rs, "H5VL_DATASET_GET_SPACE_STATUS");
+                                    break;
+
+                                case H5VL_DATASET_GET_TYPE:
+                                    H5RS_acat(rs, "H5VL_DATASET_GET_TYPE");
+                                    break;
+
+                                case H5VL_DATASET_GET_DCPL:
+                                    H5RS_acat(rs, "H5VL_DATASET_GET_DCPL");
+                                    break;
+
+                                case H5VL_DATASET_GET_DAPL:
+                                    H5RS_acat(rs, "H5VL_DATASET_GET_DAPL");
+                                    break;
+
+                                case H5VL_DATASET_GET_STORAGE_SIZE:
+                                    H5RS_acat(rs, "H5VL_DATASET_GET_STORAGE_SIZE");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)get);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'C': /* H5VL_class_value_t */
+                        {
+                            H5VL_class_value_t class_val =
+                                (H5VL_class_value_t)HDva_arg(ap, H5VL_class_value_t);
+
+                            if (H5_VOL_NATIVE == class_val)
+                                H5RS_acat(rs, "H5_VOL_NATIVE");
+                            else
+                                H5RS_asprintf_cat(rs, "%ld", (long)class_val);
+                        } /* end block */
+                        break;
+
+                        case 'd': /* H5VL_dataset_specific_t */
+                        {
+                            H5VL_dataset_specific_t specific = (H5VL_dataset_specific_t)HDva_arg(ap, int);
+
+                            switch (specific) {
+                                case H5VL_DATASET_SET_EXTENT:
+                                    H5RS_acat(rs, "H5VL_DATASET_SET_EXTENT");
+                                    break;
+
+                                case H5VL_DATASET_FLUSH:
+                                    H5RS_acat(rs, "H5VL_DATASET_FLUSH");
+                                    break;
+
+                                case H5VL_DATASET_REFRESH:
+                                    H5RS_acat(rs, "H5VL_DATASET_REFRESH");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)specific);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'e': /* H5VL_datatype_get_t */
+                        {
+                            H5VL_datatype_get_t get = (H5VL_datatype_get_t)HDva_arg(ap, int);
+
+                            switch (get) {
+                                case H5VL_DATATYPE_GET_BINARY:
+                                    H5RS_acat(rs, "H5VL_DATATYPE_GET_BINARY");
+                                    break;
+
+                                case H5VL_DATATYPE_GET_TCPL:
+                                    H5RS_acat(rs, "H5VL_DATATYPE_GET_TCPL");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)get);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'f': /* H5VL_datatype_specific_t */
+                        {
+                            H5VL_datatype_specific_t specific = (H5VL_datatype_specific_t)HDva_arg(ap, int);
+
+                            switch (specific) {
+                                case H5VL_DATATYPE_FLUSH:
+                                    H5RS_acat(rs, "H5VL_DATATYPE_FLUSH");
+                                    break;
+
+                                case H5VL_DATATYPE_REFRESH:
+                                    H5RS_acat(rs, "H5VL_DATATYPE_REFRESH");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)specific);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'g': /* H5VL_file_get_t */
+                        {
+                            H5VL_file_get_t get = (H5VL_file_get_t)HDva_arg(ap, int);
+
+                            switch (get) {
+                                case H5VL_FILE_GET_CONT_INFO:
+                                    H5RS_acat(rs, "H5VL_FILE_GET_CONT_INFO");
+                                    break;
+
+                                case H5VL_FILE_GET_FAPL:
+                                    H5RS_acat(rs, "H5VL_FILE_GET_FAPL");
+                                    break;
+
+                                case H5VL_FILE_GET_FCPL:
+                                    H5RS_acat(rs, "H5VL_FILE_GET_FCPL");
+                                    break;
+
+                                case H5VL_FILE_GET_FILENO:
+                                    H5RS_acat(rs, "H5VL_FILE_GET_FILENO");
+                                    break;
+
+                                case H5VL_FILE_GET_INTENT:
+                                    H5RS_acat(rs, "H5VL_FILE_GET_INTENT");
+                                    break;
+
+                                case H5VL_FILE_GET_NAME:
+                                    H5RS_acat(rs, "H5VL_FILE_GET_NAME");
+                                    break;
+
+                                case H5VL_FILE_GET_OBJ_COUNT:
+                                    H5RS_acat(rs, "H5VL_FILE_GET_OBJ_COUNT");
+                                    break;
+
+                                case H5VL_FILE_GET_OBJ_IDS:
+                                    H5RS_acat(rs, "H5VL_FILE_GET_OBJ_IDS");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)get);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'h': /* H5VL_file_specific_t */
+                        {
+                            H5VL_file_specific_t specific = (H5VL_file_specific_t)HDva_arg(ap, int);
+
+                            switch (specific) {
+                                case H5VL_FILE_FLUSH:
+                                    H5RS_acat(rs, "H5VL_FILE_FLUSH");
+                                    break;
+
+                                case H5VL_FILE_REOPEN:
+                                    H5RS_acat(rs, "H5VL_FILE_REOPEN");
+                                    break;
+
+                                case H5VL_FILE_MOUNT:
+                                    H5RS_acat(rs, "H5VL_FILE_MOUNT");
+                                    break;
+
+                                case H5VL_FILE_UNMOUNT:
+                                    H5RS_acat(rs, "H5VL_FILE_UNMOUNT");
+                                    break;
+
+                                case H5VL_FILE_IS_ACCESSIBLE:
+                                    H5RS_acat(rs, "H5VL_FILE_IS_ACCESSIBLE");
+                                    break;
+
+                                case H5VL_FILE_DELETE:
+                                    H5RS_acat(rs, "H5VL_FILE_DELETE");
+                                    break;
+
+                                case H5VL_FILE_IS_EQUAL:
+                                    H5RS_acat(rs, "H5VL_FILE_IS_EQUAL");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)specific);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'i': /* H5VL_group_get_t */
+                        {
+                            H5VL_group_get_t get = (H5VL_group_get_t)HDva_arg(ap, int);
+
+                            switch (get) {
+                                case H5VL_GROUP_GET_GCPL:
+                                    H5RS_acat(rs, "H5VL_GROUP_GET_GCPL");
+                                    break;
+
+                                case H5VL_GROUP_GET_INFO:
+                                    H5RS_acat(rs, "H5VL_GROUP_GET_INFO");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)get);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'j': /* H5VL_group_specific_t */
+                        {
+                            H5VL_group_specific_t specific = (H5VL_group_specific_t)HDva_arg(ap, int);
+
+                            switch (specific) {
+                                case H5VL_GROUP_FLUSH:
+                                    H5RS_acat(rs, "H5VL_GROUP_FLUSH");
+                                    break;
+
+                                case H5VL_GROUP_REFRESH:
+                                    H5RS_acat(rs, "H5VL_GROUP_REFRESH");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)specific);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'k': /* H5VL_link_create_type_t */
+                        {
+                            H5VL_link_create_type_t create = (H5VL_link_create_type_t)HDva_arg(ap, int);
+
+                            switch (create) {
+                                case H5VL_LINK_CREATE_HARD:
+                                    H5RS_acat(rs, "H5VL_LINK_CREATE_HARD");
+                                    break;
+
+                                case H5VL_LINK_CREATE_SOFT:
+                                    H5RS_acat(rs, "H5VL_LINK_CREATE_SOFT");
+                                    break;
+
+                                case H5VL_LINK_CREATE_UD:
+                                    H5RS_acat(rs, "H5VL_LINK_CREATE_UD");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)create);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'l': /* H5VL_link_get_t */
+                        {
+                            H5VL_link_get_t get = (H5VL_link_get_t)HDva_arg(ap, int);
+
+                            switch (get) {
+                                case H5VL_LINK_GET_INFO:
+                                    H5RS_acat(rs, "H5VL_LINK_GET_INFO");
+                                    break;
+
+                                case H5VL_LINK_GET_NAME:
+                                    H5RS_acat(rs, "H5VL_LINK_GET_NAME");
+                                    break;
+
+                                case H5VL_LINK_GET_VAL:
+                                    H5RS_acat(rs, "H5VL_LINK_GET_VAL");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)get);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'L': /* H5VL_get_conn_lvl_t */
+                        {
+                            H5VL_get_conn_lvl_t get = (H5VL_get_conn_lvl_t)HDva_arg(ap, int);
+
+                            switch (get) {
+                                case H5VL_GET_CONN_LVL_CURR:
+                                    H5RS_acat(rs, "H5VL_GET_CONN_LVL_CURR");
+                                    break;
+
+                                case H5VL_GET_CONN_LVL_TERM:
+                                    H5RS_acat(rs, "H5VL_GET_CONN_LVL_TERM");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)get);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'm': /* H5VL_link_specific_t */
+                        {
+                            H5VL_link_specific_t specific = (H5VL_link_specific_t)HDva_arg(ap, int);
+
+                            switch (specific) {
+                                case H5VL_LINK_DELETE:
+                                    H5RS_acat(rs, "H5VL_LINK_DELETE");
+                                    break;
+
+                                case H5VL_LINK_EXISTS:
+                                    H5RS_acat(rs, "H5VL_LINK_EXISTS");
+                                    break;
+
+                                case H5VL_LINK_ITER:
+                                    H5RS_acat(rs, "H5VL_LINK_ITER");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)specific);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'n': /* H5VL_object_get_t */
+                        {
+                            H5VL_object_get_t get = (H5VL_object_get_t)HDva_arg(ap, int);
+
+                            switch (get) {
+                                case H5VL_OBJECT_GET_FILE:
+                                    H5RS_acat(rs, "H5VL_OBJECT_GET_FILE");
+                                    break;
+
+                                case H5VL_OBJECT_GET_NAME:
+                                    H5RS_acat(rs, "H5VL_OBJECT_GET_NAME");
+                                    break;
+
+                                case H5VL_OBJECT_GET_TYPE:
+                                    H5RS_acat(rs, "H5VL_OBJECT_GET_TYPE");
+                                    break;
+
+                                case H5VL_OBJECT_GET_INFO:
+                                    H5RS_acat(rs, "H5VL_OBJECT_GET_INFO");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)get);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'N': /* H5VL_request_notify_t */
+                        {
+                            H5VL_request_notify_t vlrnot =
+                                (H5VL_request_notify_t)HDva_arg(ap, H5VL_request_notify_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)vlrnot);
+                        } /* end block */
+                        break;
+
+                        case 'o': /* H5VL_object_specific_t */
+                        {
+                            H5VL_object_specific_t specific = (H5VL_object_specific_t)HDva_arg(ap, int);
+
+                            switch (specific) {
+                                case H5VL_OBJECT_CHANGE_REF_COUNT:
+                                    H5RS_acat(rs, "H5VL_OBJECT_CHANGE_REF_COUNT");
+                                    break;
+
+                                case H5VL_OBJECT_EXISTS:
+                                    H5RS_acat(rs, "H5VL_OBJECT_EXISTS");
+                                    break;
+
+                                case H5VL_OBJECT_LOOKUP:
+                                    H5RS_acat(rs, "H5VL_OBJECT_LOOKUP");
+                                    break;
+
+                                case H5VL_OBJECT_VISIT:
+                                    H5RS_acat(rs, "H5VL_OBJECT_VISIT");
+                                    break;
+
+                                case H5VL_OBJECT_FLUSH:
+                                    H5RS_acat(rs, "H5VL_OBJECT_FLUSH");
+                                    break;
+
+                                case H5VL_OBJECT_REFRESH:
+                                    H5RS_acat(rs, "H5VL_OBJECT_REFRESH");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)specific);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'r': /* H5VL_request_specific_t */
+                        {
+                            H5VL_request_specific_t specific = (H5VL_request_specific_t)HDva_arg(ap, int);
+
+                            switch (specific) {
+                                case H5VL_REQUEST_WAITANY:
+                                    H5RS_acat(rs, "H5VL_REQUEST_WAITANY");
+                                    break;
+
+                                case H5VL_REQUEST_WAITSOME:
+                                    H5RS_acat(rs, "H5VL_REQUEST_WAITSOME");
+                                    break;
+
+                                case H5VL_REQUEST_WAITALL:
+                                    H5RS_acat(rs, "H5VL_REQUEST_WAITALL");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)specific);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 's': /* H5VL_attr_optional_t */
+                        {
+                            H5VL_attr_optional_t optional = (H5VL_attr_optional_t)HDva_arg(ap, int);
+
+                            switch (optional) {
+#ifndef H5_NO_DEPRECATED_SYMBOLS
+                                case H5VL_NATIVE_ATTR_ITERATE_OLD:
+                                    H5RS_acat(rs, "H5VL_NATIVE_ATTR_ITERATE_OLD");
+                                    break;
+#endif /* H5_NO_DEPRECATED_SYMBOLS */
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)optional);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'S': /* H5VL_subclass_t */
+                        {
+                            H5VL_subclass_t subclass = (H5VL_subclass_t)HDva_arg(ap, int);
+
+                            switch (subclass) {
+                                case H5VL_SUBCLS_NONE:
+                                    H5RS_acat(rs, "H5VL_SUBCLS_NONE");
+                                    break;
+
+                                case H5VL_SUBCLS_INFO:
+                                    H5RS_acat(rs, "H5VL_SUBCLS_INFO");
+                                    break;
+
+                                case H5VL_SUBCLS_WRAP:
+                                    H5RS_acat(rs, "H5VL_SUBCLS_WRAP");
+                                    break;
+
+                                case H5VL_SUBCLS_ATTR:
+                                    H5RS_acat(rs, "H5VL_SUBCLS_ATTR");
+                                    break;
+
+                                case H5VL_SUBCLS_DATASET:
+                                    H5RS_acat(rs, "H5VL_SUBCLS_DATASET");
+                                    break;
+
+                                case H5VL_SUBCLS_DATATYPE:
+                                    H5RS_acat(rs, "H5VL_SUBCLS_DATATYPE");
+                                    break;
+
+                                case H5VL_SUBCLS_FILE:
+                                    H5RS_acat(rs, "H5VL_SUBCLS_FILE");
+                                    break;
+
+                                case H5VL_SUBCLS_GROUP:
+                                    H5RS_acat(rs, "H5VL_SUBCLS_GROUP");
+                                    break;
+
+                                case H5VL_SUBCLS_LINK:
+                                    H5RS_acat(rs, "H5VL_SUBCLS_LINK");
+                                    break;
+
+                                case H5VL_SUBCLS_OBJECT:
+                                    H5RS_acat(rs, "H5VL_SUBCLS_OBJECT");
+                                    break;
+
+                                case H5VL_SUBCLS_REQUEST:
+                                    H5RS_acat(rs, "H5VL_SUBCLS_REQUEST");
+                                    break;
+
+                                case H5VL_SUBCLS_BLOB:
+                                    H5RS_acat(rs, "H5VL_SUBCLS_BLOB");
+                                    break;
+
+                                case H5VL_SUBCLS_TOKEN:
+                                    H5RS_acat(rs, "H5VL_SUBCLS_TOKEN");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)subclass);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 't': /* H5VL_dataset_optional_t */
+                        {
+                            H5VL_dataset_optional_t optional = (H5VL_dataset_optional_t)HDva_arg(ap, int);
+
+                            switch (optional) {
+                                case H5VL_NATIVE_DATASET_FORMAT_CONVERT:
+                                    H5RS_acat(rs, "H5VL_NATIVE_DATASET_FORMAT_CONVERT");
+                                    break;
+
+                                case H5VL_NATIVE_DATASET_GET_CHUNK_INDEX_TYPE:
+                                    H5RS_acat(rs, "H5VL_NATIVE_DATASET_GET_CHUNK_INDEX_TYPE");
+                                    break;
+
+                                case H5VL_NATIVE_DATASET_GET_CHUNK_STORAGE_SIZE:
+                                    H5RS_acat(rs, "H5VL_NATIVE_DATASET_GET_CHUNK_STORAGE_SIZE");
+                                    break;
+
+                                case H5VL_NATIVE_DATASET_GET_NUM_CHUNKS:
+                                    H5RS_acat(rs, "H5VL_NATIVE_DATASET_GET_NUM_CHUNKS");
+                                    break;
+
+                                case H5VL_NATIVE_DATASET_GET_CHUNK_INFO_BY_IDX:
+                                    H5RS_acat(rs, "H5VL_NATIVE_DATASET_GET_CHUNK_INFO_BY_IDX");
+                                    break;
+
+                                case H5VL_NATIVE_DATASET_GET_CHUNK_INFO_BY_COORD:
+                                    H5RS_acat(rs, "H5VL_NATIVE_DATASET_GET_CHUNK_INFO_BY_COORD");
+                                    break;
+
+                                case H5VL_NATIVE_DATASET_CHUNK_READ:
+                                    H5RS_acat(rs, "H5VL_NATIVE_DATASET_CHUNK_READ");
+                                    break;
+
+                                case H5VL_NATIVE_DATASET_CHUNK_WRITE:
+                                    H5RS_acat(rs, "H5VL_NATIVE_DATASET_CHUNK_WRITE");
+                                    break;
+
+                                case H5VL_NATIVE_DATASET_GET_VLEN_BUF_SIZE:
+                                    H5RS_acat(rs, "H5VL_NATIVE_DATASET_GET_VLEN_BUF_SIZE");
+                                    break;
+
+                                case H5VL_NATIVE_DATASET_GET_OFFSET:
+                                    H5RS_acat(rs, "H5VL_NATIVE_DATASET_GET_OFFSET");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)optional);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'u': /* H5VL_datatype_optional_t */
+                        {
+                            H5VL_datatype_optional_t optional = (H5VL_datatype_optional_t)HDva_arg(ap, int);
+
+                            H5RS_asprintf_cat(rs, "%ld", (long)optional);
+                        } /* end block */
+                        break;
+
+                        case 'v': /* H5VL_file_optional_t */
+                        {
+                            H5VL_file_optional_t optional = (H5VL_file_optional_t)HDva_arg(ap, int);
+
+                            switch (optional) {
+                                case H5VL_NATIVE_FILE_CLEAR_ELINK_CACHE:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_CLEAR_ELINK_CACHE");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_GET_FILE_IMAGE:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_GET_FILE_IMAGE");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_GET_FREE_SECTIONS:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_GET_FREE_SECTIONS");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_GET_FREE_SPACE:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_GET_FREE_SPACE");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_GET_INFO:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_GET_INFO");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_GET_MDC_CONF:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_GET_MDC_CONF");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_GET_MDC_HR:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_GET_MDC_HR");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_GET_MDC_SIZE:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_GET_MDC_SIZE");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_GET_SIZE:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_GET_SIZE");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_GET_VFD_HANDLE:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_GET_VFD_HANDLE");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_RESET_MDC_HIT_RATE:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_RESET_MDC_HIT_RATE");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_SET_MDC_CONFIG:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_SET_MDC_CONFIG");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_GET_METADATA_READ_RETRY_INFO:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_GET_METADATA_READ_RETRY_INFO");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_START_SWMR_WRITE:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_START_SWMR_WRITE");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_START_MDC_LOGGING:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_START_MDC_LOGGING");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_STOP_MDC_LOGGING:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_STOP_MDC_LOGGING");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_GET_MDC_LOGGING_STATUS:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_GET_MDC_LOGGING_STATUS");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_FORMAT_CONVERT:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_FORMAT_CONVERT");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_RESET_PAGE_BUFFERING_STATS:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_RESET_PAGE_BUFFERING_STATS");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_GET_PAGE_BUFFERING_STATS:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_GET_PAGE_BUFFERING_STATS");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_GET_MDC_IMAGE_INFO:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_GET_MDC_IMAGE_INFO");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_GET_EOA:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_GET_EOA");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_INCR_FILESIZE:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_INCR_FILESIZE");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_SET_LIBVER_BOUNDS:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_SET_LIBVER_BOUNDS");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_GET_MIN_DSET_OHDR_FLAG:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_GET_MIN_DSET_OHDR_FLAG");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_SET_MIN_DSET_OHDR_FLAG:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_SET_MIN_DSET_OHDR_FLAG");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_GET_MPI_ATOMICITY:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_GET_MPI_ATOMICITY");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_SET_MPI_ATOMICITY:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_SET_MPI_ATOMICITY");
+                                    break;
+
+                                case H5VL_NATIVE_FILE_POST_OPEN:
+                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_POST_OPEN");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)optional);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'w': /* H5VL_group_optional_t */
+                        {
+                            H5VL_group_optional_t optional = (H5VL_group_optional_t)HDva_arg(ap, int);
+
+                            switch (optional) {
+#ifndef H5_NO_DEPRECATED_SYMBOLS
+                                case H5VL_NATIVE_GROUP_ITERATE_OLD:
+                                    H5RS_acat(rs, "H5VL_NATIVE_GROUP_ITERATE_OLD");
+                                    break;
+
+                                case H5VL_NATIVE_GROUP_GET_OBJINFO:
+                                    H5RS_acat(rs, "H5VL_NATIVE_GROUP_GET_OBJINFO");
+                                    break;
+#endif /* H5_NO_DEPRECATED_SYMBOLS */
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)optional);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'x': /* H5VL_link_optional_t */
+                        {
+                            H5VL_link_optional_t optional = (H5VL_link_optional_t)HDva_arg(ap, int);
+
+                            H5RS_asprintf_cat(rs, "%ld", (long)optional);
+                        } /* end block */
+                        break;
+
+                        case 'y': /* H5VL_object_optional_t */
+                        {
+                            H5VL_object_optional_t optional = (H5VL_object_optional_t)HDva_arg(ap, int);
+
+                            switch (optional) {
+                                case H5VL_NATIVE_OBJECT_GET_COMMENT:
+                                    H5RS_acat(rs, "H5VL_NATIVE_OBJECT_GET_COMMENT");
+                                    break;
+
+                                case H5VL_NATIVE_OBJECT_SET_COMMENT:
+                                    H5RS_acat(rs, "H5VL_NATIVE_OBJECT_SET_COMMENT");
+                                    break;
+
+                                case H5VL_NATIVE_OBJECT_DISABLE_MDC_FLUSHES:
+                                    H5RS_acat(rs, "H5VL_NATIVE_OBJECT_DISABLE_MDC_FLUSHES");
+                                    break;
+
+                                case H5VL_NATIVE_OBJECT_ENABLE_MDC_FLUSHES:
+                                    H5RS_acat(rs, "H5VL_NATIVE_OBJECT_ENABLE_MDC_FLUSHES");
+                                    break;
+
+                                case H5VL_NATIVE_OBJECT_ARE_MDC_FLUSHES_DISABLED:
+                                    H5RS_acat(rs, "H5VL_NATIVE_OBJECT_ARE_MDC_FLUSHES_DISABLED");
+                                    break;
+
+                                case H5VL_NATIVE_OBJECT_GET_NATIVE_INFO:
+                                    H5RS_acat(rs, "H5VL_NATIVE_OBJECT_GET_NATIVE_INFO");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)optional);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'z': /* H5VL_request_optional_t */
+                        {
+                            H5VL_request_optional_t optional = (H5VL_request_optional_t)HDva_arg(ap, int);
+
+                            H5RS_asprintf_cat(rs, "%ld", (long)optional);
+                        } /* end block */
+                        break;
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(Z%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case 'x': { /* void / va_list */
+                    vp = HDva_arg(ap, void *);
+
+                    if (vp)
+                        H5RS_asprintf_cat(rs, "%p", vp);
+                    else
+                        H5RS_acat(rs, "NULL");
+                } /* end block */
+                break;
+
+                case 'z': {
+                    size_t size = HDva_arg(ap, size_t);
+
+                    H5RS_asprintf_cat(rs, "%zu", size);
+                    asize[argno] = (hssize_t)size;
+                } /* end block */
+                break;
+
+                case 'Z':
+                    switch (type[1]) {
+                        case 'a': /* H5Z_SO_scale_type_t */
+                        {
+                            H5Z_SO_scale_type_t scale_type = (H5Z_SO_scale_type_t)HDva_arg(ap, int);
+
+                            switch (scale_type) {
+                                case H5Z_SO_FLOAT_DSCALE:
+                                    H5RS_acat(rs, "H5Z_SO_FLOAT_DSCALE");
+                                    break;
+
+                                case H5Z_SO_FLOAT_ESCALE:
+                                    H5RS_acat(rs, "H5Z_SO_FLOAT_ESCALE");
+                                    break;
+
+                                case H5Z_SO_INT:
+                                    H5RS_acat(rs, "H5Z_SO_INT");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)scale_type);
+                                    break;
+                            } /* end switch */
+                        }     /* end block */
+                        break;
+
+                        case 'c': /* H5Z_class2_t */
+                        {
+                            H5Z_class2_t *filter = HDva_arg(ap, H5Z_class2_t *);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)filter);
+                        } /* end block  */
+                        break;
+
+                        case 'e': /* H5Z_EDC_t */
+                        {
+                            H5Z_EDC_t edc = (H5Z_EDC_t)HDva_arg(ap, int);
+
+                            if (H5Z_DISABLE_EDC == edc)
+                                H5RS_acat(rs, "H5Z_DISABLE_EDC");
+                            else if (H5Z_ENABLE_EDC == edc)
+                                H5RS_acat(rs, "H5Z_ENABLE_EDC");
+                            else
+                                H5RS_asprintf_cat(rs, "%ld", (long)edc);
+                        } /* end block */
+                        break;
+
+                        case 'f': /* H5Z_filter_t */
+                        {
+                            H5Z_filter_t id = HDva_arg(ap, H5Z_filter_t);
+
+                            if (H5Z_FILTER_NONE == id)
+                                H5RS_acat(rs, "H5Z_FILTER_NONE");
+                            else if (H5Z_FILTER_DEFLATE == id)
+                                H5RS_acat(rs, "H5Z_FILTER_DEFLATE");
+                            else if (H5Z_FILTER_SHUFFLE == id)
+                                H5RS_acat(rs, "H5Z_FILTER_SHUFFLE");
+                            else if (H5Z_FILTER_FLETCHER32 == id)
+                                H5RS_acat(rs, "H5Z_FILTER_FLETCHER32");
+                            else if (H5Z_FILTER_SZIP == id)
+                                H5RS_acat(rs, "H5Z_FILTER_SZIP");
+                            else if (H5Z_FILTER_NBIT == id)
+                                H5RS_acat(rs, "H5Z_FILTER_NBIT");
+                            else if (H5Z_FILTER_SCALEOFFSET == id)
+                                H5RS_acat(rs, "H5Z_FILTER_SCALEOFFSET");
+                            else
+                                H5RS_asprintf_cat(rs, "%ld", (long)id);
+                        } /* end block */
+                        break;
+
+                        case 'F': /* H5Z_filter_func_t */
+                        {
+                            H5Z_filter_func_t ffunc = (H5Z_filter_func_t)HDva_arg(ap, H5Z_filter_func_t);
+
+                            H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)ffunc);
+                        } /* end block */
+                        break;
+
+                        case 's': {
+                            ssize_t ssize = HDva_arg(ap, ssize_t);
+
+                            H5RS_asprintf_cat(rs, "%zd", ssize);
+                            asize[argno] = (hssize_t)ssize;
+                        } /* end block */
+                        break;
+
+                        default:
+                            H5RS_asprintf_cat(rs, "BADTYPE(Z%c)", type[1]);
+                            goto error;
+                    } /* end switch */
+                    break;
+
+                case '#':
+                    H5RS_acat(rs, "Unsupported type slipped through!");
+                    break;
+
+                case '!':
+                    H5RS_acat(rs, "Unknown type slipped through!");
+                    break;
+
+                default:
+                    if (HDisupper(type[0]))
+                        H5RS_asprintf_cat(rs, "BADTYPE(%c%c)", type[0], type[1]);
+                    else
+                        H5RS_asprintf_cat(rs, "BADTYPE(%c)", type[0]);
+                    goto error;
+            } /* end switch */
+        }     /* end else */
+    }         /* end for */
+
+    return SUCCEED;
+error:
+    return FAIL;
+} /* end H5_trace_args() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5_trace
@@ -112,12 +3845,8 @@ double
 H5_trace(const double *returning, const char *func, const char *type, ...)
 {
     va_list           ap;
-    char              buf[64], *rest;
-    const char *      argname;
-    int               argno = 0, ptr, asize_idx;
-    hssize_t          asize[16];
+    H5RS_str_t *      rs = NULL;
     hssize_t          i;
-    void *            vp                  = NULL;
     FILE *            out                 = H5_debug_g.trace;
     static hbool_t    is_first_invocation = TRUE;
     H5_timer_t        function_timer;
@@ -130,21 +3859,20 @@ H5_trace(const double *returning, const char *func, const char *type, ...)
     /* FUNC_ENTER() should not be called */
 
     if (!out)
-        return 0.0F; /*tracing is off*/
-    HDva_start(ap, type);
+        return (double)0.0F; /*tracing is off*/
 
     if (H5_debug_g.ttop) {
         if (returning) {
             if (current_depth > 1) {
                 --current_depth;
-                return 0.0F;
+                return (double)0.0F;
             } /* end if */
         }     /* end if */
         else {
             if (current_depth > 0) {
                 /*do not update last_call_depth*/
                 current_depth++;
-                return 0.0F;
+                return (double)0.0F;
             } /* end if */
         }     /* end else */
     }         /* end if */
@@ -161,6 +3889,9 @@ H5_trace(const double *returning, const char *func, const char *type, ...)
         H5_timer_init(&function_timer);
         H5_timer_start(&function_timer);
     } /* end if */
+
+    /* Create the ref-counted string */
+    rs = H5RS_create(NULL);
 
     /* Print the first part of the line.  This is the indication of the
      * nesting depth followed by the function name and either start of
@@ -179,3545 +3910,52 @@ H5_trace(const double *returning, const char *func, const char *type, ...)
                 H5_timer_get_times(function_timer, &function_times);
                 H5_timer_get_times(running_timer, &running_times);
                 HDsprintf(tmp, "%.6f", (function_times.elapsed - running_times.elapsed));
-                HDfprintf(out, " %*s ", (int)HDstrlen(tmp), "");
+                H5RS_asprintf_cat(rs, " %*s ", (int)HDstrlen(tmp), "");
             } /* end if */
             for (i = 0; i < current_depth; i++)
-                HDfputc('+', out);
-            HDfprintf(out, "%*s%s = ", 2 * current_depth, "", func);
+                H5RS_aputc(rs, '+');
+            H5RS_asprintf_cat(rs, "%*s%s = ", 2 * current_depth, "", func);
         } /* end if */
-        else {
+        else
             /* Continue current line with return value */
-            HDfprintf(out, " = ");
-        } /* end else */
-    }     /* end if */
+            H5RS_acat(rs, " = ");
+    } /* end if */
     else {
         if (current_depth > last_call_depth)
-            HDfputs(" = <delayed>\n", out);
+            H5RS_acat(rs, " = <delayed>\n");
         if (H5_debug_g.ttimes) {
             H5_timer_get_times(function_timer, &function_times);
             H5_timer_get_times(running_timer, &running_times);
-            HDfprintf(out, "@%.6f ", (function_times.elapsed - running_times.elapsed));
+            H5RS_asprintf_cat(rs, "@%.6f ", (function_times.elapsed - running_times.elapsed));
         } /* end if */
         for (i = 0; i < current_depth; i++)
-            HDfputc('+', out);
-        HDfprintf(out, "%*s%s(", 2 * current_depth, "", func);
+            H5RS_aputc(rs, '+');
+        H5RS_asprintf_cat(rs, "%*s%s(", 2 * current_depth, "", func);
     } /* end else */
 
-    /* Clear array sizes */
-    for (i = 0; i < (hssize_t)NELMTS(asize); i++)
-        asize[i] = -1;
-
-    /* Parse the argument types */
-    for (argno = 0; *type; argno++, type += (HDisupper(*type) ? 2 : 1)) {
-        /* Count levels of indirection */
-        for (ptr = 0; '*' == *type; type++)
-            ptr++;
-        if ('[' == *type) {
-            if ('a' == type[1]) {
-                asize_idx = (int)HDstrtol(type + 2, &rest, 10);
-                HDassert(0 <= asize_idx && asize_idx < (int)NELMTS(asize));
-                HDassert(']' == *rest);
-                type = rest + 1;
-            }
-            else {
-                rest = (char *)HDstrchr(type, ']');
-                HDassert(rest);
-                type      = rest + 1;
-                asize_idx = -1;
-            }
-        } /* end if */
-        else
-            asize_idx = -1;
-
-        /*
-         * The argument name.  Leave off the `_id' part.  If the argument
-         * name is the null pointer then don't print the argument or the
-         * following `='.  This is used for return values.
-         */
-        argname = HDva_arg(ap, char *);
-        if (argname) {
-            unsigned n = (unsigned)MAX(0, (int)HDstrlen(argname) - 3);
-
-            if (!HDstrcmp(argname + n, "_id")) {
-                HDstrncpy(buf, argname, (size_t)MIN((int)sizeof(buf) - 1, n));
-                buf[MIN((int)sizeof(buf) - 1, n)] = '\0';
-                argname                           = buf;
-            } /* end if */
-            HDfprintf(out, "%s%s=", argno ? ", " : "", argname);
-        } /* end if */
-        else
-            argname = "";
-
-        /* The value */
-        if (ptr)
-            vp = HDva_arg(ap, void *);
-        switch (type[0]) {
-            case 'a':
-                if (ptr) {
-                    if (vp)
-                        HDfprintf(out, "0x%p", vp);
-                    else
-                        HDfprintf(out, "NULL");
-                } /* end if */
-                else {
-                    haddr_t addr = HDva_arg(ap, haddr_t);
-
-                    HDfprintf(out, "%" PRIuHADDR, addr);
-                } /* end else */
-                break;
-
-            case 'b':
-                if (ptr) {
-                    if (vp)
-                        HDfprintf(out, "0x%p", vp);
-                    else
-                        HDfprintf(out, "NULL");
-                } /* end if */
-                else {
-                    /* Can't pass hbool_t to HDva_arg() */
-                    hbool_t bool_var = (hbool_t)HDva_arg(ap, int);
-                    if (TRUE == bool_var)
-                        HDfprintf(out, "TRUE");
-                    else if (!bool_var)
-                        HDfprintf(out, "FALSE");
-                    else
-                        HDfprintf(out, "TRUE(%u)", (unsigned)bool_var);
-                }
-                break;
-
-            case 'd':
-                if (ptr) {
-                    if (vp)
-                        HDfprintf(out, "0x%p", vp);
-                    else
-                        HDfprintf(out, "NULL");
-                } /* end if */
-                else {
-                    double dbl = HDva_arg(ap, double);
-
-                    HDfprintf(out, "%g", dbl);
-                } /* end else */
-                break;
-
-            case 'D':
-                switch (type[1]) {
-                    case 'a':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5D_alloc_time_t alloc_time = (H5D_alloc_time_t)HDva_arg(ap, int);
-
-                            switch (alloc_time) {
-                                case H5D_ALLOC_TIME_ERROR:
-                                    HDfprintf(out, "H5D_ALLOC_TIME_ERROR");
-                                    break;
-
-                                case H5D_ALLOC_TIME_DEFAULT:
-                                    HDfprintf(out, "H5D_ALLOC_TIME_DEFAULT");
-                                    break;
-
-                                case H5D_ALLOC_TIME_EARLY:
-                                    HDfprintf(out, "H5D_ALLOC_TIME_EARLY");
-                                    break;
-
-                                case H5D_ALLOC_TIME_LATE:
-                                    HDfprintf(out, "H5D_ALLOC_TIME_LATE");
-                                    break;
-
-                                case H5D_ALLOC_TIME_INCR:
-                                    HDfprintf(out, "H5D_ALLOC_TIME_INCR");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)alloc_time);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'c':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5FD_mpio_collective_opt_t opt = (H5FD_mpio_collective_opt_t)HDva_arg(ap, int);
-
-                            switch (opt) {
-                                case H5FD_MPIO_COLLECTIVE_IO:
-                                    HDfprintf(out, "H5FD_MPIO_COLLECTIVE_IO");
-                                    break;
-
-                                case H5FD_MPIO_INDIVIDUAL_IO:
-                                    HDfprintf(out, "H5FD_MPIO_INDIVIDUAL_IO");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)opt);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'f':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5D_fill_time_t fill_time = (H5D_fill_time_t)HDva_arg(ap, int);
-
-                            switch (fill_time) {
-                                case H5D_FILL_TIME_ERROR:
-                                    HDfprintf(out, "H5D_FILL_TIME_ERROR");
-                                    break;
-
-                                case H5D_FILL_TIME_ALLOC:
-                                    HDfprintf(out, "H5D_FILL_TIME_ALLOC");
-                                    break;
-
-                                case H5D_FILL_TIME_NEVER:
-                                    HDfprintf(out, "H5D_FILL_TIME_NEVER");
-                                    break;
-
-                                case H5D_FILL_TIME_IFSET:
-                                    HDfprintf(out, "H5D_FILL_TIME_IFSET");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)fill_time);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'F':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5D_fill_value_t fill_value = (H5D_fill_value_t)HDva_arg(ap, int);
-
-                            switch (fill_value) {
-                                case H5D_FILL_VALUE_ERROR:
-                                    HDfprintf(out, "H5D_FILL_VALUE_ERROR");
-                                    break;
-
-                                case H5D_FILL_VALUE_UNDEFINED:
-                                    HDfprintf(out, "H5D_FILL_VALUE_UNDEFINED");
-                                    break;
-
-                                case H5D_FILL_VALUE_DEFAULT:
-                                    HDfprintf(out, "H5D_FILL_VALUE_DEFAULT");
-                                    break;
-
-                                case H5D_FILL_VALUE_USER_DEFINED:
-                                    HDfprintf(out, "H5D_FILL_VALUE_USER_DEFINED");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)fill_value);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'h':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5FD_mpio_chunk_opt_t opt = (H5FD_mpio_chunk_opt_t)HDva_arg(ap, int);
-
-                            switch (opt) {
-                                case H5FD_MPIO_CHUNK_DEFAULT:
-                                    HDfprintf(out, "H5FD_MPIO_CHUNK_DEFAULT");
-                                    break;
-
-                                case H5FD_MPIO_CHUNK_ONE_IO:
-                                    HDfprintf(out, "H5FD_MPIO_CHUNK_ONE_IO");
-                                    break;
-
-                                case H5FD_MPIO_CHUNK_MULTI_IO:
-                                    HDfprintf(out, "H5FD_MPIO_CHUNK_MULTI_IO");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)opt);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'i':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5D_mpio_actual_io_mode_t actual_io_mode =
-                                (H5D_mpio_actual_io_mode_t)HDva_arg(ap, int);
-
-                            switch (actual_io_mode) {
-                                case H5D_MPIO_NO_COLLECTIVE:
-                                    HDfprintf(out, "H5D_MPIO_NO_COLLECTIVE");
-                                    break;
-
-                                case H5D_MPIO_CHUNK_INDEPENDENT:
-                                    HDfprintf(out, "H5D_MPIO_CHUNK_INDEPENDENT");
-                                    break;
-
-                                case H5D_MPIO_CHUNK_COLLECTIVE:
-                                    HDfprintf(out, "H5D_MPIO_CHUNK_COLLECTIVE");
-                                    break;
-
-                                case H5D_MPIO_CHUNK_MIXED:
-                                    HDfprintf(out, "H5D_MPIO_CHUNK_MIXED");
-                                    break;
-
-                                case H5D_MPIO_CONTIGUOUS_COLLECTIVE:
-                                    HDfprintf(out, "H5D_MPIO_CONTIGUOUS_COLLECTIVE");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)actual_io_mode);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'k':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5D_chunk_index_t idx = (H5D_chunk_index_t)HDva_arg(ap, int);
-
-                            switch (idx) {
-                                case H5D_CHUNK_IDX_BTREE:
-                                    HDfprintf(out, "H5D_CHUNK_IDX_BTREE");
-                                    break;
-
-                                case H5D_CHUNK_IDX_NONE:
-                                    HDfprintf(out, "H5D_CHUNK_IDX_NONE");
-                                    break;
-
-                                case H5D_CHUNK_IDX_FARRAY:
-                                    HDfprintf(out, "H5D_CHUNK_IDX_FARRAY");
-                                    break;
-
-                                case H5D_CHUNK_IDX_EARRAY:
-                                    HDfprintf(out, "H5D_CHUNK_IDX_EARRAY");
-                                    break;
-
-                                case H5D_CHUNK_IDX_BT2:
-                                    HDfprintf(out, "H5D_CHUNK_IDX_BT2");
-                                    break;
-
-                                case H5D_CHUNK_IDX_SINGLE:
-                                    HDfprintf(out, "H5D_CHUNK_IDX_SINGLE");
-                                    break;
-
-                                case H5D_CHUNK_IDX_NTYPES:
-                                    HDfprintf(out, "ERROR: H5D_CHUNK_IDX_NTYPES (invalid value)");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "UNKNOWN VALUE: %ld", (long)idx);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'l':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5D_layout_t layout = (H5D_layout_t)HDva_arg(ap, int);
-
-                            switch (layout) {
-                                case H5D_LAYOUT_ERROR:
-                                    HDfprintf(out, "H5D_LAYOUT_ERROR");
-                                    break;
-
-                                case H5D_COMPACT:
-                                    HDfprintf(out, "H5D_COMPACT");
-                                    break;
-
-                                case H5D_CONTIGUOUS:
-                                    HDfprintf(out, "H5D_CONTIGUOUS");
-                                    break;
-
-                                case H5D_CHUNKED:
-                                    HDfprintf(out, "H5D_CHUNKED");
-                                    break;
-
-                                case H5D_VIRTUAL:
-                                    HDfprintf(out, "H5D_VIRTUAL");
-                                    break;
-
-                                case H5D_NLAYOUTS:
-                                    HDfprintf(out, "H5D_NLAYOUTS");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)layout);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'n':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5D_mpio_no_collective_cause_t nocol_cause_mode =
-                                (H5D_mpio_no_collective_cause_t)HDva_arg(ap, int);
-                            hbool_t flag_already_displayed = FALSE;
-
-                            /* Check for all bit-flags which might be set */
-                            if (nocol_cause_mode & H5D_MPIO_COLLECTIVE) {
-                                HDfprintf(out, "H5D_MPIO_COLLECTIVE");
-                                flag_already_displayed = TRUE;
-                            } /* end if */
-                            if (nocol_cause_mode & H5D_MPIO_SET_INDEPENDENT) {
-                                HDfprintf(out, "%sH5D_MPIO_SET_INDEPENDENT",
-                                          flag_already_displayed ? " | " : "");
-                                flag_already_displayed = TRUE;
-                            } /* end if */
-                            if (nocol_cause_mode & H5D_MPIO_DATATYPE_CONVERSION) {
-                                HDfprintf(out, "%sH5D_MPIO_DATATYPE_CONVERSION",
-                                          flag_already_displayed ? " | " : "");
-                                flag_already_displayed = TRUE;
-                            } /* end if */
-                            if (nocol_cause_mode & H5D_MPIO_DATA_TRANSFORMS) {
-                                HDfprintf(out, "%sH5D_MPIO_DATA_TRANSFORMS",
-                                          flag_already_displayed ? " | " : "");
-                                flag_already_displayed = TRUE;
-                            } /* end if */
-                            if (nocol_cause_mode & H5D_MPIO_MPI_OPT_TYPES_ENV_VAR_DISABLED) {
-                                HDfprintf(out, "%sH5D_MPIO_MPI_OPT_TYPES_ENV_VAR_DISABLED",
-                                          flag_already_displayed ? " | " : "");
-                                flag_already_displayed = TRUE;
-                            } /* end if */
-                            if (nocol_cause_mode & H5D_MPIO_NOT_SIMPLE_OR_SCALAR_DATASPACES) {
-                                HDfprintf(out, "%sH5D_MPIO_NOT_SIMPLE_OR_SCALAR_DATASPACES",
-                                          flag_already_displayed ? " | " : "");
-                                flag_already_displayed = TRUE;
-                            } /* end if */
-                            if (nocol_cause_mode & H5D_MPIO_NOT_CONTIGUOUS_OR_CHUNKED_DATASET) {
-                                HDfprintf(out, "%sH5D_MPIO_NOT_CONTIGUOUS_OR_CHUNKED_DATASET",
-                                          flag_already_displayed ? " | " : "");
-                                flag_already_displayed = TRUE;
-                            } /* end if */
-
-                            /* Display '<none>' if there's no flags set */
-                            if (!flag_already_displayed)
-                                HDfprintf(out, "<none>");
-                        } /* end else */
-                        break;
-
-                    case 'o':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5D_mpio_actual_chunk_opt_mode_t chunk_opt_mode =
-                                (H5D_mpio_actual_chunk_opt_mode_t)HDva_arg(ap, int);
-
-                            switch (chunk_opt_mode) {
-                                case H5D_MPIO_NO_CHUNK_OPTIMIZATION:
-                                    HDfprintf(out, "H5D_MPIO_NO_CHUNK_OPTIMIZATION");
-                                    break;
-
-                                case H5D_MPIO_LINK_CHUNK:
-                                    HDfprintf(out, "H5D_MPIO_LINK_CHUNK");
-                                    break;
-
-                                case H5D_MPIO_MULTI_CHUNK:
-                                    HDfprintf(out, "H5D_MPIO_MULTI_CHUNK");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)chunk_opt_mode);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 's':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5D_space_status_t space_status = (H5D_space_status_t)HDva_arg(ap, int);
-
-                            switch (space_status) {
-                                case H5D_SPACE_STATUS_NOT_ALLOCATED:
-                                    HDfprintf(out, "H5D_SPACE_STATUS_NOT_ALLOCATED");
-                                    break;
-
-                                case H5D_SPACE_STATUS_PART_ALLOCATED:
-                                    HDfprintf(out, "H5D_SPACE_STATUS_PART_ALLOCATED");
-                                    break;
-
-                                case H5D_SPACE_STATUS_ALLOCATED:
-                                    HDfprintf(out, "H5D_SPACE_STATUS_ALLOCATED");
-                                    break;
-
-                                case H5D_SPACE_STATUS_ERROR:
-                                    HDfprintf(out, "H5D_SPACE_STATUS_ERROR");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)space_status);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 't':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5FD_mpio_xfer_t transfer = (H5FD_mpio_xfer_t)HDva_arg(ap, int);
-
-                            switch (transfer) {
-                                case H5FD_MPIO_INDEPENDENT:
-                                    HDfprintf(out, "H5FD_MPIO_INDEPENDENT");
-                                    break;
-
-                                case H5FD_MPIO_COLLECTIVE:
-                                    HDfprintf(out, "H5FD_MPIO_COLLECTIVE");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)transfer);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'v':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5D_vds_view_t view = (H5D_vds_view_t)HDva_arg(ap, int);
-
-                            switch (view) {
-                                case H5D_VDS_ERROR:
-                                    HDfprintf(out, "H5D_VDS_ERROR");
-                                    break;
-
-                                case H5D_VDS_FIRST_MISSING:
-                                    HDfprintf(out, "H5D_VDS_FIRST_MISSING");
-                                    break;
-
-                                case H5D_VDS_LAST_AVAILABLE:
-                                    HDfprintf(out, "H5D_VDS_LAST_AVAILABLE");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)view);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    default:
-                        HDfprintf(out, "BADTYPE(D%c)", type[1]);
-                        goto error;
-                } /* end switch */
-                break;
-
-            case 'e':
-                if (ptr) {
-                    if (vp)
-                        HDfprintf(out, "0x%p", vp);
-                    else
-                        HDfprintf(out, "NULL");
-                } /* end if */
-                else {
-                    herr_t status = HDva_arg(ap, herr_t);
-
-                    if (status >= 0)
-                        HDfprintf(out, "SUCCEED");
-                    else
-                        HDfprintf(out, "FAIL");
-                } /* end else */
-                break;
-
-            case 'E':
-                switch (type[1]) {
-                    case 'd':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5E_direction_t direction = (H5E_direction_t)HDva_arg(ap, int);
-
-                            switch (direction) {
-                                case H5E_WALK_UPWARD:
-                                    HDfprintf(out, "H5E_WALK_UPWARD");
-                                    break;
-
-                                case H5E_WALK_DOWNWARD:
-                                    HDfprintf(out, "H5E_WALK_DOWNWARD");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)direction);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'e':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5E_error2_t *error = HDva_arg(ap, H5E_error2_t *);
-
-                            HDfprintf(out, "0x%p", (void *)error);
-                        } /* end else */
-                        break;
-
-                    case 's':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5ES_status_t status = (H5ES_status_t)HDva_arg(ap, int);
-
-                            switch (status) {
-                                case H5ES_STATUS_IN_PROGRESS:
-                                    HDfprintf(out, "H5ES_STATUS_IN_PROGRESS");
-                                    break;
-                                case H5ES_STATUS_SUCCEED:
-                                    HDfprintf(out, "H5ES_STATUS_SUCCEED");
-                                    break;
-                                case H5ES_STATUS_FAIL:
-                                    HDfprintf(out, "H5ES_STATUS_FAIL");
-                                    break;
-                                case H5ES_STATUS_CANCELED:
-                                    HDfprintf(out, "H5ES_STATUS_CANCELED");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)status);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 't':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5E_type_t etype = (H5E_type_t)HDva_arg(ap, int);
-
-                            switch (etype) {
-                                case H5E_MAJOR:
-                                    HDfprintf(out, "H5E_MAJOR");
-                                    break;
-
-                                case H5E_MINOR:
-                                    HDfprintf(out, "H5E_MINOR");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)etype);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    default:
-                        HDfprintf(out, "BADTYPE(E%c)", type[1]);
-                        goto error;
-                } /* end switch */
-                break;
-
-            case 'F':
-                switch (type[1]) {
-                    case 'd':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5F_close_degree_t degree = (H5F_close_degree_t)HDva_arg(ap, int);
-
-                            switch (degree) {
-                                case H5F_CLOSE_DEFAULT:
-                                    HDfprintf(out, "H5F_CLOSE_DEFAULT");
-                                    break;
-
-                                case H5F_CLOSE_WEAK:
-                                    HDfprintf(out, "H5F_CLOSE_WEAK");
-                                    break;
-
-                                case H5F_CLOSE_SEMI:
-                                    HDfprintf(out, "H5F_CLOSE_SEMI");
-                                    break;
-
-                                case H5F_CLOSE_STRONG:
-                                    HDfprintf(out, "H5F_CLOSE_STRONG");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)degree);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'f':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5F_fspace_strategy_t fs_strategy = (H5F_fspace_strategy_t)HDva_arg(ap, int);
-
-                            switch (fs_strategy) {
-                                case H5F_FSPACE_STRATEGY_FSM_AGGR:
-                                    HDfprintf(out, "H5F_FSPACE_STRATEGY_FSM_AGGR");
-                                    break;
-
-                                case H5F_FSPACE_STRATEGY_PAGE:
-                                    HDfprintf(out, "H5F_FSPACE_STRATEGY_PAGE");
-                                    break;
-
-                                case H5F_FSPACE_STRATEGY_AGGR:
-                                    HDfprintf(out, "H5F_FSPACE_STRATEGY_AGGR");
-                                    break;
-
-                                case H5F_FSPACE_STRATEGY_NONE:
-                                    HDfprintf(out, "H5F_FSPACE_STRATEGY_NONE");
-                                    break;
-
-                                case H5F_FSPACE_STRATEGY_NTYPES:
-                                default:
-                                    HDfprintf(out, "%ld", (long)fs_strategy);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'm':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5F_mem_t mem_type = (H5F_mem_t)HDva_arg(ap, int);
-
-                            switch (mem_type) {
-                                case H5FD_MEM_NOLIST:
-                                    HDfprintf(out, "H5FD_MEM_NOLIST");
-                                    break;
-
-                                case H5FD_MEM_DEFAULT:
-                                    HDfprintf(out, "H5FD_MEM_DEFAULT");
-                                    break;
-
-                                case H5FD_MEM_SUPER:
-                                    HDfprintf(out, "H5FD_MEM_SUPER");
-                                    break;
-
-                                case H5FD_MEM_BTREE:
-                                    HDfprintf(out, "H5FD_MEM_BTREE");
-                                    break;
-
-                                case H5FD_MEM_DRAW:
-                                    HDfprintf(out, "H5FD_MEM_DRAW");
-                                    break;
-
-                                case H5FD_MEM_GHEAP:
-                                    HDfprintf(out, "H5FD_MEM_GHEAP");
-                                    break;
-
-                                case H5FD_MEM_LHEAP:
-                                    HDfprintf(out, "H5FD_MEM_LHEAP");
-                                    break;
-
-                                case H5FD_MEM_OHDR:
-                                    HDfprintf(out, "H5FD_MEM_OHDR");
-                                    break;
-
-                                case H5FD_MEM_NTYPES:
-                                default:
-                                    HDfprintf(out, "%ld", (long)mem_type);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 's':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5F_scope_t scope = (H5F_scope_t)HDva_arg(ap, int);
-
-                            switch (scope) {
-                                case H5F_SCOPE_LOCAL:
-                                    HDfprintf(out, "H5F_SCOPE_LOCAL");
-                                    break;
-
-                                case H5F_SCOPE_GLOBAL:
-                                    HDfprintf(out, "H5F_SCOPE_GLOBAL");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)scope);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 't':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        break;
-
-                    case 'v':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5F_libver_t libver_vers = (H5F_libver_t)HDva_arg(ap, int);
-
-                            switch (libver_vers) {
-                                case H5F_LIBVER_EARLIEST:
-                                    HDfprintf(out, "H5F_LIBVER_EARLIEST");
-                                    break;
-
-                                case H5F_LIBVER_V18:
-                                    HDfprintf(out, "H5F_LIBVER_V18");
-                                    break;
-
-                                case H5F_LIBVER_V110:
-                                    HDfprintf(out, "H5F_LIBVER_V110");
-                                    break;
-
-                                case H5F_LIBVER_V112:
-                                    HDfprintf(out, "H5F_LIBVER_V112");
-                                    break;
-
-                                case H5F_LIBVER_V114:
-                                    HDcompile_assert(H5F_LIBVER_LATEST == H5F_LIBVER_V114);
-                                    HDfprintf(out, "H5F_LIBVER_LATEST");
-                                    break;
-
-                                case H5F_LIBVER_ERROR:
-                                case H5F_LIBVER_NBOUNDS:
-                                default:
-                                    HDfprintf(out, "%ld", (long)libver_vers);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    default:
-                        HDfprintf(out, "BADTYPE(F%c)", type[1]);
-                        goto error;
-                } /* end switch */
-                break;
-
-            case 'G':
-                switch (type[1]) {
-#ifndef H5_NO_DEPRECATED_SYMBOLS
-                    case 'o':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5G_obj_t obj_type = (H5G_obj_t)HDva_arg(ap, int);
-
-                            switch (obj_type) {
-                                case H5G_UNKNOWN:
-                                    HDfprintf(out, "H5G_UNKNOWN");
-                                    break;
-
-                                case H5G_GROUP:
-                                    HDfprintf(out, "H5G_GROUP");
-                                    break;
-
-                                case H5G_DATASET:
-                                    HDfprintf(out, "H5G_DATASET");
-                                    break;
-
-                                case H5G_TYPE:
-                                    HDfprintf(out, "H5G_TYPE");
-                                    break;
-
-                                case H5G_LINK:
-                                    HDfprintf(out, "H5G_LINK");
-                                    break;
-
-                                case H5G_UDLINK:
-                                    HDfprintf(out, "H5G_UDLINK");
-                                    break;
-
-                                case H5G_RESERVED_5:
-                                case H5G_RESERVED_6:
-                                case H5G_RESERVED_7:
-                                    HDfprintf(out, "H5G_RESERVED(%ld)", (long)obj_type);
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)obj_type);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 's':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5G_stat_t *statbuf = HDva_arg(ap, H5G_stat_t *);
-
-                            HDfprintf(out, "0x%p", (void *)statbuf);
-                        }
-                        break;
-#endif /* H5_NO_DEPRECATED_SYMBOLS */
-
-                    default:
-                        HDfprintf(out, "BADTYPE(G%c)", type[1]);
-                        goto error;
-                }
-                break;
-
-            case 'h':
-                if (ptr) {
-                    if (vp) {
-                        HDfprintf(out, "0x%p", vp);
-                        if (asize_idx >= 0 && asize[asize_idx] >= 0) {
-                            hsize_t *p = (hsize_t *)vp;
-
-                            HDfprintf(out, " {");
-                            for (i = 0; i < asize[asize_idx]; i++) {
-                                if (H5S_UNLIMITED == p[i])
-                                    HDfprintf(out, "%sH5S_UNLIMITED", (i ? ", " : ""));
-                                else
-                                    HDfprintf(out, "%s%" PRIuHSIZE, (i ? ", " : ""), p[i]);
-                            } /* end for */
-                            HDfprintf(out, "}");
-                        } /* end if */
-                    }     /* end if */
-                    else
-                        HDfprintf(out, "NULL");
-                } /* end if */
-                else {
-                    hsize_t hsize = HDva_arg(ap, hsize_t);
-
-                    if (H5S_UNLIMITED == hsize)
-                        HDfprintf(out, "H5S_UNLIMITED");
-                    else {
-                        HDfprintf(out, "%" PRIuHSIZE, hsize);
-                        asize[argno] = (hssize_t)hsize;
-                    } /* end else */
-                }     /* end else */
-                break;
-
-            case 'H':
-                switch (type[1]) {
-                    case 's':
-                        if (ptr) {
-                            if (vp) {
-                                HDfprintf(out, "0x%p", vp);
-                                if (asize_idx >= 0 && asize[asize_idx] >= 0) {
-                                    hssize_t *p = (hssize_t *)vp;
-
-                                    HDfprintf(out, " {");
-                                    for (i = 0; i < asize[asize_idx]; i++)
-                                        HDfprintf(out, "%s%" PRIdHSIZE, (i ? ", " : ""), p[i]);
-                                    HDfprintf(out, "}");
-                                } /* end if */
-                            }     /* end if */
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            hssize_t hssize = HDva_arg(ap, hssize_t);
-
-                            HDfprintf(out, "%" PRIdHSIZE, hssize);
-                            asize[argno] = (hssize_t)hssize;
-                        } /* end else */
-                        break;
-
-                    default:
-                        HDfprintf(out, "BADTYPE(H%c)", type[1]);
-                        goto error;
-                } /* end switch */
-                break;
-
-            case 'i':
-                if (ptr) {
-                    if (vp)
-                        HDfprintf(out, "0x%p", vp);
-                    else
-                        HDfprintf(out, "NULL");
-                } /* end if */
-                else {
-                    hid_t obj = HDva_arg(ap, hid_t);
-
-                    if (H5P_DEFAULT == obj)
-                        HDfprintf(out, "H5P_DEFAULT");
-                    else if (obj < 0)
-                        HDfprintf(out, "FAIL");
-                    else {
-                        switch (H5I_TYPE(obj)) { /* Use internal H5I macro instead of function call */
-                            case H5I_UNINIT:
-                                HDfprintf(out, "%ld (uninit - error)", (long)obj);
-                                break;
-
-                            case H5I_BADID:
-                                HDfprintf(out, "%ld (error)", (long)obj);
-                                break;
-
-                            case H5I_FILE:
-                                HDfprintf(out, "%ld (file)", (long)obj);
-                                break;
-
-                            case H5I_GROUP:
-                                HDfprintf(out, "%ld (group)", (long)obj);
-                                break;
-
-                            case H5I_DATATYPE:
-                                if (obj == H5T_NATIVE_SCHAR_g)
-                                    HDfprintf(out, "H5T_NATIVE_SCHAR");
-                                else if (obj == H5T_NATIVE_UCHAR_g)
-                                    HDfprintf(out, "H5T_NATIVE_UCHAR");
-                                else if (obj == H5T_NATIVE_SHORT_g)
-                                    HDfprintf(out, "H5T_NATIVE_SHORT");
-                                else if (obj == H5T_NATIVE_USHORT_g)
-                                    HDfprintf(out, "H5T_NATIVE_USHORT");
-                                else if (obj == H5T_NATIVE_INT_g)
-                                    HDfprintf(out, "H5T_NATIVE_INT");
-                                else if (obj == H5T_NATIVE_UINT_g)
-                                    HDfprintf(out, "H5T_NATIVE_UINT");
-                                else if (obj == H5T_NATIVE_LONG_g)
-                                    HDfprintf(out, "H5T_NATIVE_LONG");
-                                else if (obj == H5T_NATIVE_ULONG_g)
-                                    HDfprintf(out, "H5T_NATIVE_ULONG");
-                                else if (obj == H5T_NATIVE_LLONG_g)
-                                    HDfprintf(out, "H5T_NATIVE_LLONG");
-                                else if (obj == H5T_NATIVE_ULLONG_g)
-                                    HDfprintf(out, "H5T_NATIVE_ULLONG");
-                                else if (obj == H5T_NATIVE_FLOAT_g)
-                                    HDfprintf(out, "H5T_NATIVE_FLOAT");
-                                else if (obj == H5T_NATIVE_DOUBLE_g)
-                                    HDfprintf(out, "H5T_NATIVE_DOUBLE");
-#if H5_SIZEOF_LONG_DOUBLE != 0
-                                else if (obj == H5T_NATIVE_LDOUBLE_g)
-                                    HDfprintf(out, "H5T_NATIVE_LDOUBLE");
-#endif
-                                else if (obj == H5T_IEEE_F32BE_g)
-                                    HDfprintf(out, "H5T_IEEE_F32BE");
-                                else if (obj == H5T_IEEE_F32LE_g)
-                                    HDfprintf(out, "H5T_IEEE_F32LE");
-                                else if (obj == H5T_IEEE_F64BE_g)
-                                    HDfprintf(out, "H5T_IEEE_F64BE");
-                                else if (obj == H5T_IEEE_F64LE_g)
-                                    HDfprintf(out, "H5T_IEEE_F64LE");
-                                else if (obj == H5T_STD_I8BE_g)
-                                    HDfprintf(out, "H5T_STD_I8BE");
-                                else if (obj == H5T_STD_I8LE_g)
-                                    HDfprintf(out, "H5T_STD_I8LE");
-                                else if (obj == H5T_STD_I16BE_g)
-                                    HDfprintf(out, "H5T_STD_I16BE");
-                                else if (obj == H5T_STD_I16LE_g)
-                                    HDfprintf(out, "H5T_STD_I16LE");
-                                else if (obj == H5T_STD_I32BE_g)
-                                    HDfprintf(out, "H5T_STD_I32BE");
-                                else if (obj == H5T_STD_I32LE_g)
-                                    HDfprintf(out, "H5T_STD_I32LE");
-                                else if (obj == H5T_STD_I64BE_g)
-                                    HDfprintf(out, "H5T_STD_I64BE");
-                                else if (obj == H5T_STD_I64LE_g)
-                                    HDfprintf(out, "H5T_STD_I64LE");
-                                else if (obj == H5T_STD_U8BE_g)
-                                    HDfprintf(out, "H5T_STD_U8BE");
-                                else if (obj == H5T_STD_U8LE_g)
-                                    HDfprintf(out, "H5T_STD_U8LE");
-                                else if (obj == H5T_STD_U16BE_g)
-                                    HDfprintf(out, "H5T_STD_U16BE");
-                                else if (obj == H5T_STD_U16LE_g)
-                                    HDfprintf(out, "H5T_STD_U16LE");
-                                else if (obj == H5T_STD_U32BE_g)
-                                    HDfprintf(out, "H5T_STD_U32BE");
-                                else if (obj == H5T_STD_U32LE_g)
-                                    HDfprintf(out, "H5T_STD_U32LE");
-                                else if (obj == H5T_STD_U64BE_g)
-                                    HDfprintf(out, "H5T_STD_U64BE");
-                                else if (obj == H5T_STD_U64LE_g)
-                                    HDfprintf(out, "H5T_STD_U64LE");
-                                else if (obj == H5T_STD_B8BE_g)
-                                    HDfprintf(out, "H5T_STD_B8BE");
-                                else if (obj == H5T_STD_B8LE_g)
-                                    HDfprintf(out, "H5T_STD_B8LE");
-                                else if (obj == H5T_STD_B16BE_g)
-                                    HDfprintf(out, "H5T_STD_B16BE");
-                                else if (obj == H5T_STD_B16LE_g)
-                                    HDfprintf(out, "H5T_STD_B16LE");
-                                else if (obj == H5T_STD_B32BE_g)
-                                    HDfprintf(out, "H5T_STD_B32BE");
-                                else if (obj == H5T_STD_B32LE_g)
-                                    HDfprintf(out, "H5T_STD_B32LE");
-                                else if (obj == H5T_STD_B64BE_g)
-                                    HDfprintf(out, "H5T_STD_B64BE");
-                                else if (obj == H5T_STD_B64LE_g)
-                                    HDfprintf(out, "H5T_STD_B64LE");
-                                else if (obj == H5T_C_S1_g)
-                                    HDfprintf(out, "H5T_C_S1");
-                                else if (obj == H5T_FORTRAN_S1_g)
-                                    HDfprintf(out, "H5T_FORTRAN_S1");
-                                else
-                                    HDfprintf(out, "%ld (dtype)", (long)obj);
-                                break;
-
-                            case H5I_DATASPACE:
-                                HDfprintf(out, "%ld (dspace)", (long)obj);
-                                /* Save the rank of simple dataspaces for arrays */
-                                /* This may generate recursive call to the library... -QAK */
-                                {
-                                    H5S_t *space;
-
-                                    if (NULL != (space = (H5S_t *)H5I_object(obj)))
-                                        if (H5S_SIMPLE == H5S_GET_EXTENT_TYPE(space))
-                                            asize[argno] = H5S_GET_EXTENT_NDIMS(space);
-                                }
-                                break;
-
-                            case H5I_DATASET:
-                                HDfprintf(out, "%ld (dset)", (long)obj);
-                                break;
-
-                            case H5I_ATTR:
-                                HDfprintf(out, "%ld (attr)", (long)obj);
-                                break;
-
-                            case H5I_MAP:
-                                HDfprintf(out, "%ld (map)", (long)obj);
-                                break;
-
-                            case H5I_VFL:
-                                HDfprintf(out, "%ld (file driver)", (long)obj);
-                                break;
-
-                            case H5I_VOL:
-                                HDfprintf(out, "%ld (VOL plugin)", (long)obj);
-                                break;
-
-                            case H5I_GENPROP_CLS:
-                                HDfprintf(out, "%ld (genprop class)", (long)obj);
-                                break;
-
-                            case H5I_GENPROP_LST:
-                                HDfprintf(out, "%ld (genprop list)", (long)obj);
-                                break;
-
-                            case H5I_ERROR_CLASS:
-                                HDfprintf(out, "%ld (err class)", (long)obj);
-                                break;
-
-                            case H5I_ERROR_MSG:
-                                HDfprintf(out, "%ld (err msg)", (long)obj);
-                                break;
-
-                            case H5I_ERROR_STACK:
-                                HDfprintf(out, "%ld (err stack)", (long)obj);
-                                break;
-
-                            case H5I_SPACE_SEL_ITER:
-                                HDfprintf(out, "%ld (dataspace selection iterator)", (long)obj);
-                                break;
-
-                            case H5I_NTYPES:
-                                HDfprintf(out, "%ld (ntypes - error)", (long)obj);
-                                break;
-
-                            default:
-                                HDfprintf(out, "%ld (unknown class)", (long)obj);
-                                break;
-                        } /* end switch */
-                    }     /* end else */
-                }         /* end else */
-                break;
-
-            case 'I':
-                switch (type[1]) {
-                    case 'i':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5_index_t idx_type = (H5_index_t)HDva_arg(ap, int);
-
-                            switch (idx_type) {
-                                case H5_INDEX_UNKNOWN:
-                                    HDfprintf(out, "H5_INDEX_UNKNOWN");
-                                    break;
-
-                                case H5_INDEX_NAME:
-                                    HDfprintf(out, "H5_INDEX_NAME");
-                                    break;
-
-                                case H5_INDEX_CRT_ORDER:
-                                    HDfprintf(out, "H5_INDEX_CRT_ORDER");
-                                    break;
-
-                                case H5_INDEX_N:
-                                    HDfprintf(out, "H5_INDEX_N");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)idx_type);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'o':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5_iter_order_t order = (H5_iter_order_t)HDva_arg(ap, int);
-
-                            switch (order) {
-                                case H5_ITER_UNKNOWN:
-                                    HDfprintf(out, "H5_ITER_UNKNOWN");
-                                    break;
-
-                                case H5_ITER_INC:
-                                    HDfprintf(out, "H5_ITER_INC");
-                                    break;
-
-                                case H5_ITER_DEC:
-                                    HDfprintf(out, "H5_ITER_DEC");
-                                    break;
-
-                                case H5_ITER_NATIVE:
-                                    HDfprintf(out, "H5_ITER_NATIVE");
-                                    break;
-
-                                case H5_ITER_N:
-                                    HDfprintf(out, "H5_ITER_N");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)order);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 's':
-                        if (ptr) {
-                            if (vp) {
-                                HDfprintf(out, "0x%p", vp);
-                                if (asize_idx >= 0 && asize[asize_idx] >= 0) {
-                                    int *p = (int *)vp;
-
-                                    HDfprintf(out, " {");
-                                    for (i = 0; i < asize[asize_idx]; i++)
-                                        HDfprintf(out, "%s%d", (i ? ", " : ""), p[i]);
-                                    HDfprintf(out, "}");
-                                } /* end if */
-                            }     /* end if */
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            int is = HDva_arg(ap, int);
-
-                            HDfprintf(out, "%d", is);
-                            asize[argno] = is;
-                        } /* end else */
-                        break;
-
-                    case 't':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5I_type_t id_type = (H5I_type_t)HDva_arg(ap, int);
-
-                            switch (id_type) {
-                                case H5I_UNINIT:
-                                    HDfprintf(out, "H5I_UNINIT");
-                                    break;
-
-                                case H5I_BADID:
-                                    HDfprintf(out, "H5I_BADID");
-                                    break;
-
-                                case H5I_FILE:
-                                    HDfprintf(out, "H5I_FILE");
-                                    break;
-
-                                case H5I_GROUP:
-                                    HDfprintf(out, "H5I_GROUP");
-                                    break;
-
-                                case H5I_DATATYPE:
-                                    HDfprintf(out, "H5I_DATATYPE");
-                                    break;
-
-                                case H5I_DATASPACE:
-                                    HDfprintf(out, "H5I_DATASPACE");
-                                    break;
-
-                                case H5I_DATASET:
-                                    HDfprintf(out, "H5I_DATASET");
-                                    break;
-
-                                case H5I_ATTR:
-                                    HDfprintf(out, "H5I_ATTR");
-                                    break;
-
-                                case H5I_MAP:
-                                    HDfprintf(out, "H5I_MAP");
-                                    break;
-
-                                case H5I_VFL:
-                                    HDfprintf(out, "H5I_VFL");
-                                    break;
-
-                                case H5I_VOL:
-                                    HDfprintf(out, "H5I_VOL");
-                                    break;
-
-                                case H5I_GENPROP_CLS:
-                                    HDfprintf(out, "H5I_GENPROP_CLS");
-                                    break;
-
-                                case H5I_GENPROP_LST:
-                                    HDfprintf(out, "H5I_GENPROP_LST");
-                                    break;
-
-                                case H5I_ERROR_CLASS:
-                                    HDfprintf(out, "H5I_ERROR_CLASS");
-                                    break;
-
-                                case H5I_ERROR_MSG:
-                                    HDfprintf(out, "H5I_ERROR_MSG");
-                                    break;
-
-                                case H5I_ERROR_STACK:
-                                    HDfprintf(out, "H5I_ERROR_STACK");
-                                    break;
-
-                                case H5I_SPACE_SEL_ITER:
-                                    HDfprintf(out, "H5I_SPACE_SEL_ITER");
-                                    break;
-
-                                case H5I_NTYPES:
-                                    HDfprintf(out, "H5I_NTYPES");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)id_type);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'u':
-                        if (ptr) {
-                            if (vp) {
-                                HDfprintf(out, "0x%p", vp);
-                                if (asize_idx >= 0 && asize[asize_idx] >= 0) {
-                                    unsigned *p = (unsigned *)vp;
-
-                                    HDfprintf(out, " {");
-                                    for (i = 0; i < asize[asize_idx]; i++)
-                                        HDfprintf(out, "%s%u", i ? ", " : "", p[i]);
-                                    HDfprintf(out, "}");
-                                } /* end if */
-                            }     /* end if */
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            unsigned iu = HDva_arg(ap, unsigned);
-
-                            HDfprintf(out, "%u", iu);
-                            asize[argno] = iu;
-                        } /* end else */
-                        break;
-
-                    default:
-                        HDfprintf(out, "BADTYPE(I%c)", type[1]);
-                        goto error;
-                } /* end switch */
-                break;
-
-            case 'k':
-                if (ptr) {
-                    if (vp)
-                        HDfprintf(out, "0x%p", vp);
-                    else
-                        HDfprintf(out, "NULL");
-                } /* end if */
-                else {
-                    H5O_token_t token = HDva_arg(ap, H5O_token_t);
-                    int         j;
-
-                    for (j = 0; j < H5O_MAX_TOKEN_SIZE; j++)
-                        HDfprintf(out, "%02x", token.__data[j]);
-                } /* end else */
-                break;
-
-            case 'L':
-                switch (type[1]) {
-                    case 'l':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5L_type_t link_type = (H5L_type_t)HDva_arg(ap, int);
-
-                            switch (link_type) {
-                                case H5L_TYPE_ERROR:
-                                    HDfprintf(out, "H5L_TYPE_ERROR");
-                                    break;
-
-                                case H5L_TYPE_HARD:
-                                    HDfprintf(out, "H5L_TYPE_HARD");
-                                    break;
-
-                                case H5L_TYPE_SOFT:
-                                    HDfprintf(out, "H5L_TYPE_SOFT");
-                                    break;
-
-                                case H5L_TYPE_EXTERNAL:
-                                    HDfprintf(out, "H5L_TYPE_EXTERNAL");
-                                    break;
-
-                                case H5L_TYPE_MAX:
-                                    HDfprintf(out, "H5L_TYPE_MAX");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)link_type);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    default:
-                        HDfprintf(out, "BADTYPE(G%c)", type[1]);
-                        goto error;
-                } /* end switch */
-                break;
-
-            case 'M':
-                switch (type[1]) {
-                    case 'c':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-#ifdef H5_HAVE_PARALLEL
-                        else {
-                            MPI_Comm comm = HDva_arg(ap, MPI_Comm);
-
-                            HDfprintf(out, "%ld", (long)comm);
-                        } /* end else */
-#endif                    /* H5_HAVE_PARALLEL */
-                        break;
-
-                    case 'i':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-#ifdef H5_HAVE_PARALLEL
-                        else {
-                            MPI_Info info = HDva_arg(ap, MPI_Info);
-
-                            HDfprintf(out, "%ld", (long)info);
-                        } /* end else */
-#endif                    /* H5_HAVE_PARALLEL */
-                        break;
-
-                    case 't':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5FD_mem_t mt = (H5FD_mem_t)HDva_arg(ap, int);
-
-                            switch (mt) {
-                                case H5FD_MEM_NOLIST:
-                                    HDfprintf(out, "H5FD_MEM_NOLIST");
-                                    break;
-
-                                case H5FD_MEM_DEFAULT:
-                                    HDfprintf(out, "H5FD_MEM_DEFAULT");
-                                    break;
-
-                                case H5FD_MEM_SUPER:
-                                    HDfprintf(out, "H5FD_MEM_SUPER");
-                                    break;
-
-                                case H5FD_MEM_BTREE:
-                                    HDfprintf(out, "H5FD_MEM_BTREE");
-                                    break;
-
-                                case H5FD_MEM_DRAW:
-                                    HDfprintf(out, "H5FD_MEM_DRAW");
-                                    break;
-
-                                case H5FD_MEM_GHEAP:
-                                    HDfprintf(out, "H5FD_MEM_GHEAP");
-                                    break;
-
-                                case H5FD_MEM_LHEAP:
-                                    HDfprintf(out, "H5FD_MEM_LHEAP");
-                                    break;
-
-                                case H5FD_MEM_OHDR:
-                                    HDfprintf(out, "H5FD_MEM_OHDR");
-                                    break;
-
-                                case H5FD_MEM_NTYPES:
-                                    HDfprintf(out, "H5FD_MEM_NTYPES");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)mt);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    default:
-                        goto error;
-                } /* end switch */
-                break;
-
-            case 'o':
-                if (ptr) {
-                    if (vp)
-                        HDfprintf(out, "0x%p", vp);
-                    else
-                        HDfprintf(out, "NULL");
-                } /* end if */
-                else {
-                    off_t offset = HDva_arg(ap, off_t);
-
-                    HDfprintf(out, "%ld", (long)offset);
-                } /* end else */
-                break;
-
-            case 'O':
-                switch (type[1]) {
-                    case 't':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5O_type_t objtype = (H5O_type_t)HDva_arg(ap, int);
-
-                            switch (objtype) {
-                                case H5O_TYPE_UNKNOWN:
-                                    HDfprintf(out, "H5O_TYPE_UNKNOWN");
-                                    break;
-
-                                case H5O_TYPE_GROUP:
-                                    HDfprintf(out, "H5O_TYPE_GROUP");
-                                    break;
-
-                                case H5O_TYPE_DATASET:
-                                    HDfprintf(out, "H5O_TYPE_DATASET");
-                                    break;
-
-                                case H5O_TYPE_NAMED_DATATYPE:
-                                    HDfprintf(out, "H5O_TYPE_NAMED_DATATYPE");
-                                    break;
-
-                                case H5O_TYPE_MAP:
-                                    HDfprintf(out, "H5O_TYPE_MAP");
-                                    break;
-
-                                case H5O_TYPE_NTYPES:
-                                    HDfprintf(out, "H5O_TYPE_NTYPES");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "BADTYPE(%ld)", (long)objtype);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    default:
-                        HDfprintf(out, "BADTYPE(S%c)", type[1]);
-                        goto error;
-                } /* end switch */
-                break;
-
-            case 'p':
-                if (ptr) {
-                    if (vp)
-                        HDfprintf(out, "0x%p", vp);
-                    else
-                        HDfprintf(out, "NULL");
-                } /* end if */
-                else {
-                    hid_t           pclass_id  = HDva_arg(ap, hid_t);
-                    char *          class_name = NULL;
-                    H5P_genclass_t *pclass;
-
-                    /* Get the class name and print it */
-                    /* (This may generate recursive call to the library... -QAK) */
-                    if (NULL != (pclass = (H5P_genclass_t *)H5I_object(pclass_id)) &&
-                        NULL != (class_name = H5P_get_class_name(pclass))) {
-                        HDfprintf(out, "%s", class_name);
-                        H5MM_xfree(class_name);
-                    } /* end if */
-                    else
-                        HDfprintf(out, "%ld", (long)pclass_id);
-                } /* end else */
-                break;
-
-            case 'R':
-                switch (type[1]) {
-
-                    case 'o':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            hobj_ref_t ref = HDva_arg(ap, hobj_ref_t);
-
-                            HDfprintf(out, "Reference Object=%" PRIuHADDR, ref);
-                        } /* end else */
-                        break;
-
-                    case 'd':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            /* Note! region references are array types */
-                            HDfprintf(out, "Reference Region");
-                            goto error;
-                        } /* end else */
-                        break;
-
-                    case 'r':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            /* Note! reference types are opaque types */
-                            HDfprintf(out, "Reference Opaque");
-                            goto error;
-                        } /* end else */
-                        break;
-
-                    case 't':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5R_type_t reftype = (H5R_type_t)HDva_arg(ap, int);
-
-                            switch (reftype) {
-                                case H5R_BADTYPE:
-                                    HDfprintf(out, "H5R_BADTYPE");
-                                    break;
-
-                                case H5R_OBJECT1:
-                                    HDfprintf(out, "H5R_OBJECT1");
-                                    break;
-
-                                case H5R_DATASET_REGION1:
-                                    HDfprintf(out, "H5R_DATASET_REGION1");
-                                    break;
-
-                                case H5R_OBJECT2:
-                                    HDfprintf(out, "H5R_OBJECT2");
-                                    break;
-
-                                case H5R_DATASET_REGION2:
-                                    HDfprintf(out, "H5R_DATASET_REGION2");
-                                    break;
-
-                                case H5R_ATTR:
-                                    HDfprintf(out, "H5R_ATTR");
-                                    break;
-
-                                case H5R_MAXTYPE:
-                                    HDfprintf(out, "H5R_MAXTYPE");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "BADTYPE(%ld)", (long)reftype);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    default:
-                        HDfprintf(out, "BADTYPE(S%c)", type[1]);
-                        goto error;
-                }
-                break;
-
-            case 'S':
-                switch (type[1]) {
-                    case 'c':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5S_class_t cls = (H5S_class_t)HDva_arg(ap, int);
-
-                            switch (cls) {
-                                case H5S_NO_CLASS:
-                                    HDfprintf(out, "H5S_NO_CLASS");
-                                    break;
-
-                                case H5S_SCALAR:
-                                    HDfprintf(out, "H5S_SCALAR");
-                                    break;
-
-                                case H5S_SIMPLE:
-                                    HDfprintf(out, "H5S_SIMPLE");
-                                    break;
-
-                                case H5S_NULL:
-                                    HDfprintf(out, "H5S_NULL");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)cls);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 's':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5S_seloper_t so = (H5S_seloper_t)HDva_arg(ap, int);
-
-                            switch (so) {
-                                case H5S_SELECT_NOOP:
-                                    HDfprintf(out, "H5S_NOOP");
-                                    break;
-
-                                case H5S_SELECT_SET:
-                                    HDfprintf(out, "H5S_SELECT_SET");
-                                    break;
-
-                                case H5S_SELECT_OR:
-                                    HDfprintf(out, "H5S_SELECT_OR");
-                                    break;
-
-                                case H5S_SELECT_AND:
-                                    HDfprintf(out, "H5S_SELECT_AND");
-                                    break;
-
-                                case H5S_SELECT_XOR:
-                                    HDfprintf(out, "H5S_SELECT_XOR");
-                                    break;
-
-                                case H5S_SELECT_NOTB:
-                                    HDfprintf(out, "H5S_SELECT_NOTB");
-                                    break;
-
-                                case H5S_SELECT_NOTA:
-                                    HDfprintf(out, "H5S_SELECT_NOTA");
-                                    break;
-
-                                case H5S_SELECT_APPEND:
-                                    HDfprintf(out, "H5S_SELECT_APPEND");
-                                    break;
-
-                                case H5S_SELECT_PREPEND:
-                                    HDfprintf(out, "H5S_SELECT_PREPEND");
-                                    break;
-
-                                case H5S_SELECT_INVALID:
-                                    HDfprintf(out, "H5S_SELECT_INVALID");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)so);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 't':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5S_sel_type st = (H5S_sel_type)HDva_arg(ap, int);
-
-                            switch (st) {
-                                case H5S_SEL_ERROR:
-                                    HDfprintf(out, "H5S_SEL_ERROR");
-                                    break;
-
-                                case H5S_SEL_NONE:
-                                    HDfprintf(out, "H5S_SEL_NONE");
-                                    break;
-
-                                case H5S_SEL_POINTS:
-                                    HDfprintf(out, "H5S_SEL_POINTS");
-                                    break;
-
-                                case H5S_SEL_HYPERSLABS:
-                                    HDfprintf(out, "H5S_SEL_HYPERSLABS");
-                                    break;
-
-                                case H5S_SEL_ALL:
-                                    HDfprintf(out, "H5S_SEL_ALL");
-                                    break;
-
-                                case H5S_SEL_N:
-                                    HDfprintf(out, "H5S_SEL_N");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)st);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    default:
-                        HDfprintf(out, "BADTYPE(S%c)", type[1]);
-                        goto error;
-                } /* end switch */
-                break;
-
-            case 's':
-                if (ptr) {
-                    if (vp)
-                        HDfprintf(out, "0x%p", vp);
-                    else
-                        HDfprintf(out, "NULL");
-                } /* end if */
-                else {
-                    const char *str = HDva_arg(ap, const char *);
-
-                    HDfprintf(out, "\"%s\"", str);
-                } /* end else */
-                break;
-
-            case 'T':
-                switch (type[1]) {
-                    case 'c':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5T_cset_t cset = (H5T_cset_t)HDva_arg(ap, int);
-
-                            switch (cset) {
-                                case H5T_CSET_ERROR:
-                                    HDfprintf(out, "H5T_CSET_ERROR");
-                                    break;
-
-                                case H5T_CSET_ASCII:
-                                    HDfprintf(out, "H5T_CSET_ASCII");
-                                    break;
-
-                                case H5T_CSET_UTF8:
-                                    HDfprintf(out, "H5T_CSET_UTF8");
-                                    break;
-
-                                case H5T_CSET_RESERVED_2:
-                                case H5T_CSET_RESERVED_3:
-                                case H5T_CSET_RESERVED_4:
-                                case H5T_CSET_RESERVED_5:
-                                case H5T_CSET_RESERVED_6:
-                                case H5T_CSET_RESERVED_7:
-                                case H5T_CSET_RESERVED_8:
-                                case H5T_CSET_RESERVED_9:
-                                case H5T_CSET_RESERVED_10:
-                                case H5T_CSET_RESERVED_11:
-                                case H5T_CSET_RESERVED_12:
-                                case H5T_CSET_RESERVED_13:
-                                case H5T_CSET_RESERVED_14:
-                                case H5T_CSET_RESERVED_15:
-                                    HDfprintf(out, "H5T_CSET_RESERVED_%ld", (long)cset);
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)cset);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'd':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5T_direction_t direct = (H5T_direction_t)HDva_arg(ap, int);
-
-                            switch (direct) {
-                                case H5T_DIR_DEFAULT:
-                                    HDfprintf(out, "H5T_DIR_DEFAULT");
-                                    break;
-
-                                case H5T_DIR_ASCEND:
-                                    HDfprintf(out, "H5T_DIR_ASCEND");
-                                    break;
-
-                                case H5T_DIR_DESCEND:
-                                    HDfprintf(out, "H5T_DIR_DESCEND");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)direct);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'e':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5T_pers_t pers = (H5T_pers_t)HDva_arg(ap, int);
-
-                            switch (pers) {
-                                case H5T_PERS_DONTCARE:
-                                    HDfprintf(out, "H5T_PERS_DONTCARE");
-                                    break;
-
-                                case H5T_PERS_SOFT:
-                                    HDfprintf(out, "H5T_PERS_SOFT");
-                                    break;
-
-                                case H5T_PERS_HARD:
-                                    HDfprintf(out, "H5T_PERS_HARD");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)pers);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'n':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5T_norm_t norm = (H5T_norm_t)HDva_arg(ap, int);
-
-                            switch (norm) {
-                                case H5T_NORM_ERROR:
-                                    HDfprintf(out, "H5T_NORM_ERROR");
-                                    break;
-
-                                case H5T_NORM_IMPLIED:
-                                    HDfprintf(out, "H5T_NORM_IMPLIED");
-                                    break;
-
-                                case H5T_NORM_MSBSET:
-                                    HDfprintf(out, "H5T_NORM_MSBSET");
-                                    break;
-
-                                case H5T_NORM_NONE:
-                                    HDfprintf(out, "H5T_NORM_NONE");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)norm);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'o':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5T_order_t order = (H5T_order_t)HDva_arg(ap, int);
-
-                            switch (order) {
-                                case H5T_ORDER_ERROR:
-                                    HDfprintf(out, "H5T_ORDER_ERROR");
-                                    break;
-
-                                case H5T_ORDER_LE:
-                                    HDfprintf(out, "H5T_ORDER_LE");
-                                    break;
-
-                                case H5T_ORDER_BE:
-                                    HDfprintf(out, "H5T_ORDER_BE");
-                                    break;
-
-                                case H5T_ORDER_VAX:
-                                    HDfprintf(out, "H5T_ORDER_VAX");
-                                    break;
-
-                                case H5T_ORDER_MIXED:
-                                    HDfprintf(out, "H5T_ORDER_MIXED");
-                                    break;
-
-                                case H5T_ORDER_NONE:
-                                    HDfprintf(out, "H5T_ORDER_NONE");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)order);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'p':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5T_pad_t pad = (H5T_pad_t)HDva_arg(ap, int);
-
-                            switch (pad) {
-                                case H5T_PAD_ERROR:
-                                    HDfprintf(out, "H5T_PAD_ERROR");
-                                    break;
-
-                                case H5T_PAD_ZERO:
-                                    HDfprintf(out, "H5T_PAD_ZERO");
-                                    break;
-
-                                case H5T_PAD_ONE:
-                                    HDfprintf(out, "H5T_PAD_ONE");
-                                    break;
-
-                                case H5T_PAD_BACKGROUND:
-                                    HDfprintf(out, "H5T_PAD_BACKGROUND");
-                                    break;
-
-                                case H5T_NPAD:
-                                    HDfprintf(out, "H5T_NPAD");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)pad);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 's':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5T_sign_t sign = (H5T_sign_t)HDva_arg(ap, int);
-
-                            switch (sign) {
-                                case H5T_SGN_ERROR:
-                                    HDfprintf(out, "H5T_SGN_ERROR");
-                                    break;
-
-                                case H5T_SGN_NONE:
-                                    HDfprintf(out, "H5T_SGN_NONE");
-                                    break;
-
-                                case H5T_SGN_2:
-                                    HDfprintf(out, "H5T_SGN_2");
-                                    break;
-
-                                case H5T_NSGN:
-                                    HDfprintf(out, "H5T_NSGN");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)sign);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 't':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5T_class_t type_class = (H5T_class_t)HDva_arg(ap, int);
-
-                            switch (type_class) {
-                                case H5T_NO_CLASS:
-                                    HDfprintf(out, "H5T_NO_CLASS");
-                                    break;
-
-                                case H5T_INTEGER:
-                                    HDfprintf(out, "H5T_INTEGER");
-                                    break;
-
-                                case H5T_FLOAT:
-                                    HDfprintf(out, "H5T_FLOAT");
-                                    break;
-
-                                case H5T_TIME:
-                                    HDfprintf(out, "H5T_TIME");
-                                    break;
-
-                                case H5T_STRING:
-                                    HDfprintf(out, "H5T_STRING");
-                                    break;
-
-                                case H5T_BITFIELD:
-                                    HDfprintf(out, "H5T_BITFIELD");
-                                    break;
-
-                                case H5T_OPAQUE:
-                                    HDfprintf(out, "H5T_OPAQUE");
-                                    break;
-
-                                case H5T_COMPOUND:
-                                    HDfprintf(out, "H5T_COMPOUND");
-                                    break;
-
-                                case H5T_REFERENCE:
-                                    HDfprintf(out, "H5T_REFERENCE");
-                                    break;
-
-                                case H5T_ENUM:
-                                    HDfprintf(out, "H5T_ENUM");
-                                    break;
-
-                                case H5T_VLEN:
-                                    HDfprintf(out, "H5T_VLEN");
-                                    break;
-
-                                case H5T_ARRAY:
-                                    HDfprintf(out, "H5T_ARRAY");
-                                    break;
-
-                                case H5T_NCLASSES:
-                                    HDfprintf(out, "H5T_NCLASSES");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)type_class);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'z':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5T_str_t str = (H5T_str_t)HDva_arg(ap, int);
-
-                            switch (str) {
-                                case H5T_STR_ERROR:
-                                    HDfprintf(out, "H5T_STR_ERROR");
-                                    break;
-
-                                case H5T_STR_NULLTERM:
-                                    HDfprintf(out, "H5T_STR_NULLTERM");
-                                    break;
-
-                                case H5T_STR_NULLPAD:
-                                    HDfprintf(out, "H5T_STR_NULLPAD");
-                                    break;
-
-                                case H5T_STR_SPACEPAD:
-                                    HDfprintf(out, "H5T_STR_SPACEPAD");
-                                    break;
-
-                                case H5T_STR_RESERVED_3:
-                                case H5T_STR_RESERVED_4:
-                                case H5T_STR_RESERVED_5:
-                                case H5T_STR_RESERVED_6:
-                                case H5T_STR_RESERVED_7:
-                                case H5T_STR_RESERVED_8:
-                                case H5T_STR_RESERVED_9:
-                                case H5T_STR_RESERVED_10:
-                                case H5T_STR_RESERVED_11:
-                                case H5T_STR_RESERVED_12:
-                                case H5T_STR_RESERVED_13:
-                                case H5T_STR_RESERVED_14:
-                                case H5T_STR_RESERVED_15:
-                                    HDfprintf(out, "H5T_STR_RESERVED(%ld)", (long)str);
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)str);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    default:
-                        HDfprintf(out, "BADTYPE(T%c)", type[1]);
-                        goto error;
-                } /* end switch */
-                break;
-
-            case 't':
-                if (ptr) {
-                    if (vp)
-                        HDfprintf(out, "0x%p", vp);
-                    else
-                        HDfprintf(out, "NULL");
-                } /* end if */
-                else {
-                    htri_t tri_var = HDva_arg(ap, htri_t);
-
-                    if (tri_var > 0)
-                        HDfprintf(out, "TRUE");
-                    else if (!tri_var)
-                        HDfprintf(out, "FALSE");
-                    else
-                        HDfprintf(out, "FAIL(%d)", (int)tri_var);
-                } /* end else */
-                break;
-
-            case 'U':
-                switch (type[1]) {
-                    case 'l':
-                        if (ptr) {
-                            if (vp) {
-                                HDfprintf(out, "0x%p", vp);
-                                if (asize_idx >= 0 && asize[asize_idx] >= 0) {
-                                    unsigned long *p = (unsigned long *)vp;
-
-                                    HDfprintf(out, " {");
-                                    for (i = 0; i < asize[asize_idx]; i++)
-                                        HDfprintf(out, "%s%lu", i ? ", " : "", p[i]);
-                                    HDfprintf(out, "}");
-                                } /* end if */
-                            }     /* end if */
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            unsigned long iul = HDva_arg(ap, unsigned long);
-
-                            HDfprintf(out, "%lu", iul);
-                            asize[argno] = (hssize_t)iul;
-                        } /* end else */
-                        break;
-
-                    case 'L':
-                        if (ptr) {
-                            if (vp) {
-                                HDfprintf(out, "0x%p", vp);
-                                if (asize_idx >= 0 && asize[asize_idx] >= 0) {
-                                    unsigned long long *p = (unsigned long long *)vp;
-
-                                    HDfprintf(out, " {");
-                                    for (i = 0; i < asize[asize_idx]; i++)
-                                        HDfprintf(out, "%s%llu", i ? ", " : "", p[i]);
-                                    HDfprintf(out, "}");
-                                } /* end if */
-                            }     /* end if */
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            unsigned long long iull = HDva_arg(ap, unsigned long long);
-
-                            HDfprintf(out, "%llu", iull);
-                            asize[argno] = (hssize_t)iull;
-                        } /* end else */
-                        break;
-
-                    default:
-                        HDfprintf(out, "BADTYPE(U%c)", type[1]);
-                        goto error;
-                } /* end switch */
-                break;
-
-            case 'V':
-                switch (type[1]) {
-                    case 'a':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_attr_get_t get = (H5VL_attr_get_t)HDva_arg(ap, int);
-
-                            switch (get) {
-                                case H5VL_ATTR_GET_SPACE:
-                                    HDfprintf(out, "H5VL_ATTR_GET_SPACE");
-                                    break;
-                                case H5VL_ATTR_GET_TYPE:
-                                    HDfprintf(out, "H5VL_ATTR_GET_TYPE");
-                                    break;
-                                case H5VL_ATTR_GET_ACPL:
-                                    HDfprintf(out, "H5VL_ATTR_GET_ACPL");
-                                    break;
-                                case H5VL_ATTR_GET_NAME:
-                                    HDfprintf(out, "H5VL_ATTR_GET_NAME");
-                                    break;
-                                case H5VL_ATTR_GET_STORAGE_SIZE:
-                                    HDfprintf(out, "H5VL_ATTR_GET_STORAGE_SIZE");
-                                    break;
-                                case H5VL_ATTR_GET_INFO:
-                                    HDfprintf(out, "H5VL_ATTR_GET_INFO");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)get);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'A':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_blob_optional_t optional = (H5VL_blob_optional_t)HDva_arg(ap, int);
-
-                            switch (optional) {
-                                default:
-                                    HDfprintf(out, "%ld", (long)optional);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'b':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_attr_specific_t specific = (H5VL_attr_specific_t)HDva_arg(ap, int);
-
-                            switch (specific) {
-                                case H5VL_ATTR_DELETE:
-                                    HDfprintf(out, "H5VL_ATTR_DELETE");
-                                    break;
-                                case H5VL_ATTR_EXISTS:
-                                    HDfprintf(out, "H5VL_ATTR_EXISTS");
-                                    break;
-                                case H5VL_ATTR_ITER:
-                                    HDfprintf(out, "H5VL_ATTR_ITER");
-                                    break;
-                                case H5VL_ATTR_RENAME:
-                                    HDfprintf(out, "H5VL_ATTR_RENAME");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)specific);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'B':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_blob_specific_t specific = (H5VL_blob_specific_t)HDva_arg(ap, int);
-
-                            switch (specific) {
-                                case H5VL_BLOB_DELETE:
-                                    HDfprintf(out, "H5VL_BLOB_DELETE");
-                                    break;
-                                case H5VL_BLOB_GETSIZE:
-                                    HDfprintf(out, "H5VL_BLOB_GETSIZE");
-                                    break;
-                                case H5VL_BLOB_ISNULL:
-                                    HDfprintf(out, "H5VL_BLOB_ISNULL");
-                                    break;
-                                case H5VL_BLOB_SETNULL:
-                                    HDfprintf(out, "H5VL_BLOB_SETNULL");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)specific);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'C':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_class_value_t class_val =
-                                (H5VL_class_value_t)HDva_arg(ap, H5VL_class_value_t);
-
-                            if (H5_VOL_NATIVE == class_val)
-                                HDfprintf(out, "H5_VOL_NATIVE");
-                            else
-                                HDfprintf(out, "%ld", (long)class_val);
-                        } /* end else */
-                        break;
-
-                    case 'c':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_dataset_get_t get = (H5VL_dataset_get_t)HDva_arg(ap, int);
-
-                            switch (get) {
-                                case H5VL_DATASET_GET_SPACE:
-                                    HDfprintf(out, "H5VL_DATASET_GET_SPACE");
-                                    break;
-                                case H5VL_DATASET_GET_SPACE_STATUS:
-                                    HDfprintf(out, "H5VL_DATASET_GET_SPACE_STATUS");
-                                    break;
-                                case H5VL_DATASET_GET_TYPE:
-                                    HDfprintf(out, "H5VL_DATASET_GET_TYPE");
-                                    break;
-                                case H5VL_DATASET_GET_DCPL:
-                                    HDfprintf(out, "H5VL_DATASET_GET_DCPL");
-                                    break;
-                                case H5VL_DATASET_GET_DAPL:
-                                    HDfprintf(out, "H5VL_DATASET_GET_DAPL");
-                                    break;
-                                case H5VL_DATASET_GET_STORAGE_SIZE:
-                                    HDfprintf(out, "H5VL_DATASET_GET_STORAGE_SIZE");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)get);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'd':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_dataset_specific_t specific = (H5VL_dataset_specific_t)HDva_arg(ap, int);
-
-                            switch (specific) {
-                                case H5VL_DATASET_SET_EXTENT:
-                                    HDfprintf(out, "H5VL_DATASET_SET_EXTENT");
-                                    break;
-                                case H5VL_DATASET_FLUSH:
-                                    HDfprintf(out, "H5VL_DATASET_FLUSH");
-                                    break;
-                                case H5VL_DATASET_REFRESH:
-                                    HDfprintf(out, "H5VL_DATASET_REFRESH");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)specific);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'e':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_datatype_get_t get = (H5VL_datatype_get_t)HDva_arg(ap, int);
-
-                            switch (get) {
-                                case H5VL_DATATYPE_GET_BINARY:
-                                    HDfprintf(out, "H5VL_DATATYPE_GET_BINARY");
-                                    break;
-                                case H5VL_DATATYPE_GET_TCPL:
-                                    HDfprintf(out, "H5VL_DATATYPE_GET_TCPL");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)get);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'f':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_datatype_specific_t specific = (H5VL_datatype_specific_t)HDva_arg(ap, int);
-
-                            switch (specific) {
-                                case H5VL_DATATYPE_FLUSH:
-                                    HDfprintf(out, "H5VL_DATATYPE_FLUSH");
-                                    break;
-                                case H5VL_DATATYPE_REFRESH:
-                                    HDfprintf(out, "H5VL_DATATYPE_REFRESH");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)specific);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'g':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_file_get_t get = (H5VL_file_get_t)HDva_arg(ap, int);
-
-                            switch (get) {
-                                case H5VL_FILE_GET_CONT_INFO:
-                                    HDfprintf(out, "H5VL_FILE_GET_CONT_INFO");
-                                    break;
-                                case H5VL_FILE_GET_FAPL:
-                                    HDfprintf(out, "H5VL_FILE_GET_FAPL");
-                                    break;
-                                case H5VL_FILE_GET_FCPL:
-                                    HDfprintf(out, "H5VL_FILE_GET_FCPL");
-                                    break;
-                                case H5VL_FILE_GET_FILENO:
-                                    HDfprintf(out, "H5VL_FILE_GET_FILENO");
-                                    break;
-                                case H5VL_FILE_GET_INTENT:
-                                    HDfprintf(out, "H5VL_FILE_GET_INTENT");
-                                    break;
-                                case H5VL_FILE_GET_NAME:
-                                    HDfprintf(out, "H5VL_FILE_GET_NAME");
-                                    break;
-                                case H5VL_FILE_GET_OBJ_COUNT:
-                                    HDfprintf(out, "H5VL_FILE_GET_OBJ_COUNT");
-                                    break;
-                                case H5VL_FILE_GET_OBJ_IDS:
-                                    HDfprintf(out, "H5VL_FILE_GET_OBJ_IDS");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)get);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'h':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_file_specific_t specific = (H5VL_file_specific_t)HDva_arg(ap, int);
-
-                            switch (specific) {
-                                case H5VL_FILE_FLUSH:
-                                    HDfprintf(out, "H5VL_FILE_FLUSH");
-                                    break;
-                                case H5VL_FILE_REOPEN:
-                                    HDfprintf(out, "H5VL_FILE_REOPEN");
-                                    break;
-                                case H5VL_FILE_MOUNT:
-                                    HDfprintf(out, "H5VL_FILE_MOUNT");
-                                    break;
-                                case H5VL_FILE_UNMOUNT:
-                                    HDfprintf(out, "H5VL_FILE_UNMOUNT");
-                                    break;
-                                case H5VL_FILE_IS_ACCESSIBLE:
-                                    HDfprintf(out, "H5VL_FILE_IS_ACCESSIBLE");
-                                    break;
-                                case H5VL_FILE_DELETE:
-                                    HDfprintf(out, "H5VL_FILE_DELETE");
-                                    break;
-                                case H5VL_FILE_IS_EQUAL:
-                                    HDfprintf(out, "H5VL_FILE_IS_EQUAL");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)specific);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'i':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_group_get_t get = (H5VL_group_get_t)HDva_arg(ap, int);
-
-                            switch (get) {
-                                case H5VL_GROUP_GET_GCPL:
-                                    HDfprintf(out, "H5VL_GROUP_GET_GCPL");
-                                    break;
-                                case H5VL_GROUP_GET_INFO:
-                                    HDfprintf(out, "H5VL_GROUP_GET_INFO");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)get);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'j':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_group_specific_t specific = (H5VL_group_specific_t)HDva_arg(ap, int);
-
-                            switch (specific) {
-                                case H5VL_GROUP_FLUSH:
-                                    HDfprintf(out, "H5VL_GROUP_FLUSH");
-                                    break;
-                                case H5VL_GROUP_REFRESH:
-                                    HDfprintf(out, "H5VL_GROUP_REFRESH");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)specific);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'k':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_link_create_type_t create = (H5VL_link_create_type_t)HDva_arg(ap, int);
-
-                            switch (create) {
-                                case H5VL_LINK_CREATE_HARD:
-                                    HDfprintf(out, "H5VL_LINK_CREATE_HARD");
-                                    break;
-                                case H5VL_LINK_CREATE_SOFT:
-                                    HDfprintf(out, "H5VL_LINK_CREATE_SOFT");
-                                    break;
-                                case H5VL_LINK_CREATE_UD:
-                                    HDfprintf(out, "H5VL_LINK_CREATE_UD");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)create);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'l':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_link_get_t get = (H5VL_link_get_t)HDva_arg(ap, int);
-
-                            switch (get) {
-                                case H5VL_LINK_GET_INFO:
-                                    HDfprintf(out, "H5VL_LINK_GET_INFO");
-                                    break;
-                                case H5VL_LINK_GET_NAME:
-                                    HDfprintf(out, "H5VL_LINK_GET_NAME");
-                                    break;
-                                case H5VL_LINK_GET_VAL:
-                                    HDfprintf(out, "H5VL_LINK_GET_VAL");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)get);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'L':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_get_conn_lvl_t get = (H5VL_get_conn_lvl_t)HDva_arg(ap, int);
-
-                            switch (get) {
-                                case H5VL_GET_CONN_LVL_CURR:
-                                    HDfprintf(out, "H5VL_GET_CONN_LVL_CURR");
-                                    break;
-                                case H5VL_GET_CONN_LVL_TERM:
-                                    HDfprintf(out, "H5VL_GET_CONN_LVL_TERM");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)get);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'm':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_link_specific_t specific = (H5VL_link_specific_t)HDva_arg(ap, int);
-
-                            switch (specific) {
-                                case H5VL_LINK_DELETE:
-                                    HDfprintf(out, "H5VL_LINK_DELETE");
-                                    break;
-                                case H5VL_LINK_EXISTS:
-                                    HDfprintf(out, "H5VL_LINK_EXISTS");
-                                    break;
-                                case H5VL_LINK_ITER:
-                                    HDfprintf(out, "H5VL_LINK_ITER");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)specific);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'n':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_object_get_t get = (H5VL_object_get_t)HDva_arg(ap, int);
-
-                            switch (get) {
-                                case H5VL_OBJECT_GET_FILE:
-                                    HDfprintf(out, "H5VL_OBJECT_GET_FILE");
-                                    break;
-                                case H5VL_OBJECT_GET_NAME:
-                                    HDfprintf(out, "H5VL_OBJECT_GET_NAME");
-                                    break;
-                                case H5VL_OBJECT_GET_TYPE:
-                                    HDfprintf(out, "H5VL_OBJECT_GET_TYPE");
-                                    break;
-                                case H5VL_OBJECT_GET_INFO:
-                                    HDfprintf(out, "H5VL_OBJECT_GET_INFO");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)get);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'o':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_object_specific_t specific = (H5VL_object_specific_t)HDva_arg(ap, int);
-
-                            switch (specific) {
-                                case H5VL_OBJECT_CHANGE_REF_COUNT:
-                                    HDfprintf(out, "H5VL_OBJECT_CHANGE_REF_COUNT");
-                                    break;
-                                case H5VL_OBJECT_EXISTS:
-                                    HDfprintf(out, "H5VL_OBJECT_EXISTS");
-                                    break;
-                                case H5VL_OBJECT_LOOKUP:
-                                    HDfprintf(out, "H5VL_OBJECT_LOOKUP");
-                                    break;
-                                case H5VL_OBJECT_VISIT:
-                                    HDfprintf(out, "H5VL_OBJECT_VISIT");
-                                    break;
-                                case H5VL_OBJECT_FLUSH:
-                                    HDfprintf(out, "H5VL_OBJECT_FLUSH");
-                                    break;
-                                case H5VL_OBJECT_REFRESH:
-                                    HDfprintf(out, "H5VL_OBJECT_REFRESH");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)specific);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'r':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_request_specific_t specific = (H5VL_request_specific_t)HDva_arg(ap, int);
-
-                            switch (specific) {
-                                case H5VL_REQUEST_WAITANY:
-                                    HDfprintf(out, "H5VL_REQUEST_WAITANY");
-                                    break;
-                                case H5VL_REQUEST_WAITSOME:
-                                    HDfprintf(out, "H5VL_REQUEST_WAITSOME");
-                                    break;
-                                case H5VL_REQUEST_WAITALL:
-                                    HDfprintf(out, "H5VL_REQUEST_WAITALL");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)specific);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 's':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_attr_optional_t optional = (H5VL_attr_optional_t)HDva_arg(ap, int);
-
-                            switch (optional) {
-#ifndef H5_NO_DEPRECATED_SYMBOLS
-                                case H5VL_NATIVE_ATTR_ITERATE_OLD:
-                                    HDfprintf(out, "H5VL_NATIVE_ATTR_ITERATE_OLD");
-                                    break;
-#endif /* H5_NO_DEPRECATED_SYMBOLS */
-                                default:
-                                    HDfprintf(out, "%ld", (long)optional);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'S':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_subclass_t subclass = (H5VL_subclass_t)HDva_arg(ap, int);
-
-                            switch (subclass) {
-                                case H5VL_SUBCLS_NONE:
-                                    HDfprintf(out, "H5VL_SUBCLS_NONE");
-                                    break;
-                                case H5VL_SUBCLS_INFO:
-                                    HDfprintf(out, "H5VL_SUBCLS_INFO");
-                                    break;
-                                case H5VL_SUBCLS_WRAP:
-                                    HDfprintf(out, "H5VL_SUBCLS_WRAP");
-                                    break;
-                                case H5VL_SUBCLS_ATTR:
-                                    HDfprintf(out, "H5VL_SUBCLS_ATTR");
-                                    break;
-                                case H5VL_SUBCLS_DATASET:
-                                    HDfprintf(out, "H5VL_SUBCLS_DATASET");
-                                    break;
-                                case H5VL_SUBCLS_DATATYPE:
-                                    HDfprintf(out, "H5VL_SUBCLS_DATATYPE");
-                                    break;
-                                case H5VL_SUBCLS_FILE:
-                                    HDfprintf(out, "H5VL_SUBCLS_FILE");
-                                    break;
-                                case H5VL_SUBCLS_GROUP:
-                                    HDfprintf(out, "H5VL_SUBCLS_GROUP");
-                                    break;
-                                case H5VL_SUBCLS_LINK:
-                                    HDfprintf(out, "H5VL_SUBCLS_LINK");
-                                    break;
-                                case H5VL_SUBCLS_OBJECT:
-                                    HDfprintf(out, "H5VL_SUBCLS_OBJECT");
-                                    break;
-                                case H5VL_SUBCLS_REQUEST:
-                                    HDfprintf(out, "H5VL_SUBCLS_REQUEST");
-                                    break;
-                                case H5VL_SUBCLS_BLOB:
-                                    HDfprintf(out, "H5VL_SUBCLS_BLOB");
-                                    break;
-                                case H5VL_SUBCLS_TOKEN:
-                                    HDfprintf(out, "H5VL_SUBCLS_TOKEN");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)subclass);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 't':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_dataset_optional_t optional = (H5VL_dataset_optional_t)HDva_arg(ap, int);
-
-                            switch (optional) {
-                                case H5VL_NATIVE_DATASET_FORMAT_CONVERT:
-                                    HDfprintf(out, "H5VL_NATIVE_DATASET_FORMAT_CONVERT");
-                                    break;
-                                case H5VL_NATIVE_DATASET_GET_CHUNK_INDEX_TYPE:
-                                    HDfprintf(out, "H5VL_NATIVE_DATASET_GET_CHUNK_INDEX_TYPE");
-                                    break;
-                                case H5VL_NATIVE_DATASET_GET_CHUNK_STORAGE_SIZE:
-                                    HDfprintf(out, "H5VL_NATIVE_DATASET_GET_CHUNK_STORAGE_SIZE");
-                                    break;
-                                case H5VL_NATIVE_DATASET_GET_NUM_CHUNKS:
-                                    HDfprintf(out, "H5VL_NATIVE_DATASET_GET_NUM_CHUNKS");
-                                    break;
-                                case H5VL_NATIVE_DATASET_GET_CHUNK_INFO_BY_IDX:
-                                    HDfprintf(out, "H5VL_NATIVE_DATASET_GET_CHUNK_INFO_BY_IDX");
-                                    break;
-                                case H5VL_NATIVE_DATASET_GET_CHUNK_INFO_BY_COORD:
-                                    HDfprintf(out, "H5VL_NATIVE_DATASET_GET_CHUNK_INFO_BY_COORD");
-                                    break;
-                                case H5VL_NATIVE_DATASET_CHUNK_READ:
-                                    HDfprintf(out, "H5VL_NATIVE_DATASET_CHUNK_READ");
-                                    break;
-                                case H5VL_NATIVE_DATASET_CHUNK_WRITE:
-                                    HDfprintf(out, "H5VL_NATIVE_DATASET_CHUNK_WRITE");
-                                    break;
-                                case H5VL_NATIVE_DATASET_GET_VLEN_BUF_SIZE:
-                                    HDfprintf(out, "H5VL_NATIVE_DATASET_GET_VLEN_BUF_SIZE");
-                                    break;
-                                case H5VL_NATIVE_DATASET_GET_OFFSET:
-                                    HDfprintf(out, "H5VL_NATIVE_DATASET_GET_OFFSET");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)optional);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'u':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_datatype_optional_t optional = (H5VL_datatype_optional_t)HDva_arg(ap, int);
-
-                            switch (optional) {
-                                default:
-                                    HDfprintf(out, "%ld", (long)optional);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'v':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_file_optional_t optional = (H5VL_file_optional_t)HDva_arg(ap, int);
-
-                            switch (optional) {
-                                case H5VL_NATIVE_FILE_CLEAR_ELINK_CACHE:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_CLEAR_ELINK_CACHE");
-                                    break;
-                                case H5VL_NATIVE_FILE_GET_FILE_IMAGE:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_GET_FILE_IMAGE");
-                                    break;
-                                case H5VL_NATIVE_FILE_GET_FREE_SECTIONS:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_GET_FREE_SECTIONS");
-                                    break;
-                                case H5VL_NATIVE_FILE_GET_FREE_SPACE:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_GET_FREE_SPACE");
-                                    break;
-                                case H5VL_NATIVE_FILE_GET_INFO:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_GET_INFO");
-                                    break;
-                                case H5VL_NATIVE_FILE_GET_MDC_CONF:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_GET_MDC_CONF");
-                                    break;
-                                case H5VL_NATIVE_FILE_GET_MDC_HR:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_GET_MDC_HR");
-                                    break;
-                                case H5VL_NATIVE_FILE_GET_MDC_SIZE:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_GET_MDC_SIZE");
-                                    break;
-                                case H5VL_NATIVE_FILE_GET_SIZE:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_GET_SIZE");
-                                    break;
-                                case H5VL_NATIVE_FILE_GET_VFD_HANDLE:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_GET_VFD_HANDLE");
-                                    break;
-                                case H5VL_NATIVE_FILE_RESET_MDC_HIT_RATE:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_RESET_MDC_HIT_RATE");
-                                    break;
-                                case H5VL_NATIVE_FILE_SET_MDC_CONFIG:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_SET_MDC_CONFIG");
-                                    break;
-                                case H5VL_NATIVE_FILE_GET_METADATA_READ_RETRY_INFO:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_GET_METADATA_READ_RETRY_INFO");
-                                    break;
-                                case H5VL_NATIVE_FILE_START_SWMR_WRITE:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_START_SWMR_WRITE");
-                                    break;
-                                case H5VL_NATIVE_FILE_START_MDC_LOGGING:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_START_MDC_LOGGING");
-                                    break;
-                                case H5VL_NATIVE_FILE_STOP_MDC_LOGGING:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_STOP_MDC_LOGGING");
-                                    break;
-                                case H5VL_NATIVE_FILE_GET_MDC_LOGGING_STATUS:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_GET_MDC_LOGGING_STATUS");
-                                    break;
-                                case H5VL_NATIVE_FILE_FORMAT_CONVERT:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_FORMAT_CONVERT");
-                                    break;
-                                case H5VL_NATIVE_FILE_RESET_PAGE_BUFFERING_STATS:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_RESET_PAGE_BUFFERING_STATS");
-                                    break;
-                                case H5VL_NATIVE_FILE_GET_PAGE_BUFFERING_STATS:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_GET_PAGE_BUFFERING_STATS");
-                                    break;
-                                case H5VL_NATIVE_FILE_GET_MDC_IMAGE_INFO:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_GET_MDC_IMAGE_INFO");
-                                    break;
-                                case H5VL_NATIVE_FILE_GET_EOA:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_GET_EOA");
-                                    break;
-                                case H5VL_NATIVE_FILE_INCR_FILESIZE:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_INCR_FILESIZE");
-                                    break;
-                                case H5VL_NATIVE_FILE_SET_LIBVER_BOUNDS:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_SET_LIBVER_BOUNDS");
-                                    break;
-                                case H5VL_NATIVE_FILE_GET_MIN_DSET_OHDR_FLAG:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_GET_MIN_DSET_OHDR_FLAG");
-                                    break;
-                                case H5VL_NATIVE_FILE_SET_MIN_DSET_OHDR_FLAG:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_SET_MIN_DSET_OHDR_FLAG");
-                                    break;
-                                case H5VL_NATIVE_FILE_GET_MPI_ATOMICITY:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_GET_MPI_ATOMICITY");
-                                    break;
-                                case H5VL_NATIVE_FILE_SET_MPI_ATOMICITY:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_SET_MPI_ATOMICITY");
-                                    break;
-                                case H5VL_NATIVE_FILE_POST_OPEN:
-                                    HDfprintf(out, "H5VL_NATIVE_FILE_POST_OPEN");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)optional);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'w':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_group_optional_t optional = (H5VL_group_optional_t)HDva_arg(ap, int);
-
-                            switch (optional) {
-#ifndef H5_NO_DEPRECATED_SYMBOLS
-                                case H5VL_NATIVE_GROUP_ITERATE_OLD:
-                                    HDfprintf(out, "H5VL_NATIVE_GROUP_ITERATE_OLD");
-                                    break;
-                                case H5VL_NATIVE_GROUP_GET_OBJINFO:
-                                    HDfprintf(out, "H5VL_NATIVE_GROUP_GET_OBJINFO");
-                                    break;
-#endif /* H5_NO_DEPRECATED_SYMBOLS */
-                                default:
-                                    HDfprintf(out, "%ld", (long)optional);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'x':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_link_optional_t optional = (H5VL_link_optional_t)HDva_arg(ap, int);
-
-                            switch (optional) {
-                                default:
-                                    HDfprintf(out, "%ld", (long)optional);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'y':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_object_optional_t optional = (H5VL_object_optional_t)HDva_arg(ap, int);
-
-                            switch (optional) {
-                                case H5VL_NATIVE_OBJECT_GET_COMMENT:
-                                    HDfprintf(out, "H5VL_NATIVE_OBJECT_GET_COMMENT");
-                                    break;
-                                case H5VL_NATIVE_OBJECT_SET_COMMENT:
-                                    HDfprintf(out, "H5VL_NATIVE_OBJECT_SET_COMMENT");
-                                    break;
-                                case H5VL_NATIVE_OBJECT_DISABLE_MDC_FLUSHES:
-                                    HDfprintf(out, "H5VL_NATIVE_OBJECT_DISABLE_MDC_FLUSHES");
-                                    break;
-                                case H5VL_NATIVE_OBJECT_ENABLE_MDC_FLUSHES:
-                                    HDfprintf(out, "H5VL_NATIVE_OBJECT_ENABLE_MDC_FLUSHES");
-                                    break;
-                                case H5VL_NATIVE_OBJECT_ARE_MDC_FLUSHES_DISABLED:
-                                    HDfprintf(out, "H5VL_NATIVE_OBJECT_ARE_MDC_FLUSHES_DISABLED");
-                                    break;
-                                case H5VL_NATIVE_OBJECT_GET_NATIVE_INFO:
-                                    HDfprintf(out, "H5VL_NATIVE_OBJECT_GET_NATIVE_INFO");
-                                    break;
-                                default:
-                                    HDfprintf(out, "%ld", (long)optional);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'z':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5VL_request_optional_t optional = (H5VL_request_optional_t)HDva_arg(ap, int);
-
-                            switch (optional) {
-                                default:
-                                    HDfprintf(out, "%ld", (long)optional);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    default:
-                        HDfprintf(out, "BADTYPE(Z%c)", type[1]);
-                        goto error;
-                } /* end switch */
-                break;
-
-            case 'x':
-                if (ptr) {
-                    if (vp) {
-                        HDfprintf(out, "0x%p", vp);
-                        if (asize_idx >= 0 && asize[asize_idx] >= 0) {
-                            void **p = (void **)vp;
-
-                            HDfprintf(out, " {");
-                            for (i = 0; i < asize[asize_idx]; i++) {
-                                if (p[i])
-                                    HDfprintf(out, "%s0x%p", (i ? ", " : ""), p[i]);
-                                else
-                                    HDfprintf(out, "%sNULL", (i ? ", " : ""));
-                            } /* end for */
-                            HDfprintf(out, "}");
-                        } /* end if */
-                    }     /* end if */
-                    else
-                        HDfprintf(out, "NULL");
-                } /* end if */
-                else {
-                    vp = HDva_arg(ap, void *);
-
-                    if (vp)
-                        HDfprintf(out, "0x%p", vp);
-                    else
-                        HDfprintf(out, "NULL");
-                } /* end else */
-                break;
-
-            case 'z':
-                if (ptr) {
-                    if (vp) {
-                        HDfprintf(out, "0x%p", vp);
-                        if (asize_idx >= 0 && asize[asize_idx] >= 0) {
-                            size_t *p = (size_t *)vp;
-
-                            HDfprintf(out, " {");
-                            for (i = 0; i < asize[asize_idx]; i++)
-                                HDfprintf(out, "%s%zu", (i ? ", " : ""), p[i]);
-                            HDfprintf(out, "}");
-                        } /* end if */
-                    }     /* end if */
-                    else
-                        HDfprintf(out, "NULL");
-                } /* end if */
-                else {
-                    size_t size = HDva_arg(ap, size_t);
-
-                    HDfprintf(out, "%zu", size);
-                    asize[argno] = (hssize_t)size;
-                } /* end else */
-                break;
-
-            case 'Z':
-                switch (type[1]) {
-                    case 'a':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5Z_SO_scale_type_t scale_type = (H5Z_SO_scale_type_t)HDva_arg(ap, int);
-
-                            switch (scale_type) {
-                                case H5Z_SO_FLOAT_DSCALE:
-                                    HDfprintf(out, "H5Z_SO_FLOAT_DSCALE");
-                                    break;
-
-                                case H5Z_SO_FLOAT_ESCALE:
-                                    HDfprintf(out, "H5Z_SO_FLOAT_ESCALE");
-                                    break;
-
-                                case H5Z_SO_INT:
-                                    HDfprintf(out, "H5Z_SO_INT");
-                                    break;
-
-                                default:
-                                    HDfprintf(out, "%ld", (long)scale_type);
-                                    break;
-                            } /* end switch */
-                        }     /* end else */
-                        break;
-
-                    case 'c':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5Z_class2_t *filter = HDva_arg(ap, H5Z_class2_t *);
-
-                            HDfprintf(out, "0x%p", (void *)filter);
-                        } /* end else */
-                        break;
-
-                    case 'e':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5Z_EDC_t edc = (H5Z_EDC_t)HDva_arg(ap, int);
-
-                            if (H5Z_DISABLE_EDC == edc)
-                                HDfprintf(out, "H5Z_DISABLE_EDC");
-                            else if (H5Z_ENABLE_EDC == edc)
-                                HDfprintf(out, "H5Z_ENABLE_EDC");
-                            else
-                                HDfprintf(out, "%ld", (long)edc);
-                        } /* end else */
-                        break;
-
-                    case 'f':
-                        if (ptr) {
-                            if (vp)
-                                HDfprintf(out, "0x%p", vp);
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            H5Z_filter_t id = HDva_arg(ap, H5Z_filter_t);
-
-                            if (H5Z_FILTER_DEFLATE == id)
-                                HDfprintf(out, "H5Z_FILTER_DEFLATE");
-                            else
-                                HDfprintf(out, "%ld", (long)id);
-                        } /* end else */
-                        break;
-
-                    case 's':
-                        if (ptr) {
-                            if (vp) {
-                                HDfprintf(out, "0x%p", vp);
-                                if (asize_idx >= 0 && asize[asize_idx] >= 0) {
-                                    ssize_t *p = (ssize_t *)vp;
-
-                                    HDfprintf(out, " {");
-                                    for (i = 0; i < asize[asize_idx]; i++)
-                                        HDfprintf(out, "%s%zd", (i ? ", " : ""), p[i]);
-                                    HDfprintf(out, "}");
-                                } /* end if */
-                            }     /* end if */
-                            else
-                                HDfprintf(out, "NULL");
-                        } /* end if */
-                        else {
-                            ssize_t ssize = HDva_arg(ap, ssize_t);
-
-                            HDfprintf(out, "%zd", ssize);
-                            asize[argno] = (hssize_t)ssize;
-                        } /* end else */
-                        break;
-
-                    default:
-                        HDfprintf(out, "BADTYPE(Z%c)", type[1]);
-                        goto error;
-                } /* end switch */
-                break;
-
-            default:
-                if (HDisupper(type[0]))
-                    HDfprintf(out, "BADTYPE(%c%c)", type[0], type[1]);
-                else
-                    HDfprintf(out, "BADTYPE(%c)", type[0]);
-                goto error;
-        } /* end switch */
-    }     /* end for */
+    /* Format arguments into the refcounted string */
+    HDva_start(ap, type);
+    H5_trace_args(rs, type, ap);
+    HDva_end(ap);
 
     /* Display event time for return */
     if (returning && H5_debug_g.ttimes) {
         H5_timer_get_times(function_timer, &function_times);
         H5_timer_get_times(running_timer, &running_times);
-        HDfprintf(out, " @%.6f [dt=%.6f]", (function_times.elapsed - running_times.elapsed),
-                  (function_times.elapsed - *returning));
+        H5RS_asprintf_cat(rs, " @%.6f [dt=%.6f]", (function_times.elapsed - running_times.elapsed),
+                          (function_times.elapsed - *returning));
     } /* end if */
 
-error:
-    HDva_end(ap);
+    /* Display generated string */
     if (returning)
-        HDfprintf(out, ";\n");
+        H5RS_acat(rs, ";\n");
     else {
         last_call_depth = current_depth++;
-        HDfprintf(out, ")");
+        H5RS_acat(rs, ")");
     } /* end else */
+    HDfputs(H5RS_get_str(rs), out);
     HDfflush(out);
+    H5RS_decr(rs);
 
     if (H5_debug_g.ttimes)
         return function_times.elapsed;

--- a/test/trefstr.c
+++ b/test/trefstr.c
@@ -280,60 +280,225 @@ test_refstr_wrap(void)
 
 /****************************************************************
 **
-**  test_refstr_own(): Test basic H5RS (ref-counted strings) code.
-**      Tests transferring ownership of dynamically allocated strings
-**      to ref-counted strings.
+**  test_refstr_asprintf_cat(): Test basic H5RS (ref-counted strings) code.
+**      Tests appending printf-formatted output to ref-counted strings.
 **
 ****************************************************************/
 static void
-test_refstr_own(void)
+test_refstr_asprintf_cat(void)
 {
-    H5RS_str_t *rs;  /* Ref-counted string created */
-    char *      s;   /* Pointer to string to transfer */
-    const char *t;   /* Temporary pointers to string */
-    int         cmp; /* Comparison value */
-    herr_t      ret; /* Generic return value */
+    H5RS_str_t *rs;       /* Ref-counted string created */
+    const char *s;        /* Pointer to raw string in ref-counted string */
+    char        buf[256]; /* Buffer to compare against */
+    int         cmp;      /* Comparison value */
+    herr_t      ret;      /* Generic return value */
 
     /* Output message about test being performed */
-    MESSAGE(5, ("Testing Transferring Ref-Counted Strings\n"));
+    MESSAGE(5, ("Testing Printf-formatted Output to Ref-Counted Strings\n"));
 
-    /* Initialize buffer */
-    s = (char *)H5FL_BLK_MALLOC(str_buf, HDstrlen("foo") + 1);
-    CHECK_PTR(s, "H5FL_BLK_MALLOC");
-    HDstrcpy(s, "foo");
+    /* Wrap ref-counted string around existing buffer */
+    rs = H5RS_create(NULL);
+    CHECK_PTR(rs, "H5RS_create");
 
-    /* Transfer ownership of dynamically allocated string to ref-counted string */
-    rs = H5RS_own(s);
-    CHECK_PTR(rs, "H5RS_own");
+    /* Print initial output to ref-counted string */
+    ret = H5RS_asprintf_cat(rs, "%d-%s", (int)10, "foo");
+    CHECK(ret, FAIL, "H5RS_asprintf_cat");
 
     /* Get pointer to raw string in ref-counted string */
-    t = H5RS_get_str(rs);
-    CHECK_PTR(t, "H5RS_get_str");
-    CHECK_PTR_EQ(t, s, "transferring");
-    cmp = HDstrcmp(s, t);
+    s = H5RS_get_str(rs);
+    CHECK_PTR(s, "H5RS_get_str");
+    HDsprintf(buf, "%d-%s", (int)10, "foo");
+    cmp = HDstrcmp(s, buf);
     VERIFY(cmp, 0, "HDstrcmp");
 
-    /* Increment reference count (should NOT duplicate string) */
-    ret = H5RS_incr(rs);
-    CHECK(ret, FAIL, "H5RS_incr");
-
-    /* Change the buffer initially wrapped */
-    *s = 'F';
+    /* Append more output to ref-counted string */
+    ret = H5RS_asprintf_cat(rs, "-%f", (double)20.0);
+    CHECK(ret, FAIL, "H5RS_asprintf_cat");
 
     /* Get pointer to raw string in ref-counted string */
-    t = H5RS_get_str(rs);
-    CHECK_PTR(t, "H5RS_get_str");
-    CHECK_PTR_EQ(t, s, "transferring");
-    cmp = HDstrcmp(t, s);
+    s = H5RS_get_str(rs);
+    CHECK_PTR(s, "H5RS_get_str");
+    HDsprintf(buf, "%d-%s-%f", (int)10, "foo", (double)20.0);
+    cmp = HDstrcmp(s, buf);
     VERIFY(cmp, 0, "HDstrcmp");
 
     /* Decrement reference count for string */
     ret = H5RS_decr(rs);
     CHECK(ret, FAIL, "H5RS_decr");
+
+} /* end test_refstr_asprintf_cat() */
+
+/****************************************************************
+**
+**  test_refstr_acat(): Test basic H5RS (ref-counted strings) code.
+**      Tests appending strings to ref-counted strings.
+**
+****************************************************************/
+static void
+test_refstr_acat(void)
+{
+    H5RS_str_t *rs;                     /* Ref-counted string created */
+    const char *s;                      /* Pointer to raw string in ref-counted string */
+    char        buf[256];               /* Buffer to compare against */
+    char *      large_str, *large_str2; /* Large strings to append */
+    int         cmp;                    /* Comparison value */
+    herr_t      ret;                    /* Generic return value */
+
+    /* Output message about test being performed */
+    MESSAGE(5, ("Testing Appending Strings to Ref-Counted Strings\n"));
+
+    /* Wrap ref-counted string around existing buffer */
+    rs = H5RS_create(NULL);
+    CHECK_PTR(rs, "H5RS_create");
+
+    /* Append first string to ref-counted string */
+    ret = H5RS_acat(rs, "foo");
+    CHECK(ret, FAIL, "H5RS_acat");
+
+    /* Get pointer to raw string in ref-counted string */
+    s = H5RS_get_str(rs);
+    CHECK_PTR(s, "H5RS_get_str");
+    HDsprintf(buf, "%s", "foo");
+    cmp = HDstrcmp(s, buf);
+    VERIFY(cmp, 0, "HDstrcmp");
+
+    /* Append another string to ref-counted string */
+    ret = H5RS_acat(rs, "bar");
+    CHECK(ret, FAIL, "H5RS_acat");
+
+    /* Get pointer to raw string in ref-counted string */
+    s = H5RS_get_str(rs);
+    CHECK_PTR(s, "H5RS_get_str");
+    HDsprintf(buf, "%s", "foobar");
+    cmp = HDstrcmp(s, buf);
+    VERIFY(cmp, 0, "HDstrcmp");
+
+    /* Append a large string to ref-counted string */
+    large_str = HDmalloc(1024);
+    CHECK(large_str, NULL, "HDmalloc");
+    HDmemset(large_str, 'a', 1024);
+    large_str[1023] = '\0';
+    ret             = H5RS_acat(rs, large_str);
+    CHECK(ret, FAIL, "H5RS_acat");
+
+    /* Get pointer to raw string in ref-counted string */
+    s = H5RS_get_str(rs);
+    CHECK_PTR(s, "H5RS_get_str");
+    HDsprintf(buf, "%s", "foobar");
+    large_str2 = HDmalloc(1024 + 6);
+    CHECK(large_str2, NULL, "HDmalloc");
+    HDstrcpy(large_str2, "foobar");
+    HDmemset(&large_str2[6], 'a', 1024);
+    large_str2[1029] = '\0';
+    cmp              = HDstrcmp(s, large_str2);
+    VERIFY(cmp, 0, "HDstrcmp");
+
+    /* Decrement reference count for string */
     ret = H5RS_decr(rs);
     CHECK(ret, FAIL, "H5RS_decr");
 
-} /* end test_refstr_own() */
+    /* Free large strings */
+    HDfree(large_str);
+    HDfree(large_str2);
+} /* end test_refstr_acat() */
+
+/****************************************************************
+**
+**  test_refstr_ancat(): Test basic H5RS (ref-counted strings) code.
+**      Tests appending length-limited strings to ref-counted strings.
+**
+****************************************************************/
+static void
+test_refstr_ancat(void)
+{
+    H5RS_str_t *rs;       /* Ref-counted string created */
+    const char *s;        /* Pointer to raw string in ref-counted string */
+    char        buf[256]; /* Buffer to compare against */
+    int         cmp;      /* Comparison value */
+    herr_t      ret;      /* Generic return value */
+
+    /* Output message about test being performed */
+    MESSAGE(5, ("Testing Appending Strings to Ref-Counted Strings\n"));
+
+    /* Wrap ref-counted string around existing buffer */
+    rs = H5RS_create(NULL);
+    CHECK_PTR(rs, "H5RS_create");
+
+    /* Append first string to ref-counted string */
+    ret = H5RS_ancat(rs, "foo", 2);
+    CHECK(ret, FAIL, "H5RS_ancat");
+
+    /* Get pointer to raw string in ref-counted string */
+    s = H5RS_get_str(rs);
+    CHECK_PTR(s, "H5RS_get_str");
+    HDstrcpy(buf, "fo");
+    cmp = HDstrcmp(s, buf);
+    VERIFY(cmp, 0, "HDstrcmp");
+
+    /* Append another string to ref-counted string */
+    ret = H5RS_ancat(rs, "bar", 2);
+    CHECK(ret, FAIL, "H5RS_ancat");
+
+    /* Get pointer to raw string in ref-counted string */
+    s = H5RS_get_str(rs);
+    CHECK_PTR(s, "H5RS_get_str");
+    HDstrcpy(buf, "foba");
+    cmp = HDstrcmp(s, buf);
+    VERIFY(cmp, 0, "HDstrcmp");
+
+    /* Decrement reference count for string */
+    ret = H5RS_decr(rs);
+    CHECK(ret, FAIL, "H5RS_decr");
+} /* end test_refstr_ancat() */
+
+/****************************************************************
+**
+**  test_refstr_aputc(): Test basic H5RS (ref-counted strings) code.
+**      Tests appending characters to ref-counted strings.
+**
+****************************************************************/
+static void
+test_refstr_aputc(void)
+{
+    H5RS_str_t *rs;       /* Ref-counted string created */
+    const char *s;        /* Pointer to raw string in ref-counted string */
+    char        buf[256]; /* Buffer to compare against */
+    int         cmp;      /* Comparison value */
+    herr_t      ret;      /* Generic return value */
+
+    /* Output message about test being performed */
+    MESSAGE(5, ("Testing Appending Strings to Ref-Counted Strings\n"));
+
+    /* Wrap ref-counted string around existing buffer */
+    rs = H5RS_create(NULL);
+    CHECK_PTR(rs, "H5RS_create");
+
+    /* Append first character to ref-counted string */
+    ret = H5RS_aputc(rs, 'f');
+    CHECK(ret, FAIL, "H5RS_ancat");
+
+    /* Get pointer to raw string in ref-counted string */
+    s = H5RS_get_str(rs);
+    CHECK_PTR(s, "H5RS_get_str");
+    HDstrcpy(buf, "f");
+    cmp = HDstrcmp(s, buf);
+    VERIFY(cmp, 0, "HDstrcmp");
+
+    /* Append another character to ref-counted string */
+    ret = H5RS_aputc(rs, 'o');
+    CHECK(ret, FAIL, "H5RS_ancat");
+
+    /* Get pointer to raw string in ref-counted string */
+    s = H5RS_get_str(rs);
+    CHECK_PTR(s, "H5RS_get_str");
+    HDstrcpy(buf, "fo");
+    cmp = HDstrcmp(s, buf);
+    VERIFY(cmp, 0, "HDstrcmp");
+
+    /* Decrement reference count for string */
+    ret = H5RS_decr(rs);
+    CHECK(ret, FAIL, "H5RS_decr");
+} /* end test_refstr_aputc() */
 
 /****************************************************************
 **
@@ -361,12 +526,15 @@ test_refstr(void)
     test_refstr_init();
 
     /* Actual ref-counted strings tests */
-    test_refstr_create(); /* Test ref-counted string creation */
-    test_refstr_count();  /* Test ref-counted string counting */
-    test_refstr_dup();    /* Test ref-counted string duplication */
-    test_refstr_cmp();    /* Test ref-counted string comparison */
-    test_refstr_wrap();   /* Test ref-counted string wrapping */
-    test_refstr_own();    /* Test ref-counted string ownership transfer */
+    test_refstr_create();       /* Test ref-counted string creation */
+    test_refstr_count();        /* Test ref-counted string counting */
+    test_refstr_dup();          /* Test ref-counted string duplication */
+    test_refstr_cmp();          /* Test ref-counted string comparison */
+    test_refstr_wrap();         /* Test ref-counted string wrapping */
+    test_refstr_asprintf_cat(); /* Test ref-counted string printf-formatted output */
+    test_refstr_acat();         /* Test ref-counted string appends */
+    test_refstr_ancat();        /* Test ref-counted length-limited string appends */
+    test_refstr_aputc();        /* Test ref-counted character appends */
 
     /* Finalize ref-counted strings testing data */
     test_refstr_finalize();


### PR DESCRIPTION
Enhance API tracing to handle more types, and to put tracing info in a string, allowing it to be used when reporting errors.  Also refactored ref-counted strings (H5RS) module to add capabilities needed for the tracing.  Refactored H5Gname.c routines to use new H5RS routines also.  Added /*out*/ tags to API routines that are returning information to the application.  Updated H5TRACE macros from running updated trace script over library code.  Added tests for new H5RS routines.