### PR TITLE
Fix undefined left shifting of negative numbers

### DIFF
--- a/test/dsets.c
+++ b/test/dsets.c
@@ -4041,7 +4041,7 @@ test_nbit_compound_2(hid_t file)
             power               = HDpow(2.0F, (double)(precision[1] - 1));
             orig_data[i][j].a.c = (char)(((long long)HDrandom() % (long long)power) << offset[1]);
             power               = HDpow(2.0F, (double)(precision[2] - 1));
-            orig_data[i][j].a.s = (short)(-((long long)HDrandom() % (long long)power) << offset[2]);
+            orig_data[i][j].a.s = (short)(-(((long long)HDrandom() % (long long)power) << offset[2]));
             orig_data[i][j].a.f = float_val[i][j];
 
             power             = HDpow(2.0F, (double)precision[3]);
@@ -4057,7 +4057,7 @@ test_nbit_compound_2(hid_t file)
                 for (n = 0; n < (size_t)array_dims[1]; n++) {
                     power = HDpow(2.0F, (double)(precision[0] - 1));
                     orig_data[i][j].d[m][n].i =
-                        (int)(-((long long)HDrandom() % (long long)power) << offset[0]);
+                        (int)(-(((long long)HDrandom() % (long long)power) << offset[0]));
                     power = HDpow(2.0F, (double)(precision[1] - 1));
                     orig_data[i][j].d[m][n].c =
                         (char)(((long long)HDrandom() % (long long)power) << offset[1]);


### PR DESCRIPTION
Undefined Bahavior Sanitizer errored here about left shifting negative numbers.

Since the numbers are random anyway, I figure they can just be negated.