### PR TITLE
Purge the buffer used in type conversion.

### DIFF
--- a/src/H5Tconv.c
+++ b/src/H5Tconv.c
@@ -1668,7 +1668,7 @@ H5T__conv_b_b(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
     size_t         olap;                    /*num overlapping elements    */
     size_t         half_size;               /*1/2 of total size for swapping*/
     uint8_t *      s, *sp, *d, *dp;         /*source and dest traversal ptrs*/
-    uint8_t        dbuf[256];               /*temp destination buffer    */
+    uint8_t        dbuf[256] = {0};         /*temp destination buffer    */
     size_t         msb_pad_offset;          /*offset for dest MSB padding    */
     size_t         i;
     uint8_t *      src_rev   = NULL;         /*order-reversed source buffer  */
@@ -3844,7 +3844,7 @@ H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
     size_t         olap;                 /*num overlapping elements    */
     uint8_t *      s, *sp, *d, *dp;      /*source and dest traversal ptrs*/
     uint8_t *      src_rev = NULL;       /*order-reversed source buffer  */
-    uint8_t        dbuf[64];             /*temp destination buffer    */
+    uint8_t        dbuf[64] = {0};       /*temp destination buffer    */
     size_t         first;
     ssize_t        sfirst;                   /*a signed version of `first'    */
     size_t         i;                        /*Local index variables         */
@@ -4287,7 +4287,7 @@ H5T__conv_f_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
     ssize_t      bitno = 0;            /*bit number            */
     uint8_t *    s, *sp, *d, *dp;      /*source and dest traversal ptrs*/
     uint8_t *    src_rev = NULL;       /*order-reversed source buffer  */
-    uint8_t      dbuf[64];             /*temp destination buffer    */
+    uint8_t      dbuf[64] = {0};       /*temp destination buffer    */
     uint8_t      tmp1, tmp2;           /*temp variables for swapping bytes*/
 
     /* Conversion-related variables */
@@ -4947,7 +4947,7 @@ H5T__conv_s_s(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
             dst_delta = (ssize_t)direction * (ssize_t)(buf_stride ? buf_stride : dst->shared->size);
 
             /* Allocate the overlap buffer */
-            if (NULL == (dbuf = (uint8_t *)H5MM_malloc(dst->shared->size)))
+            if (NULL == (dbuf = (uint8_t *)H5MM_calloc(dst->shared->size)))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for string conversion")
 
             /* The conversion loop. */
@@ -8402,7 +8402,7 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
     size_t       olap;            /*num overlapping elements    */
     uint8_t *    s, *sp, *d, *dp; /*source and dest traversal ptrs*/
     uint8_t *    src_rev = NULL;  /*order-reversed source buffer  */
-    uint8_t      dbuf[64];        /*temp destination buffer    */
+    uint8_t      dbuf[64] = {0};  /*temp destination buffer    */
     uint8_t      tmp1, tmp2;      /*temp variables for swapping bytes*/
 
     /* Conversion-related variables */
@@ -9028,7 +9028,7 @@ H5T__conv_i_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
     size_t       olap;            /*num overlapping elements    */
     uint8_t *    s, *sp, *d, *dp; /*source and dest traversal ptrs*/
     uint8_t *    src_rev = NULL;  /*order-reversed source buffer  */
-    uint8_t      dbuf[64];        /*temp destination buffer    */
+    uint8_t      dbuf[64] = {0};  /*temp destination buffer    */
     uint8_t      tmp1, tmp2;      /*temp variables for swapping bytes*/
 
     /* Conversion-related variables */


### PR DESCRIPTION
Some of the uninitialized bits in the buffer may get carried through
all the way to disk, creating a risk for leaks.

We observed an msan error during the floating point output conversion.
Due to the encoding certain bits could remain untouched during the conversion.

In this draft we zero initialize the dbuf buffer used by every converter.

@schwehr