### PR TITLE
Add flag to H5CX_pop that allow setting the properties to return to application to be skipped

### DIFF
--- a/src/H5Atest.c
+++ b/src/H5Atest.c
@@ -136,7 +136,7 @@ H5A__get_shared_rc_test(hid_t attr_id, hsize_t *ref_count)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTGET, FAIL, "can't retrieve shared message ref count")
 
 done:
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_ATTR, H5E_CANTRESET, FAIL, "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5CX.c
+++ b/src/H5CX.c
@@ -422,7 +422,7 @@ typedef struct H5CX_fapl_cache_t {
 static H5CX_node_t **H5CX__get_context(void);
 #endif /* H5_HAVE_THREADSAFE */
 static void         H5CX__push_common(H5CX_node_t *cnode);
-static H5CX_node_t *H5CX__pop_common(void);
+static H5CX_node_t *H5CX__pop_common(hbool_t update_dxpl_props);
 
 /*********************/
 /* Package Variables */
@@ -678,7 +678,7 @@ H5CX_term_package(void)
 
         /* Pop the top context node from the stack */
         /* (Can't check for errors, as rest of library is shut down) */
-        cnode = H5CX__pop_common();
+        cnode = H5CX__pop_common(FALSE);
 
         /* Free the context node */
         /* (Allocated with HDmalloc() in H5CX_push_special() ) */
@@ -3563,7 +3563,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static H5CX_node_t *
-H5CX__pop_common(void)
+H5CX__pop_common(hbool_t update_dxpl_props)
 {
     H5CX_node_t **head =
         H5CX_get_my_context();     /* Get the pointer to the head of the API context, for this thread */
@@ -3579,21 +3579,23 @@ H5CX__pop_common(void)
     HDassert(head && *head);
 
     /* Check for cached DXPL properties to return to application */
+    if (update_dxpl_props) {
 #ifdef H5_HAVE_PARALLEL
-    H5CX_SET_PROP(H5D_MPIO_ACTUAL_CHUNK_OPT_MODE_NAME, mpio_actual_chunk_opt)
-    H5CX_SET_PROP(H5D_MPIO_ACTUAL_IO_MODE_NAME, mpio_actual_io_mode)
-    H5CX_SET_PROP(H5D_MPIO_LOCAL_NO_COLLECTIVE_CAUSE_NAME, mpio_local_no_coll_cause)
-    H5CX_SET_PROP(H5D_MPIO_GLOBAL_NO_COLLECTIVE_CAUSE_NAME, mpio_global_no_coll_cause)
+        H5CX_SET_PROP(H5D_MPIO_ACTUAL_CHUNK_OPT_MODE_NAME, mpio_actual_chunk_opt)
+        H5CX_SET_PROP(H5D_MPIO_ACTUAL_IO_MODE_NAME, mpio_actual_io_mode)
+        H5CX_SET_PROP(H5D_MPIO_LOCAL_NO_COLLECTIVE_CAUSE_NAME, mpio_local_no_coll_cause)
+        H5CX_SET_PROP(H5D_MPIO_GLOBAL_NO_COLLECTIVE_CAUSE_NAME, mpio_global_no_coll_cause)
 #ifdef H5_HAVE_INSTRUMENTED_LIBRARY
-    H5CX_SET_PROP(H5D_XFER_COLL_CHUNK_LINK_HARD_NAME, mpio_coll_chunk_link_hard)
-    H5CX_SET_PROP(H5D_XFER_COLL_CHUNK_MULTI_HARD_NAME, mpio_coll_chunk_multi_hard)
-    H5CX_SET_PROP(H5D_XFER_COLL_CHUNK_LINK_NUM_TRUE_NAME, mpio_coll_chunk_link_num_true)
-    H5CX_SET_PROP(H5D_XFER_COLL_CHUNK_LINK_NUM_FALSE_NAME, mpio_coll_chunk_link_num_false)
-    H5CX_SET_PROP(H5D_XFER_COLL_CHUNK_MULTI_RATIO_COLL_NAME, mpio_coll_chunk_multi_ratio_coll)
-    H5CX_SET_PROP(H5D_XFER_COLL_CHUNK_MULTI_RATIO_IND_NAME, mpio_coll_chunk_multi_ratio_ind)
-    H5CX_SET_PROP(H5D_XFER_COLL_RANK0_BCAST_NAME, mpio_coll_rank0_bcast)
+        H5CX_SET_PROP(H5D_XFER_COLL_CHUNK_LINK_HARD_NAME, mpio_coll_chunk_link_hard)
+        H5CX_SET_PROP(H5D_XFER_COLL_CHUNK_MULTI_HARD_NAME, mpio_coll_chunk_multi_hard)
+        H5CX_SET_PROP(H5D_XFER_COLL_CHUNK_LINK_NUM_TRUE_NAME, mpio_coll_chunk_link_num_true)
+        H5CX_SET_PROP(H5D_XFER_COLL_CHUNK_LINK_NUM_FALSE_NAME, mpio_coll_chunk_link_num_false)
+        H5CX_SET_PROP(H5D_XFER_COLL_CHUNK_MULTI_RATIO_COLL_NAME, mpio_coll_chunk_multi_ratio_coll)
+        H5CX_SET_PROP(H5D_XFER_COLL_CHUNK_MULTI_RATIO_IND_NAME, mpio_coll_chunk_multi_ratio_ind)
+        H5CX_SET_PROP(H5D_XFER_COLL_RANK0_BCAST_NAME, mpio_coll_rank0_bcast)
 #endif /* H5_HAVE_INSTRUMENTED_LIBRARY */
 #endif /* H5_HAVE_PARALLEL */
+    } /* end if */
 
     /* Pop the top context node from the stack */
     ret_value = (*head);
@@ -3618,7 +3620,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5CX_pop(void)
+H5CX_pop(hbool_t update_dxpl_props)
 {
     H5CX_node_t *cnode;               /* Context node */
     herr_t       ret_value = SUCCEED; /* Return value */
@@ -3626,7 +3628,7 @@ H5CX_pop(void)
     FUNC_ENTER_NOAPI(FAIL)
 
     /* Perform common operations and get top context from stack */
-    if (NULL == (cnode = H5CX__pop_common()))
+    if (NULL == (cnode = H5CX__pop_common(update_dxpl_props)))
         HGOTO_ERROR(H5E_CONTEXT, H5E_CANTGET, FAIL, "error getting API context node")
 
     /* Free the context node */

--- a/src/H5CXprivate.h
+++ b/src/H5CXprivate.h
@@ -63,7 +63,7 @@ typedef struct H5CX_state_t {
 /* Library private routines */
 #ifndef _H5private_H
 H5_DLL herr_t H5CX_push(void);
-H5_DLL herr_t H5CX_pop(void);
+H5_DLL herr_t H5CX_pop(hbool_t update_dxpl_props);
 #endif /* _H5private_H */
 H5_DLL void    H5CX_push_special(void);
 H5_DLL hbool_t H5CX_is_def_dxpl(void);

--- a/src/H5Ftest.c
+++ b/src/H5Ftest.c
@@ -108,7 +108,7 @@ H5F__get_sohm_mesg_count_test(hid_t file_id, unsigned type_id, size_t *mesg_coun
         HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "can't retrieve shared message count")
 
 done:
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_FILE, H5E_CANTRESET, FAIL, "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -152,7 +152,7 @@ H5F__check_cached_stab_test(hid_t file_id)
         HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "unable to verify cached symbol table info")
 
 done:
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_FILE, H5E_CANTRESET, FAIL, "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Gtest.c
+++ b/src/H5Gtest.c
@@ -178,7 +178,7 @@ H5G__is_empty_test(hid_t gid)
     } /* end if */
 
 done:
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_SYM, H5E_CANTRESET, FAIL, "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -245,7 +245,7 @@ H5G__has_links_test(hid_t gid, unsigned *nmsgs)
     } /* end if */
 
 done:
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_SYM, H5E_CANTRESET, FAIL, "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -301,7 +301,7 @@ H5G__has_stab_test(hid_t gid)
         HGOTO_ERROR(H5E_SYM, H5E_BADVALUE, FAIL, "both symbol table and link messages found")
 
 done:
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_SYM, H5E_CANTRESET, FAIL, "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -376,7 +376,7 @@ H5G__is_new_dense_test(hid_t gid)
     } /* end if */
 
 done:
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_SYM, H5E_CANTRESET, FAIL, "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -469,7 +469,7 @@ done:
         HDONE_ERROR(H5E_SYM, H5E_CANTCLOSEOBJ, FAIL, "can't close v2 B-tree for name index")
     if (bt2_corder && H5B2_close(bt2_corder) < 0)
         HDONE_ERROR(H5E_SYM, H5E_CANTCLOSEOBJ, FAIL, "can't close v2 B-tree for creation order index")
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_SYM, H5E_CANTRESET, FAIL, "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -522,7 +522,7 @@ H5G__lheap_size_test(hid_t gid, size_t *lheap_size)
         HGOTO_ERROR(H5E_SYM, H5E_CANTGETSIZE, FAIL, "can't query local heap size")
 
 done:
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_SYM, H5E_CANTRESET, FAIL, "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -633,7 +633,7 @@ H5G__user_path_test(hid_t obj_id, char *user_path, size_t *user_path_len, unsign
     } /* end else */
 
 done:
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_SYM, H5E_CANTRESET, FAIL, "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Itest.c
+++ b/src/H5Itest.c
@@ -102,7 +102,7 @@ done:
     if (vol_wrapper_set && H5VL_reset_vol_wrapper() < 0)
         HDONE_ERROR(H5E_ATOM, H5E_CANTRESET, FAIL, "can't reset VOL wrapper info")
 
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_SYM, H5E_CANTRESET, (-1), "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Otest.c
+++ b/src/H5Otest.c
@@ -128,7 +128,7 @@ H5O__is_attr_dense_test(hid_t oid)
 done:
     if (oh && H5O_unprotect(loc, oh, H5AC__NO_FLAGS_SET) < 0)
         HDONE_ERROR(H5E_OHDR, H5E_CANTUNPROTECT, FAIL, "unable to release object header")
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_OHDR, H5E_CANTRESET, FAIL, "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -230,7 +230,7 @@ done:
         HDONE_ERROR(H5E_OHDR, H5E_CANTCLOSEOBJ, FAIL, "can't close v2 B-tree for name index")
     if (oh && H5O_unprotect(loc, oh, H5AC__NO_FLAGS_SET) < 0)
         HDONE_ERROR(H5E_OHDR, H5E_CANTUNPROTECT, FAIL, "unable to release object header")
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_OHDR, H5E_CANTRESET, FAIL, "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -327,7 +327,7 @@ done:
         HDONE_ERROR(H5E_OHDR, H5E_CANTCLOSEOBJ, FAIL, "can't close v2 B-tree for name index")
     if (oh && H5O_unprotect(loc, oh, H5AC__NO_FLAGS_SET) < 0)
         HDONE_ERROR(H5E_OHDR, H5E_CANTUNPROTECT, FAIL, "unable to release object header")
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_OHDR, H5E_CANTRESET, FAIL, "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -431,7 +431,7 @@ done:
         HDONE_ERROR(H5E_OHDR, H5E_CANTCLOSEOBJ, FAIL, "can't close v2 B-tree for creation order index")
     if (oh && H5O_unprotect(loc, oh, H5AC__NO_FLAGS_SET) < 0)
         HDONE_ERROR(H5E_OHDR, H5E_CANTUNPROTECT, FAIL, "unable to release object header")
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_OHDR, H5E_CANTRESET, FAIL, "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -667,7 +667,7 @@ H5O__msg_get_chunkno_test(hid_t oid, unsigned msg_type, unsigned *chunk_num)
 done:
     if (oh && H5O_unprotect(loc, oh, H5AC__NO_FLAGS_SET) < 0)
         HDONE_ERROR(H5E_OHDR, H5E_CANTUNPROTECT, FAIL, "unable to release object header")
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_OHDR, H5E_CANTRESET, FAIL, "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -778,7 +778,7 @@ H5O__msg_move_to_new_chunk_test(hid_t oid, unsigned msg_type)
 done:
     if (oh && H5O_unprotect(loc, oh, H5AC__NO_FLAGS_SET) < 0)
         HDONE_ERROR(H5E_OHDR, H5E_CANTUNPROTECT, FAIL, "unable to release object header")
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         HDONE_ERROR(H5E_OHDR, H5E_CANTRESET, FAIL, "can't reset API context")
 
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -2022,7 +2022,7 @@ H5VL_reset_lib_state(void)
     FUNC_ENTER_NOAPI(FAIL)
 
     /* Pop the API context off the stack */
-    if (H5CX_pop() < 0)
+    if (H5CX_pop(FALSE) < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTRESET, FAIL, "can't pop API context")
 
 done:

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -2185,7 +2185,7 @@ extern hbool_t H5_MPEinit_g; /* Has the MPE Library been initialized? */
 /* Forward declaration of H5CXpush() / H5CXpop() */
 /* (Including H5CXprivate.h creates bad circular dependencies - QAK, 3/18/2018) */
 H5_DLL herr_t H5CX_push(void);
-H5_DLL herr_t H5CX_pop(void);
+H5_DLL herr_t H5CX_pop(hbool_t update_dxpl_props);
 
 #ifndef NDEBUG
 #define FUNC_ENTER_CHECK_NAME(asrt)                                                                          \
@@ -2543,7 +2543,7 @@ H5_DLL herr_t H5CX_pop(void);
 
 #define FUNC_LEAVE_API(ret_value)                                                                            \
     FUNC_LEAVE_API_COMMON(ret_value);                                                                        \
-    (void)H5CX_pop();                                                                                        \
+    (void)H5CX_pop(TRUE);                                                                                    \
     H5_POP_FUNC                                                                                              \
     if (err_occurred)                                                                                        \
         (void)H5E_dump_api_stack(TRUE);                                                                      \

--- a/test/accum.c
+++ b/test/accum.c
@@ -139,7 +139,7 @@ main(void)
     nerrors += test_random_write(f);
 
     /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         FAIL_STACK_ERROR
     api_ctx_pushed = FALSE;
 
@@ -160,7 +160,7 @@ main(void)
 
 error:
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     HDputs("*** TESTS FAILED ***");
     return 1;
@@ -2266,7 +2266,7 @@ test_swmr_write_big(hbool_t newest_format)
             FAIL_STACK_ERROR;
 
         /* Pop API context */
-        if (api_ctx_pushed && H5CX_pop() < 0)
+        if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
             FAIL_STACK_ERROR
         api_ctx_pushed = FALSE;
 
@@ -2284,7 +2284,7 @@ error:
     H5Fclose(fid);
 
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     H5Pclose(fapl);
 

--- a/test/accum_swmr_reader.c
+++ b/test/accum_swmr_reader.c
@@ -98,7 +98,7 @@ main(void)
         FAIL_STACK_ERROR;
 
     /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         FAIL_STACK_ERROR
     api_ctx_pushed = FALSE;
 
@@ -113,7 +113,7 @@ error:
     H5E_END_TRY;
 
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     return EXIT_FAILURE;
 } /* end main() */

--- a/test/btree2.c
+++ b/test/btree2.c
@@ -10016,7 +10016,7 @@ main(void)
     nerrors += (h5_verify_cached_stabs(FILENAME, fapl) < 0 ? 1 : 0);
 
     /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         FAIL_STACK_ERROR
     api_ctx_pushed = FALSE;
 
@@ -10036,7 +10036,7 @@ error:
     H5E_END_TRY;
 
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     return 1;
 } /* end main() */

--- a/test/cache.c
+++ b/test/cache.c
@@ -35871,7 +35871,7 @@ takedown_cache(H5F_t *file_ptr, hbool_t dump_stats, hbool_t dump_detailed_stats)
         }
 
         /* Pop API context */
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
         if ((!try_core_file_driver) || (core_file_driver_failed)) {
 

--- a/test/cache_tagging.c
+++ b/test/cache_tagging.c
@@ -4520,7 +4520,7 @@ check_invalid_tag_application(void)
         TEST_ERROR;
 
     /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         TEST_ERROR
     api_ctx_pushed = FALSE;
 
@@ -4540,7 +4540,7 @@ check_invalid_tag_application(void)
 #if H5C_DO_TAGGING_SANITY_CHECKS
 error:
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     return 1;
 #endif /* H5C_DO_TAGGING_SANITY_CHECKS */

--- a/test/dsets.c
+++ b/test/dsets.c
@@ -3010,7 +3010,7 @@ test_missing_filter(hid_t file)
 #endif /* H5_HAVE_FILTER_DEFLATE */
 
     /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         FAIL_STACK_ERROR
     api_ctx_pushed = FALSE;
 
@@ -3019,7 +3019,7 @@ test_missing_filter(hid_t file)
 
 error:
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     return FAIL;
 } /* end test_missing_filter() */

--- a/test/earray.c
+++ b/test/earray.c
@@ -2552,7 +2552,7 @@ main(void)
     nerrors += (h5_verify_cached_stabs(FILENAME, fapl) < 0 ? 1 : 0);
 
     /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         FAIL_STACK_ERROR
     api_ctx_pushed = FALSE;
 
@@ -2572,7 +2572,7 @@ error:
     H5E_END_TRY;
 
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     return 1;
 } /* end main() */

--- a/test/efc.c
+++ b/test/efc.c
@@ -2704,7 +2704,7 @@ main(void)
     nerrors += (h5_verify_cached_stabs(FILENAME, fapl_id) < 0 ? 1 : 0);
 
     /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         FAIL_STACK_ERROR
     api_ctx_pushed = FALSE;
 
@@ -2728,7 +2728,7 @@ error:
     H5E_END_TRY
 
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     for (i = 0; i < N_FILENAMES; i++) {
         HDfree(filename[i]);

--- a/test/farray.c
+++ b/test/farray.c
@@ -1767,7 +1767,7 @@ main(void)
     nerrors += (h5_verify_cached_stabs(FILENAME, fapl) < 0 ? 1 : 0);
 
     /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         FAIL_STACK_ERROR
     api_ctx_pushed = FALSE;
 
@@ -1787,7 +1787,7 @@ error:
     H5E_END_TRY;
 
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     HDexit(EXIT_FAILURE);
 } /* end main() */

--- a/test/fheap.c
+++ b/test/fheap.c
@@ -16885,7 +16885,7 @@ main(void)
         TEST_ERROR
 
     /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         FAIL_STACK_ERROR
     api_ctx_pushed = FALSE;
 
@@ -16911,7 +16911,7 @@ error:
     H5E_END_TRY;
 
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     return 1;
 } /* end main() */

--- a/test/freespace.c
+++ b/test/freespace.c
@@ -2907,7 +2907,7 @@ main(void)
     HDputs("All free-space tests passed.");
 
     /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         FAIL_STACK_ERROR
     api_ctx_pushed = FALSE;
 
@@ -2920,7 +2920,7 @@ error:
     H5E_END_TRY;
 
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     HDexit(EXIT_FAILURE);
 } /* main() */

--- a/test/gheap.c
+++ b/test/gheap.c
@@ -589,7 +589,7 @@ main(void)
     HDputs("All global heap tests passed.");
 
     /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         FAIL_STACK_ERROR
     api_ctx_pushed = FALSE;
 
@@ -601,7 +601,7 @@ error:
     H5E_END_TRY;
 
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     HDputs("*** TESTS FAILED ***");
     HDexit(EXIT_FAILURE);

--- a/test/lheap.c
+++ b/test/lheap.c
@@ -201,7 +201,7 @@ main(void)
         TEST_ERROR
 
     /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         FAIL_STACK_ERROR
     api_ctx_pushed = FALSE;
 
@@ -216,7 +216,7 @@ error:
     H5E_END_TRY;
 
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     return EXIT_FAILURE;
 }

--- a/test/mf.c
+++ b/test/mf.c
@@ -9177,7 +9177,7 @@ main(void)
     h5_cleanup(FILENAME, fapl);
 
     /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         FAIL_STACK_ERROR
     api_ctx_pushed = FALSE;
 
@@ -9197,7 +9197,7 @@ error:
     H5E_END_TRY;
 
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     return (1);
 } /* main() */

--- a/test/ohdr.c
+++ b/test/ohdr.c
@@ -2040,7 +2040,7 @@ main(void)
         TEST_ERROR
 
     /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         FAIL_STACK_ERROR
     api_ctx_pushed = FALSE;
 
@@ -2054,7 +2054,7 @@ error:
     H5E_END_TRY;
 
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     return 1;
 } /* end main() */

--- a/test/page_buffer.c
+++ b/test/page_buffer.c
@@ -2184,7 +2184,7 @@ main(void)
         goto error;
 
     /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         FAIL_STACK_ERROR
     api_ctx_pushed = FALSE;
 
@@ -2199,7 +2199,7 @@ error:
     H5E_END_TRY;
 
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     HDexit(EXIT_FAILURE);
 } /* main() */

--- a/test/unregister.c
+++ b/test/unregister.c
@@ -295,7 +295,7 @@ main(void)
     HDprintf("All filter unregistration tests passed.\n");
 
     /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop() < 0)
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
         FAIL_STACK_ERROR
     api_ctx_pushed = FALSE;
 
@@ -306,7 +306,7 @@ error:
     HDprintf("***** %d FILTER UNREGISTRATION TEST%s FAILED! *****\n", nerrors, 1 == nerrors ? "" : "S");
 
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     HDexit(EXIT_FAILURE);
 } /* end main() */

--- a/testpar/t_cache.c
+++ b/testpar/t_cache.c
@@ -4187,7 +4187,7 @@ take_down_cache(hid_t fid, H5C_t *cache_ptr)
     }
 
     /* Pop API context */
-    H5CX_pop();
+    H5CX_pop(FALSE);
 
     if (success) {
 

--- a/testpar/t_file.c
+++ b/testpar/t_file.c
@@ -284,7 +284,7 @@ test_page_buffer_access(void)
 
         /* Pop API context */
         if (api_ctx_pushed) {
-            ret = H5CX_pop();
+            ret = H5CX_pop(FALSE);
             VRFY((ret == 0), "H5CX_pop()");
             api_ctx_pushed = FALSE;
         }
@@ -418,7 +418,7 @@ test_page_buffer_access(void)
 
     /* Pop API context */
     if (api_ctx_pushed) {
-        ret = H5CX_pop();
+        ret = H5CX_pop(FALSE);
         VRFY((ret == 0), "H5CX_pop()");
         api_ctx_pushed = FALSE;
     }
@@ -574,7 +574,7 @@ create_file(const char *filename, hid_t fcpl, hid_t fapl, int metadata_write_str
 
     /* Pop API context */
     if (api_ctx_pushed) {
-        ret = H5CX_pop();
+        ret = H5CX_pop(FALSE);
         VRFY((ret == 0), "H5CX_pop()");
         api_ctx_pushed = FALSE;
     }
@@ -738,7 +738,7 @@ open_file(const char *filename, hid_t fapl, int metadata_write_strategy, hsize_t
 
     /* Pop API context */
     if (api_ctx_pushed) {
-        ret = H5CX_pop();
+        ret = H5CX_pop(FALSE);
         VRFY((ret == 0), "H5CX_pop()");
         api_ctx_pushed = FALSE;
     }

--- a/tools/src/misc/h5debug.c
+++ b/tools/src/misc/h5debug.c
@@ -824,7 +824,7 @@ done:
 
     /* Pop API context */
     if (api_ctx_pushed)
-        H5CX_pop();
+        H5CX_pop(FALSE);
 
     H5Eset_auto2(H5E_DEFAULT, func, edata);
 


### PR DESCRIPTION
The properties only need to be set for API routines, not restoring the library state, or in tests.