### PR TITLE
(1) Add new routine to configure for VFD SWMR: init_vfd_swmr_config()

### DIFF
--- a/test/testvfdswmr.sh.in
+++ b/test/testvfdswmr.sh.in
@@ -168,7 +168,7 @@ for index_type in "-i ea" "-i b2"
 do
     # Try without compression, only; uncomment "-c 5" to try with compression.
 
-    for compress in "" #"-c 5"
+    for compress in "" "-c 5"
     do
         echo
         echo "** Loop testing parameters: $index_type $compress"

--- a/test/vfd_swmr_bigset_writer.c
+++ b/test/vfd_swmr_bigset_writer.c
@@ -1134,14 +1134,18 @@ main(int argc, char **argv)
 
     for (i = 0; i < NELMTS(s.file); i++) {
         hid_t fapl;
+        H5F_vfd_swmr_config_t config;
 
         if (s.vds != vds_multi && i > 0) {
             s.file[i] = s.file[0];
             continue;
         }
 
-        fapl = vfd_swmr_create_fapl(s.writer, true, s.use_vfd_swmr,
-            "./bigset-shadow-%zu", i);
+        /* config, tick_len, max_lag, writer, flush_raw_data, md_pages_reserved, md_file_path */
+        init_vfd_swmr_config(&config, 4, 7, s.writer, FALSE, 128, "./bigset-shadow-%zu", i);
+
+        /* use_latest_format, use_vfd_swmr, only_meta_page, config */
+        fapl = vfd_swmr_create_fapl(true, s.use_vfd_swmr, true, &config);
 
         if (fapl < 0)
             errx(EXIT_FAILURE, "vfd_swmr_create_fapl");

--- a/test/vfd_swmr_common.h
+++ b/test/vfd_swmr_common.h
@@ -30,15 +30,10 @@
  */
 #define MAX_SIZE_CHANGE     10
 
-#define NLEVELS         5   /* # of datasets in the SWMR test file */
-
-#define NMAPPING        9   
-
-#define COMMON_FILENAME        "vfd_swmr_data.h5"  /* SWMR test file name */
-#define DTYPE_SIZE      150             /* Data size in opaque type */
+#define VFD_SWMR_FILENAME        "vfd_swmr_data.h5"  /* SWMR test file name */
 
 /* The message sent by writer that the file open is done--releasing the file lock */
-#define WRITER_MESSAGE "VFD_SWMR_WRITER_MESSAGE"
+#define VFD_SWMR_WRITER_MESSAGE "VFD_SWMR_WRITER_MESSAGE"
 
 /************/
 /* Typedefs */
@@ -49,19 +44,6 @@ typedef struct _estack_state {
     void *edata;
 } estack_state_t;
 
-/* Information about a symbol/dataset */
-typedef struct {
-    char *name;         /* Dataset name for symbol */
-    hid_t dsid;         /* Dataset ID for symbol */
-    hsize_t nrecords;   /* Number of records for the symbol */
-} symbol_info_t;
-
-/* A symbol's record */
-typedef struct {
-    uint64_t rec_id;    /* ID for this record (unique in symbol) */
-    uint8_t info[DTYPE_SIZE];   /* "Other" information for this record */
-} symbol_t;
-
 typedef enum _testsel {
   TEST_NONE = 0
 , TEST_NULL
@@ -71,8 +53,6 @@ typedef enum _testsel {
 /********************/
 /* Global Variables */
 /********************/
-H5TEST_DLLVAR symbol_info_t *symbol_info[NLEVELS];
-H5TEST_DLLVAR unsigned symbol_count[NLEVELS];
 
 /**************/
 /* Prototypes */
@@ -87,18 +67,19 @@ H5TEST_DLL estack_state_t estack_get_state(void);
 H5TEST_DLL estack_state_t disable_estack(void);
 H5TEST_DLL void restore_estack(estack_state_t);
 
-H5TEST_DLL symbol_info_t * choose_dataset(unsigned *, unsigned *);
-H5TEST_DLL hid_t create_symbol_datatype(void);
-H5TEST_DLL int generate_name(char *name_buf, unsigned level, unsigned count);
-H5TEST_DLL int generate_symbols(void);
-H5TEST_DLL int shutdown_symbols(void);
-H5TEST_DLL int print_metadata_retries_info(hid_t fid);
 
 H5TEST_DLL void block_signals(sigset_t *);
 H5TEST_DLL void restore_signals(sigset_t *);
 H5TEST_DLL void await_signal(hid_t);
-H5TEST_DLL hid_t vfd_swmr_create_fapl(bool, bool, bool, const char *, ...)
-    H5_ATTR_FORMAT(printf, 4, 5);
+
+H5TEST_DLL hid_t 
+vfd_swmr_create_fapl(bool use_latest_format, bool use_vfd_swmr, bool only_meta_pages, 
+    H5F_vfd_swmr_config_t *config);
+
+H5TEST_DLL void
+init_vfd_swmr_config(H5F_vfd_swmr_config_t *config, uint32_t tick_len, uint32_t max_lag, hbool_t writer,
+    hbool_t flush_raw_data, uint32_t md_pages_reserved, const char *md_file_fmtstr, ...)
+    H5_ATTR_FORMAT(printf, 7, 8);
 
 H5TEST_DLL void dbgf(int, const char *, ...) H5_ATTR_FORMAT(printf, 2, 3);
 H5TEST_DLL void evsnprintf(char *, size_t, const char *, va_list);

--- a/test/vfd_swmr_group_writer.c
+++ b/test/vfd_swmr_group_writer.c
@@ -272,6 +272,7 @@ main(int argc, char **argv)
     bool writer;
     state_t s;
     const char *personality;
+    H5F_vfd_swmr_config_t config;
 
     state_init(&s, argc, argv);
 
@@ -288,7 +289,11 @@ main(int argc, char **argv)
              "unknown personality, expected vfd_swmr_group_{reader,writer}");
     }
 
-    fapl = vfd_swmr_create_fapl(writer, true, s.use_vfd_swmr, "./group-shadow");
+    /* config, tick_len, max_lag, writer, flush_raw_data, md_pages_reserved, md_file_path */
+    init_vfd_swmr_config(&config, 4, 7, writer, FALSE, 128, "./group-shadow");
+
+    /* use_latest_format, use_vfd_swmr, only_meta_page, config */
+    fapl = vfd_swmr_create_fapl(true, s.use_vfd_swmr, true, &config);
 
     if (fapl < 0)
         errx(EXIT_FAILURE, "vfd_swmr_create_fapl");

--- a/test/vfd_swmr_remove_reader.c
+++ b/test/vfd_swmr_remove_reader.c
@@ -32,6 +32,7 @@
 
 #include "h5test.h"
 #include "vfd_swmr_common.h"
+#include "swmr_common.h"
 
 /*******************/
 /* Local Variables */
@@ -297,31 +298,18 @@ read_records(const char *filename, unsigned verbose, unsigned long nseconds,
     start_time = HDtime(NULL);
     curr_time = start_time;
 
-    /* Create file access property list */
-    if((fapl = h5_fileaccess()) < 0)
-        goto error;
-
-    /*
-     * Set up to open the file with VFD SWMR configured.
-     */
-    /* Enable page buffering */
-    if(H5Pset_page_buffer_size(fapl, 4096, 0, 0) < 0)
-        goto error;
-
     /* Allocate memory for the configuration structure */
     if((config = HDcalloc(1, sizeof(*config))) == NULL)
         goto error;
 
-    config->version = H5F__CURR_VFD_SWMR_CONFIG_VERSION;
-    config->tick_len = 4;
-    config->max_lag = 5;
-    config->writer = FALSE;
-    config->md_pages_reserved = 128;
-    HDstrcpy(config->md_file_path, "./rw-shadow");
+     /* config, tick_len, max_lag, writer, flush_raw_data, md_pages_reserved, md_file_path */
+    init_vfd_swmr_config(config, 4, 5 , FALSE, FALSE, 128, "./rw-shadow");
 
-    /* Enable VFD SWMR configuration */
-    if(H5Pset_vfd_swmr_config(fapl, config) < 0)
+    /* use_latest_format, use_vfd_swmr, only_meta_page, config */
+    if((fapl = vfd_swmr_create_fapl(FALSE, TRUE, FALSE, config)) < 0) {
+        fprintf(stderr, "%s.%d: vfd_swmr_create_fapl failed\n", __func__, __LINE__);
         goto error;
+    }
 
     /* Loop over reading records until [at least] the correct # of seconds have passed */
     while(curr_time < (time_t)(start_time + (time_t)nseconds)) {
@@ -567,7 +555,7 @@ int main(int argc, const char *argv[])
         return -1;
 
     /* Reading records from datasets */
-    if(read_records(COMMON_FILENAME, verbose, (unsigned long)nseconds, (unsigned)poll_time, (unsigned)ncommon, (unsigned)nrandom) < 0) {
+    if(read_records(VFD_SWMR_FILENAME, verbose, (unsigned long)nseconds, (unsigned)poll_time, (unsigned)ncommon, (unsigned)nrandom) < 0) {
         HDfprintf(stderr, "READER: Error reading records from datasets!\n");
         HDexit(1);
     } /* end if */

--- a/test/vfd_swmr_remove_writer.c
+++ b/test/vfd_swmr_remove_writer.c
@@ -34,6 +34,7 @@
 
 #include "h5test.h"
 #include "vfd_swmr_common.h"
+#include "swmr_common.h"
 
 /****************/
 /* Local Macros */
@@ -83,35 +84,15 @@ open_skeleton(const char *filename, unsigned verbose,
 
     HDassert(filename);
 
-    /* Create file access property list */
-    if((fapl = h5_fileaccess()) < 0)
+    /* Allocate memory for the configuration structure */
+    if((config = (H5F_vfd_swmr_config_t *)HDcalloc(1, sizeof(H5F_vfd_swmr_config_t))) == NULL)
         goto error;
 
-    /* FOR NOW: set to use latest format, the "old" parameter is not used */
-    if(H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        goto error;
+    /* config, tick_len, max_lag, writer, flush_raw_data, md_pages_reserved, md_file_path */
+    init_vfd_swmr_config(config, 4, 5 , TRUE, FALSE, 128, "./rw-shadow");
 
-     /*
-     * Set up to open the file with VFD SWMR configured.
-     */
-
-    /* Enable page buffering */
-    if(H5Pset_page_buffer_size(fapl, 4096, 0, 0) < 0)
-        goto error;
-
-     /* Allocate memory for the configuration structure */
-     if((config = (H5F_vfd_swmr_config_t *)HDcalloc(1, sizeof(H5F_vfd_swmr_config_t))) == NULL)
-        goto error;
-
-    config->version = H5F__CURR_VFD_SWMR_CONFIG_VERSION;
-    config->tick_len = 4;
-    config->max_lag = 5;
-    config->writer = TRUE;
-    config->md_pages_reserved = 128;
-    HDstrcpy(config->md_file_path, "./rw-shadow");
-
-    /* Enable VFD SWMR configuration */
-    if(H5Pset_vfd_swmr_config(fapl, config) < 0)
+    /* use_latest_format, use_vfd_swmr, only_meta_page, config */
+    if((fapl = vfd_swmr_create_fapl(TRUE, TRUE, FALSE, config)) < 0)
         goto error;
 
     /* Open the file */
@@ -224,12 +205,6 @@ remove_records(hid_t fid, unsigned verbose, unsigned long nshrinks, unsigned lon
 
             /* Check for counter being reached */
             if(0 == shrink_to_flush) {
-#ifdef TEMP_OUT
-                /* Flush contents of file */
-                if(H5Fflush(fid, H5F_SCOPE_GLOBAL) < 0)
-                    return -1;
-#endif
-
                 /* Reset flush counter */
                 shrink_to_flush = flush_count;
             } /* end if */
@@ -376,17 +351,17 @@ int main(int argc, const char *argv[])
     /* Emit informational message */
     if(verbose) {
         HDfprintf(stderr, "WRITER: Opening skeleton file: %s\n",
-            COMMON_FILENAME);
+            VFD_SWMR_FILENAME);
     }
 
     /* Open file skeleton */
-    if((fid = open_skeleton(COMMON_FILENAME, verbose, old)) < 0) {
+    if((fid = open_skeleton(VFD_SWMR_FILENAME, verbose, old)) < 0) {
         HDfprintf(stderr, "WRITER: Error opening skeleton file!\n");
         HDexit(1);
     } /* end if */
 
     /* Send a message to indicate "H5Fopen" is complete--releasing the file lock */
-    h5_send_message(WRITER_MESSAGE, NULL, NULL);
+    h5_send_message(VFD_SWMR_WRITER_MESSAGE, NULL, NULL);
 
     /* Emit informational message */
     if(verbose)

--- a/test/vfd_swmr_sparse_writer.c
+++ b/test/vfd_swmr_sparse_writer.c
@@ -33,6 +33,7 @@
 
 #include "h5test.h"
 #include "vfd_swmr_common.h"
+#include "swmr_common.h"
 
 /****************/
 /* Local Macros */
@@ -83,35 +84,15 @@ open_skeleton(const char *filename, unsigned verbose)
 
     HDassert(filename);
 
-    /* Create file access property list */
-    if((fapl = h5_fileaccess()) < 0)
+    /* Allocate memory for the configuration structure */
+    if((config = (H5F_vfd_swmr_config_t *)HDcalloc(1, sizeof(H5F_vfd_swmr_config_t))) == NULL)
         goto error;
 
-    /* Set to use the latest library format */
-    if(H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        goto error;
+    /* config, tick_len, max_lag, writer, flush_raw_data, md_pages_reserved, md_file_path */
+    init_vfd_swmr_config(config, 4, 5 , TRUE, FALSE, 128, "./rw-shadow");
 
-    /*
-     * Set up to open the file with VFD SWMR configured.
-     */
-
-    /* Enable page buffering */
-    if(H5Pset_page_buffer_size(fapl, 4096, 0, 0) < 0)
-        goto error;
-
-     /* Allocate memory for the configuration structure */
-     if((config = (H5F_vfd_swmr_config_t *)HDcalloc(1, sizeof(H5F_vfd_swmr_config_t))) == NULL)
-        goto error;
-
-    config->version = H5F__CURR_VFD_SWMR_CONFIG_VERSION;
-    config->tick_len = 4;
-    config->max_lag = 5;
-    config->writer = TRUE;
-    config->md_pages_reserved = 128;
-    HDstrcpy(config->md_file_path, "./rw-shadow");
-
-    /* Enable VFD SWMR configuration */
-    if(H5Pset_vfd_swmr_config(fapl, config) < 0)
+    /* use_latest_format, use_vfd_swmr, only_meta_page, config */
+    if((fapl = vfd_swmr_create_fapl(TRUE, TRUE, FALSE, config)) < 0)
         goto error;
 
     /* Open the file */
@@ -288,12 +269,6 @@ add_records(hid_t fid, unsigned verbose, unsigned long nrecords, unsigned long f
 
             /* Check for counter being reached */
             if(0 == rec_to_flush) {
-#ifdef TEMP_OUT
-                /* Flush contents of file */
-                if(H5Fflush(fid, H5F_SCOPE_GLOBAL) < 0)
-                    return -1;
-#endif
-
                 /* Reset flush counter */
                 rec_to_flush = flush_count;
             } /* end if */
@@ -438,17 +413,17 @@ int main(int argc, const char *argv[])
     /* Emit informational message */
     if(verbose) {
         HDfprintf(stderr, "WRITER: Opening skeleton file: %s\n",
-            COMMON_FILENAME);
+            VFD_SWMR_FILENAME);
     }
 
     /* Open file skeleton */
-    if((fid = open_skeleton(COMMON_FILENAME, verbose)) < 0) {
+    if((fid = open_skeleton(VFD_SWMR_FILENAME, verbose)) < 0) {
         HDfprintf(stderr, "WRITER: Error opening skeleton file!\n");
         HDexit(1);
     } /* end if */
 
     /* Send a message to indicate "H5Fopen" is complete--releasing the file lock */
-    h5_send_message(WRITER_MESSAGE, NULL, NULL);
+    h5_send_message(VFD_SWMR_WRITER_MESSAGE, NULL, NULL);
 
     /* Emit informational message */
     if(verbose)

--- a/test/vfd_swmr_vlstr_reader.c
+++ b/test/vfd_swmr_vlstr_reader.c
@@ -94,6 +94,7 @@ main(int argc, char **argv)
     const struct timespec delay =
         {.tv_sec = 0, .tv_nsec = millisec_in_nanosecs * 11 / 10};
     testsel_t sel = TEST_NONE;
+    H5F_vfd_swmr_config_t config;
 
     assert(H5T_C_S1 != badhid);
 
@@ -135,8 +136,12 @@ main(int argc, char **argv)
     if (argc > 0)
         errx(EXIT_FAILURE, "unexpected command-line arguments");
 
-    fapl = vfd_swmr_create_fapl(false, sel == TEST_OOB, use_vfd_swmr,
-        "./vlstr-shadow");
+    /* config, tick_len, max_lag, writer, flush_raw_data, md_pages_reserved, md_file_path */
+    init_vfd_swmr_config(&config, 4, 7, false, FALSE, 128, "./vlstr-shadow");
+
+    /* use_latest_format, use_vfd_swmr, only_meta_page, config */
+    fapl = vfd_swmr_create_fapl(true, use_vfd_swmr, sel == TEST_OOB, &config);
+
     if (fapl < 0)
         errx(EXIT_FAILURE, "vfd_swmr_create_fapl");
 

--- a/test/vfd_swmr_vlstr_writer.c
+++ b/test/vfd_swmr_vlstr_writer.c
@@ -155,6 +155,7 @@ main(int argc, char **argv)
     const struct timespec delay =
         {.tv_sec = 0, .tv_nsec = 1000 * 1000 * 1000 / 10};
     testsel_t sel = TEST_NONE;
+    H5F_vfd_swmr_config_t config;
 
     assert(H5T_C_S1 != badhid);
 
@@ -202,8 +203,12 @@ main(int argc, char **argv)
     if (argc > 0)
         errx(EXIT_FAILURE, "unexpected command-line arguments");
 
-    fapl = vfd_swmr_create_fapl(true, sel == TEST_OOB, use_vfd_swmr,
-        "./vlstr-shadow");
+    /* config, tick_len, max_lag, writer, flush_raw_data, md_pages_reserved, md_file_path */
+    init_vfd_swmr_config(&config, 4, 7, true, FALSE, 128, "./vlstr-shadow");
+
+    /* use_latest_format, use_vfd_swmr, only_meta_page, config */
+    fapl = vfd_swmr_create_fapl(true, use_vfd_swmr, sel == TEST_OOB, &config);
+
     if (fapl < 0)
         errx(EXIT_FAILURE, "vfd_swmr_create_fapl");
 

--- a/test/vfd_swmr_zoo_writer.c
+++ b/test/vfd_swmr_zoo_writer.c
@@ -231,6 +231,7 @@ main(int argc, char **argv)
     const char *personality = strstr(progname, "vfd_swmr_zoo_");
     estack_state_t es;
     char step = 'b';
+    H5F_vfd_swmr_config_t vfd_swmr_config;
 
     if (personality != NULL && strcmp(personality, "vfd_swmr_zoo_writer") == 0)
         writer = wait_for_signal = true;
@@ -290,7 +291,12 @@ main(int argc, char **argv)
     if (argc > 0)
         errx(EXIT_FAILURE, "unexpected command-line arguments");
 
-    fapl = vfd_swmr_create_fapl(writer, true, use_vfd_swmr, "./zoo-shadow");
+    /* config, tick_len, max_lag, writer, flush_raw_data, md_pages_reserved, md_file_path */
+    init_vfd_swmr_config(&vfd_swmr_config, 4, 7, writer, FALSE, 128, "./zoo-shadow");
+
+    /* ? turn off use latest format argument via 1st argument? since later on it reset to early format */
+    /* use_latest_format, use_vfd_swmr, only_meta_page, config */
+    fapl = vfd_swmr_create_fapl(true, use_vfd_swmr, true, &vfd_swmr_config);
 
     if (use_vfd_swmr && H5Pget_vfd_swmr_config(fapl, &swmr_config) < 0)
         errx(EXIT_FAILURE, "H5Pget_vfd_swmr_config");


### PR DESCRIPTION
(2) Revise routine to setup fapl for VFD SWMR legacy and other integration tests: vfd_swmr_create_fapl()
(3) Update all VFD SWMR integration tests to use the above two routines
(4) Clean up VFD SWMR legacy tests: turn on compression in test script, remove #ifdef OUT H5Fflush(), message file name