### PR TITLE
H5FD__mpio_read: Fix MPI_Bcast datatype

### DIFF
--- a/src/H5FDmpio.c
+++ b/src/H5FDmpio.c
@@ -1271,7 +1271,11 @@ H5FD__mpio_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UNU
      *          of the data.  (QAK - 2019/1/2)
      */
     if (rank0_bcast)
-        if (MPI_SUCCESS != MPI_Bcast(&bytes_read, 1, MPI_LONG_LONG, 0, file->comm))
+#if MPI_VERSION >= 3
+        if (MPI_SUCCESS != MPI_Bcast(&bytes_read, 1, MPI_COUNT, 0, file->comm))
+#else
+        if (MPI_SUCCESS != MPI_Bcast(&bytes_read, 1, MPI_INT, 0, file->comm))
+#endif
             HMPI_GOTO_ERROR(FAIL, "MPI_Bcast failed", 0)
 
             /* Get the type's size */


### PR DESCRIPTION
This is a fix for a small bug, which I believe I originally found using a sanitizer tool such as ASan. The datatype passed to this MPI_Bcast is MPI_LONG_LONG, while the variable being broadcast is either an MPI_Count or an int depending on the MPI version. This leads to an out-of-bounds memory access.

This is likely a good candidate for backporting to older major release branches if there are any being maintained. If you would like me to help with this in any way, please let me know.