### PR TITLE
Minor/solaris gcc fix

### DIFF
--- a/config/gnu-flags
+++ b/config/gnu-flags
@@ -118,15 +118,16 @@ if test "X-gcc" = "X-$cc_vendor"; then
     esac
 
     case "$host_os-$host_cpu" in
-        # cygwin needs the "-std=c99" flag removed, so make
-        # a specific case for Cygwin without the flag and a default
-        # case to add the flag everywhere else
+        # Cygwin needs the "-std=c99" flag removed.
         cygwin-*)
             ;;
-        # On Solaris, gcc needs the gnu99 standard to pick up certain POSIX-y things
+        # On Solaris, gcc needs the gnu99 standard to pick up certain POSIX
+        # things. Do NOT use this as the gcc norm as this encourages the use
+        # of non-standard gcc extensions.
         *solaris*)
             H5_CFLAGS="$H5_CFLAGS -std=gnu99"
             ;;
+        # Everybody else gets c99 as the standard.
         *)
             H5_CFLAGS="$H5_CFLAGS -std=c99"
             ;;

--- a/config/gnu-flags
+++ b/config/gnu-flags
@@ -123,7 +123,10 @@ if test "X-gcc" = "X-$cc_vendor"; then
         # case to add the flag everywhere else
         cygwin-*)
             ;;
-
+        # On Solaris, gcc needs the gnu99 standard to pick up certain POSIX-y things
+        *solaris*)
+            H5_CFLAGS="$H5_CFLAGS -std=gnu99"
+            ;;
         *)
             H5_CFLAGS="$H5_CFLAGS -std=c99"
             ;;

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -47,6 +47,19 @@ New Features
 
     Configuration:
     -------------
+    - Fixed POSIX problems when building w/ gcc on Solaris
+
+      When building on Solaris using gcc, the POSIX symbols were not
+      being set correctly, which could lead to issues like clock_gettime()
+      not being found.
+
+      The standard is now set to gnu99 when building with gcc on Solaris,
+      which allows POSIX things to be #defined and linked correctly. This
+      differs slightly from the gcc norm, where we set the standard to c99
+      and manually set POSIX #define symbols.
+
+      (DER - 2020/11/25, HDFFV-11191)
+
     - Added a configure-time option to consider certain compiler warnings
       as errors
 


### PR DESCRIPTION
Allows gcc builds on Solaris using the Autotools