### PR TITLE
FreeBSD autotools changes

### DIFF
--- a/config/freebsd
+++ b/config/freebsd
@@ -18,19 +18,26 @@
 #
 # See BlankForm in this directory for details.
 
-# The default compiler is `gcc'
+# The default compiler is 'cc'
 if test "X-" = "X-$CC"; then
-  CC=gcc
-  CC_BASENAME=gcc
+  CC=cc
+  CC_BASENAME=cc
 fi
 
-# Figure out C compiler flags
+# Figure out clang C compiler flags
+. $srcdir/config/clang-flags
+
+# Figure out GNU C compiler flags
 . $srcdir/config/gnu-flags
 
 # Figure out Intel C compiler flags
 . $srcdir/config/intel-flags
 
 # The default Fortran 90 compiler
+# No default Fortran compiler for clang. flang exists on
+# FreeBSD as a port, but this is tied to an ancient LLVM
+# and lacks Fortran 2003 features which causes configure
+# to fail.
 if test "X-" = "X-$FC"; then
     case $CC_BASENAME in
         gcc*|pgcc*)
@@ -54,3 +61,16 @@ fi
 # Figure out Intel F90 compiler flags
 . $srcdir/config/intel-fflags
 
+# The default C++ compiler
+
+# The default compiler is 'c++'.
+if test -z "$CXX"; then
+  CXX=c++
+  CXX_BASENAME=c++
+fi
+
+# Figure out Clang CXX compiler flags
+. $srcdir/config/clang-cxxflags
+
+# Figure out GNU CXX compiler flags
+. $srcdir/config/gnu-cxxflags

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -47,6 +47,20 @@ New Features
 
     Configuration:
     -------------
+    - FreeBSD Autotools configuration now defaults to 'cc' and 'c++' compilers
+
+      On FreeBSD, the autotools defaulted to 'gcc' as the C compiler and did
+      not process C++ options. Since FreeBSD 10, the default compiler has
+      been clang (via 'cc').
+
+      The default compilers have been set to 'cc' for C and 'c++' for C++,
+      which will pick up clang and clang++ respectively on FreeBSD 10+.
+      Additionally, clang options are now set correctly for both C and C++
+      and g++ options will now be set if that compiler is being used (an
+      omission from the former functionality).
+
+      (DER - 2020/11/28, HDFFV-11193)
+
     - Fixed POSIX problems when building w/ gcc on Solaris
 
       When building on Solaris using gcc, the POSIX symbols were not


### PR DESCRIPTION
Updates the freebsd file in config/ to work on FreeBSD 10+ where clang is the default compiler.