### PR TITLE
(fix) Segmentation fault when using a compound type.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1096,6 +1096,7 @@
 ./test/cache_tagging.c
 ./test/chunk_info.c
 ./test/cmpd_dset.c
+./test/cmpd_dtransform.c
 ./test/cork.c
 ./test/corrupt_stab_msg.h5
 ./test/cross_read.c

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -5218,8 +5218,6 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
 
     /* Set the flag to indicate both source and destination types are compound types
      * for the optimization of data reading (in H5Dio.c).
-     *
-     * Jan-Willem Blokland, 11 March 2020
      * Make sure that path->are_compounds is only TRUE for compound types.
      */
     path->are_compounds = FALSE;

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -3405,8 +3405,8 @@ done:
  * Note:      Common code for both H5T_copy and H5T_copy_reopen, as part of
  *            the const-correct datatype copying routines.
  *
- * Programmer:	David Young
- *	        January 18, 2020
+ * Programmer:  David Young
+ *              January 18, 2020
  *
  *-------------------------------------------------------------------------
  */
@@ -3453,8 +3453,8 @@ done:
  * Return:    Success:    Pointer to a new copy of the OLD_DT argument.
  *            Failure:    NULL
  *
- * Programmer:	David Young
- *	        January 18, 2020
+ * Programmer:  David Young
+ *              January 18, 2020
  *
  *-------------------------------------------------------------------------
  */
@@ -3481,8 +3481,8 @@ done:
  * Return:    Success:    Pointer to a new copy of the OLD_DT argument.
  *            Failure:    NULL
  *
- * Programmer:	David Young
- *	        January 18, 2020
+ * Programmer:  David Young
+ *              January 18, 2020
  *
  *-------------------------------------------------------------------------
  */
@@ -3512,8 +3512,8 @@ done:
  *
  * Note:      Common code for both H5T_copy and H5T_copy_reopen.
  *
- * Programmer:	David Young
- *	        January 18, 2020
+ * Programmer:  David Young
+ *              January 18, 2020
  *
  *-------------------------------------------------------------------------
  */
@@ -3783,8 +3783,8 @@ done:
  * Return:    Success:    Pointer to a new copy of the OLD_DT argument.
  *            Failure:    NULL
  *
- * Programmer:	David Young
- *	        January 18, 2020
+ * Programmer:  David Young
+ *              January 18, 2020
  *
  *-------------------------------------------------------------------------
  */
@@ -5217,7 +5217,12 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
     } /* end else-if */
 
     /* Set the flag to indicate both source and destination types are compound types
-     * for the optimization of data reading (in H5Dio.c). */
+     * for the optimization of data reading (in H5Dio.c).
+     *
+     * Jan-Willem Blokland, 11 March 2020
+     * Make sure that path->are_compounds is only TRUE for compound types.
+     */
+    path->are_compounds = FALSE;
     if (H5T_COMPOUND == H5T_get_class(src, TRUE) && H5T_COMPOUND == H5T_get_class(dst, TRUE))
         path->are_compounds = TRUE;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -332,6 +332,7 @@ set (H5_TESTS
     thread_id # special link
     vol
     timer
+    cmpd_dtransform
 )
 
 macro (ADD_H5_EXE file)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -60,7 +60,7 @@ TEST_PROG= testhdf5 \
            cache cache_api cache_image cache_tagging lheap ohdr \
            stab gheap evict_on_close farray earray btree2 fheap \
            pool accum hyperslab istore bittests dt_arith page_buffer \
-           dtypes dsets chunk_info cmpd_dset filter_fail extend direct_chunk \
+           dtypes dsets chunk_info cmpd_dset cmpd_dtransform filter_fail extend direct_chunk \
            external efc objcopy objcopy_ref links unlink twriteorder big mtime \
            fillval mount \
            flush1 flush2 app_ref enum set_extent ttsafe enc_dec_plist \

--- a/test/cmpd_dtransform.c
+++ b/test/cmpd_dtransform.c
@@ -1,16 +1,13 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  * Copyright by The HDF Group.                                               *
- * Copyright by the Board of Trustees of the University of Illinois.         *
  * All rights reserved.                                                      *
  *                                                                           *
  * This file is part of HDF5.  The full HDF5 copyright notice, including     *
  * terms governing use, modification, and redistribution, is contained in    *
- * the files COPYING and Copyright.html.  COPYING can be found at the root   *
- * of the source code distribution tree; Copyright.html can be found at the  *
- * root level of an installed copy of the electronic HDF5 document set and   *
- * is linked from the top-level documents page.  It can also be found at     *
- * http://hdfgroup.org/HDF5/doc/Copyright.html.  If you do not have          *
- * access to either file, you may request a copy from help@hdfgroup.org.     *
+ * the COPYING file, which can be found at the root of the source code       *
+ * distribution tree, or in https://www.hdfgroup.org/licenses.               *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
@@ -18,7 +15,7 @@
  *              December 1, 2020
  *
  * Purpose:     Test writing compounded attribute followed by
- *              writing data with a data transform functiun.
+ *              writing data with a data transform function.
  */
 
 #include "h5test.h"

--- a/test/cmpd_dtransform.c
+++ b/test/cmpd_dtransform.c
@@ -1,0 +1,139 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Board of Trustees of the University of Illinois.         *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the files COPYING and Copyright.html.  COPYING can be found at the root   *
+ * of the source code distribution tree; Copyright.html can be found at the  *
+ * root level of an installed copy of the electronic HDF5 document set and   *
+ * is linked from the top-level documents page.  It can also be found at     *
+ * http://hdfgroup.org/HDF5/doc/Copyright.html.  If you do not have          *
+ * access to either file, you may request a copy from help@hdfgroup.org.     *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/*
+ * Programmer:  Jan-Willem Blokland
+ *              December 1, 2020
+ *
+ * Purpose:     Test writing compounded attribute followed by
+ *              writing data with a data transform functiun.
+ */
+
+#include "h5test.h"
+
+#define FILENAME "cmpd_dtransform.h5"
+#define LENGTH   11
+
+typedef struct {
+  char name[64];
+  char unit[64];
+} att_t;
+
+int
+main(void)
+{
+    hsize_t  dima[] = { 1 };
+    hsize_t  dims[] = { LENGTH };
+    hid_t    str_dtyp_id, att_dtyp_id, file_id, fspace_id, dset_id, att_dspc_id, att_attr_id, dxpl_id;
+
+    /* Compound datatype */
+    att_t *atts = HDmalloc(sizeof(att_t));
+    HDstrcpy(atts[0].name, "Name");
+    HDstrcpy(atts[0].unit, "Unit");
+
+    /* String type */
+    if ((str_dtyp_id = H5Tcopy(H5T_C_S1)) < 0)
+      TEST_ERROR;
+    H5Tset_size(str_dtyp_id, 64);
+
+    /* Attribute type */
+    if ((att_dtyp_id = H5Tcreate(H5T_COMPOUND, sizeof(att_t))) < 0)
+      TEST_ERROR;
+    H5Tinsert(att_dtyp_id, "NAME", HOFFSET(att_t, name), str_dtyp_id);
+    H5Tinsert(att_dtyp_id, "UNIT", HOFFSET(att_t, unit), str_dtyp_id);
+
+    /* Create file. */
+    if ((file_id = H5Fcreate(FILENAME, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+      TEST_ERROR;
+
+    /* Create file dataspace. */
+    if ((fspace_id = H5Screate_simple(1, dims, NULL)) < 0)
+      TEST_ERROR;
+
+    /* Create dataset. */
+    if ((dset_id = H5Dcreate2(file_id, "test_dset", H5T_NATIVE_INT, fspace_id, 
+                              H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+      TEST_ERROR;
+
+    /* Write the attribute (compound) to the dataset */
+    if ((att_dspc_id = H5Screate_simple(1, dima, NULL)) < 0)
+      TEST_ERROR;
+    if ((att_attr_id = H5Acreate2(dset_id, "ATTRIBUTES", att_dtyp_id, att_dspc_id, 
+                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
+      TEST_ERROR;
+    if (H5Awrite(att_attr_id, att_dtyp_id, atts) < 0)
+      TEST_ERROR;
+
+    /* Create dataset transfer property list */
+    const char *expr = "2*x";
+    if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
+      TEST_ERROR;
+    if (H5Pset_data_transform(dxpl_id, expr) < 0) {
+      HDprintf("**** ERROR: H5Pset_data_transform (expression: %s) ****\n", expr);
+      TEST_ERROR;
+    }
+
+    int *data     = HDmalloc(LENGTH * sizeof(int));
+    int *data_res = HDmalloc(LENGTH * sizeof(int));
+    for (unsigned i = 0; i < LENGTH; i++) {
+      data[i]     = 10;
+      data_res[i] = 2 * data[i];
+    }
+
+    /* Write the data */
+    if (H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, dxpl_id, data) < 0)
+      TEST_ERROR;
+    
+    /* Read attribute */
+    att_t *atts_res  =HDmalloc(sizeof(att_t));
+    if (H5Aread(att_attr_id, att_dtyp_id, atts_res) < 0)
+      TEST_ERROR;
+    
+    /* Verify attribute */
+    if (HDstrcmp(atts_res[0].name, atts[0].name) != 0)
+      TEST_ERROR;
+    if (HDstrcmp(atts_res[0].unit, atts[0].unit) != 0)
+      TEST_ERROR;
+
+    /* Read the data */
+    if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data) < 0)
+      TEST_ERROR;
+
+    /* Verify data */
+    for (unsigned idx = 0; idx < LENGTH; idx++) {
+      if (data[idx] != data_res[idx])
+        TEST_ERROR;
+    }
+
+    HDfree(atts);
+    HDfree(atts_res);
+    HDfree(data);
+    HDfree(data_res);
+
+    /* Close all identifiers. */
+    H5Pclose(dxpl_id);
+    H5Aclose(att_attr_id);
+    H5Sclose(att_dspc_id);
+    H5Dclose(dset_id);
+    H5Sclose(fspace_id);
+    H5Fclose(file_id);
+    H5Tclose(att_dtyp_id);
+    H5Tclose(str_dtyp_id);
+
+    return 0;
+
+ error:
+    return 1;
+}


### PR DESCRIPTION

In the case when a compounded attribute is written to dataset
followed by writing the data with a data transform function
to the dataset will result in a segmentation fault. It turns out
the data is classified as compounded while it is not. Now, the
state is always reset first to not compounded followed by the
existing check if the variable is compounded.

An example of the problem and to show it is solved by this pull request: [compound.txt](https://github.com/HDFGroup/hdf5/files/5614090/compound.txt)

This pull request solves the items SUPPORT-857 and HDFFV-11050
