### PR TITLE
Moves the lists of VOL connectors and VFDs in Autotools builds

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -28,11 +28,6 @@ endif
 if BUILD_CXX_CONDITIONAL
    SUBDIRS=src $(TEST_DIR)
 
-# Test with just the native connector, with a single pass-through connector
-# and with a doubly-stacked pass-through.
-VOL_LIST = native "pass_through under_vol=0;under_info={}" \
-           "pass_through under_vol=505;under_info={under_vol=0;under_info={}}"
-
 endif
 DIST_SUBDIRS = src test examples
 

--- a/config/conclude.am
+++ b/config/conclude.am
@@ -270,6 +270,11 @@ build-check-p: $(LIB) $(PROGS) $(chk_TESTS)
 	    echo "===Parallel tests in `echo ${PWD} | sed -e s:.*/::` ended `date`===";\
 	fi
 
+VFD_LIST = sec2 stdio core core_paged split multi family
+if DIRECT_VFD_CONDITIONAL
+  VFD_LIST += direct
+endif
+
 # Run test with different Virtual File Driver
 check-vfd: $(LIB) $(PROGS) $(chk_TESTS)
 	@for vfd in $(VFD_LIST) dummy; do                                     \
@@ -281,6 +286,14 @@ check-vfd: $(LIB) $(PROGS) $(chk_TESTS)
 	        HDF5_DRIVER=$$vfd $(MAKE) $(AM_MAKEFLAGS) check || exit 1;    \
 	    fi;                                                               \
 	done
+
+# Test with just the native connector, with a single pass-through connector
+# and with a doubly-stacked pass-through.
+#
+# native = 0
+# pass-through = 1
+VOL_LIST = native "pass_through under_vol=0;under_info={}" \
+           "pass_through under_vol=1;under_info={under_vol=0;under_info={}}"
 
 # Run test with different passthrough Virtual Object Layer Connector
 # NOTE: Will only succeed with passthrough VOL connectors that use

--- a/fortran/Makefile.am
+++ b/fortran/Makefile.am
@@ -38,11 +38,6 @@ endif
 if BUILD_FORTRAN_CONDITIONAL
    SUBDIRS=src $(TESTSERIAL_DIR) $(TESTPARALLEL_DIR)
 
-# Test with just the native connector, with a single pass-through connector
-# and with a doubly-stacked pass-through.
-VOL_LIST = native "pass_through under_vol=0;under_info={}" \
-           "pass_through under_vol=505;under_info={under_vol=0;under_info={}}"
-
 endif
 
 # All directories that have Makefiles

--- a/hl/Makefile.am
+++ b/hl/Makefile.am
@@ -47,11 +47,6 @@ endif
 if BUILD_HDF5_HL_CONDITIONAL
    SUBDIRS=src $(TEST_DIR) $(TOOLS_DIR) $(CXX_DIR) $(FORTRAN_DIR)
 
-# Test with just the native connector, with a single pass-through connector
-# and with a doubly-stacked pass-through.
-VOL_LIST = native "pass_through under_vol=0;under_info={}" \
-           "pass_through under_vol=505;under_info={under_vol=0;under_info={}}"
-
 endif
 DIST_SUBDIRS=src test tools c++ fortran examples
 

--- a/java/Makefile.am
+++ b/java/Makefile.am
@@ -39,11 +39,6 @@ JAVA_API=yes
 
 SUBDIRS=src $(TESTSERIAL_DIR) $(TESTEXAMPLES_DIR)
 
-# Test with just the native connector, with a single pass-through connector
-# and with a doubly-stacked pass-through.
-VOL_LIST = native "pass_through under_vol=0;under_info={}" \
-           "pass_through under_vol=505;under_info={under_vol=0;under_info={}}"
-
 endif
 
 include $(top_srcdir)/config/conclude.am

--- a/java/test/CMakeLists.txt
+++ b/java/test/CMakeLists.txt
@@ -191,9 +191,11 @@ if (HDF5_TEST_JAVA AND HDF5_TEST_SERIAL)
         vol_pass_through2
     )
 
+    # native VOL = 0
+    # pass-through VOL = 1
     set (vol_native native)
     set (vol_pass_through1 "pass_through under_vol=0\;under_info={}")
-    set (vol_pass_through2 "pass_through under_vol=505\;under_info={under_vol=0\;under_info={}}")
+    set (vol_pass_through2 "pass_through under_vol=1\;under_info={under_vol=0\;under_info={}}")
 
     foreach (voltest ${VOL_LIST})
       file (MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/${voltest}")

--- a/java/test/Makefile.am
+++ b/java/test/Makefile.am
@@ -84,11 +84,6 @@ noinst_DATA = $(jarfile)
 
 .PHONY: classes
 
-# Test with just the native connector, with a single pass-through connector
-# and with a doubly-stacked pass-through.
-VOL_LIST = native "pass_through under_vol=0;under_info={}" \
-           "pass_through under_vol=505;under_info={under_vol=0;under_info={}}"
-
 check_SCRIPTS = junit.sh
 TEST_SCRIPT = $(check_SCRIPTS)
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -151,19 +151,6 @@ ttsafe_SOURCES=ttsafe.c ttsafe_dcreate.c ttsafe_error.c ttsafe_cancel.c       \
 cache_image_SOURCES=cache_image.c genall5.c
 mirror_vfd_SOURCES=mirror_vfd.c genall5.c
 
-VFD_LIST = sec2 stdio core core_paged split multi family
-if DIRECT_VFD_CONDITIONAL
-  VFD_LIST += direct
-endif
-
-# Test with just the native connector, with a single pass-through connector
-# and with a doubly-stacked pass-through.
-#
-# native = 0
-# pass-through = 1
-VOL_LIST = native "pass_through under_vol=0;under_info={}" \
-           "pass_through under_vol=1;under_info={under_vol=0;under_info={}}"
-
 # Additional target for running timing test
 timings _timings: testmeta
 	@for timing in $(TIMINGS) dummy; do                                   \
@@ -172,7 +159,6 @@ timings _timings: testmeta
 	      $(RUNEXEC) ./$$timing $(TEST_FLAGS) || exit 1;                  \
 	   fi;                                                                \
 	done;
-
 
 # The flush1 test must run before the flush2 test
 flush2.chkexe_: flush1.chkexe_

--- a/testpar/Makefile.am
+++ b/testpar/Makefile.am
@@ -42,11 +42,6 @@ testphdf5_SOURCES=testphdf5.c t_dset.c t_file.c t_file_image.c t_mdset.c \
 # The tests all depend on the hdf5 library and the test library
 LDADD = $(LIBH5TEST) $(LIBHDF5)
 
-# Test with just the native connector, with a single pass-through connector
-# and with a doubly-stacked pass-through.
-VOL_LIST = native "pass_through under_vol=0;under_info={}" \
-           "pass_through under_vol=505;under_info={under_vol=0;under_info={}}"
-
 # Temporary files
 # MPItest.h5 is from t_mpi
 # Para*.h5 are from testphdf

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -30,9 +30,4 @@ CONFIG=ordered
 # All subdirectories
 SUBDIRS=lib src $(TESTSERIAL_DIR)
 
-# Test with just the native connector, with a single pass-through connector
-# and with a doubly-stacked pass-through.
-VOL_LIST = native "pass_through under_vol=0;under_info={}" \
-           "pass_through under_vol=505;under_info={under_vol=0;under_info={}}"
-
 include $(top_srcdir)/config/conclude.am


### PR DESCRIPTION
The VOL_LIST variable used in the Autotools was duplicated in many
subdirectories. It's been moved to config/conclude.am to avoid
duplication. VFD_LIST was also moved to conclude.am.