### PR TITLE
Ensure that H5TSpublic.h header gets installed

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -845,6 +845,7 @@ set (H5_PUBLIC_HEADERS
     ${H5S_HDRS}
     ${H5SM_HDRS}
     ${H5T_HDRS}
+    ${H5TS_HDRS}
     ${H5VL_HDRS}
     ${H5Z_HDRS}
 )


### PR DESCRIPTION
Compile errors in the VOL tests when including hdf5.h otherwise.