### PR TITLE
Fixes clang debug optimization level w/ Autotools

### DIFF
--- a/config/clang-flags
+++ b/config/clang-flags
@@ -160,7 +160,7 @@ if test "X-clang" = "X-$cc_vendor" -o "X-Apple LLVM" = "X-$cc_vendor"; then
     ################
 
     HIGH_OPT_CFLAGS="-O3"
-    DEBUG_OPT_CFLAGS="-g"
+    DEBUG_OPT_CFLAGS="-Og"
     NO_OPT_CFLAGS="-O0"
 
     ############


### PR DESCRIPTION
The debug warning flag was changed from "-g" (probably a typo) to "-Og".

NOTE: This was only released in HDF5 1.10.7, so only the 1.10
      branch needs a note in RELEASE.txt.