### PR TITLE
Detect correct long double size with universal binaires

### DIFF
--- a/config/cmake/H5pubconf.h.in
+++ b/config/cmake/H5pubconf.h.in
@@ -608,6 +608,7 @@
 #cmakedefine H5_SIZEOF_INT_LEAST8_T @H5_SIZEOF_INT_LEAST8_T@
 
 #if !defined(__APPLE__)
+
 /* The size of `size_t', as computed by sizeof. */
 #cmakedefine H5_SIZEOF_SIZE_T @H5_SIZEOF_SIZE_T@
 
@@ -617,8 +618,17 @@
 /* The size of `long', as computed by sizeof. */
 #cmakedefine H5_SIZEOF_LONG @H5_SIZEOF_LONG@
 
+/* The size of `long double', as computed by sizeof. */
+#cmakedefine H5_SIZEOF_LONG_DOUBLE @H5_SIZEOF_LONG_DOUBLE@
+
 #else
-   # if defined(__LP64__) && __LP64__
+
+  /* On Apple, to support Universal Binaries (where multiple CPU
+     architectures exist in one library/executable), we can't assume
+     the machine doing the compiling has the same endianness or type
+     sizes as all the various architectures (PowerPC, Intel, ARM). */
+
+  # if defined(__LP64__) && __LP64__
   #define H5_SIZEOF_LONG 8
   #define H5_SIZEOF_SIZE_T 8
   #define H5_SIZEOF_SSIZE_T 8
@@ -628,10 +638,15 @@
   #define H5_SIZEOF_SSIZE_T 4
   # endif
 
-#endif
+  # if defined(__i386__) || defined(__x86_64__)
+  #define H5_SIZEOF_LONG_DOUBLE 16
+  # elif defined(__aarch64__)
+  #define H5_SIZEOF_LONG_DOUBLE 8
+  # else
+  #cmakedefine H5_SIZEOF_LONG_DOUBLE @H5_SIZEOF_LONG_DOUBLE@
+  # endif
 
-/* The size of `long double', as computed by sizeof. */
-#cmakedefine H5_SIZEOF_LONG_DOUBLE @H5_SIZEOF_LONG_DOUBLE@
+#endif
 
 /* Define size of long long and/or __int64 bit integer type only if the type
    exists.  */


### PR DESCRIPTION
On macOS on x86_64, long double is 16 bytes; on macOS on arm64, it's 8 bytes.

Use the same existing technique used to properly detect other sizes to now also properly detect the size of long double.

For bug #311.