### PR TITLE
Restores maintainer mode in the autotools (#200)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -97,6 +97,7 @@
 ./bin/runtest                       _DO_NOT_DISTRIBUTE_
 ./bin/snapshot
 ./bin/snapshot_version              _DO_NOT_DISTRIBUTE_
+./bin/switch_maint_mode             _DO_NOT_DISTRIBUTE_
 ./bin/test-driver
 ./bin/pkgscrpts/testbinaries.sh     _DO_NOT_DISTRIBUTE_
 ./bin/timekeeper                    _DO_NOT_DISTRIBUTE_

--- a/bin/switch_maint_mode
+++ b/bin/switch_maint_mode
@@ -1,0 +1,81 @@
+#!/bin/sh
+#
+# Copyright by The HDF Group.
+# Copyright by the Board of Trustees of the University of Illinois.
+# All rights reserved.
+#
+# This file is part of HDF5.  The full HDF5 copyright notice, including
+# terms governing use, modification, and redistribution, is contained in
+# the COPYING file, which can be found at the root of the source code
+# distribution tree, or in https://support.hdfgroup.org/ftp/HDF5/releases.
+# If you do not have access to either file, you may request a copy from
+# help@hdfgroup.org.
+#
+# Switch AM_MAINTAINER_MODE value in configure.ac
+# Usage: See USAGE()
+# Programmer: Dana Robinson
+# Creation date: January 2016
+
+USAGE()
+{
+cat <<EOF
+
+switch_maint_mode reverses the status of AM_MAINTAINER_MODE in
+configure.ac from enable to disable or vice-versa. When enabled,
+this feature forces the autotools to run when the input files are
+older than the output files. This is the default for development
+branches. When disabled, the autotools will NOT be re-run regardless
+of their timestamps or any modifications. This is the default for
+tarballs and release branches since it avoids having end-users
+requiring the autotools.
+
+Command Syntax
+==============
+switch_maint_mode [-help] [-enable|disable] <path-to-configure.ac>
+
+EOF
+}
+
+MODE="notset"
+CONFIG_AC_PATH=
+
+# Display help/usage if any options were passed in
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -enable)
+        MODE="enable"
+        ;;
+    -disable)
+        MODE="disable"
+        ;;
+	-help)
+	    USAGE
+	    exit 0
+	    ;;
+    *)
+	    CONFIG_AC_PATH="$1"
+	    ;;
+    esac
+    shift
+done
+
+# Did we get a file path?
+if test -z $CONFIG_AC_PATH ; then
+    USAGE
+    exit 1
+fi
+
+# Did we get a mode?
+if test -z $MODE ; then
+    USAGE
+    exit 1
+fi
+
+# Run perl over configure.ac
+if test "X-$MODE" = "X-enable" ; then
+    perl -pi -e 's/^(AM_MAINTAINER_MODE\(\[)([a-z]+)(\]\))/$1enable$3/g' $CONFIG_AC_PATH
+fi
+if test "X-$MODE" = "X-disable" ; then
+    perl -pi -e 's/^(AM_MAINTAINER_MODE\(\[)([a-z]+)(\]\))/$1disable$3/g' $CONFIG_AC_PATH
+fi
+

--- a/configure
+++ b/configure
@@ -3764,16 +3764,45 @@ fi
 AM_BACKSLASH='\'
 
 
-## AM_MAINTAINER_MODE turns off "rebuild rules" that contain dependencies
-## for Makefiles, configure, src/H5config.h, etc.  If AM_MAINTAINER_MODE
-## is *not* included here, these files will be rebuilt if out of date.
-## This is a problem because if users try to build on a machine with
-## the wrong versions of autoconf and automake, these files will be
-## rebuilt with the wrong versions and bad things can happen.
-## Also, CVS doesn't preserve dependencies between timestamps, so
-## Makefiles will often think rebuilding needs to occur when it doesn't.
-## Developers should './configure --enable-maintainer-mode' to turn on
-## rebuild rules.
+## AM_MAINTAINER_MODE determines the behavior of "rebuild rules" that contain
+## dependencies for Makefile.in files, configure, src/H5config.h, etc. If
+## AM_MAINTAINER_MODE is enabled, these files will be rebuilt if out of date.
+## When disabled, the autotools build files can get out of sync and the build
+## system will not complain or try to regenerate downstream files.
+##
+## The AM_MAINTAINER_MODE macro also determines whether the
+## --(enable|disable)-maintainer-mode configure option is available. When the
+## macro is present, with or without a parameter, the option will be added
+## to the generated configure script.
+##
+## In summary:
+##
+##  AM_MAINTAINER_MODE([enable])
+##      - Build dependencies ON by default
+##      - Configure option exists
+##
+##  AM_MAINTAINER_MODE([disable])
+##      - Build dependencies OFF by default
+##      - Configure option exists
+##
+##  AM_MAINTAINER_MODE
+##      - Build dependencies OFF by default
+##      - Configure option exists
+##
+##  No AM_MAINTAINER_MODE macro
+##      - Build dependencies ON by default
+##      - No configure option to control build dependencies
+##
+## The biggest concern for us is that version control systems like git
+## usually don't preserve dependencies between timestamps, so the build
+## system will often think that upstream build files like Makefile.am are
+## dirty and that rebuilding needs to occur when it doesn't. This is a problem
+## in release branches where we provide the autotools-generated files. Users
+## who don't have autoconf, automake, etc. will then have difficulty building
+## release branches checked out from git.
+##
+## By default, maintainer mode is enabled in development branches and disabled
+## in release branches.
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to enable maintainer-specific portions of Makefiles" >&5
 $as_echo_n "checking whether to enable maintainer-specific portions of Makefiles... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -36,17 +36,46 @@ AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign])
 AM_SILENT_RULES([yes])
 
-## AM_MAINTAINER_MODE turns off "rebuild rules" that contain dependencies
-## for Makefiles, configure, src/H5config.h, etc.  If AM_MAINTAINER_MODE
-## is *not* included here, these files will be rebuilt if out of date.
-## This is a problem because if users try to build on a machine with
-## the wrong versions of autoconf and automake, these files will be
-## rebuilt with the wrong versions and bad things can happen.
-## Also, CVS doesn't preserve dependencies between timestamps, so
-## Makefiles will often think rebuilding needs to occur when it doesn't.
-## Developers should './configure --enable-maintainer-mode' to turn on
-## rebuild rules.
-AM_MAINTAINER_MODE
+## AM_MAINTAINER_MODE determines the behavior of "rebuild rules" that contain
+## dependencies for Makefile.in files, configure, src/H5config.h, etc. If
+## AM_MAINTAINER_MODE is enabled, these files will be rebuilt if out of date.
+## When disabled, the autotools build files can get out of sync and the build
+## system will not complain or try to regenerate downstream files.
+##
+## The AM_MAINTAINER_MODE macro also determines whether the
+## --(enable|disable)-maintainer-mode configure option is available. When the
+## macro is present, with or without a parameter, the option will be added
+## to the generated configure script.
+##
+## In summary:
+##
+##  AM_MAINTAINER_MODE([enable])
+##      - Build dependencies ON by default
+##      - Configure option exists
+##
+##  AM_MAINTAINER_MODE([disable])
+##      - Build dependencies OFF by default
+##      - Configure option exists
+##
+##  AM_MAINTAINER_MODE
+##      - Build dependencies OFF by default
+##      - Configure option exists
+##
+##  No AM_MAINTAINER_MODE macro
+##      - Build dependencies ON by default
+##      - No configure option to control build dependencies
+##
+## The biggest concern for us is that version control systems like git
+## usually don't preserve dependencies between timestamps, so the build
+## system will often think that upstream build files like Makefile.am are
+## dirty and that rebuilding needs to occur when it doesn't. This is a problem
+## in release branches where we provide the autotools-generated files. Users
+## who don't have autoconf, automake, etc. will then have difficulty building
+## release branches checked out from git.
+##
+## By default, maintainer mode is enabled in development branches and disabled
+## in release branches.
+AM_MAINTAINER_MODE([disable])
 
 ## ----------------------------------------------------------------------
 ## Set prefix default (install directory) to a directory in the build area.

--- a/src/H5FDhdfs.c
+++ b/src/H5FDhdfs.c
@@ -1729,13 +1729,13 @@ H5Pget_fapl_hdfs(hid_t fapl_id, H5FD_hdfs_fapl_t *fa_out)
 {
     herr_t ret_value = FAIL;
 
-    FUNC_ENTER_NOAPI_NOINIT
+    FUNC_ENTER_API_NOINIT
     H5TRACE2("e", "i*x", fapl_id, fa_out);
 
     HGOTO_ERROR(H5E_VFL, H5E_UNSUPPORTED, FAIL, "HDFS VFD not included in the HDF5 library")
 
 done:
-    FUNC_LEAVE_NOAPI(ret_value)
+    FUNC_LEAVE_API(ret_value)
 }
 
 herr_t
@@ -1743,13 +1743,13 @@ H5Pset_fapl_hdfs(hid_t fapl_id, H5FD_hdfs_fapl_t *fa)
 {
     herr_t ret_value = FAIL;
 
-    FUNC_ENTER_NOAPI_NOINIT
+    FUNC_ENTER_API_NOINIT
     H5TRACE2("e", "i*x", fapl_id, fa);
 
     HGOTO_ERROR(H5E_VFL, H5E_UNSUPPORTED, FAIL, "HDFS VFD not included in the HDF5 library")
 
 done:
-    FUNC_LEAVE_NOAPI(ret_value)
+    FUNC_LEAVE_API(ret_value)
 }
 
 #endif /* H5_HAVE_LIBHDFS */


### PR DESCRIPTION
Maintainer mode should be enabled in development branches.

Also adds helpful commenting.

Add bin/switch_maint_mode
Disable maintainer mode for release.
Fix incomplete merge for stub functions in H5Fdhdfs.c