### PR TITLE
Brings changes to ttsafe_attr_vlen.c from develop

### DIFF
--- a/test/ttsafe_attr_vlen.c
+++ b/test/ttsafe_attr_vlen.c
@@ -6,7 +6,7 @@
  * This file is part of HDF5.  The full HDF5 copyright notice, including     *
  * terms governing use, modification, and redistribution, is contained in    *
  * the COPYING file, which can be found at the root of the source code       *
- * distribution tree, or in https://support.hdfgroup.org/ftp/HDF5/releases.  *
+ * distribution tree, or in https://www.hdfgroup.org/licenses.               *
  * If you do not have access to either file, you may request a copy from     *
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/test/ttsafe_attr_vlen.c
+++ b/test/ttsafe_attr_vlen.c
@@ -6,7 +6,7 @@
  * This file is part of HDF5.  The full HDF5 copyright notice, including     *
  * terms governing use, modification, and redistribution, is contained in    *
  * the COPYING file, which can be found at the root of the source code       *
- * distribution tree, or in https://www.hdfgroup.org/licenses.               *
+ * distribution tree, or in https://support.hdfgroup.org/ftp/HDF5/releases.  *
  * If you do not have access to either file, you may request a copy from     *
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -54,15 +54,15 @@ void *tts_attr_vlen_thread(void *);
 void
 tts_attr_vlen(void)
 {
-    pthread_t threads[NUM_THREADS] = {0};             /* Thread declaration */
-    hid_t     fid                  = H5I_INVALID_HID; /* File ID */
-    hid_t     gid                  = H5I_INVALID_HID; /* Group ID */
-    hid_t     atid                 = H5I_INVALID_HID; /* Datatype ID for attribute */
-    hid_t     asid                 = H5I_INVALID_HID; /* Dataspace ID for attribute */
-    hid_t     aid                  = H5I_INVALID_HID; /* The attribute ID */
-    char *    string_attr          = "2.0";           /* The attribute data */
-    int       ret;                                    /* Return value */
-    int       i;                                      /* Local index variable */
+    H5TS_thread_t threads[NUM_THREADS] = {0};             /* Thread declaration */
+    hid_t         fid                  = H5I_INVALID_HID; /* File ID */
+    hid_t         gid                  = H5I_INVALID_HID; /* Group ID */
+    hid_t         atid                 = H5I_INVALID_HID; /* Datatype ID for attribute */
+    hid_t         asid                 = H5I_INVALID_HID; /* Dataspace ID for attribute */
+    hid_t         aid                  = H5I_INVALID_HID; /* The attribute ID */
+    const char *  string_attr          = "2.0";           /* The attribute data */
+    int           ret;                                    /* Return value */
+    int           i;                                      /* Local index variable */
 
     /* Create the HDF5 test file */
     fid = H5Fcreate(FILENAME, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
@@ -106,26 +106,27 @@ tts_attr_vlen(void)
     CHECK(ret, H5I_INVALID_HID, "H5Tclose");
 
     /* Start multiple threads and execute tts_attr_vlen_thread() for each thread */
-    for (i = 0; i < NUM_THREADS; i++)
-        pthread_create(&threads[i], NULL, tts_attr_vlen_thread, NULL);
+    for (i = 0; i < NUM_THREADS; i++) {
+        threads[i] = H5TS_create_thread(tts_attr_vlen_thread, NULL, NULL);
+    }
 
     /* Wait for the threads to end */
     for (i = 0; i < NUM_THREADS; i++)
-        pthread_join(threads[i], NULL);
+        H5TS_wait_for_thread(threads[i]);
 
 } /* end tts_attr_vlen() */
 
 /* Start execution for each thread */
 void *
-tts_attr_vlen_thread(void *client_data)
+tts_attr_vlen_thread(void H5_ATTR_UNUSED *client_data)
 {
-    hid_t  fid  = H5I_INVALID_HID; /* File ID */
-    hid_t  gid  = H5I_INVALID_HID; /* Group ID */
-    hid_t  aid  = H5I_INVALID_HID; /* Attribute ID */
-    hid_t  atid = H5I_INVALID_HID; /* Datatype ID for the attribute */
-    char * string_attr_check;      /* The attribute data being read */
-    char * string_attr = "2.0";    /* The expected attribute data */
-    herr_t ret;                    /* Return value */
+    hid_t       fid  = H5I_INVALID_HID; /* File ID */
+    hid_t       gid  = H5I_INVALID_HID; /* Group ID */
+    hid_t       aid  = H5I_INVALID_HID; /* Attribute ID */
+    hid_t       atid = H5I_INVALID_HID; /* Datatype ID for the attribute */
+    char *      string_attr_check;      /* The attribute data being read */
+    const char *string_attr = "2.0";    /* The expected attribute data */
+    herr_t      ret;                    /* Return value */
 
     /* Open the test file */
     fid = H5Fopen(FILENAME, H5F_ACC_RDONLY, H5P_DEFAULT);


### PR DESCRIPTION
Fix for exposed pthreads code that causes Windows builds to fail.