### PR TITLE
Reverts lock/unlock callback signature to 1.8.21 version

### DIFF
--- a/src/H5FDhdfs.c
+++ b/src/H5FDhdfs.c
@@ -286,8 +286,6 @@ static herr_t  H5FD_hdfs_read(H5FD_t *_file, H5FD_mem_t type, hid_t fapl_id, had
 static herr_t  H5FD_hdfs_write(H5FD_t *_file, H5FD_mem_t type, hid_t fapl_id, haddr_t addr, size_t size,
                                const void *buf);
 static herr_t  H5FD_hdfs_truncate(H5FD_t *_file, hid_t dxpl_id, hbool_t closing);
-static herr_t  H5FD_hdfs_lock(H5FD_t *_file, hbool_t rw);
-static herr_t  H5FD_hdfs_unlock(H5FD_t *_file);
 
 static herr_t H5FD_hdfs_validate_config(const H5FD_hdfs_fapl_t *fa);
 
@@ -320,8 +318,8 @@ static const H5FD_class_t H5FD_hdfs_g = {
     H5FD_hdfs_write,          /* write                */
     NULL,                     /* flush                */
     H5FD_hdfs_truncate,       /* truncate             */
-    H5FD_hdfs_lock,           /* lock                 */
-    H5FD_hdfs_unlock,         /* unlock               */
+    NULL,                     /* lock                 */
+    NULL,                     /* unlock               */
     H5FD_FLMAP_DICHOTOMY      /* fl_map               */
 };
 
@@ -1646,61 +1644,6 @@ H5FD_hdfs_truncate(H5FD_t H5_ATTR_UNUSED *_file, hid_t H5_ATTR_UNUSED dxpl_id, h
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5FD_hdfs_truncate() */
-
-/*-------------------------------------------------------------------------
- *
- * Function: H5FD_hdfs_lock
- *
- * Purpose:
- *
- *     Place an advisory lock on a file.
- *     No effect on Read-Only S3 file.
- *
- *     Suggestion: remove lock/unlock from class
- *                 would result in error at H5FD_[un]lock() (H5FD.c)
- *
- * Return:
- *
- *     SUCCEED (No-op always succeeds)
- *
- * Programmer: Jacob Smith
- *             2017-11-03
- *
- *-------------------------------------------------------------------------
- */
-static herr_t
-H5FD_hdfs_lock(H5FD_t H5_ATTR_UNUSED *_file, hbool_t H5_ATTR_UNUSED rw)
-{
-    FUNC_ENTER_NOAPI_NOINIT_NOERR
-
-    FUNC_LEAVE_NOAPI(SUCCEED)
-} /* end H5FD_hdfs_lock() */
-
-/*-------------------------------------------------------------------------
- *
- * Function: H5FD_hdfs_unlock
- *
- * Purpose:
- *
- *     Remove the existing lock on the file.
- *     No effect on Read-Only S3 file.
- *
- * Return:
- *
- *     SUCCEED (No-op always succeeds)
- *
- * Programmer: Jacob Smith
- *             2017-11-03
- *
- *-------------------------------------------------------------------------
- */
-static herr_t
-H5FD_hdfs_unlock(H5FD_t H5_ATTR_UNUSED *_file)
-{
-    FUNC_ENTER_NOAPI_NOINIT_NOERR
-
-    FUNC_LEAVE_NOAPI(SUCCEED)
-} /* end H5FD_hdfs_unlock() */
 
 #else /* H5_HAVE_LIBHDFS */
 

--- a/src/H5FDpublic.h
+++ b/src/H5FDpublic.h
@@ -236,8 +236,8 @@ typedef struct H5FD_class_t {
     herr_t (*write)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, const void *buffer);
     herr_t (*flush)(H5FD_t *file, hid_t dxpl_id, unsigned closing);
     herr_t (*truncate)(H5FD_t *file, hid_t dxpl_id, hbool_t closing);
-    herr_t (*lock)(H5FD_t *file, hbool_t last);
-    herr_t (*unlock)(H5FD_t *file);
+    herr_t  (*lock)(H5FD_t *file, unsigned char *oid, unsigned lock_type, hbool_t last);
+    herr_t  (*unlock)(H5FD_t *file, unsigned char *oid, hbool_t last);
     H5FD_mem_t fl_map[H5FD_MEM_NTYPES];
 } H5FD_class_t;
 

--- a/src/H5FDpublic.h
+++ b/src/H5FDpublic.h
@@ -236,8 +236,8 @@ typedef struct H5FD_class_t {
     herr_t (*write)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl, haddr_t addr, size_t size, const void *buffer);
     herr_t (*flush)(H5FD_t *file, hid_t dxpl_id, unsigned closing);
     herr_t (*truncate)(H5FD_t *file, hid_t dxpl_id, hbool_t closing);
-    herr_t  (*lock)(H5FD_t *file, unsigned char *oid, unsigned lock_type, hbool_t last);
-    herr_t  (*unlock)(H5FD_t *file, unsigned char *oid, hbool_t last);
+    herr_t (*lock)(H5FD_t *file, unsigned char *oid, unsigned lock_type, hbool_t last);
+    herr_t (*unlock)(H5FD_t *file, unsigned char *oid, hbool_t last);
     H5FD_mem_t fl_map[H5FD_MEM_NTYPES];
 } H5FD_class_t;
 

--- a/src/H5FDros3.c
+++ b/src/H5FDros3.c
@@ -229,8 +229,6 @@ static herr_t  H5FD_ros3_read(H5FD_t *_file, H5FD_mem_t type, hid_t fapl_id, had
 static herr_t  H5FD_ros3_write(H5FD_t *_file, H5FD_mem_t type, hid_t fapl_id, haddr_t addr, size_t size,
                                const void *buf);
 static herr_t  H5FD_ros3_truncate(H5FD_t *_file, hid_t dxpl_id, hbool_t closing);
-static herr_t  H5FD_ros3_lock(H5FD_t *_file, hbool_t rw);
-static herr_t  H5FD_ros3_unlock(H5FD_t *_file);
 static herr_t  H5FD_ros3_validate_config(const H5FD_ros3_fapl_t *fa);
 static void *  H5FD_ros3_fapl_get(H5FD_t *_file);
 static void *  H5FD_ros3_fapl_copy(const void *_old_fa);
@@ -265,8 +263,8 @@ static const H5FD_class_t H5FD_ros3_g = {
     H5FD_ros3_write,          /* write                */
     NULL,                     /* flush                */
     H5FD_ros3_truncate,       /* truncate             */
-    H5FD_ros3_lock,           /* lock                 */
-    H5FD_ros3_unlock,         /* unlock               */
+    NULL,                     /* lock                 */
+    NULL,                     /* unlock               */
     H5FD_FLMAP_DICHOTOMY      /* fl_map               */
 };
 
@@ -1574,60 +1572,5 @@ H5FD_ros3_truncate(H5FD_t H5_ATTR_UNUSED *_file, hid_t H5_ATTR_UNUSED dxpl_id, h
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5FD_ros3_truncate() */
-
-/*-------------------------------------------------------------------------
- *
- * Function: H5FD_ros3_lock()
- *
- * Purpose:
- *
- *     Place an advisory lock on a file.
- *     No effect on Read-Only S3 file.
- *
- *     Suggestion: remove lock/unlock from class
- *               > would result in error at H5FD_[un]lock() (H5FD.c)
- *
- * Return:
- *
- *     SUCCEED (No-op always succeeds)
- *
- * Programmer: Jacob Smith
- *             2017-11-03
- *
- *-------------------------------------------------------------------------
- */
-static herr_t
-H5FD_ros3_lock(H5FD_t H5_ATTR_UNUSED *_file, hbool_t H5_ATTR_UNUSED rw)
-{
-    FUNC_ENTER_NOAPI_NOINIT_NOERR
-
-    FUNC_LEAVE_NOAPI(SUCCEED)
-} /* end H5FD_ros3_lock() */
-
-/*-------------------------------------------------------------------------
- *
- * Function: H5FD_ros3_unlock()
- *
- * Purpose:
- *
- *     Remove the existing lock on the file.
- *     No effect on Read-Only S3 file.
- *
- * Return:
- *
- *     SUCCEED (No-op always succeeds)
- *
- * Programmer: Jacob Smith
- *             2017-11-03
- *
- *-------------------------------------------------------------------------
- */
-static herr_t
-H5FD_ros3_unlock(H5FD_t H5_ATTR_UNUSED *_file)
-{
-    FUNC_ENTER_NOAPI_NOINIT_NOERR
-
-    FUNC_LEAVE_NOAPI(SUCCEED)
-} /* end H5FD_ros3_unlock() */
 
 #endif /* H5_HAVE_ROS3_VFD */


### PR DESCRIPTION
This callback is unused in 1.8. The ros3 and hdfs VFDs are the only VFDs
that have the lock callback implemented and that is just as no-op stubs.
These stubs were removed so the callbacks are now NULL pointers, like
the other VFDs in 1.8.