### PR TITLE
Ensure processes always synchronize in t_shapesame test setup

### DIFF
--- a/testpar/t_shapesame.c
+++ b/testpar/t_shapesame.c
@@ -441,11 +441,8 @@ hs_dr_pio_test__setup(const int test_num, const int edge_size, const int checker
     VRFY((ret >= 0), "H5Dwrite() small_dataset initial write succeeded");
 
     /* sync with the other processes before checking data */
-    if (!use_collective_io) {
-
-        mrc = MPI_Barrier(MPI_COMM_WORLD);
-        VRFY((mrc == MPI_SUCCESS), "Sync after small dataset writes");
-    }
+    mrc = MPI_Barrier(MPI_COMM_WORLD);
+    VRFY((mrc == MPI_SUCCESS), "Sync after small dataset writes");
 
     /* read the small data set back to verify that it contains the
      * expected data.  Note that each process reads in the entire
@@ -515,11 +512,8 @@ hs_dr_pio_test__setup(const int test_num, const int edge_size, const int checker
     VRFY((ret >= 0), "H5Dwrite() large_dataset initial write succeeded");
 
     /* sync with the other processes before checking data */
-    if (!use_collective_io) {
-
-        mrc = MPI_Barrier(MPI_COMM_WORLD);
-        VRFY((mrc == MPI_SUCCESS), "Sync after large dataset writes");
-    }
+    mrc = MPI_Barrier(MPI_COMM_WORLD);
+    VRFY((mrc == MPI_SUCCESS), "Sync after large dataset writes");
 
     /* read the large data set back to verify that it contains the
      * expected data.  Note that each process reads in the entire
@@ -547,12 +541,8 @@ hs_dr_pio_test__setup(const int test_num, const int edge_size, const int checker
     VRFY((mis_match == FALSE), "large ds init data good.");
 
     /* sync with the other processes before changing data */
-
-    if (!use_collective_io) {
-
-        mrc = MPI_Barrier(MPI_COMM_WORLD);
-        VRFY((mrc == MPI_SUCCESS), "Sync initial values check");
-    }
+    mrc = MPI_Barrier(MPI_COMM_WORLD);
+    VRFY((mrc == MPI_SUCCESS), "Sync initial values check");
 
     return;
 


### PR DESCRIPTION
As the MPI standard does not guarantee process synchronization in collective operations, VOL connectors with different synchronization semantics (such as the DAOS VOL) could cause t_shapesame to have data verification issues during collective I/O. When the final barrier in t_shapesame's test setup function didn't execute, some ranks could be writing to a dataset during one iteration, while other ranks are reading the same dataset during a previous iteration.