### PR TITLE
Port PR 291 to 1.12 branch: Allow using virtual datasets in files opened with H5F_CLOSE_SEMI and H5F_CLOSE_STRONG

### DIFF
--- a/src/H5Dvirtual.c
+++ b/src/H5Dvirtual.c
@@ -2238,7 +2238,7 @@ H5D__virtual_init(H5F_t *f, const H5D_t *dset, hid_t dapl_id)
 
     /* Retrieve VDS file FAPL to layout */
     if (storage->source_fapl <= 0) {
-        H5P_genplist_t *source_fapl = NULL;               /* Source file FAPL */
+        H5P_genplist_t *   source_fapl  = NULL;           /* Source file FAPL */
         H5F_close_degree_t close_degree = H5F_CLOSE_WEAK; /* Close degree for source files */
 
         if ((storage->source_fapl = H5F_get_access_plist(f, FALSE)) < 0)
@@ -2254,8 +2254,8 @@ H5D__virtual_init(H5F_t *f, const H5D_t *dset, hid_t dapl_id)
     } /* end if */
 #ifndef NDEBUG
     else {
-        H5P_genplist_t *source_fapl = NULL; /* Source file FAPL */
-        H5F_close_degree_t close_degree;    /* Close degree for source files */
+        H5P_genplist_t *   source_fapl = NULL; /* Source file FAPL */
+        H5F_close_degree_t close_degree;       /* Close degree for source files */
 
         /* Get property list pointer */
         if (NULL == (source_fapl = (H5P_genplist_t *)H5I_object(storage->source_fapl)))
@@ -2266,7 +2266,7 @@ H5D__virtual_init(H5F_t *f, const H5D_t *dset, hid_t dapl_id)
             HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get file close degree")
 
         HDassert(close_degree == H5F_CLOSE_WEAK);
-    } /* end else */
+    }  /* end else */
 #endif /* NDEBUG */
 
     /* Copy DAPL to layout */

--- a/src/H5Dvirtual.c
+++ b/src/H5Dvirtual.c
@@ -2237,9 +2237,37 @@ H5D__virtual_init(H5F_t *f, const H5D_t *dset, hid_t dapl_id)
         storage->printf_gap = (hsize_t)0;
 
     /* Retrieve VDS file FAPL to layout */
-    if (storage->source_fapl <= 0)
+    if (storage->source_fapl <= 0) {
+        H5P_genplist_t *source_fapl = NULL;               /* Source file FAPL */
+        H5F_close_degree_t close_degree = H5F_CLOSE_WEAK; /* Close degree for source files */
+
         if ((storage->source_fapl = H5F_get_access_plist(f, FALSE)) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get fapl")
+
+        /* Get property list pointer */
+        if (NULL == (source_fapl = (H5P_genplist_t *)H5I_object(storage->source_fapl)))
+            HGOTO_ERROR(H5E_PLIST, H5E_BADTYPE, H5I_INVALID_HID, "not a property list")
+
+        /* Source files must always be opened with H5F_CLOSE_WEAK close degree */
+        if (H5P_set(source_fapl, H5F_ACS_CLOSE_DEGREE_NAME, &close_degree) < 0)
+            HGOTO_ERROR(H5E_PLIST, H5E_CANTSET, FAIL, "can't set file close degree")
+    } /* end if */
+#ifndef NDEBUG
+    else {
+        H5P_genplist_t *source_fapl = NULL; /* Source file FAPL */
+        H5F_close_degree_t close_degree;    /* Close degree for source files */
+
+        /* Get property list pointer */
+        if (NULL == (source_fapl = (H5P_genplist_t *)H5I_object(storage->source_fapl)))
+            HGOTO_ERROR(H5E_PLIST, H5E_BADTYPE, H5I_INVALID_HID, "not a property list")
+
+        /* Verify H5F_CLOSE_WEAK close degree is set */
+        if (H5P_get(source_fapl, H5F_ACS_CLOSE_DEGREE_NAME, &close_degree) < 0)
+            HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get file close degree")
+
+        HDassert(close_degree == H5F_CLOSE_WEAK);
+    } /* end else */
+#endif /* NDEBUG */
 
     /* Copy DAPL to layout */
     if (storage->source_dapl <= 0)

--- a/test/vds.c
+++ b/test/vds.c
@@ -33,11 +33,57 @@ const char *FILENAME[] = {"vds_virt_0", "vds_virt_1", "vds_src_0",  "vds_src_1",
                           "vds_dapl",   "vds_virt_2", "vds_virt_3", "vds_src_2", "vds_src_3",
                           "vds%%_src2", "vds_dapl2",  NULL};
 
+/* Define to enable verbose test output */
+/* #define VDS_TEST_VERBOSE 1 */
+
+#ifdef VDS_TEST_VERBOSE
+
+/* For verbose output just use standard error printing */
+#define TESTING_2_SUPPRESSED(WHAT) TESTING_2(WHAT)
+#define PASSED_SUPPRESSED() PASSED()
+#define TEST_ERROR_SUPPRESSED TEST_ERROR
+
+/* Print config directly to output */
+#define PRINT_CONFIG(...)                                                                                    \
+    {                                                                                                        \
+        HDprintf("Config: " __VA_ARGS__);                                                                    \
+        HDputs("");                                                                                          \
+    }
+
+#else /* VDS_TEST_VERBOSE */
+
+/* Global strings for error output */
+char vds_config_str_g[128] = "";
+char vds_test_str_g[128] = "";
+
+/* Replacement for TESTING_2 for non-verbose-output */
+#define TESTING_2_SUPPRESSED(WHAT)                                                                           \
+    {                                                                                                        \
+        HDsnprintf(vds_test_str_g, sizeof(vds_test_str_g), WHAT);                                            \
+    }
+
+/* Suppress output from PASSED() */
+#define PASSED_SUPPRESSED()
+
+/* Replacement for TEST_ERROR for non-verbose output */
+#define TEST_ERROR_SUPPRESSED                                                                                \
+    {                                                                                                        \
+        printf("Failed config: %s\nFailed test: %s\n", vds_config_str_g, vds_test_str_g);                     \
+        TEST_ERROR                                                                                           \
+    }
+
+/* Replacement for HDprintf for printing configuration for non-verbose output */
+#define PRINT_CONFIG(...) HDsnprintf(vds_config_str_g, sizeof(vds_config_str_g), __VA_ARGS__);
+
+#endif /* VDS_TEST_VERBOSE */
+
 /* I/O test config flags */
 #define TEST_IO_CLOSE_SRC      0x01u
 #define TEST_IO_DIFFERENT_FILE 0x02u
 #define TEST_IO_REOPEN_VIRT    0x04u
-#define TEST_IO_NTESTS         0x08u
+#define TEST_IO_FCLOSE_SEMI    0x08u
+#define TEST_IO_FCLOSE_STRONG  0x10u
+#define TEST_IO_NTESTS         0x20u
 
 #define LIST_DOUBLE_SIZE (H5D_VIRTUAL_DEF_LIST_SIZE + 1)
 
@@ -485,22 +531,22 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
 
     switch (config) {
         case TEST_API_BASIC:
-            TESTING("virtual dataset API functions")
+            TESTING_2("virtual dataset API functions")
             break;
         case TEST_API_COPY_PLIST:
-            TESTING("virtual dataset API functions with copied plists")
+            TESTING_2("virtual dataset API functions with copied plists")
             break;
         case TEST_API_ENCDEC_PLIST:
-            TESTING("virtual dataset API functions with encoded and decoded plists")
+            TESTING_2("virtual dataset API functions with encoded and decoded plists")
             break;
         case TEST_API_CREATE_DSET:
-            TESTING("virtual dataset create")
+            TESTING_2("virtual dataset create")
             break;
         case TEST_API_REOPEN_DSET:
-            TESTING("virtual dataset create with reopened dataset")
+            TESTING_2("virtual dataset create with reopened dataset")
             break;
         case TEST_API_REOPEN_FILE:
-            TESTING("virtual dataset create with reopened file")
+            TESTING_2("virtual dataset create with reopened file")
             break;
         case TEST_API_NTESTS:
         default:
@@ -1115,7 +1161,7 @@ error:
  *-------------------------------------------------------------------------
  */
 static int
-test_vds_prefix_first(unsigned config, hid_t fapl)
+test_vds_prefix_first(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 {
     char *      srcfilename             = NULL;
     char *      srcfilename_map         = NULL;
@@ -1139,97 +1185,97 @@ test_vds_prefix_first(unsigned config, hid_t fapl)
     int         i, j;
     char        buffer[1024]; /* buffer to read vds_prefix       */
 
-    TESTING("basic virtual dataset I/O via H5Pset_vds_prefix(): all selection")
+    TESTING_2_SUPPRESSED("basic virtual dataset I/O via H5Pset_vds_prefix(): all selection")
 
     if ((srcfilename = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilename_map = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((vfilename = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilenamepct = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilenamepct_map = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
 
-    h5_fixname(FILENAME[0], fapl, vfilename, FILENAME_BUF_SIZE);
-    h5_fixname(FILENAME[8], fapl, srcfilename, FILENAME_BUF_SIZE);
-    h5_fixname_printf(FILENAME[8], fapl, srcfilename_map, FILENAME_BUF_SIZE);
-    h5_fixname(FILENAME[10], fapl, srcfilenamepct, FILENAME_BUF_SIZE);
-    h5_fixname_printf(srcfilenamepct_map_orig, fapl, srcfilenamepct_map, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[0], vds_fapl, vfilename, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[8], src_fapl, srcfilename, FILENAME_BUF_SIZE);
+    h5_fixname_printf(FILENAME[8], src_fapl, srcfilename_map, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[10], src_fapl, srcfilenamepct, FILENAME_BUF_SIZE);
+    h5_fixname_printf(srcfilenamepct_map_orig, src_fapl, srcfilenamepct_map, FILENAME_BUF_SIZE);
 
     /* create tmp directory and get current working directory path */
     if (HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create DCPL */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Set fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Initialize VDS prefix items */
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     if (H5Pset_virtual_prefix(dapl, TMPDIR) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pget_virtual_prefix(dapl, buffer, sizeof(buffer)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     if (HDstrcmp(buffer, TMPDIR) != 0)
         FAIL_PUTS_ERROR("vds prefix not set correctly");
 
     /* Create source dataspace */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspace */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select all (should not be necessary, but just to be sure) */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_all(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if (NULL == HDgetcwd(buffer, 1024))
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (HDchdir(TMPDIR) < 0)
-            TEST_ERROR
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if (HDchdir(buffer) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source dataset */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1238,17 +1284,17 @@ test_vds_prefix_first(unsigned config, hid_t fapl)
 
     /* Write data directly to source dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -1256,27 +1302,27 @@ test_vds_prefix_first(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++) {
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j]) {
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             }
     }
 
@@ -1287,59 +1333,59 @@ test_vds_prefix_first(unsigned config, hid_t fapl)
 
     /* Write data through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (NULL == HDgetcwd(buffer, 1024))
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             if (HDchdir(TMPDIR) < 0)
-                TEST_ERROR
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, fapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
             if (HDchdir(buffer) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data directly from source dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Pclose(dapl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dapl = -1;
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dcpl = -1;
 
     HDfree(srcfilename);
@@ -1348,7 +1394,7 @@ test_vds_prefix_first(unsigned config, hid_t fapl)
     HDfree(srcfilenamepct);
     HDfree(srcfilenamepct_map);
 
-    PASSED();
+    PASSED_SUPPRESSED();
     return 0;
 
 error:
@@ -1371,7 +1417,7 @@ error:
     H5E_END_TRY;
 
     if (HDsetenv("HDF5_VDS_PREFIX", "", 1) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     HDfree(srcfilename);
     HDfree(srcfilename_map);
@@ -1393,7 +1439,7 @@ error:
  *-------------------------------------------------------------------------
  */
 static int
-test_basic_io(unsigned config, hid_t fapl)
+test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 {
     char *      srcfilename             = NULL;
     char *      srcfilename_map         = NULL;
@@ -1426,81 +1472,81 @@ test_basic_io(unsigned config, hid_t fapl)
     herr_t      ret;                                        /* Generic return value */
     int         i, j, u, v;
 
-    TESTING("basic virtual dataset I/O")
+    TESTING_2_SUPPRESSED("basic virtual dataset I/O")
 
     if ((srcfilename = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilename_map = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((vfilename = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((vfilename2 = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilenamepct = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilenamepct_map = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
 
-    h5_fixname(FILENAME[0], fapl, vfilename, FILENAME_BUF_SIZE);
-    h5_fixname(FILENAME[1], fapl, vfilename2, FILENAME_BUF_SIZE);
-    h5_fixname(FILENAME[2], fapl, srcfilename, FILENAME_BUF_SIZE);
-    h5_fixname_printf(FILENAME[2], fapl, srcfilename_map, FILENAME_BUF_SIZE);
-    h5_fixname(FILENAME[4], fapl, srcfilenamepct, FILENAME_BUF_SIZE);
-    h5_fixname_printf(srcfilenamepct_map_orig, fapl, srcfilenamepct_map, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[0], vds_fapl, vfilename, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[1], vds_fapl, vfilename2, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[2], src_fapl, srcfilename, FILENAME_BUF_SIZE);
+    h5_fixname_printf(FILENAME[2], src_fapl, srcfilename_map, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[4], src_fapl, srcfilenamepct, FILENAME_BUF_SIZE);
+    h5_fixname_printf(srcfilenamepct_map_orig, src_fapl, srcfilenamepct_map, FILENAME_BUF_SIZE);
 
     /* Create DCPL */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Set fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /*
      * Test 1: All - all selection
      */
     /* Create source dataspace */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspace */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select all (should not be necessary, but just to be sure) */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_all(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source dataset */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1509,17 +1555,17 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write data directly to source dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -1527,27 +1573,27 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1556,46 +1602,46 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write data through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data directly from source dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
 
     /*
@@ -1604,70 +1650,70 @@ test_basic_io(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[1] = 13;
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select all in source space (should not be necessary, but just to be sure)
      */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 13;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "%%src_dset1", srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset2%%", srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset dims */
     dims[1] = 26;
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "%src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2%", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1676,22 +1722,22 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write data directly to source datasets */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -1699,27 +1745,27 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1728,40 +1774,40 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write data through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "%src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2%", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data directly from source datasets */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Test H5Ocopy() to same file */
     /* Copy virtual dataset */
     if (H5Ocopy(vfile, "v_dset", vfile, "v_dset2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close v_dset */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
 
     /* Adjust write buffer */
@@ -1771,22 +1817,22 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write data directly to source datasets */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -1794,36 +1840,36 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen virtual file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Open v_dset2 */
     if ((vdset = H5Dopen2(vfile, "v_dset2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through copied virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "%src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2%", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Only copy to a different file if the source datasets are in a different
@@ -1831,16 +1877,16 @@ test_basic_io(unsigned config, hid_t fapl)
     if (config & TEST_IO_DIFFERENT_FILE) {
         /* Close v_dset2 */
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
 
         /* Create file to copy virtual dataset to */
-        if ((vfile2 = H5Fcreate(vfilename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile2 = H5Fcreate(vfilename2, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
         /* Copy virtual dataset */
         if (H5Ocopy(vfile, "v_dset", vfile2, "v_dset3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Adjust write buffer */
         for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1849,22 +1895,22 @@ test_basic_io(unsigned config, hid_t fapl)
 
         /* Write data directly to source datasets */
         if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Close srcdsets and srcfile if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (H5Dclose(srcdset[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[0] = -1;
             if (H5Dclose(srcdset[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[1] = -1;
 
             if (config & TEST_IO_DIFFERENT_FILE) {
                 if (H5Fclose(srcfile[0]) < 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
                 srcfile[0] = -1;
             }
         }
@@ -1872,68 +1918,66 @@ test_basic_io(unsigned config, hid_t fapl)
         /* Reopen copied virtual file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Fclose(vfile2) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vfile2 = -1;
-            if ((vfile2 = H5Fopen(vfilename2, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((vfile2 = H5Fopen(vfilename2, H5F_ACC_RDWR, vds_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         }
 
         /* Open v_dset3 */
         if ((vdset = H5Dopen2(vfile2, "v_dset3", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through copied virtual dataset */
         HDmemset(rbuf[0], 0, sizeof(rbuf));
         if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
             for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
                 if (rbuf[i][j] != buf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
 
         /* Reopen srcdsets and srcfile if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (config & TEST_IO_DIFFERENT_FILE)
-                if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, fapl)) < 0)
-                    TEST_ERROR
+                if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
+                    TEST_ERROR_SUPPRESSED
             if ((srcdset[0] = H5Dopen2(srcfile[0], "%src_dset1", H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2%", H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
-
-        /* Close copied virtual file */
-        if (H5Fclose(vfile2) < 0)
-            TEST_ERROR
-        vfile2 = -1;
     }
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[1] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
+    if (vfile2 >= 0 && H5Fclose(vfile2) < 0)
+        TEST_ERROR_SUPPRESSED
+    vfile2 = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /*
@@ -1941,71 +1985,71 @@ test_basic_io(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[1] = 13;
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select all in source space (should not be necessary, but just to be sure)
      */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     start[0] = 0;
     start[1] = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     offset[1] = -3;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "%%src_dset1", srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     offset[1] = 10;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset2%%", srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset dims */
     dims[1] = 26;
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "%src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2%", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2015,27 +2059,27 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Write data directly to source datasets */
     offset[1] = -3;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     offset[1] = 10;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -2043,27 +2087,27 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2072,59 +2116,59 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write data through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "%src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2%", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data directly from source datasets */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     offset[1] = -3;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     offset[1] = 10;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[1] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
 
     /*
@@ -2133,70 +2177,70 @@ test_basic_io(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[1] = 13;
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select all in source space (should not be necessary, but just to be sure)
      */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 13;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilenamepct_map : ".",
                        "src_dset1", srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilenamepct_map : ".",
                        "src_dset2", srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset dims */
     dims[1] = 26;
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilenamepct, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilenamepct, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2205,22 +2249,22 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write data directly to source datasets */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -2228,38 +2272,38 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read first source dataset through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, vspace[0], vspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != (j < (int)(sizeof(buf[0]) / sizeof(buf[0][0]) / 2) ? buf[i][j] : 0))
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Read second source dataset through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, vspace[1], vspace[1], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != (j < (int)(sizeof(buf[0]) / sizeof(buf[0][0]) / 2) ? 0 : buf[i][j]))
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2268,7 +2312,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write first source dataset through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, vspace[0], vspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2277,25 +2321,25 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write second source dataset through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, vspace[1], vspace[1], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilenamepct, H5F_ACC_RDONLY, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilenamepct, H5F_ACC_RDONLY, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data directly from source datasets */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2303,32 +2347,32 @@ test_basic_io(unsigned config, hid_t fapl)
             if (rbuf[i][j] != (j < (int)(sizeof(buf[0]) / sizeof(buf[0][0]) / 2)
                                    ? (buf[i][j] - (int)(sizeof(buf) / sizeof(buf[0][0])))
                                    : buf[i][j]))
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[1] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /*
@@ -2336,19 +2380,19 @@ test_basic_io(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspaces */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in source space */
     start[0] = 0;
@@ -2356,10 +2400,10 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 10;
     count[1] = 13;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 13;
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     start[0] = 0;
@@ -2367,45 +2411,45 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 5;
     count[1] = 26;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 5;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[1], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2415,7 +2459,7 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Write data directly to source datasets */
     /* Write first dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update evbuf */
     for (i = 0; i < 5; i++) {
@@ -2432,7 +2476,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update evbuf */
     for (i = 0; i < 5; i++) {
@@ -2445,15 +2489,15 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -2461,15 +2505,15 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data through virtual dataset by hyperslab */
@@ -2478,7 +2522,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Read first slice */
     if (H5Dread(vdset, H5T_NATIVE_INT, vspace[0], srcspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++) {
@@ -2490,7 +2534,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Read second slice */
     if (H5Dread(vdset, H5T_NATIVE_INT, vspace[1], srcspace[1], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++) {
@@ -2504,7 +2548,7 @@ test_basic_io(unsigned config, hid_t fapl)
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2514,7 +2558,7 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Write data through virtual dataset */
     /* Write first slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, vspace[0], srcspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update evbuf */
     for (i = 0; i < 5; i++) {
@@ -2531,7 +2575,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write second slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, vspace[1], srcspace[1], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update evbuf */
     for (i = 0; i < 5; i++) {
@@ -2544,12 +2588,12 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data directly from source datasets */
@@ -2558,7 +2602,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Read first dataset */
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, srcspace[0], srcspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++) {
@@ -2570,7 +2614,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Read second dataset */
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, srcspace[1], srcspace[1], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++) {
@@ -2584,35 +2628,35 @@ test_basic_io(unsigned config, hid_t fapl)
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[1] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[1] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /*
@@ -2621,25 +2665,25 @@ test_basic_io(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create memory dataspace */
     if ((memspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     dims[1] = 52;
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace and file space for second operation (srcspace[1])
      */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset dims */
     dims[1] = 26;
@@ -2655,10 +2699,10 @@ test_basic_io(unsigned config, hid_t fapl)
     block[0]  = 10;
     block[1]  = 1;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 1;
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs (checkerboard) in virtual spaces */
     start[0]  = 0;
@@ -2670,53 +2714,53 @@ test_basic_io(unsigned config, hid_t fapl)
     block[0]  = 1;
     block[1]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 1;
     start[1] = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 0;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 1;
     start[1] = 0;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2726,7 +2770,7 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Write data directly to source datasets */
     /* Write first dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i += 2)
@@ -2740,7 +2784,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 1; i < 10; i += 2)
@@ -2750,15 +2794,15 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -2766,15 +2810,15 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data through virtual dataset by hyperslab */
@@ -2783,17 +2827,17 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Read first stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Read second stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, srcspace[1], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i += 2)
@@ -2806,7 +2850,7 @@ test_basic_io(unsigned config, hid_t fapl)
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2816,7 +2860,7 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Write data through virtual dataset */
     /* Write first slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i += 2)
@@ -2830,7 +2874,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write second slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, srcspace[1], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 1; i < 10; i += 2)
@@ -2840,12 +2884,12 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data directly from source datasets */
@@ -2854,13 +2898,13 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Read first dataset */
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i += 2)
@@ -2871,44 +2915,44 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Read second dataset */
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[1] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[1] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     memspace = -1;
 
     /*
@@ -2917,11 +2961,11 @@ test_basic_io(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create memory dataspace */
     if ((memspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     dims[0] = 3;
@@ -2929,18 +2973,18 @@ test_basic_io(unsigned config, hid_t fapl)
     dims[2] = 3;
     dims[3] = 3;
     if ((vspace[0] = H5Screate_simple(4, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(4, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspaces */
     dims[0] = 2;
     dims[1] = 4;
     dims[2] = 4;
     if ((srcspace[0] = H5Screate_simple(3, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcspace[1] = H5Screate_simple(3, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset dims */
     dims[0] = 10;
@@ -2960,10 +3004,10 @@ test_basic_io(unsigned config, hid_t fapl)
     block[1]  = 1;
     block[2]  = 4;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 1;
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs (corners) in first virtual space */
     start[0]  = 0;
@@ -2983,7 +3027,7 @@ test_basic_io(unsigned config, hid_t fapl)
     block[2]  = 1;
     block[3]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs ("+" pattern) in second virtual space */
     start[0]  = 1;
@@ -3003,61 +3047,61 @@ test_basic_io(unsigned config, hid_t fapl)
     block[2]  = 1;
     block[3]  = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
     start[2] = 1;
     count[1] = 2;
     count[2] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 0;
     start[1] = 1;
     count[0] = 2;
     count[1] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 1;
     count[0] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
     start[3] = 1;
     count[1] = 2;
     count[3] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source dataset */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -3070,21 +3114,21 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 2;
     count[1] = 16;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write data directly to source dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -3092,15 +3136,15 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data through virtual dataset */
@@ -3113,7 +3157,7 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 9;
     count[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset by hyperslab */
     /* Reset rbuf */
@@ -3129,11 +3173,11 @@ test_basic_io(unsigned config, hid_t fapl)
     count[2] = 1;
     count[3] = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read first stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     HDmemset(erbuf, 0, sizeof(erbuf));
@@ -3155,7 +3199,7 @@ test_basic_io(unsigned config, hid_t fapl)
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Reset rbuf */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
@@ -3170,7 +3214,7 @@ test_basic_io(unsigned config, hid_t fapl)
     count[2] = 1;
     count[3] = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslab in memory space */
     start[0] = 0;
@@ -3178,11 +3222,11 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 9;
     count[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read second stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 9; i++)
@@ -3206,10 +3250,10 @@ test_basic_io(unsigned config, hid_t fapl)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if ((j >= 3) && (j < 6)) {
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Reset rbuf */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
@@ -3224,7 +3268,7 @@ test_basic_io(unsigned config, hid_t fapl)
     count[2] = 1;
     count[3] = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslab in memory space */
     start[0] = 0;
@@ -3232,11 +3276,11 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 9;
     count[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read third stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 9; i++)
@@ -3258,10 +3302,10 @@ test_basic_io(unsigned config, hid_t fapl)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if ((j >= 6) && (j < 9)) {
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Now read entire VDS */
     /* Set memory space extent to 9x9, select all in order to reach part of the
@@ -3269,19 +3313,19 @@ test_basic_io(unsigned config, hid_t fapl)
     dims[0] = 9;
     dims[1] = 9;
     if (H5Sset_extent_simple(memspace, 2, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_all(memspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read third stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf99[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(rbuf99) / sizeof(rbuf99[0])); i++)
         for (j = 0; j < (int)(sizeof(rbuf99[0]) / sizeof(rbuf99[0][0])); j++)
             if (rbuf99[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -3303,7 +3347,7 @@ test_basic_io(unsigned config, hid_t fapl)
     count[2]  = 1;
     count[3]  = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0]  = 1;
     start[1]  = 1;
     start[2]  = 0;
@@ -3317,24 +3361,24 @@ test_basic_io(unsigned config, hid_t fapl)
     count[2]  = 1;
     count[3]  = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_OR, start, stride, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset extent of memspace, select hyperslab */
     dims[0] = 10;
     dims[1] = 26;
     if (H5Sset_extent_simple(memspace, 2, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 0;
     start[1] = 0;
     count[0] = 1;
     count[1] = 10;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write data through virtual dataset by hyperslab */
     /* Write first stripe pattern */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     HDmemset(erbuf, 0, sizeof(erbuf));
@@ -3368,7 +3412,7 @@ test_basic_io(unsigned config, hid_t fapl)
     count[2]  = 1;
     count[3]  = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0]  = 1;
     start[1]  = 0;
     start[2]  = 1;
@@ -3382,7 +3426,7 @@ test_basic_io(unsigned config, hid_t fapl)
     count[2]  = 1;
     count[3]  = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_OR, start, stride, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslab in memory space */
     start[0] = 0;
@@ -3390,11 +3434,11 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 1;
     count[1] = 12;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write second slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     erbuf[0][4]  = buf[0][0];
@@ -3429,7 +3473,7 @@ test_basic_io(unsigned config, hid_t fapl)
     count[2]  = 1;
     count[3]  = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0]  = 1;
     start[1]  = 1;
     start[2]  = 2;
@@ -3443,7 +3487,7 @@ test_basic_io(unsigned config, hid_t fapl)
     count[2]  = 1;
     count[3]  = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_OR, start, stride, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslab in memory space */
     start[0] = 0;
@@ -3451,11 +3495,11 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 1;
     count[1] = 10;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write third slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     erbuf[0][2]  = buf[0][0];
@@ -3472,10 +3516,10 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data directly from source dataset */
@@ -3485,58 +3529,58 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 2;
     count[1] = 16;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset rbuf */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
 
     /* Read dataset */
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Now try writing to whole VDS (should fail due to unmapped elements) */
     count[0] = 9;
     count[1] = 9;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     H5E_BEGIN_TRY { ret = H5Dwrite(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]); }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[1] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     memspace = -1;
 
     /*
@@ -3545,77 +3589,77 @@ test_basic_io(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create memory dataspace */
     if ((memspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     dims[0] = 8;
     dims[1] = 15;
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[0] = 4;
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select all in source space (should not be necessary, but just to be sure)
      */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 4;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset dims */
     dims[0] = 10;
     dims[1] = 26;
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset erbuf */
     HDmemset(erbuf[0], 0, sizeof(rbuf));
@@ -3631,11 +3675,11 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 4;
     count[1] = 15;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write data directly to first source dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     u = 0;
@@ -3653,11 +3697,11 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Select hyperslab in memory */
     start[0] = 4;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write data directly to second source dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 4; i < 6; i++)
@@ -3673,28 +3717,28 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Select hyperslab in memory */
@@ -3707,7 +3751,7 @@ test_basic_io(unsigned config, hid_t fapl)
     block[0]  = 1;
     block[1]  = 1;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslab in file */
     start[0] = 2;
@@ -3715,48 +3759,48 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 4;
     count[1] = 15;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     memspace = -1;
 
     /*
@@ -3765,90 +3809,90 @@ test_basic_io(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create memory dataspace */
     dims[1] = 13;
     dims[2] = 2;
     if ((memspace = H5Screate_simple(3, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     dims[0] = 6;
     dims[1] = 10;
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[2] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[0] = 2;
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select all in source space (should not be necessary, but just to be sure)
      */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 2;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 4;
     if (H5Sselect_hyperslab(vspace[2], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[2], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset3",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset dims */
     dims[0] = 10;
     dims[1] = 26;
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset3", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset erbuf */
     HDmemset(erbuf[0], 0, sizeof(rbuf));
@@ -3866,11 +3910,11 @@ test_basic_io(unsigned config, hid_t fapl)
     count[1] = 5;
     count[2] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write data directly to first source dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     u = 0;
@@ -3889,11 +3933,11 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Select hyperslab in memory */
     start[0] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write data directly to second source dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 2; i < 4; i++)
@@ -3910,11 +3954,11 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Select hyperslab in memory */
     start[0] = 4;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write data directly to third source dataset */
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 4; i < 6; i++)
@@ -3931,31 +3975,31 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[2] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Select hyperslab in memory */
@@ -3972,54 +4016,54 @@ test_basic_io(unsigned config, hid_t fapl)
     block[1]  = 3;
     block[2]  = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[2] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
     if (H5Sclose(vspace[2]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[2] = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     memspace = -1;
 
     /*
@@ -4028,30 +4072,30 @@ test_basic_io(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create memory dataspace */
     if ((memspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     dims[0] = 10;
     dims[1] = 9;
     dims[2] = 6;
     if ((vspace[0] = H5Screate_simple(3, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(3, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[1] = 12;
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select all in source space (should not be necessary, but just to be sure)
      */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     start[0]  = 0;
@@ -4067,49 +4111,49 @@ test_basic_io(unsigned config, hid_t fapl)
     block[1]  = 1;
     block[2]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[2] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset dims */
     dims[0] = 10;
     dims[1] = 26;
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Initialize erbuf */
     HDmemset(erbuf[0], 0, sizeof(rbuf));
@@ -4130,11 +4174,11 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 10;
     count[1] = 12;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write data directly to first source dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     u = 0;
@@ -4155,11 +4199,11 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Select hyperslab in memory */
     start[1] = 8;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write data directly to second source dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     u = 0;
@@ -4180,28 +4224,28 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Select hyperslab in memory */
@@ -4214,7 +4258,7 @@ test_basic_io(unsigned config, hid_t fapl)
     block[0]  = 10;
     block[1]  = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslab in file */
     start[0] = 0;
@@ -4224,53 +4268,53 @@ test_basic_io(unsigned config, hid_t fapl)
     count[1] = 4;
     count[2] = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     memspace = -1;
 
     /* Close */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dcpl = -1;
 
     HDfree(srcfilename);
@@ -4280,7 +4324,7 @@ test_basic_io(unsigned config, hid_t fapl)
     HDfree(srcfilenamepct);
     HDfree(srcfilenamepct_map);
 
-    PASSED();
+    PASSED_SUPPRESSED();
     return 0;
 
 error:
@@ -4322,7 +4366,7 @@ error:
  *-------------------------------------------------------------------------
  */
 static int
-test_unlim(unsigned config, hid_t fapl)
+test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 {
     char           srcfilename[FILENAME_BUF_SIZE];
     char           srcfilename_map[FILENAME_BUF_SIZE];
@@ -4353,52 +4397,52 @@ test_unlim(unsigned config, hid_t fapl)
     H5D_vds_view_t virtual_view;                   /* Virtual view property */
     int            i, j;
 
-    TESTING("virtual dataset I/O with unlimited selections")
+    TESTING_2_SUPPRESSED("virtual dataset I/O with unlimited selections")
 
-    h5_fixname(FILENAME[0], fapl, vfilename, sizeof vfilename);
-    h5_fixname(FILENAME[2], fapl, srcfilename, sizeof srcfilename);
-    h5_fixname_printf(FILENAME[2], fapl, srcfilename_map, sizeof srcfilename_map);
+    h5_fixname(FILENAME[0], vds_fapl, vfilename, sizeof vfilename);
+    h5_fixname(FILENAME[2], src_fapl, srcfilename, sizeof srcfilename);
+    h5_fixname_printf(FILENAME[2], src_fapl, srcfilename_map, sizeof srcfilename_map);
 
     /* Create DCPLs */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Set fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Set chunk dimensions */
     if (H5Pset_chunk(srcdcpl, 2, cdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create DAPL */
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create memory space */
     if ((memspace = H5Screate_simple(2, mdims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /*
      * Test 1: 2 Source datasets, single unlimited hyperslab virtual mappings
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[0]  = 5;
     mdims[0] = 5;
     if ((srcspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     mdims[0] = 10;
 
     /* Select hyperslab in source space */
@@ -4407,49 +4451,49 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 5;
     count[1] = H5S_UNLIMITED;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 5;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -4466,11 +4510,11 @@ test_unlim(unsigned config, hid_t fapl)
     start[0] = 0;
     count[1] = 10;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write first dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -4484,7 +4528,7 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -4494,15 +4538,15 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -4510,40 +4554,40 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4552,74 +4596,74 @@ test_unlim(unsigned config, hid_t fapl)
     /* Select hyperslab in memory space */
     start[0] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Test H5Pget_virtual_view() */
     if (H5Pget_virtual_view(dapl, &virtual_view) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (virtual_view != H5D_VDS_LAST_AVAILABLE)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Test H5Pget_virtual_view() */
     if (H5Pget_virtual_view(dapl, &virtual_view) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (virtual_view != H5D_VDS_FIRST_MISSING)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4627,33 +4671,33 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[0] */
     dims[0] = 5;
     dims[1] = 15;
     if (H5Dset_extent(srcdset[0], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -4663,26 +4707,26 @@ test_unlim(unsigned config, hid_t fapl)
     /* Write to new area of srcdset */
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[0])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 10;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -4690,42 +4734,42 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  Note that since we are using
      * H5D_VDS_FIRST_MISSING and we only extended one source dataset the
      * dimensions will not have changed. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4734,38 +4778,38 @@ test_unlim(unsigned config, hid_t fapl)
     /* Select hyperslab in memory space */
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf to reflect new data that is now visible due to the change to
      * H5D_VDS_LAST_AVAILABLE */
@@ -4775,27 +4819,27 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 15)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4804,37 +4848,37 @@ test_unlim(unsigned config, hid_t fapl)
     /* Select hyperslab in memory space */
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[1] */
     dims[0] = 5;
     dims[1] = 20;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -4844,16 +4888,16 @@ test_unlim(unsigned config, hid_t fapl)
     /* Write to new area of srcdset */
     count[1] = 10;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[1])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 10;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -4863,12 +4907,12 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -4876,40 +4920,40 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4918,17 +4962,17 @@ test_unlim(unsigned config, hid_t fapl)
     /* Select hyperslab in memory space */
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Now just read middle 2 rows */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
@@ -4936,9 +4980,9 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 2;
     count[1] = 20;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, memspace, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data - algorithmically check for only 2 middle rows being
      * read so we don't have to wipe out erbuf and then restore it afterwards */
@@ -4946,24 +4990,24 @@ test_unlim(unsigned config, hid_t fapl)
         for (j = 0; j < (int)mdims[1]; j++)
             if ((i == 4) || (i == 5)) {
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Now test reopening virtual dataset without calling H5Dget_space, if
      * REOPEN_VIRT flag set */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -4973,23 +5017,23 @@ test_unlim(unsigned config, hid_t fapl)
         start[0] = 0;
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++)
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
 
         /* Now try setting extent manually */
         /* Shrink to 18 */
         dims[1] = 18;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -4999,27 +5043,27 @@ test_unlim(unsigned config, hid_t fapl)
         start[0] = 0;
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Shrink to 15 */
         dims[1] = 15;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -5029,63 +5073,63 @@ test_unlim(unsigned config, hid_t fapl)
         start[0] = 0;
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
     }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 15)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5095,36 +5139,36 @@ test_unlim(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Now test reopening virtual dataset without calling H5Dget_space, if
      * REOPEN_VIRT flag set */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -5133,28 +5177,28 @@ test_unlim(unsigned config, hid_t fapl)
         /* Select hyperslab in memory space */
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Now try setting extent manually */
         /* Grow to 18 */
         dims[1] = 18;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -5164,27 +5208,27 @@ test_unlim(unsigned config, hid_t fapl)
         start[0] = 0;
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Grow to 20 */
         dims[1] = 20;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -5194,50 +5238,50 @@ test_unlim(unsigned config, hid_t fapl)
         start[0] = 0;
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++)
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
     }
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /*
@@ -5245,21 +5289,21 @@ test_unlim(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     dims[0] = 10;
     dims[1] = 10;
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[1]  = 5;
     mdims[1] = 10;
     if ((srcspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     mdims[1] = 20;
 
     /* Select hyperslab in source space */
@@ -5268,7 +5312,7 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 10;
     count[1] = H5S_UNLIMITED;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     stride[0] = 1;
@@ -5278,46 +5322,46 @@ test_unlim(unsigned config, hid_t fapl)
     block[0]  = 10;
     block[1]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -5334,11 +5378,11 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 10;
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write first dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -5352,7 +5396,7 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -5362,15 +5406,15 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -5378,40 +5422,40 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5419,62 +5463,62 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5482,32 +5526,32 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[0] */
     dims[1] = 7;
     if (H5Dset_extent(srcdset[0], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -5517,17 +5561,17 @@ test_unlim(unsigned config, hid_t fapl)
     /* Write to new area of srcdset */
     count[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[0])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 5;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf to reflect only new data that is now visible under
      * H5D_VDS_FIRST_MISSING (first slice) */
@@ -5537,12 +5581,12 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -5550,42 +5594,42 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  Note that since we are using
      * H5D_VDS_FIRST_MISSING and we only extended one source dataset the
      * dimension will only have changed to add one more slice. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 11)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5593,38 +5637,38 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf to reflect new data that is now visible due to the change to
      * H5D_VDS_LAST_AVAILABLE (second new slice) */
@@ -5633,27 +5677,27 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 13)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5661,36 +5705,36 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[1] */
     dims[1] = 10;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -5700,17 +5744,17 @@ test_unlim(unsigned config, hid_t fapl)
     /* Write to new area of srcdset */
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[1])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 5;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -5720,12 +5764,12 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -5733,40 +5777,40 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5774,17 +5818,17 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Now just read middle 2 rows */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
@@ -5792,10 +5836,10 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 2;
     count[1] = 20;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 0;
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, memspace, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data - algorithmically check for only 2 middle rows being
      * read so we don't have to wipe out erbuf and then restore it afterwards */
@@ -5803,26 +5847,26 @@ test_unlim(unsigned config, hid_t fapl)
         for (j = 0; j < (int)mdims[1]; j++)
             if ((i == 4) || (i == 5)) {
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf to reflect new data that is no longer visible due to the
      * change to H5D_VDS_FIRST_MISSING */
@@ -5832,27 +5876,27 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 14)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5860,54 +5904,54 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /*
@@ -5915,31 +5959,31 @@ test_unlim(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     dims[0] = 10;
     dims[1] = 10;
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[2] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspaces */
     dims[1]  = 4;
     mdims[1] = 8;
     if ((srcspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dims[1]  = 4;
     mdims[1] = 6;
     if ((srcspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dims[1]  = 2;
     mdims[1] = 6;
     if ((srcspace[2] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     mdims[1] = 20;
 
     /* Select hyperslab in source spaces */
@@ -5948,11 +5992,11 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 10;
     count[1] = H5S_UNLIMITED;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_hyperslab(srcspace[2], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     stride[0] = 1;
@@ -5962,55 +6006,55 @@ test_unlim(unsigned config, hid_t fapl)
     block[0]  = 10;
     block[1]  = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 2;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 4;
     if (H5Sselect_hyperslab(vspace[2], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[2], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset3",
                        srcspace[2]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[1], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset3", H5T_NATIVE_INT, srcspace[2], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -6027,11 +6071,11 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 10;
     count[1] = 4;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write first dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -6047,7 +6091,7 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -6065,11 +6109,11 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 10;
     count[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write third dataset */
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++) {
@@ -6080,18 +6124,18 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[2] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -6099,40 +6143,40 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6140,62 +6184,62 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6203,32 +6247,32 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[0] */
     dims[1] = 7;
     if (H5Dset_extent(srcdset[0], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -6238,27 +6282,27 @@ test_unlim(unsigned config, hid_t fapl)
     /* Write to new area of srcdset */
     count[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[0])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 4;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -6266,41 +6310,41 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  Note that since we are using
      * H5D_VDS_FIRST_MISSING the size will not have changed. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6308,38 +6352,38 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf to reflect new data that is now visible due to the change to
      * H5D_VDS_LAST_AVAILABLE */
@@ -6351,27 +6395,27 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 19)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6379,36 +6423,36 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[2] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[2] = H5Dopen2(srcfile[0], "src_dset3", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[2] */
     dims[1] = 5;
     if (H5Dset_extent(srcdset[2], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -6418,17 +6462,17 @@ test_unlim(unsigned config, hid_t fapl)
     /* Write to new area of srcdset */
     count[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[2])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 2;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++) {
@@ -6440,12 +6484,12 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdset[2] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[2] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -6453,41 +6497,41 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  Note that the dimensions will not have
      * changed. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 19)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6495,62 +6539,62 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 14)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6558,36 +6602,36 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[1] */
     dims[1] = 6;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -6597,17 +6641,17 @@ test_unlim(unsigned config, hid_t fapl)
     /* Write to new area of srcdset */
     count[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[1])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 4;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++) {
@@ -6618,12 +6662,12 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -6631,40 +6675,40 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 17)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6672,58 +6716,58 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 19)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6731,21 +6775,21 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Now just read middle 2 rows */
@@ -6754,16 +6798,16 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 2;
     count[1] = 19;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 0;
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data - algorithmically check for only 2 middle rows being
      * read */
@@ -6771,55 +6815,55 @@ test_unlim(unsigned config, hid_t fapl)
         for (j = 0; j < (int)mdims[1]; j++)
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if ((i == 4) || (i == 5)) {
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[2] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[1] = -1;
     if (H5Sclose(srcspace[2]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[2] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /*
@@ -6827,23 +6871,23 @@ test_unlim(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspaces */
     dims[0]  = 5;
     dims[1]  = 0;
     mdims[0] = 5;
     if ((srcspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dims[1] = 5;
     if ((srcspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     mdims[0] = 10;
 
     /* Select hyperslab in source spaces */
@@ -6852,53 +6896,53 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 5;
     count[1] = H5S_UNLIMITED;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     start[1] = 10;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 5;
     start[1] = 0;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[1], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -6917,11 +6961,11 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 5;
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -6931,15 +6975,15 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -6947,40 +6991,40 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 5)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6990,62 +7034,62 @@ test_unlim(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 5)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7053,33 +7097,33 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[0] */
     dims[0] = 5;
     dims[1] = 5;
     if (H5Dset_extent(srcdset[0], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -7092,9 +7136,9 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 5;
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -7104,12 +7148,12 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -7117,40 +7161,40 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 5)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7160,62 +7204,62 @@ test_unlim(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 15)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7225,74 +7269,74 @@ test_unlim(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[1] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /* Close */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dcpl = -1;
     if (H5Pclose(srcdcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dcpl = -1;
     if (H5Pclose(dapl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dapl = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     memspace = -1;
 
-    PASSED();
+    PASSED_SUPPRESSED();
     return 0;
 
 error:
@@ -7330,7 +7374,7 @@ error:
  *-------------------------------------------------------------------------
  */
 static int
-test_printf(unsigned config, hid_t fapl)
+test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 {
     char *      srcfilename                 = NULL;
     char *      srcfilename_map             = NULL;
@@ -7366,65 +7410,65 @@ test_printf(unsigned config, hid_t fapl)
     hsize_t     gap_size;                                               /* Gap size property */
     int         i, j;
 
-    TESTING("virtual dataset I/O with printf source")
+    TESTING_2_SUPPRESSED("virtual dataset I/O with printf source")
 
     if ((srcfilename = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilename_map = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilename2 = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilename2_map = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((vfilename = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((printf_srcfilename_map = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilenamepct = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilenamepct_map = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
 
-    h5_fixname(FILENAME[0], fapl, vfilename, FILENAME_BUF_SIZE);
-    h5_fixname(FILENAME[2], fapl, srcfilename, FILENAME_BUF_SIZE);
-    h5_fixname_printf(FILENAME[2], fapl, srcfilename_map, FILENAME_BUF_SIZE);
-    h5_fixname(FILENAME[3], fapl, srcfilename2, FILENAME_BUF_SIZE);
-    h5_fixname_printf(FILENAME[2], fapl, srcfilename2_map, FILENAME_BUF_SIZE);
-    h5_fixname_printf(printf_srcfilename_map_orig, fapl, printf_srcfilename_map, FILENAME_BUF_SIZE);
-    h5_fixname(FILENAME[4], fapl, srcfilenamepct, FILENAME_BUF_SIZE);
-    h5_fixname_printf(srcfilenamepct_map_orig, fapl, srcfilenamepct_map, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[0], vds_fapl, vfilename, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[2], src_fapl, srcfilename, FILENAME_BUF_SIZE);
+    h5_fixname_printf(FILENAME[2], src_fapl, srcfilename_map, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[3], src_fapl, srcfilename2, FILENAME_BUF_SIZE);
+    h5_fixname_printf(FILENAME[2], src_fapl, srcfilename2_map, FILENAME_BUF_SIZE);
+    h5_fixname_printf(printf_srcfilename_map_orig, src_fapl, printf_srcfilename_map, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[4], src_fapl, srcfilenamepct, FILENAME_BUF_SIZE);
+    h5_fixname_printf(srcfilenamepct_map_orig, src_fapl, srcfilenamepct_map, FILENAME_BUF_SIZE);
 
     /* Create DCPL */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Set fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create DAPL */
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create memory space */
     if ((memspace = H5Screate_simple(2, mdims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /*
      * Test 1: 1 Source dataset mapping, 10x5 blocks
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspace */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[1] = 5;
     if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual space */
     stride[0] = 1;
@@ -7434,91 +7478,91 @@ test_printf(unsigned config, hid_t fapl)
     block[0]  = 10;
     block[1]  = 5;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset%b",
                        srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
 
     /* Create 2 source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -7532,9 +7576,9 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[0] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -7548,7 +7592,7 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[1] */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -7558,15 +7602,15 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -7574,40 +7618,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7615,32 +7659,32 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
-        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
     /* Create 3rd source dataset */
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -7649,9 +7693,9 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[2] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -7661,12 +7705,12 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdset[2] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[2] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -7674,36 +7718,36 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 15)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7711,21 +7755,21 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Now try with different selections */
@@ -7737,25 +7781,25 @@ test_printf(unsigned config, hid_t fapl)
 
             /* Select hyperslab in memory space */
             if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
             /* Select hyperslab in file space */
             if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
             /* Read data */
             if (H5Dread(vdset, H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, rbuf[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
             /* Verify read data */
             for (i = 0; i < (int)mdims[0]; i++)
                 for (j = 0; j < (int)mdims[1]; j++) {
                     if ((j < (int)start[1]) || (j >= (int)(start[1] + count[1]))) {
                         if (rbuf[i][j] != 0)
-                            TEST_ERROR
+                            TEST_ERROR_SUPPRESSED
                     }
                     else if (rbuf[i][j] != erbuf[i][j])
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
         }
     start[1] = 0;
@@ -7763,11 +7807,11 @@ test_printf(unsigned config, hid_t fapl)
     /* Now try writing through VDS */
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslab in file space */
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -7776,83 +7820,83 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write data through VDS */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset0", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[2] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read srcdset[0] */
     count[0] = 10;
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < 10; i++)
         for (j = 0; j < 5; j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Read srcdset[1] */
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < 10; i++)
         for (j = 0; j < 5; j++)
             if (rbuf[i][j] != buf[i][j + 5])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Read srcdset[2] */
     if (H5Dread(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < 10; i++)
         for (j = 0; j < 5; j++)
             if (rbuf[i][j] != buf[i][j + 10])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[1] = -1;
     if (H5Dclose(srcdset[2]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[2] = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
 
     /*
@@ -7861,16 +7905,16 @@ test_printf(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[1] = 1;
     if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual space */
     stride[0] = 1;
@@ -7880,104 +7924,104 @@ test_printf(unsigned config, hid_t fapl)
     block[0]  = 10;
     block[1]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilenamepct_map : ".",
                        "src_dset%b", srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilenamepct, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilenamepct, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilenamepct, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilenamepct, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
 
     /* Create source datasets in a pattern with increasing gaps:
      * XX-X--X---X----X */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset3", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[3] = H5Dcreate2(srcfile[0], "src_dset6", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[4] = H5Dcreate2(srcfile[0], "src_dset10", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[5] = H5Dcreate2(srcfile[0], "src_dset15", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -7991,9 +8035,9 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[0] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -8006,7 +8050,7 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[1] */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -8019,7 +8063,7 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[2] */
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -8032,7 +8076,7 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[3] */
     if (H5Dwrite(srcdset[3], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -8045,7 +8089,7 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[4] */
     if (H5Dwrite(srcdset[4], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -8058,7 +8102,7 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[5] */
     if (H5Dwrite(srcdset[5], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -8068,13 +8112,13 @@ test_printf(unsigned config, hid_t fapl)
     if (config & TEST_IO_CLOSE_SRC) {
         for (i = 0; i < 6; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[i] = -1;
         }
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -8082,40 +8126,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8123,74 +8167,74 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Test H5Pget_virtual_printf_gap() */
     if (H5Pget_virtual_printf_gap(dapl, &gap_size) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (gap_size != (hsize_t)0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close VDS and reopen with printf gap set to 1, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)1) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Test H5Pget_virtual_printf_gap() */
     if (H5Pget_virtual_printf_gap(dapl, &gap_size) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (gap_size != (hsize_t)1)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 4)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8198,68 +8242,68 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with printf gap set to 2, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)2) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Test H5Pget_virtual_printf_gap() */
     if (H5Pget_virtual_printf_gap(dapl, &gap_size) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (gap_size != (hsize_t)2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 7)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8267,68 +8311,68 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with printf gap set to 3, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)3) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Test H5Pget_virtual_printf_gap() */
     if (H5Pget_virtual_printf_gap(dapl, &gap_size) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (gap_size != (hsize_t)3)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 11)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8336,68 +8380,68 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with printf gap set to 4, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)4) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Test H5Pget_virtual_printf_gap() */
     if (H5Pget_virtual_printf_gap(dapl, &gap_size) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (gap_size != (hsize_t)4)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 16)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8405,62 +8449,62 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8468,56 +8512,56 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reset dapl */
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)0) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         for (i = 0; i < 6; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[i] = -1;
         }
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
 
     /* Next 2 tests are always run with a different source file, so only run if
@@ -8528,21 +8572,21 @@ test_printf(unsigned config, hid_t fapl)
          * Test 3: 1 Source dataset mapping, 10x5 blocks, printf source file
          */
         /* Clean up files so the source files do not exist yet */
-        H5Iinc_ref(fapl); /* Prevent FAPL from being closed */
-        h5_clean_files(FILENAME, fapl);
+        H5Iinc_ref(vds_fapl); /* Prevent FAPL from being closed */
+        h5_clean_files(FILENAME, vds_fapl);
 
         /* Clear virtual layout in DCPL */
         if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Create virtual dataspaces */
         if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Create source dataspace */
         dims[1] = 5;
         if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Select hyperslabs in virtual space */
         stride[0] = 1;
@@ -8552,66 +8596,66 @@ test_printf(unsigned config, hid_t fapl)
         block[0]  = 10;
         block[1]  = 5;
         if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Add virtual layout mapping */
         if (H5Pset_virtual(dcpl, vspace[0], printf_srcfilename_map, "src_dset", srcspace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Create virtual file */
-        if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
         /* Create virtual dataset */
         if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vfile = -1;
-            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (ndims != 2)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[1] != 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[1] != 20)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Create 2 source files, one source dataset */
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                      H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
-        if ((srcfile[1] = H5Fcreate(srcfilename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
+        if ((srcfile[1] = H5Fcreate(srcfilename2, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
         /* Populate write buffer */
         for (i = 0; i < (int)mdims[0]; i++)
@@ -8625,9 +8669,9 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Write to srcdset[0] */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Update erbuf */
         for (i = 0; i < 10; i++)
@@ -8637,53 +8681,53 @@ test_printf(unsigned config, hid_t fapl)
         /* Close srcdset and srcfiles if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (H5Dclose(srcdset[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[0] = -1;
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[1] = -1;
         }
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vfile = -1;
-            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (ndims != 2)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[1] != 5)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[1] != 20)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -8691,32 +8735,32 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Reopen srcfile[1] if config option specified */
         if (config & TEST_IO_CLOSE_SRC)
-            if ((srcfile[1] = H5Fopen(srcfilename2, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[1] = H5Fopen(srcfilename2, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
 
         /* Create 2nd source dataset */
         if ((srcdset[1] = H5Dcreate2(srcfile[1], "src_dset", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                      H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Adjust write buffer */
         for (i = 0; i < (int)mdims[0]; i++)
@@ -8725,9 +8769,9 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Write to srcdset[1] */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Update erbuf */
         for (i = 0; i < 10; i++)
@@ -8737,50 +8781,50 @@ test_printf(unsigned config, hid_t fapl)
         /* Close srcdset[1] and srcfile[1] if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (H5Dclose(srcdset[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[1] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[1] = -1;
         }
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vfile = -1;
-            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (ndims != 2)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[1] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[1] != 20)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -8788,49 +8832,49 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Close */
         if (!(config & TEST_IO_CLOSE_SRC)) {
             if (H5Dclose(srcdset[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[0] = -1;
             if (H5Dclose(srcdset[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[1] = -1;
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[1] = -1;
         }
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
         if (H5Sclose(srcspace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcspace = -1;
         if (H5Sclose(vspace[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vspace[0] = -1;
 
         /*
@@ -8838,21 +8882,21 @@ test_printf(unsigned config, hid_t fapl)
          * source dset, extra %%s in source dataset name
          */
         /* Clean up files so the source files do not exist yet */
-        H5Iinc_ref(fapl); /* Prevent FAPL from being closed */
-        h5_clean_files(FILENAME, fapl);
+        H5Iinc_ref(vds_fapl); /* Prevent FAPL from being closed */
+        h5_clean_files(FILENAME, vds_fapl);
 
         /* Clear virtual layout in DCPL */
         if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Create virtual dataspaces */
         if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Create source dataspace */
         dims[1] = 5;
         if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Select hyperslabs in virtual space */
         stride[0] = 1;
@@ -8862,66 +8906,66 @@ test_printf(unsigned config, hid_t fapl)
         block[0]  = 10;
         block[1]  = 5;
         if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Add virtual layout mapping */
         if (H5Pset_virtual(dcpl, vspace[0], printf_srcfilename_map, "%%src%%_dset%%%b", srcspace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Create virtual file */
-        if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
         /* Create virtual dataset */
         if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vfile = -1;
-            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (ndims != 2)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[1] != 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[1] != 20)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Create 2 source files, one source dataset */
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dcreate2(srcfile[0], "%src%_dset%0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                      H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
-        if ((srcfile[1] = H5Fcreate(srcfilename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
+        if ((srcfile[1] = H5Fcreate(srcfilename2, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
         /* Populate write buffer */
         for (i = 0; i < (int)mdims[0]; i++)
@@ -8935,9 +8979,9 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Write to srcdset[0] */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Update erbuf */
         for (i = 0; i < 10; i++)
@@ -8947,53 +8991,53 @@ test_printf(unsigned config, hid_t fapl)
         /* Close srcdset and srcfiles if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (H5Dclose(srcdset[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[0] = -1;
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[1] = -1;
         }
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vfile = -1;
-            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (ndims != 2)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[1] != 5)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[1] != 20)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -9001,32 +9045,32 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Reopen srcfile[1] if config option specified */
         if (config & TEST_IO_CLOSE_SRC)
-            if ((srcfile[1] = H5Fopen(srcfilename2, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[1] = H5Fopen(srcfilename2, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
 
         /* Create 2nd source dataset */
         if ((srcdset[1] = H5Dcreate2(srcfile[1], "%src%_dset%1", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                      H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Adjust write buffer */
         for (i = 0; i < (int)mdims[0]; i++)
@@ -9035,9 +9079,9 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Write to srcdset[1] */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Update erbuf */
         for (i = 0; i < 10; i++)
@@ -9047,50 +9091,50 @@ test_printf(unsigned config, hid_t fapl)
         /* Close srcdset[1] and srcfile[1] if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (H5Dclose(srcdset[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[1] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[1] = -1;
         }
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vfile = -1;
-            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (ndims != 2)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[1] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[1] != 20)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -9098,49 +9142,49 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Close */
         if (!(config & TEST_IO_CLOSE_SRC)) {
             if (H5Dclose(srcdset[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[0] = -1;
             if (H5Dclose(srcdset[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[1] = -1;
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[1] = -1;
         }
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
         if (H5Sclose(srcspace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcspace = -1;
         if (H5Sclose(vspace[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vspace[0] = -1;
     }
 
@@ -9150,26 +9194,26 @@ test_printf(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     dims[0] = 10;
     dims[1] = 10;
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace (2 elements wide) */
     dims[1] = 2;
     if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslab in source space */
     count[0] = 10;
     count[1] = 1;
     if (H5Sselect_hyperslab(srcspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     stride[0] = 1;
@@ -9179,98 +9223,98 @@ test_printf(unsigned config, hid_t fapl)
     block[0]  = 10;
     block[1]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "%bsrc_dset_a%b%%", srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_b%b%%%%", srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
 
     /* Create 2 source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "0src_dset_a0%", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset_b0%%", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -9286,9 +9330,9 @@ test_printf(unsigned config, hid_t fapl)
     block[0] = 10;
     block[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -9301,7 +9345,7 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[1] */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -9310,15 +9354,15 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -9326,40 +9370,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9367,32 +9411,32 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
-        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
     /* Create 3rd source dataset */
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset_b1%%", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -9401,9 +9445,9 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[2] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -9412,12 +9456,12 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdset[2] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[2] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -9425,40 +9469,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 4)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9466,63 +9510,63 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  Make sure that the 4th slice is no longer
      * visible due to the change to H5D_VDS_FIRST_MISSING. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9530,32 +9574,32 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
-        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
     /* Create 4th source dataset */
     if ((srcdset[3] = H5Dcreate2(srcfile[0], "2src_dset_a2%", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -9564,9 +9608,9 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[3] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[3], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -9575,12 +9619,12 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdset[3] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[3]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[3] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -9588,40 +9632,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9629,63 +9673,63 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  Make sure that the 4th slice is now visible
      * due to the change to H5D_VDS_LAST_AVAILABLE. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 4)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9693,63 +9737,63 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with printf_gap set to 1, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)1) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  Make sure that the 6th slice is now visible
      * due to the change to printf_gap. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 5)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9757,59 +9801,59 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reset dapl */
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)0) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         for (i = 0; i < 4; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[i] = -1;
         }
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /*
@@ -9817,25 +9861,25 @@ test_printf(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     dims[0] = 10;
     dims[1] = 10;
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace (1 dimensional) */
     dims[0] = 50;
     if ((srcspace = H5Screate_simple(1, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslab in source space */
     count[0] = 25;
     if (H5Sselect_hyperslab(srcspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     stride[0] = 1;
@@ -9845,103 +9889,103 @@ test_printf(unsigned config, hid_t fapl)
     block[0]  = 5;
     block[1]  = 5;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0]  = 5;
     stride[1] = 10;
     block[1]  = 10;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 0;
 
     /* Add virtual layout mappings (select ALL in source space for second
      * mapping) */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_a%b", srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_all(srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_b%b", srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
 
     /* Create 2 source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset_a0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset_b0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -9957,12 +10001,12 @@ test_printf(unsigned config, hid_t fapl)
     block[0] = 5;
     block[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     count[0] = 25;
     if (H5Sselect_hyperslab(srcspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, srcspace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -9977,11 +10021,11 @@ test_printf(unsigned config, hid_t fapl)
     /* Write to srcdset[1] */
     block[1] = 10;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_all(srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, srcspace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -9991,15 +10035,15 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -10007,40 +10051,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10048,63 +10092,63 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  Make sure that the 4th slice is no longer
      * visible due to the change to H5D_VDS_FIRST_MISSING. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 5)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10112,32 +10156,32 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
-        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
     /* Create 3rd source dataset */
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset_a1", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -10147,11 +10191,11 @@ test_printf(unsigned config, hid_t fapl)
     /* Write to srcdset[2] */
     block[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_hyperslab(srcspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, srcspace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -10161,12 +10205,12 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdset[2] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[2] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -10174,40 +10218,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10215,62 +10259,62 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  There should be no change. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10278,32 +10322,32 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
-        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
     /* Create 4th source dataset */
     if ((srcdset[3] = H5Dcreate2(srcfile[0], "src_dset_a2", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -10312,9 +10356,9 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[3] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[3], H5T_NATIVE_INT, memspace, srcspace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -10324,12 +10368,12 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdset[3] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[3]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[3] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -10337,40 +10381,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 15)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10378,36 +10422,36 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Now test reopening virtual dataset without calling H5Dget_space, if
      * REOPEN_VIRT flag set */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -10415,28 +10459,28 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Now try setting extent manually */
         /* Shrink to 12 */
         dims[1] = 12;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -10444,27 +10488,27 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Shrink to 10 */
         dims[1] = 12;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -10472,63 +10516,63 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
     }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10536,36 +10580,36 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Now test reopening virtual dataset without calling H5Dget_space, if
      * REOPEN_VIRT flag set */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -10573,28 +10617,28 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Now try setting extent manually */
         /* Grow to 12 */
         dims[1] = 12;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -10602,27 +10646,27 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Grow to 15 */
         dims[1] = 15;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -10630,58 +10674,58 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
     }
 
     /* Reset dapl */
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         for (i = 0; i < 4; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[i] = -1;
         }
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /*
@@ -10690,16 +10734,16 @@ test_printf(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[1] = 1;
     if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual space */
     stride[0] = 1;
@@ -10709,88 +10753,88 @@ test_printf(unsigned config, hid_t fapl)
     block[0]  = 10;
     block[1]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilenamepct_map : ".",
                        "src_dset%b", srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilenamepct, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilenamepct, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilenamepct, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilenamepct, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
 
     /* Create 1 source dataset */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -10804,9 +10848,9 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[0] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -10815,12 +10859,12 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -10828,40 +10872,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 1)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10869,62 +10913,62 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with printf gap set to 127, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)127) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 1)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10932,63 +10976,63 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reset dapl */
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)0) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
 
     /* Close */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dcpl = -1;
     if (H5Pclose(dapl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dapl = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     memspace = -1;
 
     HDfree(srcfilename);
@@ -11000,7 +11044,7 @@ test_printf(unsigned config, hid_t fapl)
     HDfree(srcfilenamepct);
     HDfree(srcfilenamepct_map);
 
-    PASSED();
+    PASSED_SUPPRESSED();
     return 0;
 
 error:
@@ -11045,7 +11089,7 @@ error:
  *-------------------------------------------------------------------------
  */
 static int
-test_all(unsigned config, hid_t fapl)
+test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 {
     char    vfilename[FILENAME_BUF_SIZE];
     char    srcfilename[FILENAME_BUF_SIZE];
@@ -11074,52 +11118,52 @@ test_all(unsigned config, hid_t fapl)
     int     fill = -1;                          /* Fill value */
     int     i, j;
 
-    TESTING("virtual dataset I/O with mixed selection types")
+    TESTING_2_SUPPRESSED("virtual dataset I/O with mixed selection types")
 
-    h5_fixname(FILENAME[0], fapl, vfilename, sizeof vfilename);
-    h5_fixname(FILENAME[2], fapl, srcfilename, sizeof srcfilename);
-    h5_fixname_printf(FILENAME[2], fapl, srcfilename_map, sizeof srcfilename_map);
+    h5_fixname(FILENAME[0], vds_fapl, vfilename, sizeof vfilename);
+    h5_fixname(FILENAME[2], src_fapl, srcfilename, sizeof srcfilename);
+    h5_fixname_printf(FILENAME[2], src_fapl, srcfilename_map, sizeof srcfilename_map);
 
     /* Create DCPLs */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Set fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Set chunk dimensions */
     if (H5Pset_chunk(srcdcpl, 2, cdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create memory space */
     if ((memspace = H5Screate_simple(2, mdims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create fixed mapping */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 3;
     start[1] = 3;
     count[0] = 3;
     count[1] = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcspace[0] = H5Screate_simple(2, count, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_fixed", srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create unlimited mapping */
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 3;
     start[1] = 0;
     count[0] = 1;
@@ -11127,21 +11171,21 @@ test_all(unsigned config, hid_t fapl)
     block[0] = H5S_UNLIMITED;
     block[1] = 3;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dims[0] = 0;
     dims[1] = 3;
     if ((srcspace[1] = H5Screate_simple(2, dims, block)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 0;
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_unlim", srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create printf mapping */
     if ((vspace[2] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0]  = 0;
     start[1]  = 2;
     stride[0] = 1;
@@ -11151,93 +11195,93 @@ test_all(unsigned config, hid_t fapl)
     block[0]  = 3;
     block[1]  = 2;
     if (H5Sselect_hyperslab(vspace[2], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcspace[2] = H5Screate_simple(2, block, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[2], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_printf_%b", srcspace[2]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile = vfile;
         if (H5Iinc_ref(srcfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
 
     /* Create fixed source dataset */
     if ((srcdset[0] = H5Dcreate2(srcfile, "src_dset_fixed", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create unlimited source_dataset */
     if ((srcdset[1] = H5Dcreate2(srcfile, "src_dset_unlim", H5T_NATIVE_INT, srcspace[1], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -11255,9 +11299,9 @@ test_all(unsigned config, hid_t fapl)
     block[0] = 3;
     block[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 3; i++)
@@ -11268,13 +11312,13 @@ test_all(unsigned config, hid_t fapl)
     if (config & TEST_IO_CLOSE_SRC) {
         for (i = 0; i < 2; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[i] = -1;
         }
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile = -1;
         }
     }
@@ -11282,40 +11326,40 @@ test_all(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -11325,37 +11369,37 @@ test_all(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if ((i >= (int)dims[0]) || (j >= (int)dims[1])) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile, "src_dset_unlim", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[1] */
     dims[0] = 2;
     dims[1] = 3;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -11366,9 +11410,9 @@ test_all(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 2; i++)
@@ -11378,11 +11422,11 @@ test_all(unsigned config, hid_t fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile = -1;
         }
     }
@@ -11390,40 +11434,40 @@ test_all(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -11433,32 +11477,32 @@ test_all(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if ((i >= (int)dims[0]) || (j >= (int)dims[1])) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
-        if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
     /* Create first printf source dataset */
     if ((srcdset[2] = H5Dcreate2(srcfile, "src_dset_printf_0", H5T_NATIVE_INT, srcspace[2], H5P_DEFAULT,
                                  srcdcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -11471,9 +11515,9 @@ test_all(unsigned config, hid_t fapl)
     block[0] = 3;
     block[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 3; i++)
@@ -11483,11 +11527,11 @@ test_all(unsigned config, hid_t fapl)
     /* Close srcdset[2] srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[2] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile = -1;
         }
     }
@@ -11495,40 +11539,40 @@ test_all(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -11538,37 +11582,37 @@ test_all(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if ((i >= (int)dims[0]) || (j >= (int)dims[1])) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile, "src_dset_unlim", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[1] */
     dims[0] = 3;
     dims[1] = 3;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -11581,17 +11625,17 @@ test_all(unsigned config, hid_t fapl)
     block[0] = 1;
     block[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[1])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 2;
     start[1] = 0;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 3; i++)
@@ -11600,11 +11644,11 @@ test_all(unsigned config, hid_t fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile = -1;
         }
     }
@@ -11612,40 +11656,40 @@ test_all(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -11655,32 +11699,32 @@ test_all(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if ((i >= (int)dims[0]) || (j >= (int)dims[1])) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
-        if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
     /* Create second printf source dataset, this time without using srcdcpl */
     if ((srcdset[3] = H5Dcreate2(srcfile, "src_dset_printf_1", H5T_NATIVE_INT, srcspace[2], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -11693,9 +11737,9 @@ test_all(unsigned config, hid_t fapl)
     block[0] = 3;
     block[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[3], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 3; i++)
@@ -11705,11 +11749,11 @@ test_all(unsigned config, hid_t fapl)
     /* Close srcdset[3] srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[3]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[3] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile = -1;
         }
     }
@@ -11717,40 +11761,40 @@ test_all(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 7)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -11760,37 +11804,37 @@ test_all(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if ((i >= (int)dims[0]) || (j >= (int)dims[1])) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile, "src_dset_unlim", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[1] */
     dims[0] = 7;
     dims[1] = 3;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -11803,17 +11847,17 @@ test_all(unsigned config, hid_t fapl)
     block[0] = 4;
     block[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[1])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 3;
     start[1] = 0;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 4; i++)
@@ -11823,11 +11867,11 @@ test_all(unsigned config, hid_t fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile = -1;
         }
     }
@@ -11835,40 +11879,40 @@ test_all(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 7)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -11878,32 +11922,32 @@ test_all(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
-        if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
     /* Create third printf source dataset */
     if ((srcdset[4] = H5Dcreate2(srcfile, "src_dset_printf_2", H5T_NATIVE_INT, srcspace[2], H5P_DEFAULT,
                                  srcdcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -11916,9 +11960,9 @@ test_all(unsigned config, hid_t fapl)
     block[0] = 3;
     block[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[4], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 3; i++)
@@ -11928,11 +11972,11 @@ test_all(unsigned config, hid_t fapl)
     /* Close srcdset[4] srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[4]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[4] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile = -1;
         }
     }
@@ -11940,40 +11984,40 @@ test_all(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -11983,61 +12027,61 @@ test_all(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         for (i = 0; i < 5; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[i] = -1;
         }
         if (H5Fclose(srcfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     for (i = 0; i < (int)(sizeof(srcspace) / sizeof(srcspace[0])); i++) {
         if (H5Sclose(srcspace[i]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcspace[i] = -1;
     }
     for (i = 0; i < (int)(sizeof(vspace) / sizeof(vspace[0])); i++) {
         if (H5Sclose(vspace[i]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vspace[i] = -1;
     }
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dcpl = -1;
     if (H5Pclose(srcdcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdcpl = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     memspace = -1;
 
-    PASSED();
+    PASSED_SUPPRESSED();
     return 0;
 
 error:
@@ -12092,7 +12136,7 @@ test_dapl_values(hid_t fapl_id)
     hsize_t        gap_size;       /* gap size from dapl                   */
     char           filename[1024]; /* file names                           */
 
-    TESTING("H5Dget_access_plist() returns dapl w/ correct values");
+    TESTING_2("H5Dget_access_plist() returns dapl w/ correct values");
 
     /* Create the file */
     h5_fixname(FILENAME[5], fapl_id, filename, sizeof(filename));
@@ -12231,7 +12275,8 @@ main(void)
 {
     char         filename[FILENAME_BUF_SIZE];
     hid_t        fapl;
-    hid_t        my_fapl = -1; /* File access property list */
+    hid_t        vds_fapl = -1; /* File access property list */
+    hid_t        src_fapl = -1; /* File access property list */
     int          test_api_config;
     unsigned     bit_config;
     H5F_libver_t low, high; /* Low and high bounds */
@@ -12243,16 +12288,21 @@ main(void)
 
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
-    /* Set to use the latest file format */
-    if ((my_fapl = H5Pcopy(fapl)) < 0)
+    /* Create FAPLs for VDS and source files */
+    if ((vds_fapl = H5Pcopy(fapl)) < 0)
+        TEST_ERROR
+    if ((src_fapl = H5Pcopy(fapl)) < 0)
         TEST_ERROR
 
     /* Loop through all the combinations of low/high version bounds */
     for (low = H5F_LIBVER_EARLIEST; low < H5F_LIBVER_NBOUNDS; low++) {
         for (high = H5F_LIBVER_EARLIEST; high < H5F_LIBVER_NBOUNDS; high++) {
-            char        msg[80];     /* Message for file version bounds */
+            char        msg[128];    /* Message for file version bounds */
             const char *low_string;  /* The low bound string */
             const char *high_string; /* The high bound string */
+#ifndef VDS_TEST_VERBOSE
+            int tmp_nerrors;
+#endif /* VDS_TEST_VERBOSE */
 
             /* Invalid combinations, just continue */
             if (high == H5F_LIBVER_EARLIEST || high < low)
@@ -12263,39 +12313,80 @@ main(void)
                 continue;
 
             /* Set the low/high version bounds */
-            if (H5Pset_libver_bounds(my_fapl, low, high) < 0)
+            if (H5Pset_libver_bounds(vds_fapl, low, high) < 0)
+                TEST_ERROR
+            if (H5Pset_libver_bounds(src_fapl, low, high) < 0)
                 TEST_ERROR
 
             /* Display testing info */
             low_string  = h5_get_version_string(low);
             high_string = h5_get_version_string(high);
-            HDsprintf(msg, "Testing virtual dataset with file version bounds: (%s, %s):", low_string,
+            HDsnprintf(msg, sizeof(msg), "Testing virtual dataset I/O with file version bounds: (%s, %s):", low_string,
                       high_string);
             HDputs(msg);
 
             for (test_api_config = (int)TEST_API_BASIC; test_api_config < (int)TEST_API_NTESTS;
                  test_api_config++)
-                nerrors += test_api((test_api_config_t)test_api_config, my_fapl, low);
+                nerrors += test_api((test_api_config_t)test_api_config, vds_fapl, low);
+
+            TESTING_2("Virtual dataset I/O")
+#ifdef VDS_TEST_VERBOSE
+            HDputs("");
+#else /* VDS_TEST_VERBOSE */
+            tmp_nerrors = nerrors;
+#endif /* VDS_TEST_VERBOSE */
+
             for (bit_config = 0; bit_config < TEST_IO_NTESTS; bit_config++) {
-                HDprintf("Config: %s%s%s\n", bit_config & TEST_IO_CLOSE_SRC ? "closed source dataset, " : "",
+                /* Skip invalid configurations */
+                if ((bit_config & TEST_IO_FCLOSE_SEMI)
+                        && (bit_config & TEST_IO_FCLOSE_STRONG))
+                    continue;
+
+                /* Print message */
+                PRINT_CONFIG("%s%s%s, %s file close degree", bit_config & TEST_IO_CLOSE_SRC ? "closed source dataset, " : "",
                          bit_config & TEST_IO_DIFFERENT_FILE ? "different source file" : "same source file",
-                         bit_config & TEST_IO_REOPEN_VIRT ? ", reopen virtual file" : "");
-                nerrors += test_basic_io(bit_config, my_fapl);
-                nerrors += test_vds_prefix_first(bit_config, my_fapl);
-                nerrors += test_unlim(bit_config, my_fapl);
-                nerrors += test_printf(bit_config, my_fapl);
-                nerrors += test_all(bit_config, my_fapl);
+                         bit_config & TEST_IO_REOPEN_VIRT ? ", reopen virtual file" : "",
+                         bit_config & TEST_IO_FCLOSE_SEMI ? "H5F_CLOSE_SEMI" :
+                         (bit_config & TEST_IO_FCLOSE_STRONG ? "H5F_CLOSE_STRONG" : "H5F_CLOSE_WEAK"));
+
+                /* Set file close degree */
+                if (bit_config & TEST_IO_FCLOSE_SEMI) {
+                    if (H5Pset_fclose_degree(vds_fapl, H5F_CLOSE_SEMI) < 0)
+                        TEST_ERROR
+                }
+                else if (bit_config & TEST_IO_FCLOSE_STRONG) {
+                    if (H5Pset_fclose_degree(vds_fapl, H5F_CLOSE_STRONG) < 0)
+                        TEST_ERROR
+                }
+                else {
+                    if (H5Pset_fclose_degree(vds_fapl, H5F_CLOSE_WEAK) < 0)
+                        TEST_ERROR
+                }
+
+                /* Run tests */
+                nerrors += test_basic_io(bit_config, vds_fapl, src_fapl);
+                nerrors += test_vds_prefix_first(bit_config, vds_fapl, src_fapl);
+                nerrors += test_unlim(bit_config, vds_fapl, src_fapl);
+                nerrors += test_printf(bit_config, vds_fapl, src_fapl);
+                nerrors += test_all(bit_config, vds_fapl, src_fapl);
             }
 
-            nerrors += test_dapl_values(my_fapl);
+#ifndef VDS_TEST_VERBOSE
+            if(tmp_nerrors == nerrors)
+                PASSED();
+#endif /* VDS_TEST_VERBOSE */
+
+            nerrors += test_dapl_values(vds_fapl);
 
             /* Verify symbol table messages are cached */
-            nerrors += (h5_verify_cached_stabs(FILENAME, my_fapl) < 0 ? 1 : 0);
+            nerrors += (h5_verify_cached_stabs(FILENAME, vds_fapl) < 0 ? 1 : 0);
 
         } /* end for high */
     }     /* end for low */
 
-    if (H5Pclose(my_fapl) < 0)
+    if (H5Pclose(vds_fapl) < 0)
+        TEST_ERROR
+    if (H5Pclose(src_fapl) < 0)
         TEST_ERROR
 
     if (nerrors)

--- a/test/vds.c
+++ b/test/vds.c
@@ -40,8 +40,8 @@ const char *FILENAME[] = {"vds_virt_0", "vds_virt_1", "vds_src_0",  "vds_src_1",
 
 /* For verbose output just use standard error printing */
 #define TESTING_2_SUPPRESSED(WHAT) TESTING_2(WHAT)
-#define PASSED_SUPPRESSED() PASSED()
-#define TEST_ERROR_SUPPRESSED TEST_ERROR
+#define PASSED_SUPPRESSED()        PASSED()
+#define TEST_ERROR_SUPPRESSED      TEST_ERROR
 
 /* Print config directly to output */
 #define PRINT_CONFIG(...)                                                                                    \
@@ -54,7 +54,7 @@ const char *FILENAME[] = {"vds_virt_0", "vds_virt_1", "vds_src_0",  "vds_src_1",
 
 /* Global strings for error output */
 char vds_config_str_g[128] = "";
-char vds_test_str_g[128] = "";
+char vds_test_str_g[128]   = "";
 
 /* Replacement for TESTING_2 for non-verbose-output */
 #define TESTING_2_SUPPRESSED(WHAT)                                                                           \
@@ -68,7 +68,7 @@ char vds_test_str_g[128] = "";
 /* Replacement for TEST_ERROR for non-verbose output */
 #define TEST_ERROR_SUPPRESSED                                                                                \
     {                                                                                                        \
-        printf("Failed config: %s\nFailed test: %s\n", vds_config_str_g, vds_test_str_g);                     \
+        printf("Failed config: %s\nFailed test: %s\n", vds_config_str_g, vds_test_str_g);                    \
         TEST_ERROR                                                                                           \
     }
 
@@ -12321,8 +12321,9 @@ main(void)
             /* Display testing info */
             low_string  = h5_get_version_string(low);
             high_string = h5_get_version_string(high);
-            HDsnprintf(msg, sizeof(msg), "Testing virtual dataset I/O with file version bounds: (%s, %s):", low_string,
-                      high_string);
+            HDsnprintf(msg, sizeof(msg),
+                       "Testing virtual dataset I/O with file version bounds: (%s, %s):", low_string,
+                       high_string);
             HDputs(msg);
 
             for (test_api_config = (int)TEST_API_BASIC; test_api_config < (int)TEST_API_NTESTS;
@@ -12332,22 +12333,24 @@ main(void)
             TESTING_2("Virtual dataset I/O")
 #ifdef VDS_TEST_VERBOSE
             HDputs("");
-#else /* VDS_TEST_VERBOSE */
+#else  /* VDS_TEST_VERBOSE */
             tmp_nerrors = nerrors;
 #endif /* VDS_TEST_VERBOSE */
 
             for (bit_config = 0; bit_config < TEST_IO_NTESTS; bit_config++) {
                 /* Skip invalid configurations */
-                if ((bit_config & TEST_IO_FCLOSE_SEMI)
-                        && (bit_config & TEST_IO_FCLOSE_STRONG))
+                if ((bit_config & TEST_IO_FCLOSE_SEMI) && (bit_config & TEST_IO_FCLOSE_STRONG))
                     continue;
 
                 /* Print message */
-                PRINT_CONFIG("%s%s%s, %s file close degree", bit_config & TEST_IO_CLOSE_SRC ? "closed source dataset, " : "",
-                         bit_config & TEST_IO_DIFFERENT_FILE ? "different source file" : "same source file",
-                         bit_config & TEST_IO_REOPEN_VIRT ? ", reopen virtual file" : "",
-                         bit_config & TEST_IO_FCLOSE_SEMI ? "H5F_CLOSE_SEMI" :
-                         (bit_config & TEST_IO_FCLOSE_STRONG ? "H5F_CLOSE_STRONG" : "H5F_CLOSE_WEAK"));
+                PRINT_CONFIG(
+                    "%s%s%s, %s file close degree",
+                    bit_config & TEST_IO_CLOSE_SRC ? "closed source dataset, " : "",
+                    bit_config & TEST_IO_DIFFERENT_FILE ? "different source file" : "same source file",
+                    bit_config & TEST_IO_REOPEN_VIRT ? ", reopen virtual file" : "",
+                    bit_config & TEST_IO_FCLOSE_SEMI
+                        ? "H5F_CLOSE_SEMI"
+                        : (bit_config & TEST_IO_FCLOSE_STRONG ? "H5F_CLOSE_STRONG" : "H5F_CLOSE_WEAK"));
 
                 /* Set file close degree */
                 if (bit_config & TEST_IO_FCLOSE_SEMI) {
@@ -12372,7 +12375,7 @@ main(void)
             }
 
 #ifndef VDS_TEST_VERBOSE
-            if(tmp_nerrors == nerrors)
+            if (tmp_nerrors == nerrors)
                 PASSED();
 #endif /* VDS_TEST_VERBOSE */
 


### PR DESCRIPTION
Modify VDS code to always open source files with H5F_CLOSE_WEAK close degree.  Add test cases to VDS test for this, and reduce the amount of output from that test.