### PR TITLE
Fixes Autotools detection of the st_blocks field in stat

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1986,7 +1986,7 @@ esac
 
 
 ## ----------------------------------------------------------------------
-## Does the struct stat have the st_blocks field?  This field is not Posix.
+## Does the struct stat have the st_blocks field? This field is not POSIX.
 ##
 AC_MSG_CHECKING([for st_blocks in struct stat])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[

--- a/configure.ac
+++ b/configure.ac
@@ -1989,7 +1989,7 @@ esac
 ## Does the struct stat have the st_blocks field?  This field is not Posix.
 ##
 AC_MSG_CHECKING([for st_blocks in struct stat])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM[[
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   #include <sys/stat.h>]],[[struct stat sb; sb.st_blocks=0;]])],
   [AC_DEFINE([HAVE_STAT_ST_BLOCKS], [1],
           [Define if struct stat has the st_blocks field])

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -762,7 +762,16 @@ Bug Fixes since HDF5-1.12.0 release
 
     Configuration
     -------------
-    -
+    - Fixes Autotools determination of the stat struct having an st_blocks field
+
+      A missing parenthesis in an autoconf macro prevented building the test
+      code used to determine if the stat struct contains the st_blocks field.
+      Now that the test functions correctly, the H5_HAVE_STAT_ST_BLOCKS #define
+      found in H5pubconf.h will be defined correctly on both the Autotools and
+      CMake. This #define is only used in the tests and does not affect the
+      HDF5 C library.
+
+      (DER - 2021/07/01, HDFFV-11201)
 
 
     Performance


### PR DESCRIPTION
The Autotools and CMake will now both correctly determine if the
stat struct has the st_blocks field and set H5_HAVE_STAT_ST_BLOCKS
appropriately.