### PR TITLE
Port PR #291 to 1.10 branch: Allow using virtual datasets in files opened with H5F_CLOSE_SEMI and H5F_CLOSE_STRONG

### DIFF
--- a/src/H5Dvirtual.c
+++ b/src/H5Dvirtual.c
@@ -2237,7 +2237,7 @@ H5D__virtual_init(H5F_t *f, const H5D_t *dset, hid_t dapl_id)
 
     /* Retrieve VDS file FAPL to layout */
     if (storage->source_fapl <= 0) {
-        H5P_genplist_t *source_fapl = NULL;               /* Source file FAPL */
+        H5P_genplist_t *   source_fapl  = NULL;           /* Source file FAPL */
         H5F_close_degree_t close_degree = H5F_CLOSE_WEAK; /* Close degree for source files */
 
         if ((storage->source_fapl = H5F_get_access_plist(f, FALSE)) < 0)
@@ -2253,8 +2253,8 @@ H5D__virtual_init(H5F_t *f, const H5D_t *dset, hid_t dapl_id)
     } /* end if */
 #ifndef NDEBUG
     else {
-        H5P_genplist_t *source_fapl = NULL; /* Source file FAPL */
-        H5F_close_degree_t close_degree;    /* Close degree for source files */
+        H5P_genplist_t *   source_fapl = NULL; /* Source file FAPL */
+        H5F_close_degree_t close_degree;       /* Close degree for source files */
 
         /* Get property list pointer */
         if (NULL == (source_fapl = (H5P_genplist_t *)H5I_object(storage->source_fapl)))
@@ -2265,7 +2265,7 @@ H5D__virtual_init(H5F_t *f, const H5D_t *dset, hid_t dapl_id)
             HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get file close degree")
 
         HDassert(close_degree == H5F_CLOSE_WEAK);
-    } /* end else */
+    }  /* end else */
 #endif /* NDEBUG */
 
     /* Copy DAPL to layout */

--- a/test/vds.c
+++ b/test/vds.c
@@ -33,11 +33,57 @@ const char *FILENAME[] = {"vds_virt_0", "vds_virt_1", "vds_src_0",  "vds_src_1",
                           "vds_dapl",   "vds_virt_2", "vds_virt_3", "vds_src_2", "vds_src_3",
                           "vds%%_src2", "vds_dapl2",  NULL};
 
+/* Define to enable verbose test output */
+/* #define VDS_TEST_VERBOSE 1 */
+
+#ifdef VDS_TEST_VERBOSE
+
+/* For verbose output just use standard error printing */
+#define TESTING_2_SUPPRESSED(WHAT) TESTING_2(WHAT)
+#define PASSED_SUPPRESSED() PASSED()
+#define TEST_ERROR_SUPPRESSED TEST_ERROR
+
+/* Print config directly to output */
+#define PRINT_CONFIG(...)                                                                                    \
+    {                                                                                                        \
+        HDprintf("Config: " __VA_ARGS__);                                                                    \
+        HDputs("");                                                                                          \
+    }
+
+#else /* VDS_TEST_VERBOSE */
+
+/* Global strings for error output */
+char vds_config_str_g[128] = "";
+char vds_test_str_g[128] = "";
+
+/* Replacement for TESTING_2 for non-verbose-output */
+#define TESTING_2_SUPPRESSED(WHAT)                                                                           \
+    {                                                                                                        \
+        HDsnprintf(vds_test_str_g, sizeof(vds_test_str_g), WHAT);                                            \
+    }
+
+/* Suppress output from PASSED() */
+#define PASSED_SUPPRESSED()
+
+/* Replacement for TEST_ERROR for non-verbose output */
+#define TEST_ERROR_SUPPRESSED                                                                                \
+    {                                                                                                        \
+        printf("Failed config: %s\nFailed test: %s\n", vds_config_str_g, vds_test_str_g);                     \
+        TEST_ERROR                                                                                           \
+    }
+
+/* Replacement for HDprintf for printing configuration for non-verbose output */
+#define PRINT_CONFIG(...) HDsnprintf(vds_config_str_g, sizeof(vds_config_str_g), __VA_ARGS__);
+
+#endif /* VDS_TEST_VERBOSE */
+
 /* I/O test config flags */
 #define TEST_IO_CLOSE_SRC      0x01u
 #define TEST_IO_DIFFERENT_FILE 0x02u
 #define TEST_IO_REOPEN_VIRT    0x04u
-#define TEST_IO_NTESTS         0x08u
+#define TEST_IO_FCLOSE_SEMI    0x08u
+#define TEST_IO_FCLOSE_STRONG  0x10u
+#define TEST_IO_NTESTS         0x20u
 
 #define LIST_DOUBLE_SIZE (H5D_VIRTUAL_DEF_LIST_SIZE + 1)
 
@@ -485,22 +531,22 @@ test_api(test_api_config_t config, hid_t fapl)
 
     switch (config) {
         case TEST_API_BASIC:
-            TESTING("virtual dataset API functions")
+            TESTING_2("virtual dataset API functions")
             break;
         case TEST_API_COPY_PLIST:
-            TESTING("virtual dataset API functions with copied plists")
+            TESTING_2("virtual dataset API functions with copied plists")
             break;
         case TEST_API_ENCDEC_PLIST:
-            TESTING("virtual dataset API functions with encoded and decoded plists")
+            TESTING_2("virtual dataset API functions with encoded and decoded plists")
             break;
         case TEST_API_CREATE_DSET:
-            TESTING("virtual dataset create")
+            TESTING_2("virtual dataset create")
             break;
         case TEST_API_REOPEN_DSET:
-            TESTING("virtual dataset create with reopened dataset")
+            TESTING_2("virtual dataset create with reopened dataset")
             break;
         case TEST_API_REOPEN_FILE:
-            TESTING("virtual dataset create with reopened file")
+            TESTING_2("virtual dataset create with reopened file")
             break;
         case TEST_API_NTESTS:
         default:
@@ -1114,7 +1160,7 @@ error:
  *-------------------------------------------------------------------------
  */
 static int
-test_vds_prefix_first(unsigned config, hid_t fapl)
+test_vds_prefix_first(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 {
     char *      srcfilename             = NULL;
     char *      srcfilename_map         = NULL;
@@ -1138,97 +1184,97 @@ test_vds_prefix_first(unsigned config, hid_t fapl)
     int         i, j;
     char        buffer[1024]; /* buffer to read vds_prefix       */
 
-    TESTING("basic virtual dataset I/O via H5Pset_vds_prefix(): all selection")
+    TESTING_2_SUPPRESSED("basic virtual dataset I/O via H5Pset_vds_prefix(): all selection")
 
     if ((srcfilename = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilename_map = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((vfilename = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilenamepct = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilenamepct_map = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
 
-    h5_fixname(FILENAME[0], fapl, vfilename, FILENAME_BUF_SIZE);
-    h5_fixname(FILENAME[8], fapl, srcfilename, FILENAME_BUF_SIZE);
-    h5_fixname_printf(FILENAME[8], fapl, srcfilename_map, FILENAME_BUF_SIZE);
-    h5_fixname(FILENAME[10], fapl, srcfilenamepct, FILENAME_BUF_SIZE);
-    h5_fixname_printf(srcfilenamepct_map_orig, fapl, srcfilenamepct_map, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[0], vds_fapl, vfilename, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[8], src_fapl, srcfilename, FILENAME_BUF_SIZE);
+    h5_fixname_printf(FILENAME[8], src_fapl, srcfilename_map, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[10], src_fapl, srcfilenamepct, FILENAME_BUF_SIZE);
+    h5_fixname_printf(srcfilenamepct_map_orig, src_fapl, srcfilenamepct_map, FILENAME_BUF_SIZE);
 
     /* create tmp directory and get current working directory path */
     if (HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create DCPL */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Set fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Initialize VDS prefix items */
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     if (H5Pset_virtual_prefix(dapl, TMPDIR) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pget_virtual_prefix(dapl, buffer, sizeof(buffer)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     if (HDstrcmp(buffer, TMPDIR) != 0)
         FAIL_PUTS_ERROR("vds prefix not set correctly");
 
     /* Create source dataspace */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspace */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select all (should not be necessary, but just to be sure) */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_all(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if (NULL == HDgetcwd(buffer, 1024))
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (HDchdir(TMPDIR) < 0)
-            TEST_ERROR
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if (HDchdir(buffer) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source dataset */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1237,17 +1283,17 @@ test_vds_prefix_first(unsigned config, hid_t fapl)
 
     /* Write data directly to source dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -1255,27 +1301,27 @@ test_vds_prefix_first(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++) {
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j]) {
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             }
     }
 
@@ -1286,59 +1332,59 @@ test_vds_prefix_first(unsigned config, hid_t fapl)
 
     /* Write data through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (NULL == HDgetcwd(buffer, 1024))
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             if (HDchdir(TMPDIR) < 0)
-                TEST_ERROR
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, fapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
             if (HDchdir(buffer) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data directly from source dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Pclose(dapl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dapl = -1;
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dcpl = -1;
 
     HDfree(srcfilename);
@@ -1347,7 +1393,7 @@ test_vds_prefix_first(unsigned config, hid_t fapl)
     HDfree(srcfilenamepct);
     HDfree(srcfilenamepct_map);
 
-    PASSED();
+    PASSED_SUPPRESSED();
     return 0;
 
 error:
@@ -1370,7 +1416,7 @@ error:
     H5E_END_TRY;
 
     if (HDsetenv("HDF5_VDS_PREFIX", "", 1) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     HDfree(srcfilename);
     HDfree(srcfilename_map);
@@ -1392,7 +1438,7 @@ error:
  *-------------------------------------------------------------------------
  */
 static int
-test_basic_io(unsigned config, hid_t fapl)
+test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 {
     char *      srcfilename             = NULL;
     char *      srcfilename_map         = NULL;
@@ -1425,81 +1471,81 @@ test_basic_io(unsigned config, hid_t fapl)
     herr_t      ret;                                        /* Generic return value */
     int         i, j;
 
-    TESTING("basic virtual dataset I/O")
+    TESTING_2_SUPPRESSED("basic virtual dataset I/O")
 
     if ((srcfilename = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilename_map = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((vfilename = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((vfilename2 = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilenamepct = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilenamepct_map = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
 
-    h5_fixname(FILENAME[0], fapl, vfilename, FILENAME_BUF_SIZE);
-    h5_fixname(FILENAME[1], fapl, vfilename2, FILENAME_BUF_SIZE);
-    h5_fixname(FILENAME[2], fapl, srcfilename, FILENAME_BUF_SIZE);
-    h5_fixname_printf(FILENAME[2], fapl, srcfilename_map, FILENAME_BUF_SIZE);
-    h5_fixname(FILENAME[4], fapl, srcfilenamepct, FILENAME_BUF_SIZE);
-    h5_fixname_printf(srcfilenamepct_map_orig, fapl, srcfilenamepct_map, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[0], vds_fapl, vfilename, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[1], vds_fapl, vfilename2, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[2], src_fapl, srcfilename, FILENAME_BUF_SIZE);
+    h5_fixname_printf(FILENAME[2], src_fapl, srcfilename_map, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[4], src_fapl, srcfilenamepct, FILENAME_BUF_SIZE);
+    h5_fixname_printf(srcfilenamepct_map_orig, src_fapl, srcfilenamepct_map, FILENAME_BUF_SIZE);
 
     /* Create DCPL */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Set fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /*
      * Test 1: All - all selection
      */
     /* Create source dataspace */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspace */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select all (should not be necessary, but just to be sure) */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_all(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source dataset */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1508,17 +1554,17 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write data directly to source dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -1526,27 +1572,27 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1555,46 +1601,46 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write data through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data directly from source dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
 
     /*
@@ -1603,70 +1649,70 @@ test_basic_io(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[1] = 13;
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select all in source space (should not be necessary, but just to be sure)
      */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 13;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "%%src_dset1", srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset2%%", srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset dims */
     dims[1] = 26;
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "%src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2%", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1675,22 +1721,22 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write data directly to source datasets */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -1698,27 +1744,27 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1727,40 +1773,40 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write data through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "%src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2%", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data directly from source datasets */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Test H5Ocopy() to same file */
     /* Copy virtual dataset */
     if (H5Ocopy(vfile, "v_dset", vfile, "v_dset2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close v_dset */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
 
     /* Adjust write buffer */
@@ -1770,22 +1816,22 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write data directly to source datasets */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -1793,36 +1839,36 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen virtual file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Open v_dset2 */
     if ((vdset = H5Dopen2(vfile, "v_dset2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through copied virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "%src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2%", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Only copy to a different file if the source datasets are in a different
@@ -1830,16 +1876,16 @@ test_basic_io(unsigned config, hid_t fapl)
     if (config & TEST_IO_DIFFERENT_FILE) {
         /* Close v_dset2 */
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
 
         /* Create file to copy virtual dataset to */
-        if ((vfile2 = H5Fcreate(vfilename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile2 = H5Fcreate(vfilename2, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
         /* Copy virtual dataset */
         if (H5Ocopy(vfile, "v_dset", vfile2, "v_dset3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Adjust write buffer */
         for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1848,22 +1894,22 @@ test_basic_io(unsigned config, hid_t fapl)
 
         /* Write data directly to source datasets */
         if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Close srcdsets and srcfile if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (H5Dclose(srcdset[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[0] = -1;
             if (H5Dclose(srcdset[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[1] = -1;
 
             if (config & TEST_IO_DIFFERENT_FILE) {
                 if (H5Fclose(srcfile[0]) < 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
                 srcfile[0] = -1;
             }
         }
@@ -1871,68 +1917,66 @@ test_basic_io(unsigned config, hid_t fapl)
         /* Reopen copied virtual file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Fclose(vfile2) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vfile2 = -1;
-            if ((vfile2 = H5Fopen(vfilename2, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((vfile2 = H5Fopen(vfilename2, H5F_ACC_RDWR, vds_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         }
 
         /* Open v_dset3 */
         if ((vdset = H5Dopen2(vfile2, "v_dset3", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through copied virtual dataset */
         HDmemset(rbuf[0], 0, sizeof(rbuf));
         if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
             for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
                 if (rbuf[i][j] != buf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
 
         /* Reopen srcdsets and srcfile if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (config & TEST_IO_DIFFERENT_FILE)
-                if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, fapl)) < 0)
-                    TEST_ERROR
+                if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
+                    TEST_ERROR_SUPPRESSED
             if ((srcdset[0] = H5Dopen2(srcfile[0], "%src_dset1", H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2%", H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
-
-        /* Close copied virtual file */
-        if (H5Fclose(vfile2) < 0)
-            TEST_ERROR
-        vfile2 = -1;
     }
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[1] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
+    if (vfile2 >= 0 && H5Fclose(vfile2) < 0)
+        TEST_ERROR_SUPPRESSED
+    vfile2 = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /*
@@ -1940,71 +1984,71 @@ test_basic_io(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[1] = 13;
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select all in source space (should not be necessary, but just to be sure)
      */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     start[0] = 0;
     start[1] = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     offset[1] = -3;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "%%src_dset1", srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     offset[1] = 10;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset2%%", srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset dims */
     dims[1] = 26;
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "%src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2%", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2014,27 +2058,27 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Write data directly to source datasets */
     offset[1] = -3;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     offset[1] = 10;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -2042,27 +2086,27 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2071,59 +2115,59 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write data through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "%src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2%", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data directly from source datasets */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     offset[1] = -3;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     offset[1] = 10;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[1] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
 
     /*
@@ -2132,70 +2176,70 @@ test_basic_io(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[1] = 13;
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select all in source space (should not be necessary, but just to be sure)
      */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 13;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilenamepct_map : ".",
                        "src_dset1", srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilenamepct_map : ".",
                        "src_dset2", srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset dims */
     dims[1] = 26;
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilenamepct, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilenamepct, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2204,22 +2248,22 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write data directly to source datasets */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -2227,38 +2271,38 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read first source dataset through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, vspace[0], vspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != (j < (int)(sizeof(buf[0]) / sizeof(buf[0][0]) / 2) ? buf[i][j] : 0))
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Read second source dataset through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, vspace[1], vspace[1], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != (j < (int)(sizeof(buf[0]) / sizeof(buf[0][0]) / 2) ? 0 : buf[i][j]))
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2267,7 +2311,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write first source dataset through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, vspace[0], vspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2276,25 +2320,25 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write second source dataset through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, vspace[1], vspace[1], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilenamepct, H5F_ACC_RDONLY, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilenamepct, H5F_ACC_RDONLY, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data directly from source datasets */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2302,32 +2346,32 @@ test_basic_io(unsigned config, hid_t fapl)
             if (rbuf[i][j] != (j < (int)(sizeof(buf[0]) / sizeof(buf[0][0]) / 2)
                                    ? (buf[i][j] - (int)(sizeof(buf) / sizeof(buf[0][0])))
                                    : buf[i][j]))
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[1] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /*
@@ -2335,19 +2379,19 @@ test_basic_io(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspaces */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in source space */
     start[0] = 0;
@@ -2355,10 +2399,10 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 10;
     count[1] = 13;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 13;
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     start[0] = 0;
@@ -2366,45 +2410,45 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 5;
     count[1] = 26;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 5;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[1], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2414,7 +2458,7 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Write data directly to source datasets */
     /* Write first dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update evbuf */
     for (i = 0; i < 5; i++) {
@@ -2431,7 +2475,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update evbuf */
     for (i = 0; i < 5; i++) {
@@ -2444,15 +2488,15 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -2460,15 +2504,15 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data through virtual dataset by hyperslab */
@@ -2477,7 +2521,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Read first slice */
     if (H5Dread(vdset, H5T_NATIVE_INT, vspace[0], srcspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++) {
@@ -2489,7 +2533,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Read second slice */
     if (H5Dread(vdset, H5T_NATIVE_INT, vspace[1], srcspace[1], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++) {
@@ -2503,7 +2547,7 @@ test_basic_io(unsigned config, hid_t fapl)
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2513,7 +2557,7 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Write data through virtual dataset */
     /* Write first slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, vspace[0], srcspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update evbuf */
     for (i = 0; i < 5; i++) {
@@ -2530,7 +2574,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write second slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, vspace[1], srcspace[1], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update evbuf */
     for (i = 0; i < 5; i++) {
@@ -2543,12 +2587,12 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data directly from source datasets */
@@ -2557,7 +2601,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Read first dataset */
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, srcspace[0], srcspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++) {
@@ -2569,7 +2613,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Read second dataset */
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, srcspace[1], srcspace[1], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++) {
@@ -2583,35 +2627,35 @@ test_basic_io(unsigned config, hid_t fapl)
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[1] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[1] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /*
@@ -2620,25 +2664,25 @@ test_basic_io(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create memory dataspace */
     if ((memspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     dims[1] = 52;
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace and file space for second operation (srcspace[1])
      */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset dims */
     dims[1] = 26;
@@ -2654,10 +2698,10 @@ test_basic_io(unsigned config, hid_t fapl)
     block[0]  = 10;
     block[1]  = 1;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 1;
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs (checkerboard) in virtual spaces */
     start[0]  = 0;
@@ -2669,53 +2713,53 @@ test_basic_io(unsigned config, hid_t fapl)
     block[0]  = 1;
     block[1]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 1;
     start[1] = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 0;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 1;
     start[1] = 0;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2725,7 +2769,7 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Write data directly to source datasets */
     /* Write first dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i += 2)
@@ -2739,7 +2783,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 1; i < 10; i += 2)
@@ -2749,15 +2793,15 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -2765,15 +2809,15 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data through virtual dataset by hyperslab */
@@ -2782,17 +2826,17 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Read first stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Read second stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, srcspace[1], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i += 2)
@@ -2805,7 +2849,7 @@ test_basic_io(unsigned config, hid_t fapl)
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2815,7 +2859,7 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Write data through virtual dataset */
     /* Write first slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i += 2)
@@ -2829,7 +2873,7 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Write second slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, srcspace[1], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 1; i < 10; i += 2)
@@ -2839,12 +2883,12 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data directly from source datasets */
@@ -2853,13 +2897,13 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Read first dataset */
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i += 2)
@@ -2870,44 +2914,44 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Read second dataset */
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[1] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[1] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     memspace = -1;
 
     /*
@@ -2916,11 +2960,11 @@ test_basic_io(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create memory dataspace */
     if ((memspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     dims[0] = 3;
@@ -2928,18 +2972,18 @@ test_basic_io(unsigned config, hid_t fapl)
     dims[2] = 3;
     dims[3] = 3;
     if ((vspace[0] = H5Screate_simple(4, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(4, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspaces */
     dims[0] = 2;
     dims[1] = 4;
     dims[2] = 4;
     if ((srcspace[0] = H5Screate_simple(3, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcspace[1] = H5Screate_simple(3, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset dims */
     dims[0] = 10;
@@ -2959,10 +3003,10 @@ test_basic_io(unsigned config, hid_t fapl)
     block[1]  = 1;
     block[2]  = 4;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 1;
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs (corners) in first virtual space */
     start[0]  = 0;
@@ -2982,7 +3026,7 @@ test_basic_io(unsigned config, hid_t fapl)
     block[2]  = 1;
     block[3]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs ("+" pattern) in second virtual space */
     start[0]  = 1;
@@ -3002,61 +3046,61 @@ test_basic_io(unsigned config, hid_t fapl)
     block[2]  = 1;
     block[3]  = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
     start[2] = 1;
     count[1] = 2;
     count[2] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 0;
     start[1] = 1;
     count[0] = 2;
     count[1] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 1;
     count[0] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
     start[3] = 1;
     count[1] = 2;
     count[3] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source dataset */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -3069,21 +3113,21 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 2;
     count[1] = 16;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write data directly to source dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -3091,15 +3135,15 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data through virtual dataset */
@@ -3112,7 +3156,7 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 9;
     count[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset by hyperslab */
     /* Reset rbuf */
@@ -3128,11 +3172,11 @@ test_basic_io(unsigned config, hid_t fapl)
     count[2] = 1;
     count[3] = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read first stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     HDmemset(erbuf, 0, sizeof(erbuf));
@@ -3154,7 +3198,7 @@ test_basic_io(unsigned config, hid_t fapl)
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Reset rbuf */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
@@ -3169,7 +3213,7 @@ test_basic_io(unsigned config, hid_t fapl)
     count[2] = 1;
     count[3] = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslab in memory space */
     start[0] = 0;
@@ -3177,11 +3221,11 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 9;
     count[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read second stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 9; i++)
@@ -3205,10 +3249,10 @@ test_basic_io(unsigned config, hid_t fapl)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if ((j >= 3) && (j < 6)) {
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Reset rbuf */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
@@ -3223,7 +3267,7 @@ test_basic_io(unsigned config, hid_t fapl)
     count[2] = 1;
     count[3] = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslab in memory space */
     start[0] = 0;
@@ -3231,11 +3275,11 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 9;
     count[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read third stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 9; i++)
@@ -3257,10 +3301,10 @@ test_basic_io(unsigned config, hid_t fapl)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if ((j >= 6) && (j < 9)) {
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Now read entire VDS */
     /* Set memory space extent to 9x9, select all in order to reach part of the
@@ -3268,19 +3312,19 @@ test_basic_io(unsigned config, hid_t fapl)
     dims[0] = 9;
     dims[1] = 9;
     if (H5Sset_extent_simple(memspace, 2, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_all(memspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read third stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf99[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(rbuf99) / sizeof(rbuf99[0])); i++)
         for (j = 0; j < (int)(sizeof(rbuf99[0]) / sizeof(rbuf99[0][0])); j++)
             if (rbuf99[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -3302,7 +3346,7 @@ test_basic_io(unsigned config, hid_t fapl)
     count[2]  = 1;
     count[3]  = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0]  = 1;
     start[1]  = 1;
     start[2]  = 0;
@@ -3316,7 +3360,7 @@ test_basic_io(unsigned config, hid_t fapl)
     count[2]  = 1;
     count[3]  = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_OR, start, stride, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset extent of memspace, select hyperslab */
     dims[0] = 10;
@@ -3328,12 +3372,12 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 1;
     count[1] = 10;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write data through virtual dataset by hyperslab */
     /* Write first stripe pattern */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     HDmemset(erbuf, 0, sizeof(erbuf));
@@ -3389,11 +3433,11 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 1;
     count[1] = 12;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write second slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     erbuf[0][4]  = buf[0][0];
@@ -3450,11 +3494,11 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 1;
     count[1] = 10;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write third slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     erbuf[0][2]  = buf[0][0];
@@ -3471,10 +3515,10 @@ test_basic_io(unsigned config, hid_t fapl)
     /* Reopen srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read data directly from source dataset */
@@ -3484,20 +3528,20 @@ test_basic_io(unsigned config, hid_t fapl)
     count[0] = 2;
     count[1] = 16;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reset rbuf */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
 
     /* Read dataset */
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Now try writing to whole VDS (should fail due to unmapped elements) */
     count[0] = 9;
@@ -3511,36 +3555,36 @@ test_basic_io(unsigned config, hid_t fapl)
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
         TEST_ERROR
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(srcspace[1]) < 0)
         TEST_ERROR
     srcspace[1] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     memspace = -1;
 
     /* Close */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dcpl = -1;
 
     HDfree(srcfilename);
@@ -3550,7 +3594,7 @@ test_basic_io(unsigned config, hid_t fapl)
     HDfree(srcfilenamepct);
     HDfree(srcfilenamepct_map);
 
-    PASSED();
+    PASSED_SUPPRESSED();
     return 0;
 
 error:
@@ -3592,7 +3636,7 @@ error:
  *-------------------------------------------------------------------------
  */
 static int
-test_unlim(unsigned config, hid_t fapl)
+test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 {
     char           srcfilename[FILENAME_BUF_SIZE];
     char           srcfilename_map[FILENAME_BUF_SIZE];
@@ -3623,52 +3667,52 @@ test_unlim(unsigned config, hid_t fapl)
     H5D_vds_view_t virtual_view;                   /* Virtual view property */
     int            i, j;
 
-    TESTING("virtual dataset I/O with unlimited selections")
+    TESTING_2_SUPPRESSED("virtual dataset I/O with unlimited selections")
 
-    h5_fixname(FILENAME[0], fapl, vfilename, sizeof vfilename);
-    h5_fixname(FILENAME[2], fapl, srcfilename, sizeof srcfilename);
-    h5_fixname_printf(FILENAME[2], fapl, srcfilename_map, sizeof srcfilename_map);
+    h5_fixname(FILENAME[0], vds_fapl, vfilename, sizeof vfilename);
+    h5_fixname(FILENAME[2], src_fapl, srcfilename, sizeof srcfilename);
+    h5_fixname_printf(FILENAME[2], src_fapl, srcfilename_map, sizeof srcfilename_map);
 
     /* Create DCPLs */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Set fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Set chunk dimensions */
     if (H5Pset_chunk(srcdcpl, 2, cdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create DAPL */
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create memory space */
     if ((memspace = H5Screate_simple(2, mdims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /*
      * Test 1: 2 Source datasets, single unlimited hyperslab virtual mappings
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[0]  = 5;
     mdims[0] = 5;
     if ((srcspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     mdims[0] = 10;
 
     /* Select hyperslab in source space */
@@ -3677,49 +3721,49 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 5;
     count[1] = H5S_UNLIMITED;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 5;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -3736,11 +3780,11 @@ test_unlim(unsigned config, hid_t fapl)
     start[0] = 0;
     count[1] = 10;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write first dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -3754,7 +3798,7 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -3764,15 +3808,15 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -3780,40 +3824,40 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -3822,74 +3866,74 @@ test_unlim(unsigned config, hid_t fapl)
     /* Select hyperslab in memory space */
     start[0] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Test H5Pget_virtual_view() */
     if (H5Pget_virtual_view(dapl, &virtual_view) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (virtual_view != H5D_VDS_LAST_AVAILABLE)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Test H5Pget_virtual_view() */
     if (H5Pget_virtual_view(dapl, &virtual_view) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (virtual_view != H5D_VDS_FIRST_MISSING)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -3897,33 +3941,33 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[0] */
     dims[0] = 5;
     dims[1] = 15;
     if (H5Dset_extent(srcdset[0], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -3933,26 +3977,26 @@ test_unlim(unsigned config, hid_t fapl)
     /* Write to new area of srcdset */
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[0])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 10;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -3960,42 +4004,42 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  Note that since we are using
      * H5D_VDS_FIRST_MISSING and we only extended one source dataset the
      * dimensions will not have changed. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4004,38 +4048,38 @@ test_unlim(unsigned config, hid_t fapl)
     /* Select hyperslab in memory space */
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf to reflect new data that is now visible due to the change to
      * H5D_VDS_LAST_AVAILABLE */
@@ -4045,27 +4089,27 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 15)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4074,37 +4118,37 @@ test_unlim(unsigned config, hid_t fapl)
     /* Select hyperslab in memory space */
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[1] */
     dims[0] = 5;
     dims[1] = 20;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -4114,16 +4158,16 @@ test_unlim(unsigned config, hid_t fapl)
     /* Write to new area of srcdset */
     count[1] = 10;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[1])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 10;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -4133,12 +4177,12 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -4146,40 +4190,40 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4188,17 +4232,17 @@ test_unlim(unsigned config, hid_t fapl)
     /* Select hyperslab in memory space */
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Now just read middle 2 rows */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
@@ -4206,9 +4250,9 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 2;
     count[1] = 20;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, memspace, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data - algorithmically check for only 2 middle rows being
      * read so we don't have to wipe out erbuf and then restore it afterwards */
@@ -4216,24 +4260,24 @@ test_unlim(unsigned config, hid_t fapl)
         for (j = 0; j < (int)mdims[1]; j++)
             if ((i == 4) || (i == 5)) {
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Now test reopening virtual dataset without calling H5Dget_space, if
      * REOPEN_VIRT flag set */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -4243,23 +4287,23 @@ test_unlim(unsigned config, hid_t fapl)
         start[0] = 0;
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++)
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
 
         /* Now try setting extent manually */
         /* Shrink to 18 */
         dims[1] = 18;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -4269,27 +4313,27 @@ test_unlim(unsigned config, hid_t fapl)
         start[0] = 0;
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Shrink to 15 */
         dims[1] = 15;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -4299,63 +4343,63 @@ test_unlim(unsigned config, hid_t fapl)
         start[0] = 0;
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
     }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 15)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4365,36 +4409,36 @@ test_unlim(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Now test reopening virtual dataset without calling H5Dget_space, if
      * REOPEN_VIRT flag set */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -4403,28 +4447,28 @@ test_unlim(unsigned config, hid_t fapl)
         /* Select hyperslab in memory space */
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Now try setting extent manually */
         /* Grow to 18 */
         dims[1] = 18;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -4434,27 +4478,27 @@ test_unlim(unsigned config, hid_t fapl)
         start[0] = 0;
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Grow to 20 */
         dims[1] = 20;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -4464,50 +4508,50 @@ test_unlim(unsigned config, hid_t fapl)
         start[0] = 0;
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++)
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
     }
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /*
@@ -4515,21 +4559,21 @@ test_unlim(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     dims[0] = 10;
     dims[1] = 10;
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[1]  = 5;
     mdims[1] = 10;
     if ((srcspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     mdims[1] = 20;
 
     /* Select hyperslab in source space */
@@ -4538,7 +4582,7 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 10;
     count[1] = H5S_UNLIMITED;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     stride[0] = 1;
@@ -4548,46 +4592,46 @@ test_unlim(unsigned config, hid_t fapl)
     block[0]  = 10;
     block[1]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -4604,11 +4648,11 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 10;
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write first dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -4622,7 +4666,7 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -4632,15 +4676,15 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -4648,40 +4692,40 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4689,62 +4733,62 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4752,32 +4796,32 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[0] */
     dims[1] = 7;
     if (H5Dset_extent(srcdset[0], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -4787,17 +4831,17 @@ test_unlim(unsigned config, hid_t fapl)
     /* Write to new area of srcdset */
     count[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[0])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 5;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf to reflect only new data that is now visible under
      * H5D_VDS_FIRST_MISSING (first slice) */
@@ -4807,12 +4851,12 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -4820,42 +4864,42 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  Note that since we are using
      * H5D_VDS_FIRST_MISSING and we only extended one source dataset the
      * dimension will only have changed to add one more slice. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 11)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4863,38 +4907,38 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf to reflect new data that is now visible due to the change to
      * H5D_VDS_LAST_AVAILABLE (second new slice) */
@@ -4903,27 +4947,27 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 13)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4931,36 +4975,36 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[1] */
     dims[1] = 10;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -4970,17 +5014,17 @@ test_unlim(unsigned config, hid_t fapl)
     /* Write to new area of srcdset */
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[1])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 5;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -4990,12 +5034,12 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -5003,40 +5047,40 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5044,17 +5088,17 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Now just read middle 2 rows */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
@@ -5062,10 +5106,10 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 2;
     count[1] = 20;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 0;
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, memspace, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data - algorithmically check for only 2 middle rows being
      * read so we don't have to wipe out erbuf and then restore it afterwards */
@@ -5073,26 +5117,26 @@ test_unlim(unsigned config, hid_t fapl)
         for (j = 0; j < (int)mdims[1]; j++)
             if ((i == 4) || (i == 5)) {
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf to reflect new data that is no longer visible due to the
      * change to H5D_VDS_FIRST_MISSING */
@@ -5102,27 +5146,27 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 14)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5130,54 +5174,54 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /*
@@ -5185,31 +5229,31 @@ test_unlim(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     dims[0] = 10;
     dims[1] = 10;
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[2] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspaces */
     dims[1]  = 4;
     mdims[1] = 8;
     if ((srcspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dims[1]  = 4;
     mdims[1] = 6;
     if ((srcspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dims[1]  = 2;
     mdims[1] = 6;
     if ((srcspace[2] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     mdims[1] = 20;
 
     /* Select hyperslab in source spaces */
@@ -5218,11 +5262,11 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 10;
     count[1] = H5S_UNLIMITED;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_hyperslab(srcspace[2], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     stride[0] = 1;
@@ -5232,55 +5276,55 @@ test_unlim(unsigned config, hid_t fapl)
     block[0]  = 10;
     block[1]  = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 2;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 4;
     if (H5Sselect_hyperslab(vspace[2], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[2], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset3",
                        srcspace[2]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[1], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset3", H5T_NATIVE_INT, srcspace[2], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -5297,11 +5341,11 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 10;
     count[1] = 4;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write first dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -5317,7 +5361,7 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -5335,11 +5379,11 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 10;
     count[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write third dataset */
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++) {
@@ -5350,18 +5394,18 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[2] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -5369,40 +5413,40 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5410,62 +5454,62 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5473,32 +5517,32 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[0] */
     dims[1] = 7;
     if (H5Dset_extent(srcdset[0], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -5508,27 +5552,27 @@ test_unlim(unsigned config, hid_t fapl)
     /* Write to new area of srcdset */
     count[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[0])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 4;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -5536,41 +5580,41 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  Note that since we are using
      * H5D_VDS_FIRST_MISSING the size will not have changed. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5578,38 +5622,38 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf to reflect new data that is now visible due to the change to
      * H5D_VDS_LAST_AVAILABLE */
@@ -5621,27 +5665,27 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 19)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5649,36 +5693,36 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[2] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[2] = H5Dopen2(srcfile[0], "src_dset3", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[2] */
     dims[1] = 5;
     if (H5Dset_extent(srcdset[2], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -5688,17 +5732,17 @@ test_unlim(unsigned config, hid_t fapl)
     /* Write to new area of srcdset */
     count[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[2])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 2;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++) {
@@ -5710,12 +5754,12 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdset[2] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[2] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -5723,41 +5767,41 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  Note that the dimensions will not have
      * changed. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 19)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5765,62 +5809,62 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 14)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5828,36 +5872,36 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[1] */
     dims[1] = 6;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -5867,17 +5911,17 @@ test_unlim(unsigned config, hid_t fapl)
     /* Write to new area of srcdset */
     count[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[1])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 4;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++) {
@@ -5888,12 +5932,12 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -5901,40 +5945,40 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 17)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5942,58 +5986,58 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 19)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6001,21 +6045,21 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Now just read middle 2 rows */
@@ -6024,16 +6068,16 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 2;
     count[1] = 19;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 0;
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data - algorithmically check for only 2 middle rows being
      * read */
@@ -6041,55 +6085,55 @@ test_unlim(unsigned config, hid_t fapl)
         for (j = 0; j < (int)mdims[1]; j++)
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if ((i == 4) || (i == 5)) {
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[2] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[1] = -1;
     if (H5Sclose(srcspace[2]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[2] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /*
@@ -6097,23 +6141,23 @@ test_unlim(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspaces */
     dims[0]  = 5;
     dims[1]  = 0;
     mdims[0] = 5;
     if ((srcspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dims[1] = 5;
     if ((srcspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     mdims[0] = 10;
 
     /* Select hyperslab in source spaces */
@@ -6122,53 +6166,53 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 5;
     count[1] = H5S_UNLIMITED;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     start[1] = 10;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 5;
     start[1] = 0;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[1], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -6187,11 +6231,11 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 5;
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -6201,15 +6245,15 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -6217,40 +6261,40 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 5)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6260,62 +6304,62 @@ test_unlim(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 5)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6323,33 +6367,33 @@ test_unlim(unsigned config, hid_t fapl)
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[0] */
     dims[0] = 5;
     dims[1] = 5;
     if (H5Dset_extent(srcdset[0], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -6362,9 +6406,9 @@ test_unlim(unsigned config, hid_t fapl)
     count[0] = 5;
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -6374,12 +6418,12 @@ test_unlim(unsigned config, hid_t fapl)
     /* Close srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -6387,40 +6431,40 @@ test_unlim(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 5)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6430,62 +6474,62 @@ test_unlim(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 15)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6495,74 +6539,74 @@ test_unlim(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[0] = -1;
     if (H5Sclose(srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace[1] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /* Close */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dcpl = -1;
     if (H5Pclose(srcdcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dcpl = -1;
     if (H5Pclose(dapl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dapl = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     memspace = -1;
 
-    PASSED();
+    PASSED_SUPPRESSED();
     return 0;
 
 error:
@@ -6600,7 +6644,7 @@ error:
  *-------------------------------------------------------------------------
  */
 static int
-test_printf(unsigned config, hid_t fapl)
+test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 {
     char *      srcfilename                 = NULL;
     char *      srcfilename_map             = NULL;
@@ -6636,65 +6680,65 @@ test_printf(unsigned config, hid_t fapl)
     hsize_t     gap_size;                                               /* Gap size property */
     int         i, j;
 
-    TESTING("virtual dataset I/O with printf source")
+    TESTING_2_SUPPRESSED("virtual dataset I/O with printf source")
 
     if ((srcfilename = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilename_map = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilename2 = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilename2_map = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((vfilename = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((printf_srcfilename_map = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilenamepct = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
     if ((srcfilenamepct_map = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
-        TEST_ERROR;
+        TEST_ERROR_SUPPRESSED;
 
-    h5_fixname(FILENAME[0], fapl, vfilename, FILENAME_BUF_SIZE);
-    h5_fixname(FILENAME[2], fapl, srcfilename, FILENAME_BUF_SIZE);
-    h5_fixname_printf(FILENAME[2], fapl, srcfilename_map, FILENAME_BUF_SIZE);
-    h5_fixname(FILENAME[3], fapl, srcfilename2, FILENAME_BUF_SIZE);
-    h5_fixname_printf(FILENAME[2], fapl, srcfilename2_map, FILENAME_BUF_SIZE);
-    h5_fixname_printf(printf_srcfilename_map_orig, fapl, printf_srcfilename_map, FILENAME_BUF_SIZE);
-    h5_fixname(FILENAME[4], fapl, srcfilenamepct, FILENAME_BUF_SIZE);
-    h5_fixname_printf(srcfilenamepct_map_orig, fapl, srcfilenamepct_map, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[0], vds_fapl, vfilename, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[2], src_fapl, srcfilename, FILENAME_BUF_SIZE);
+    h5_fixname_printf(FILENAME[2], src_fapl, srcfilename_map, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[3], src_fapl, srcfilename2, FILENAME_BUF_SIZE);
+    h5_fixname_printf(FILENAME[2], src_fapl, srcfilename2_map, FILENAME_BUF_SIZE);
+    h5_fixname_printf(printf_srcfilename_map_orig, src_fapl, printf_srcfilename_map, FILENAME_BUF_SIZE);
+    h5_fixname(FILENAME[4], src_fapl, srcfilenamepct, FILENAME_BUF_SIZE);
+    h5_fixname_printf(srcfilenamepct_map_orig, src_fapl, srcfilenamepct_map, FILENAME_BUF_SIZE);
 
     /* Create DCPL */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Set fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create DAPL */
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create memory space */
     if ((memspace = H5Screate_simple(2, mdims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /*
      * Test 1: 1 Source dataset mapping, 10x5 blocks
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspace */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[1] = 5;
     if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual space */
     stride[0] = 1;
@@ -6704,91 +6748,91 @@ test_printf(unsigned config, hid_t fapl)
     block[0]  = 10;
     block[1]  = 5;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset%b",
                        srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
 
     /* Create 2 source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -6802,9 +6846,9 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[0] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -6818,7 +6862,7 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[1] */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -6828,15 +6872,15 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -6844,40 +6888,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6885,32 +6929,32 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
-        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
     /* Create 3rd source dataset */
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -6919,9 +6963,9 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[2] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -6931,12 +6975,12 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdset[2] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[2] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -6944,36 +6988,36 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 15)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6981,21 +7025,21 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Now try with different selections */
@@ -7007,25 +7051,25 @@ test_printf(unsigned config, hid_t fapl)
 
             /* Select hyperslab in memory space */
             if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
             /* Select hyperslab in file space */
             if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
             /* Read data */
             if (H5Dread(vdset, H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, rbuf[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
             /* Verify read data */
             for (i = 0; i < (int)mdims[0]; i++)
                 for (j = 0; j < (int)mdims[1]; j++) {
                     if ((j < (int)start[1]) || (j >= (int)(start[1] + count[1]))) {
                         if (rbuf[i][j] != 0)
-                            TEST_ERROR
+                            TEST_ERROR_SUPPRESSED
                     }
                     else if (rbuf[i][j] != erbuf[i][j])
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
         }
     start[1] = 0;
@@ -7033,11 +7077,11 @@ test_printf(unsigned config, hid_t fapl)
     /* Now try writing through VDS */
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslab in file space */
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -7046,83 +7090,83 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write data through VDS */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset0", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[2] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Read srcdset[0] */
     count[0] = 10;
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < 10; i++)
         for (j = 0; j < 5; j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Read srcdset[1] */
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < 10; i++)
         for (j = 0; j < 5; j++)
             if (rbuf[i][j] != buf[i][j + 5])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Read srcdset[2] */
     if (H5Dread(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < 10; i++)
         for (j = 0; j < 5; j++)
             if (rbuf[i][j] != buf[i][j + 10])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[1] = -1;
     if (H5Dclose(srcdset[2]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdset[2] = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcfile[0] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
 
     /*
@@ -7131,16 +7175,16 @@ test_printf(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[1] = 1;
     if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual space */
     stride[0] = 1;
@@ -7150,104 +7194,104 @@ test_printf(unsigned config, hid_t fapl)
     block[0]  = 10;
     block[1]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilenamepct_map : ".",
                        "src_dset%b", srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilenamepct, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilenamepct, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilenamepct, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilenamepct, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
 
     /* Create source datasets in a pattern with increasing gaps:
      * XX-X--X---X----X */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset3", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[3] = H5Dcreate2(srcfile[0], "src_dset6", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[4] = H5Dcreate2(srcfile[0], "src_dset10", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[5] = H5Dcreate2(srcfile[0], "src_dset15", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -7261,9 +7305,9 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[0] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -7276,7 +7320,7 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[1] */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -7289,7 +7333,7 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[2] */
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -7302,7 +7346,7 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[3] */
     if (H5Dwrite(srcdset[3], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -7315,7 +7359,7 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[4] */
     if (H5Dwrite(srcdset[4], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -7328,7 +7372,7 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[5] */
     if (H5Dwrite(srcdset[5], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -7338,13 +7382,13 @@ test_printf(unsigned config, hid_t fapl)
     if (config & TEST_IO_CLOSE_SRC) {
         for (i = 0; i < 6; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[i] = -1;
         }
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -7352,40 +7396,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7393,74 +7437,74 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Test H5Pget_virtual_printf_gap() */
     if (H5Pget_virtual_printf_gap(dapl, &gap_size) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (gap_size != (hsize_t)0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close VDS and reopen with printf gap set to 1, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)1) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Test H5Pget_virtual_printf_gap() */
     if (H5Pget_virtual_printf_gap(dapl, &gap_size) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (gap_size != (hsize_t)1)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 4)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7468,68 +7512,68 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with printf gap set to 2, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)2) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Test H5Pget_virtual_printf_gap() */
     if (H5Pget_virtual_printf_gap(dapl, &gap_size) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (gap_size != (hsize_t)2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 7)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7537,68 +7581,68 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with printf gap set to 3, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)3) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Test H5Pget_virtual_printf_gap() */
     if (H5Pget_virtual_printf_gap(dapl, &gap_size) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (gap_size != (hsize_t)3)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 11)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7606,68 +7650,68 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with printf gap set to 4, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)4) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Test H5Pget_virtual_printf_gap() */
     if (H5Pget_virtual_printf_gap(dapl, &gap_size) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (gap_size != (hsize_t)4)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 16)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7675,62 +7719,62 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7738,56 +7782,56 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reset dapl */
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)0) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         for (i = 0; i < 6; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[i] = -1;
         }
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
 
     /* Next 2 tests are always run with a different source file, so only run if
@@ -7798,21 +7842,21 @@ test_printf(unsigned config, hid_t fapl)
          * Test 3: 1 Source dataset mapping, 10x5 blocks, printf source file
          */
         /* Clean up files so the source files do not exist yet */
-        H5Iinc_ref(fapl); /* Prevent FAPL from being closed */
-        h5_clean_files(FILENAME, fapl);
+        H5Iinc_ref(vds_fapl); /* Prevent FAPL from being closed */
+        h5_clean_files(FILENAME, vds_fapl);
 
         /* Clear virtual layout in DCPL */
         if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Create virtual dataspaces */
         if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Create source dataspace */
         dims[1] = 5;
         if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Select hyperslabs in virtual space */
         stride[0] = 1;
@@ -7822,66 +7866,66 @@ test_printf(unsigned config, hid_t fapl)
         block[0]  = 10;
         block[1]  = 5;
         if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Add virtual layout mapping */
         if (H5Pset_virtual(dcpl, vspace[0], printf_srcfilename_map, "src_dset", srcspace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Create virtual file */
-        if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
         /* Create virtual dataset */
         if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vfile = -1;
-            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (ndims != 2)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[1] != 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[1] != 20)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Create 2 source files, one source dataset */
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                      H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
-        if ((srcfile[1] = H5Fcreate(srcfilename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
+        if ((srcfile[1] = H5Fcreate(srcfilename2, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
         /* Populate write buffer */
         for (i = 0; i < (int)mdims[0]; i++)
@@ -7895,9 +7939,9 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Write to srcdset[0] */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Update erbuf */
         for (i = 0; i < 10; i++)
@@ -7907,53 +7951,53 @@ test_printf(unsigned config, hid_t fapl)
         /* Close srcdset and srcfiles if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (H5Dclose(srcdset[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[0] = -1;
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[1] = -1;
         }
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vfile = -1;
-            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (ndims != 2)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[1] != 5)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[1] != 20)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -7961,32 +8005,32 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Reopen srcfile[1] if config option specified */
         if (config & TEST_IO_CLOSE_SRC)
-            if ((srcfile[1] = H5Fopen(srcfilename2, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[1] = H5Fopen(srcfilename2, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
 
         /* Create 2nd source dataset */
         if ((srcdset[1] = H5Dcreate2(srcfile[1], "src_dset", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                      H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Adjust write buffer */
         for (i = 0; i < (int)mdims[0]; i++)
@@ -7995,9 +8039,9 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Write to srcdset[1] */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Update erbuf */
         for (i = 0; i < 10; i++)
@@ -8007,50 +8051,50 @@ test_printf(unsigned config, hid_t fapl)
         /* Close srcdset[1] and srcfile[1] if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (H5Dclose(srcdset[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[1] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[1] = -1;
         }
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vfile = -1;
-            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (ndims != 2)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[1] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[1] != 20)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -8058,49 +8102,49 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Close */
         if (!(config & TEST_IO_CLOSE_SRC)) {
             if (H5Dclose(srcdset[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[0] = -1;
             if (H5Dclose(srcdset[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[1] = -1;
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[1] = -1;
         }
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
         if (H5Sclose(srcspace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcspace = -1;
         if (H5Sclose(vspace[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vspace[0] = -1;
 
         /*
@@ -8108,21 +8152,21 @@ test_printf(unsigned config, hid_t fapl)
          * source dset, extra %%s in source dataset name
          */
         /* Clean up files so the source files do not exist yet */
-        H5Iinc_ref(fapl); /* Prevent FAPL from being closed */
-        h5_clean_files(FILENAME, fapl);
+        H5Iinc_ref(vds_fapl); /* Prevent FAPL from being closed */
+        h5_clean_files(FILENAME, vds_fapl);
 
         /* Clear virtual layout in DCPL */
         if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Create virtual dataspaces */
         if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Create source dataspace */
         dims[1] = 5;
         if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Select hyperslabs in virtual space */
         stride[0] = 1;
@@ -8132,66 +8176,66 @@ test_printf(unsigned config, hid_t fapl)
         block[0]  = 10;
         block[1]  = 5;
         if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Add virtual layout mapping */
         if (H5Pset_virtual(dcpl, vspace[0], printf_srcfilename_map, "%%src%%_dset%%%b", srcspace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Create virtual file */
-        if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
         /* Create virtual dataset */
         if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vfile = -1;
-            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (ndims != 2)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[1] != 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[1] != 20)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Create 2 source files, one source dataset */
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((srcdset[0] = H5Dcreate2(srcfile[0], "%src%_dset%0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                      H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
-        if ((srcfile[1] = H5Fcreate(srcfilename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
+        if ((srcfile[1] = H5Fcreate(srcfilename2, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
         /* Populate write buffer */
         for (i = 0; i < (int)mdims[0]; i++)
@@ -8205,9 +8249,9 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Write to srcdset[0] */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Update erbuf */
         for (i = 0; i < 10; i++)
@@ -8217,53 +8261,53 @@ test_printf(unsigned config, hid_t fapl)
         /* Close srcdset and srcfiles if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (H5Dclose(srcdset[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[0] = -1;
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[1] = -1;
         }
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vfile = -1;
-            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (ndims != 2)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[1] != 5)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[1] != 20)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -8271,32 +8315,32 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Reopen srcfile[1] if config option specified */
         if (config & TEST_IO_CLOSE_SRC)
-            if ((srcfile[1] = H5Fopen(srcfilename2, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[1] = H5Fopen(srcfilename2, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
 
         /* Create 2nd source dataset */
         if ((srcdset[1] = H5Dcreate2(srcfile[1], "%src%_dset%1", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                      H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Adjust write buffer */
         for (i = 0; i < (int)mdims[0]; i++)
@@ -8305,9 +8349,9 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Write to srcdset[1] */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Update erbuf */
         for (i = 0; i < 10; i++)
@@ -8317,50 +8361,50 @@ test_printf(unsigned config, hid_t fapl)
         /* Close srcdset[1] and srcfile[1] if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (H5Dclose(srcdset[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[1] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[1] = -1;
         }
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             vfile = -1;
-            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (ndims != 2)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (dims[1] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[0] != 10)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         if (mdims[1] != 20)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -8368,49 +8412,49 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Close */
         if (!(config & TEST_IO_CLOSE_SRC)) {
             if (H5Dclose(srcdset[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[0] = -1;
             if (H5Dclose(srcdset[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[1] = -1;
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[1] = -1;
         }
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
         if (H5Sclose(srcspace) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcspace = -1;
         if (H5Sclose(vspace[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vspace[0] = -1;
     }
 
@@ -8420,26 +8464,26 @@ test_printf(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     dims[0] = 10;
     dims[1] = 10;
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace (2 elements wide) */
     dims[1] = 2;
     if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslab in source space */
     count[0] = 10;
     count[1] = 1;
     if (H5Sselect_hyperslab(srcspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     stride[0] = 1;
@@ -8449,98 +8493,98 @@ test_printf(unsigned config, hid_t fapl)
     block[0]  = 10;
     block[1]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[1] = 0;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "%bsrc_dset_a%b%%", srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_b%b%%%%", srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
 
     /* Create 2 source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "0src_dset_a0%", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset_b0%%", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -8556,9 +8600,9 @@ test_printf(unsigned config, hid_t fapl)
     block[0] = 10;
     block[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -8571,7 +8615,7 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[1] */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -8580,15 +8624,15 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -8596,40 +8640,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8637,32 +8681,32 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
-        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
     /* Create 3rd source dataset */
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset_b1%%", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -8671,9 +8715,9 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[2] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -8682,12 +8726,12 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdset[2] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[2] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -8695,40 +8739,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 4)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8736,63 +8780,63 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  Make sure that the 4th slice is no longer
      * visible due to the change to H5D_VDS_FIRST_MISSING. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8800,32 +8844,32 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
-        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
     /* Create 4th source dataset */
     if ((srcdset[3] = H5Dcreate2(srcfile[0], "2src_dset_a2%", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -8834,9 +8878,9 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[3] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[3], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -8845,12 +8889,12 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdset[3] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[3]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[3] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -8858,40 +8902,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8899,63 +8943,63 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  Make sure that the 4th slice is now visible
      * due to the change to H5D_VDS_LAST_AVAILABLE. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 4)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8963,63 +9007,63 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with printf_gap set to 1, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)1) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  Make sure that the 6th slice is now visible
      * due to the change to printf_gap. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 5)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9027,59 +9071,59 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reset dapl */
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)0) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         for (i = 0; i < 4; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[i] = -1;
         }
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /*
@@ -9087,25 +9131,25 @@ test_printf(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     dims[0] = 10;
     dims[1] = 10;
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace (1 dimensional) */
     dims[0] = 50;
     if ((srcspace = H5Screate_simple(1, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslab in source space */
     count[0] = 25;
     if (H5Sselect_hyperslab(srcspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual spaces */
     stride[0] = 1;
@@ -9115,103 +9159,103 @@ test_printf(unsigned config, hid_t fapl)
     block[0]  = 5;
     block[1]  = 5;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0]  = 5;
     stride[1] = 10;
     block[1]  = 10;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 0;
 
     /* Add virtual layout mappings (select ALL in source space for second
      * mapping) */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_a%b", srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_all(srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_b%b", srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
 
     /* Create 2 source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset_a0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset_b0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -9227,12 +9271,12 @@ test_printf(unsigned config, hid_t fapl)
     block[0] = 5;
     block[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     count[0] = 25;
     if (H5Sselect_hyperslab(srcspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, srcspace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -9247,11 +9291,11 @@ test_printf(unsigned config, hid_t fapl)
     /* Write to srcdset[1] */
     block[1] = 10;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_all(srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, srcspace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -9261,15 +9305,15 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -9277,40 +9321,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9318,63 +9362,63 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  Make sure that the 4th slice is no longer
      * visible due to the change to H5D_VDS_FIRST_MISSING. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 5)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9382,32 +9426,32 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
-        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
     /* Create 3rd source dataset */
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset_a1", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -9417,11 +9461,11 @@ test_printf(unsigned config, hid_t fapl)
     /* Write to srcdset[2] */
     block[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sselect_hyperslab(srcspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, srcspace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -9431,12 +9475,12 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdset[2] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[2] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -9444,40 +9488,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9485,62 +9529,62 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions.  There should be no change. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9548,32 +9592,32 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
-        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
     /* Create 4th source dataset */
     if ((srcdset[3] = H5Dcreate2(srcfile[0], "src_dset_a2", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -9582,9 +9626,9 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[3] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[3], H5T_NATIVE_INT, memspace, srcspace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -9594,12 +9638,12 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdset[3] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[3]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[3] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -9607,40 +9651,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 15)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9648,36 +9692,36 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Now test reopening virtual dataset without calling H5Dget_space, if
      * REOPEN_VIRT flag set */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -9685,28 +9729,28 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Now try setting extent manually */
         /* Shrink to 12 */
         dims[1] = 12;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -9714,27 +9758,27 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Shrink to 10 */
         dims[1] = 12;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -9742,63 +9786,63 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
     }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9806,36 +9850,36 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Now test reopening virtual dataset without calling H5Dget_space, if
      * REOPEN_VIRT flag set */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -9843,28 +9887,28 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Now try setting extent manually */
         /* Grow to 12 */
         dims[1] = 12;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -9872,27 +9916,27 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
 
         /* Grow to 15 */
         dims[1] = 15;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -9900,58 +9944,58 @@ test_printf(unsigned config, hid_t fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR
+                        TEST_ERROR_SUPPRESSED
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
     }
 
     /* Reset dapl */
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         for (i = 0; i < 4; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[i] = -1;
         }
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[1] = -1;
 
     /*
@@ -9960,16 +10004,16 @@ test_printf(unsigned config, hid_t fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create source dataspace */
     dims[1] = 1;
     if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Select hyperslabs in virtual space */
     stride[0] = 1;
@@ -9979,88 +10023,88 @@ test_printf(unsigned config, hid_t fapl)
     block[0]  = 10;
     block[1]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilenamepct_map : ".",
                        "src_dset%b", srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile[0] = H5Fcreate(srcfilenamepct, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile[0] = H5Fcreate(srcfilenamepct, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile[0] = H5Fopen(srcfilenamepct, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile[0] = H5Fopen(srcfilenamepct, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
 
     /* Create 1 source dataset */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -10074,9 +10118,9 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Write to srcdset[0] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -10085,12 +10129,12 @@ test_printf(unsigned config, hid_t fapl)
     /* Close srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile[0] = -1;
         }
     }
@@ -10098,40 +10142,40 @@ test_printf(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 1)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10139,62 +10183,62 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Close VDS and reopen with printf gap set to 127, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)127) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 1)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 20)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10202,63 +10246,63 @@ test_printf(unsigned config, hid_t fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reset dapl */
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)0) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[0] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     if (H5Sclose(srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcspace = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vspace[0] = -1;
 
     /* Close */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dcpl = -1;
     if (H5Pclose(dapl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dapl = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     memspace = -1;
 
     HDfree(srcfilename);
@@ -10270,7 +10314,7 @@ test_printf(unsigned config, hid_t fapl)
     HDfree(srcfilenamepct);
     HDfree(srcfilenamepct_map);
 
-    PASSED();
+    PASSED_SUPPRESSED();
     return 0;
 
 error:
@@ -10315,7 +10359,7 @@ error:
  *-------------------------------------------------------------------------
  */
 static int
-test_all(unsigned config, hid_t fapl)
+test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 {
     char    vfilename[FILENAME_BUF_SIZE];
     char    srcfilename[FILENAME_BUF_SIZE];
@@ -10344,52 +10388,52 @@ test_all(unsigned config, hid_t fapl)
     int     fill = -1;                          /* Fill value */
     int     i, j;
 
-    TESTING("virtual dataset I/O with mixed selection types")
+    TESTING_2_SUPPRESSED("virtual dataset I/O with mixed selection types")
 
-    h5_fixname(FILENAME[0], fapl, vfilename, sizeof vfilename);
-    h5_fixname(FILENAME[2], fapl, srcfilename, sizeof srcfilename);
-    h5_fixname_printf(FILENAME[2], fapl, srcfilename_map, sizeof srcfilename_map);
+    h5_fixname(FILENAME[0], vds_fapl, vfilename, sizeof vfilename);
+    h5_fixname(FILENAME[2], src_fapl, srcfilename, sizeof srcfilename);
+    h5_fixname_printf(FILENAME[2], src_fapl, srcfilename_map, sizeof srcfilename_map);
 
     /* Create DCPLs */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcdcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Set fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Set chunk dimensions */
     if (H5Pset_chunk(srcdcpl, 2, cdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create memory space */
     if ((memspace = H5Screate_simple(2, mdims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create fixed mapping */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 3;
     start[1] = 3;
     count[0] = 3;
     count[1] = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcspace[0] = H5Screate_simple(2, count, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_fixed", srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create unlimited mapping */
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 3;
     start[1] = 0;
     count[0] = 1;
@@ -10397,21 +10441,21 @@ test_all(unsigned config, hid_t fapl)
     block[0] = H5S_UNLIMITED;
     block[1] = 3;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dims[0] = 0;
     dims[1] = 3;
     if ((srcspace[1] = H5Screate_simple(2, dims, block)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 0;
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_unlim", srcspace[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create printf mapping */
     if ((vspace[2] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0]  = 0;
     start[1]  = 2;
     stride[0] = 1;
@@ -10421,93 +10465,93 @@ test_all(unsigned config, hid_t fapl)
     block[0]  = 3;
     block[1]  = 2;
     if (H5Sselect_hyperslab(vspace[2], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((srcspace[2] = H5Screate_simple(2, block, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Pset_virtual(dcpl, vspace[2], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_printf_%b", srcspace[2]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create virtual file */
-    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+    if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
+        TEST_ERROR_SUPPRESSED
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
-        if ((srcfile = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
     }
     else {
         srcfile = vfile;
         if (H5Iinc_ref(srcfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
 
     /* Create fixed source dataset */
     if ((srcdset[0] = H5Dcreate2(srcfile, "src_dset_fixed", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Create unlimited source_dataset */
     if ((srcdset[1] = H5Dcreate2(srcfile, "src_dset_unlim", H5T_NATIVE_INT, srcspace[1], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -10525,9 +10569,9 @@ test_all(unsigned config, hid_t fapl)
     block[0] = 3;
     block[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 3; i++)
@@ -10538,13 +10582,13 @@ test_all(unsigned config, hid_t fapl)
     if (config & TEST_IO_CLOSE_SRC) {
         for (i = 0; i < 2; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[i] = -1;
         }
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile = -1;
         }
     }
@@ -10552,40 +10596,40 @@ test_all(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10595,37 +10639,37 @@ test_all(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if ((i >= (int)dims[0]) || (j >= (int)dims[1])) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile, "src_dset_unlim", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[1] */
     dims[0] = 2;
     dims[1] = 3;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -10636,9 +10680,9 @@ test_all(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 2; i++)
@@ -10648,11 +10692,11 @@ test_all(unsigned config, hid_t fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile = -1;
         }
     }
@@ -10660,40 +10704,40 @@ test_all(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10703,32 +10747,32 @@ test_all(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if ((i >= (int)dims[0]) || (j >= (int)dims[1])) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
-        if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
     /* Create first printf source dataset */
     if ((srcdset[2] = H5Dcreate2(srcfile, "src_dset_printf_0", H5T_NATIVE_INT, srcspace[2], H5P_DEFAULT,
                                  srcdcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -10741,9 +10785,9 @@ test_all(unsigned config, hid_t fapl)
     block[0] = 3;
     block[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 3; i++)
@@ -10753,11 +10797,11 @@ test_all(unsigned config, hid_t fapl)
     /* Close srcdset[2] srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[2] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile = -1;
         }
     }
@@ -10765,40 +10809,40 @@ test_all(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10808,37 +10852,37 @@ test_all(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if ((i >= (int)dims[0]) || (j >= (int)dims[1])) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile, "src_dset_unlim", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[1] */
     dims[0] = 3;
     dims[1] = 3;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -10851,17 +10895,17 @@ test_all(unsigned config, hid_t fapl)
     block[0] = 1;
     block[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[1])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 2;
     start[1] = 0;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 3; i++)
@@ -10870,11 +10914,11 @@ test_all(unsigned config, hid_t fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile = -1;
         }
     }
@@ -10882,40 +10926,40 @@ test_all(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10925,32 +10969,32 @@ test_all(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if ((i >= (int)dims[0]) || (j >= (int)dims[1])) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
-        if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
     /* Create second printf source dataset, this time without using srcdcpl */
     if ((srcdset[3] = H5Dcreate2(srcfile, "src_dset_printf_1", H5T_NATIVE_INT, srcspace[2], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -10963,9 +11007,9 @@ test_all(unsigned config, hid_t fapl)
     block[0] = 3;
     block[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[3], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 3; i++)
@@ -10975,11 +11019,11 @@ test_all(unsigned config, hid_t fapl)
     /* Close srcdset[3] srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[3]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[3] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile = -1;
         }
     }
@@ -10987,40 +11031,40 @@ test_all(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 6)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 7)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -11030,37 +11074,37 @@ test_all(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if ((i >= (int)dims[0]) || (j >= (int)dims[1])) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
-            if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-                TEST_ERROR
+            if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+                TEST_ERROR_SUPPRESSED
         if ((srcdset[1] = H5Dopen2(srcfile, "src_dset_unlim", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Extend srcdset[1] */
     dims[0] = 7;
     dims[1] = 3;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -11073,17 +11117,17 @@ test_all(unsigned config, hid_t fapl)
     block[0] = 4;
     block[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if ((filespace = H5Dget_space(srcdset[1])) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     start[0] = 3;
     start[1] = 0;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 4; i++)
@@ -11093,11 +11137,11 @@ test_all(unsigned config, hid_t fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[1] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile = -1;
         }
     }
@@ -11105,40 +11149,40 @@ test_all(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 7)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -11148,32 +11192,32 @@ test_all(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR
+                    TEST_ERROR_SUPPRESSED
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
-        if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
 
     /* Create third printf source dataset */
     if ((srcdset[4] = H5Dcreate2(srcfile, "src_dset_printf_2", H5T_NATIVE_INT, srcspace[2], H5P_DEFAULT,
                                  srcdcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -11186,9 +11230,9 @@ test_all(unsigned config, hid_t fapl)
     block[0] = 3;
     block[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Dwrite(srcdset[4], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Update erbuf */
     for (i = 0; i < 3; i++)
@@ -11198,11 +11242,11 @@ test_all(unsigned config, hid_t fapl)
     /* Close srcdset[4] srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[4]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcdset[4] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcfile = -1;
         }
     }
@@ -11210,40 +11254,40 @@ test_all(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vfile = -1;
-        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+        if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
+            TEST_ERROR_SUPPRESSED
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (ndims != 2)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (dims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[0] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     if (mdims[1] != 10)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -11253,61 +11297,61 @@ test_all(unsigned config, hid_t fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         for (i = 0; i < 5; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR
+                TEST_ERROR_SUPPRESSED
             srcdset[i] = -1;
         }
         if (H5Fclose(srcfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcfile = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     vfile = -1;
     for (i = 0; i < (int)(sizeof(srcspace) / sizeof(srcspace[0])); i++) {
         if (H5Sclose(srcspace[i]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         srcspace[i] = -1;
     }
     for (i = 0; i < (int)(sizeof(vspace) / sizeof(vspace[0])); i++) {
         if (H5Sclose(vspace[i]) < 0)
-            TEST_ERROR
+            TEST_ERROR_SUPPRESSED
         vspace[i] = -1;
     }
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     dcpl = -1;
     if (H5Pclose(srcdcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     srcdcpl = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR
+        TEST_ERROR_SUPPRESSED
     memspace = -1;
 
-    PASSED();
+    PASSED_SUPPRESSED();
     return 0;
 
 error:
@@ -11362,7 +11406,7 @@ test_dapl_values(hid_t fapl_id)
     hsize_t        gap_size;       /* gap size from dapl                   */
     char           filename[1024]; /* file names                           */
 
-    TESTING("H5Dget_access_plist() returns dapl w/ correct values");
+    TESTING_2("H5Dget_access_plist() returns dapl w/ correct values");
 
     /* Create the file */
     h5_fixname(FILENAME[5], fapl_id, filename, sizeof(filename));
@@ -11496,8 +11540,13 @@ main(void)
 {
     char     filename[FILENAME_BUF_SIZE];
     hid_t    fapl;
+    hid_t    vds_fapl = -1; /* File access property list */
+    hid_t    src_fapl = -1; /* File access property list */
     int      test_api_config;
     unsigned bit_config;
+#ifndef VDS_TEST_VERBOSE
+    int tmp_nerrors;
+#endif /* VDS_TEST_VERBOSE */
     int      nerrors = 0;
 
     /* Testing setup */
@@ -11506,23 +11555,70 @@ main(void)
 
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
+    /* Create FAPLs for VDS and source files */
+    if ((vds_fapl = H5Pcopy(fapl)) < 0)
+        TEST_ERROR
+    if ((src_fapl = H5Pcopy(fapl)) < 0)
+        TEST_ERROR
+
     for (test_api_config = (int)TEST_API_BASIC; test_api_config < (int)TEST_API_NTESTS; test_api_config++)
-        nerrors += test_api((test_api_config_t)test_api_config, fapl);
+        nerrors += test_api((test_api_config_t)test_api_config, vds_fapl);
+
+    TESTING_2("Virtual dataset I/O")
+#ifdef VDS_TEST_VERBOSE
+    HDputs("");
+#else /* VDS_TEST_VERBOSE */
+    tmp_nerrors = nerrors;
+#endif /* VDS_TEST_VERBOSE */
+
     for (bit_config = 0; bit_config < TEST_IO_NTESTS; bit_config++) {
-        printf("Config: %s%s%s\n", bit_config & TEST_IO_CLOSE_SRC ? "closed source dataset, " : "",
-               bit_config & TEST_IO_DIFFERENT_FILE ? "different source file" : "same source file",
-               bit_config & TEST_IO_REOPEN_VIRT ? ", reopen virtual file" : "");
-        nerrors += test_basic_io(bit_config, fapl);
-        nerrors += test_vds_prefix_first(bit_config, fapl);
-        nerrors += test_unlim(bit_config, fapl);
-        nerrors += test_printf(bit_config, fapl);
-        nerrors += test_all(bit_config, fapl);
+        /* Skip invalid configurations */
+        if ((bit_config & TEST_IO_FCLOSE_SEMI)
+                && (bit_config & TEST_IO_FCLOSE_STRONG))
+            continue;
+
+        /* Print message */
+        PRINT_CONFIG("%s%s%s, %s file close degree", bit_config & TEST_IO_CLOSE_SRC ? "closed source dataset, " : "",
+                 bit_config & TEST_IO_DIFFERENT_FILE ? "different source file" : "same source file",
+                 bit_config & TEST_IO_REOPEN_VIRT ? ", reopen virtual file" : "",
+                 bit_config & TEST_IO_FCLOSE_SEMI ? "H5F_CLOSE_SEMI" :
+                 (bit_config & TEST_IO_FCLOSE_STRONG ? "H5F_CLOSE_STRONG" : "H5F_CLOSE_WEAK"));
+
+        /* Set file close degree */
+        if (bit_config & TEST_IO_FCLOSE_SEMI) {
+            if (H5Pset_fclose_degree(vds_fapl, H5F_CLOSE_SEMI) < 0)
+                TEST_ERROR
+        }
+        else if (bit_config & TEST_IO_FCLOSE_STRONG) {
+            if (H5Pset_fclose_degree(vds_fapl, H5F_CLOSE_STRONG) < 0)
+                TEST_ERROR
+        }
+        else {
+            if (H5Pset_fclose_degree(vds_fapl, H5F_CLOSE_WEAK) < 0)
+                TEST_ERROR
+        }
+
+        nerrors += test_basic_io(bit_config, vds_fapl, src_fapl);
+        nerrors += test_vds_prefix_first(bit_config, vds_fapl, src_fapl);
+        nerrors += test_unlim(bit_config, vds_fapl, src_fapl);
+        nerrors += test_printf(bit_config, vds_fapl, src_fapl);
+        nerrors += test_all(bit_config, vds_fapl, src_fapl);
     }
 
-    nerrors += test_dapl_values(fapl);
+#ifndef VDS_TEST_VERBOSE
+    if(tmp_nerrors == nerrors)
+        PASSED();
+#endif /* VDS_TEST_VERBOSE */
+
+    nerrors += test_dapl_values(vds_fapl);
 
     /* Verify symbol table messages are cached */
-    nerrors += (h5_verify_cached_stabs(FILENAME, fapl) < 0 ? 1 : 0);
+    nerrors += (h5_verify_cached_stabs(FILENAME, vds_fapl) < 0 ? 1 : 0);
+
+    if (H5Pclose(vds_fapl) < 0)
+        TEST_ERROR
+    if (H5Pclose(src_fapl) < 0)
+        TEST_ERROR
 
     if (nerrors)
         goto error;

--- a/test/vds.c
+++ b/test/vds.c
@@ -40,8 +40,8 @@ const char *FILENAME[] = {"vds_virt_0", "vds_virt_1", "vds_src_0",  "vds_src_1",
 
 /* For verbose output just use standard error printing */
 #define TESTING_2_SUPPRESSED(WHAT) TESTING_2(WHAT)
-#define PASSED_SUPPRESSED() PASSED()
-#define TEST_ERROR_SUPPRESSED TEST_ERROR
+#define PASSED_SUPPRESSED()        PASSED()
+#define TEST_ERROR_SUPPRESSED      TEST_ERROR
 
 /* Print config directly to output */
 #define PRINT_CONFIG(...)                                                                                    \
@@ -54,7 +54,7 @@ const char *FILENAME[] = {"vds_virt_0", "vds_virt_1", "vds_src_0",  "vds_src_1",
 
 /* Global strings for error output */
 char vds_config_str_g[128] = "";
-char vds_test_str_g[128] = "";
+char vds_test_str_g[128]   = "";
 
 /* Replacement for TESTING_2 for non-verbose-output */
 #define TESTING_2_SUPPRESSED(WHAT)                                                                           \
@@ -68,7 +68,7 @@ char vds_test_str_g[128] = "";
 /* Replacement for TEST_ERROR for non-verbose output */
 #define TEST_ERROR_SUPPRESSED                                                                                \
     {                                                                                                        \
-        printf("Failed config: %s\nFailed test: %s\n", vds_config_str_g, vds_test_str_g);                     \
+        printf("Failed config: %s\nFailed test: %s\n", vds_config_str_g, vds_test_str_g);                    \
         TEST_ERROR                                                                                           \
     }
 
@@ -11547,7 +11547,7 @@ main(void)
 #ifndef VDS_TEST_VERBOSE
     int tmp_nerrors;
 #endif /* VDS_TEST_VERBOSE */
-    int      nerrors = 0;
+    int nerrors = 0;
 
     /* Testing setup */
     h5_reset();
@@ -11567,22 +11567,23 @@ main(void)
     TESTING_2("Virtual dataset I/O")
 #ifdef VDS_TEST_VERBOSE
     HDputs("");
-#else /* VDS_TEST_VERBOSE */
+#else  /* VDS_TEST_VERBOSE */
     tmp_nerrors = nerrors;
 #endif /* VDS_TEST_VERBOSE */
 
     for (bit_config = 0; bit_config < TEST_IO_NTESTS; bit_config++) {
         /* Skip invalid configurations */
-        if ((bit_config & TEST_IO_FCLOSE_SEMI)
-                && (bit_config & TEST_IO_FCLOSE_STRONG))
+        if ((bit_config & TEST_IO_FCLOSE_SEMI) && (bit_config & TEST_IO_FCLOSE_STRONG))
             continue;
 
         /* Print message */
-        PRINT_CONFIG("%s%s%s, %s file close degree", bit_config & TEST_IO_CLOSE_SRC ? "closed source dataset, " : "",
-                 bit_config & TEST_IO_DIFFERENT_FILE ? "different source file" : "same source file",
-                 bit_config & TEST_IO_REOPEN_VIRT ? ", reopen virtual file" : "",
-                 bit_config & TEST_IO_FCLOSE_SEMI ? "H5F_CLOSE_SEMI" :
-                 (bit_config & TEST_IO_FCLOSE_STRONG ? "H5F_CLOSE_STRONG" : "H5F_CLOSE_WEAK"));
+        PRINT_CONFIG("%s%s%s, %s file close degree",
+                     bit_config & TEST_IO_CLOSE_SRC ? "closed source dataset, " : "",
+                     bit_config & TEST_IO_DIFFERENT_FILE ? "different source file" : "same source file",
+                     bit_config & TEST_IO_REOPEN_VIRT ? ", reopen virtual file" : "",
+                     bit_config & TEST_IO_FCLOSE_SEMI
+                         ? "H5F_CLOSE_SEMI"
+                         : (bit_config & TEST_IO_FCLOSE_STRONG ? "H5F_CLOSE_STRONG" : "H5F_CLOSE_WEAK"));
 
         /* Set file close degree */
         if (bit_config & TEST_IO_FCLOSE_SEMI) {
@@ -11606,7 +11607,7 @@ main(void)
     }
 
 #ifndef VDS_TEST_VERBOSE
-    if(tmp_nerrors == nerrors)
+    if (tmp_nerrors == nerrors)
         PASSED();
 #endif /* VDS_TEST_VERBOSE */
 


### PR DESCRIPTION
Modify VDS code to always open source files with H5F_CLOSE_WEAK close degree.  Add test cases to VDS test for this, and reduce the amount of output from that test.