### PR TITLE
Check for wrap context before unwrapping file VOL object in H5F__dest

### DIFF
--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -1602,8 +1602,16 @@ H5F__dest(H5F_t *f, hbool_t flush)
     f->open_name   = (char *)H5MM_xfree(f->open_name);
     f->actual_name = (char *)H5MM_xfree(f->actual_name);
     if (f->vol_obj) {
-        if (NULL == H5VL_object_unwrap(f->vol_obj))
+        void *vol_wrap_ctx = NULL;
+
+        /* If a VOL wrapping context is available, retrieve it
+         * and unwrap file VOL object
+         */
+        if (H5CX_get_vol_wrap_ctx((void **)&vol_wrap_ctx) < 0)
+            HDONE_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "can't get VOL object wrap context")
+        if (vol_wrap_ctx && (NULL == H5VL_object_unwrap(f->vol_obj)))
             HDONE_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "can't unwrap VOL object")
+
         if (H5VL_free_object(f->vol_obj) < 0)
             HDONE_ERROR(H5E_FILE, H5E_CANTDEC, FAIL, "unable to free VOL object")
         f->vol_obj = NULL;


### PR DESCRIPTION
In the EFC test, H5F__efc_open is called directly, which has the side effect of not setting the VOL wrapping context and thus not wrapping the file VOL object. Since there doesn't seem to be a reasonable way to set the VOL wrap context (no VOL object is available) in H5F__efc_open, we simply check that a VOL wrapping context is available before trying to unwrap the file VOL object. There is still a failure with the passthrough connector and the file image tests, but that seems to have existed before the file VOL object unwrapping changes.