### PR TITLE
Fixes a minor memory leak in the SWMR use cases tests

### DIFF
--- a/test/use_common.c
+++ b/test/use_common.c
@@ -442,7 +442,7 @@ read_uc_file(hbool_t towait, options_t *opts)
 {
     hid_t     fid;                            /* File ID for new HDF5 file */
     hid_t     dsid;                           /* dataset ID */
-    UC_CTYPE *buffer, *bufptr;                /* read data buffer */
+    UC_CTYPE *buffer = NULL, *bufptr = NULL;  /* read data buffer */
     hid_t     f_sid;                          /* dataset file space id */
     hid_t     m_sid;                          /* memory space id */
     int       rank;                           /* rank */
@@ -604,6 +604,8 @@ read_uc_file(hbool_t towait, options_t *opts)
         HDfprintf(stderr, "H5Fclose failed\n");
         return -1;
     }
+
+    HDfree(buffer);
 
     if (nreadererr)
         return -1;


### PR DESCRIPTION
* Due to a missing free(3) call