### PR TITLE
Unwrap file VOL object when destroying file

### DIFF
--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -247,7 +247,8 @@ H5F__close_cb(H5VL_object_t *file_vol_obj, void **request)
     if (H5VL_file_close(file_vol_obj, H5P_DATASET_XFER_DEFAULT, request) < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTCLOSEFILE, FAIL, "unable to close file")
 
-    /* Free the VOL object */
+    /* Free the VOL object; it is unnecessary to unwrap the VOL
+     * object before freeing it, as the object was not wrapped */
     if (H5VL_free_object(file_vol_obj) < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTDEC, FAIL, "unable to free VOL object")
 
@@ -1320,6 +1321,8 @@ H5F__new(H5F_shared_t *shared, unsigned flags, hid_t fcpl_id, hid_t fapl_id, H5F
 
 done:
     if (!ret_value && f) {
+        HDassert(NULL == f->vol_obj);
+
         if (!shared) {
             /* Attempt to clean up some of the shared file structures */
             if (f->shared->efc)
@@ -1331,11 +1334,6 @@ done:
 
             f->shared = H5FL_FREE(H5F_shared_t, f->shared);
         }
-
-        /* Free VOL object */
-        if (f->vol_obj)
-            if (H5VL_free_object(f->vol_obj) < 0)
-                HDONE_ERROR(H5E_FILE, H5E_CANTDEC, NULL, "unable to free VOL object")
 
         f = H5FL_FREE(H5F_t, f);
     }
@@ -1603,9 +1601,13 @@ H5F__dest(H5F_t *f, hbool_t flush)
     /* Free the non-shared part of the file */
     f->open_name   = (char *)H5MM_xfree(f->open_name);
     f->actual_name = (char *)H5MM_xfree(f->actual_name);
-    if (f->vol_obj && H5VL_free_object(f->vol_obj) < 0)
-        HDONE_ERROR(H5E_FILE, H5E_CANTDEC, FAIL, "unable to free VOL object")
-    f->vol_obj = NULL;
+    if (f->vol_obj) {
+        if (NULL == H5VL_object_unwrap(f->vol_obj))
+            HDONE_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "can't unwrap VOL object")
+        if (H5VL_free_object(f->vol_obj) < 0)
+            HDONE_ERROR(H5E_FILE, H5E_CANTDEC, FAIL, "unable to free VOL object")
+        f->vol_obj = NULL;
+    }
     if (H5FO_top_dest(f) < 0)
         HDONE_ERROR(H5E_FILE, H5E_CANTINIT, FAIL, "problems closing file")
     f->shared = NULL;


### PR DESCRIPTION
During a native file "post open" call, a file VOL object is created, wrapped through the VOL stack and then set on the H5F_t struct. When destroying the file, the VOL object was being freed without being unwrapped first, leading to memory leaks when passthrough connectors are stacked on top of the native connector.