### PR TITLE
BUG: Missing output dependency shared/H5init.c

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1123,7 +1123,8 @@ else ()
   )
   if (BUILD_SHARED_LIBS)
     add_custom_command (
-        OUTPUT     ${HDF5_GENERATED_SOURCE_DIR}/shared/shared_gen_SRCS.stamp1
+        OUTPUT     ${HDF5_GENERATED_SOURCE_DIR}/shared/H5Tinit.c
+                   ${HDF5_GENERATED_SOURCE_DIR}/shared/shared_gen_SRCS.stamp1
         COMMAND    ${CMAKE_COMMAND}
         ARGS       -E copy_if_different "${HDF5_GENERATED_SOURCE_DIR}/H5Tinit.c" "${HDF5_GENERATED_SOURCE_DIR}/shared/H5Tinit.c"
         COMMAND    ${CMAKE_COMMAND}


### PR DESCRIPTION
All outputs depenancies need to be listed for
the custom command.

ninja: error: 'cmake_object_order_depends_target_hdf5-shared_DEBUG', needed by 'Modules/ThirdParty/HDF5/src/itkhdf5/shared/H5Tinit.c', missing and no known rule to make it