### PR TITLE
Fixed many -Wreserved-id-macro warnings by fixing header guard spelling

### DIFF
--- a/bin/make_err
+++ b/bin/make_err
@@ -64,8 +64,8 @@ sub print_startprotect ($$) {
     $file =~ s/(\w*)\.h/$1/;
 
     # Print the ifdef info
-    print $fh "\n#ifndef _${file}_H\n";
-    print $fh "#define _${file}_H\n";
+    print $fh "\n#ifndef ${file}_H\n";
+    print $fh "#define ${file}_H\n";
 }
 
 ##############################################################################

--- a/bin/make_overflow
+++ b/bin/make_overflow
@@ -93,8 +93,8 @@ sub print_startprotect ($$) {
     $file =~ s/(\w*)\.h/$1/;
 
     # Print the ifdef info
-    print $fh "\n#ifndef _${file}_H\n";
-    print $fh "#define _${file}_H\n";
+    print $fh "\n#ifndef ${file}_H\n";
+    print $fh "#define ${file}_H\n";
 }
 
 ##############################################################################

--- a/bin/make_vers
+++ b/bin/make_vers
@@ -78,8 +78,8 @@ sub print_startprotect ($$) {
     $file =~ s/(\w*)\.h/$1/;
 
     # Print the ifdef info
-    print $fh "\n#ifndef _${file}_H\n";
-    print $fh "#define _${file}_H\n";
+    print $fh "\n#ifndef ${file}_H\n";
+    print $fh "#define ${file}_H\n";
 }
 
 ##############################################################################

--- a/c++/src/H5ArrayType.h
+++ b/c++/src/H5ArrayType.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5ArrayType_H
-#define __H5ArrayType_H
+#ifndef H5ArrayType_H
+#define H5ArrayType_H
 
 namespace H5 {
 
@@ -69,4 +69,4 @@ class H5_DLLCPP ArrayType : public DataType {
 }; // end of ArrayType
 } // namespace H5
 
-#endif // __H5ArrayType_H
+#endif // H5ArrayType_H

--- a/c++/src/H5AtomType.h
+++ b/c++/src/H5AtomType.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5AtomType_H
-#define __H5AtomType_H
+#ifndef H5AtomType_H
+#define H5AtomType_H
 
 namespace H5 {
 
@@ -83,4 +83,4 @@ class H5_DLLCPP AtomType : public DataType {
 }; // end of AtomType
 } // namespace H5
 
-#endif // __H5AtomType_H
+#endif // H5AtomType_H

--- a/c++/src/H5Attribute.h
+++ b/c++/src/H5Attribute.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5Attribute_H
-#define __H5Attribute_H
+#ifndef H5Attribute_H
+#define H5Attribute_H
 
 namespace H5 {
 
@@ -104,4 +104,4 @@ class H5_DLLCPP Attribute : public AbstractDs, public H5Location {
 }; // end of Attribute
 } // namespace H5
 
-#endif // __H5Attribute_H
+#endif // H5Attribute_H

--- a/c++/src/H5Classes.h
+++ b/c++/src/H5Classes.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5Classes_H
-#define __H5Classes_H
+#ifndef H5Classes_H
+#define H5Classes_H
 
 namespace H5 {
 class Exception;
@@ -43,4 +43,4 @@ class H5File;
 class Attribute;
 class H5Library;
 } // namespace H5
-#endif // __H5Classes_H
+#endif // H5Classes_H

--- a/c++/src/H5CompType.h
+++ b/c++/src/H5CompType.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5CompType_H
-#define __H5CompType_H
+#ifndef H5CompType_H
+#define H5CompType_H
 
 namespace H5 {
 
@@ -124,4 +124,4 @@ class H5_DLLCPP CompType : public DataType {
 }; // end of CompType
 } // namespace H5
 
-#endif // __H5CompType_H
+#endif // H5CompType_H

--- a/c++/src/H5Cpp.h
+++ b/c++/src/H5Cpp.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5Cpp_H
-#define __H5Cpp_H
+#ifndef H5Cpp_H
+#define H5Cpp_H
 
 #include "H5Include.h"
 #include "H5Exception.h"
@@ -58,4 +58,4 @@
 #define HOFFSET(TYPE, MEMBER) ((size_t) & ((TYPE *)0)->MEMBER)
 #endif
 
-#endif // __H5Cpp_H
+#endif // H5Cpp_H

--- a/c++/src/H5CppDoc.h
+++ b/c++/src/H5CppDoc.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5CppDoc_H
-#define __H5CppDoc_H
+#ifndef H5CppDoc_H
+#define H5CppDoc_H
 
 //-------------------------------------------------------------------------
 // The following section will be used to generate the 'Mainpage'
@@ -92,4 +92,4 @@
 ///        This example shows how to work with groups.
 ///\example     h5group.cpp
 
-#endif // __H5CppDoc_H
+#endif // H5CppDoc_H

--- a/c++/src/H5DaccProp.h
+++ b/c++/src/H5DaccProp.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5DSetAccPropList_H
-#define __H5DSetAccPropList_H
+#ifndef H5DSetAccPropList_H
+#define H5DSetAccPropList_H
 
 namespace H5 {
 
@@ -69,4 +69,4 @@ class H5_DLLCPP DSetAccPropList : public LinkAccPropList {
 }; // end of DSetAccPropList
 } // namespace H5
 
-#endif // __H5DSetAccPropList_H
+#endif // H5DSetAccPropList_H

--- a/c++/src/H5DataSet.h
+++ b/c++/src/H5DataSet.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5DataSet_H
-#define __H5DataSet_H
+#ifndef H5DataSet_H
+#define H5DataSet_H
 
 namespace H5 {
 
@@ -153,4 +153,4 @@ class H5_DLLCPP DataSet : public H5Object, public AbstractDs {
 }; // end of DataSet
 } // namespace H5
 
-#endif // __H5DataSet_H
+#endif // H5DataSet_H

--- a/c++/src/H5DataSpace.h
+++ b/c++/src/H5DataSpace.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5DataSpace_H
-#define __H5DataSpace_H
+#ifndef H5DataSpace_H
+#define H5DataSpace_H
 
 namespace H5 {
 
@@ -155,4 +155,4 @@ class H5_DLLCPP DataSpace : public IdComponent {
 }; // end of DataSpace
 } // namespace H5
 
-#endif // __H5DataSpace_H
+#endif // H5DataSpace_H

--- a/c++/src/H5DataType.h
+++ b/c++/src/H5DataType.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5DataType_H
-#define __H5DataType_H
+#ifndef H5DataType_H
+#define H5DataType_H
 
 namespace H5 {
 
@@ -183,4 +183,4 @@ class H5_DLLCPP DataType : public H5Object {
 }; // end of DataType
 } // namespace H5
 
-#endif // __H5DataType_H
+#endif // H5DataType_H

--- a/c++/src/H5DcreatProp.h
+++ b/c++/src/H5DcreatProp.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5DSCreatPropList_H
-#define __H5DSCreatPropList_H
+#ifndef H5DSCreatPropList_H
+#define H5DSCreatPropList_H
 
 namespace H5 {
 
@@ -159,4 +159,4 @@ class H5_DLLCPP DSetCreatPropList : public ObjCreatPropList {
 }; // end of DSetCreatPropList
 } // namespace H5
 
-#endif // __H5DSCreatPropList_H
+#endif // H5DSCreatPropList_H

--- a/c++/src/H5DxferProp.h
+++ b/c++/src/H5DxferProp.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5DSetMemXferPropList_H
-#define __H5DSetMemXferPropList_H
+#ifndef H5DSetMemXferPropList_H
+#define H5DSetMemXferPropList_H
 
 namespace H5 {
 
@@ -131,4 +131,4 @@ class H5_DLLCPP DSetMemXferPropList : public PropList {
 }; // end of DSetMemXferPropList
 } // namespace H5
 
-#endif // __H5DSetMemXferPropList_H
+#endif // H5DSetMemXferPropList_H

--- a/c++/src/H5EnumType.h
+++ b/c++/src/H5EnumType.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5EnumType_H
-#define __H5EnumType_H
+#ifndef H5EnumType_H
+#define H5EnumType_H
 
 namespace H5 {
 
@@ -87,4 +87,4 @@ class H5_DLLCPP EnumType : public DataType {
 }; // end of EnumType
 } // namespace H5
 
-#endif // __H5EnumType_H
+#endif // H5EnumType_H

--- a/c++/src/H5Exception.h
+++ b/c++/src/H5Exception.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5Exception_H
-#define __H5Exception_H
+#ifndef H5Exception_H
+#define H5Exception_H
 
 #include <string>
 
@@ -176,4 +176,4 @@ class H5_DLLCPP IdComponentException : public Exception {
 }; // end of IdComponentException
 } // namespace H5
 
-#endif // __H5Exception_H
+#endif // H5Exception_H

--- a/c++/src/H5FaccProp.h
+++ b/c++/src/H5FaccProp.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5FileAccPropList_H
-#define __H5FileAccPropList_H
+#ifndef H5FileAccPropList_H
+#define H5FileAccPropList_H
 
 namespace H5 {
 
@@ -168,4 +168,4 @@ class H5_DLLCPP FileAccPropList : public PropList {
 }; // end of FileAccPropList
 } // namespace H5
 
-#endif // __H5FileAccPropList_H
+#endif // H5FileAccPropList_H

--- a/c++/src/H5FcreatProp.h
+++ b/c++/src/H5FcreatProp.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5FileCreatPropList_H
-#define __H5FileCreatPropList_H
+#ifndef H5FileCreatPropList_H
+#define H5FileCreatPropList_H
 
 namespace H5 {
 
@@ -109,4 +109,4 @@ class H5_DLLCPP FileCreatPropList : public PropList {
 }; // end of FileCreatPropList
 } // namespace H5
 
-#endif // __H5FileCreatPropList_H
+#endif // H5FileCreatPropList_H

--- a/c++/src/H5File.h
+++ b/c++/src/H5File.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5File_H
-#define __H5File_H
+#ifndef H5File_H
+#define H5File_H
 
 namespace H5 {
 
@@ -136,4 +136,4 @@ class H5_DLLCPP H5File : public Group {
 }; // end of H5File
 } // namespace H5
 
-#endif // __H5File_H
+#endif // H5File_H

--- a/c++/src/H5FloatType.h
+++ b/c++/src/H5FloatType.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5FloatType_H
-#define __H5FloatType_H
+#ifndef H5FloatType_H
+#define H5FloatType_H
 
 namespace H5 {
 
@@ -84,4 +84,4 @@ class H5_DLLCPP FloatType : public AtomType {
 }; // end of FloatType
 } // namespace H5
 
-#endif // __H5FloatType_H
+#endif // H5FloatType_H

--- a/c++/src/H5IntType.h
+++ b/c++/src/H5IntType.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5IntType_H
-#define __H5IntType_H
+#ifndef H5IntType_H
+#define H5IntType_H
 
 namespace H5 {
 
@@ -66,4 +66,4 @@ class H5_DLLCPP IntType : public AtomType {
 }; // end of IntType
 } // namespace H5
 
-#endif // __H5IntType_H
+#endif // H5IntType_H

--- a/c++/src/H5LaccProp.h
+++ b/c++/src/H5LaccProp.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5LinkAccPropList_H
-#define __H5LinkAccPropList_H
+#ifndef H5LinkAccPropList_H
+#define H5LinkAccPropList_H
 
 namespace H5 {
 
@@ -70,4 +70,4 @@ class H5_DLLCPP LinkAccPropList : public PropList {
 }; // end of LinkAccPropList
 } // namespace H5
 
-#endif // __H5LinkAccPropList_H
+#endif // H5LinkAccPropList_H

--- a/c++/src/H5LcreatProp.h
+++ b/c++/src/H5LcreatProp.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5LinkCreatPropList_H
-#define __H5LinkCreatPropList_H
+#ifndef H5LinkCreatPropList_H
+#define H5LinkCreatPropList_H
 
 namespace H5 {
 
@@ -77,4 +77,4 @@ class H5_DLLCPP LinkCreatPropList : public PropList {
 }; // end of LinkCreatPropList
 } // namespace H5
 
-#endif // __H5LinkCreatPropList_H
+#endif // H5LinkCreatPropList_H

--- a/c++/src/H5Library.h
+++ b/c++/src/H5Library.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5Library_H
-#define __H5Library_H
+#ifndef H5Library_H
+#define H5Library_H
 
 namespace H5 {
 
@@ -69,4 +69,4 @@ class H5_DLLCPP H5Library {
 }; // end of H5Library
 } // namespace H5
 
-#endif // __H5Library_H
+#endif // H5Library_H

--- a/c++/src/H5Location.h
+++ b/c++/src/H5Location.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5Location_H
-#define __H5Location_H
+#ifndef H5Location_H
+#define H5Location_H
 
 #include "H5Classes.h" // constains forward class declarations
 
@@ -339,4 +339,4 @@ class H5_DLLCPP H5Location : public IdComponent {
 }; // end of H5Location
 } // namespace H5
 
-#endif // __H5Location_H
+#endif // H5Location_H

--- a/c++/src/H5Object.h
+++ b/c++/src/H5Object.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5Object_H
-#define __H5Object_H
+#ifndef H5Object_H
+#define H5Object_H
 
 namespace H5 {
 
@@ -132,4 +132,4 @@ class H5_DLLCPP H5Object : public H5Location {
 }; // end of H5Object
 } // namespace H5
 
-#endif // __H5Object_H
+#endif // H5Object_H

--- a/c++/src/H5OcreatProp.h
+++ b/c++/src/H5OcreatProp.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5ObjCreatPropList_H
-#define __H5ObjCreatPropList_H
+#ifndef H5ObjCreatPropList_H
+#define H5ObjCreatPropList_H
 
 namespace H5 {
 
@@ -75,4 +75,4 @@ class H5_DLLCPP ObjCreatPropList : public PropList {
 }; // end of ObjCreatPropList
 } // namespace H5
 
-#endif // __H5ObjCreatPropList_H
+#endif // H5ObjCreatPropList_H

--- a/c++/src/H5PredType.h
+++ b/c++/src/H5PredType.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5PredType_H
-#define __H5PredType_H
+#ifndef H5PredType_H
+#define H5PredType_H
 
 namespace H5 {
 
@@ -442,4 +442,4 @@ class H5_DLLCPP PredType : public AtomType {
 }; // end of PredType
 } // namespace H5
 
-#endif // __H5PredType_H
+#endif // H5PredType_H

--- a/c++/src/H5PropList.h
+++ b/c++/src/H5PropList.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5PropList_H
-#define __H5PropList_H
+#ifndef H5PropList_H
+#define H5PropList_H
 
 namespace H5 {
 
@@ -144,4 +144,4 @@ class H5_DLLCPP PropList : public IdComponent {
 }; // end of PropList
 } // namespace H5
 
-#endif // __H5PropList_H
+#endif // H5PropList_H

--- a/c++/src/H5StrType.h
+++ b/c++/src/H5StrType.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5StrType_H
-#define __H5StrType_H
+#ifndef H5StrType_H
+#define H5StrType_H
 
 namespace H5 {
 
@@ -78,4 +78,4 @@ class H5_DLLCPP StrType : public AtomType {
 }; // end of StrType
 } // namespace H5
 
-#endif // __H5StrType_H
+#endif // H5StrType_H

--- a/c++/src/H5VarLenType.h
+++ b/c++/src/H5VarLenType.h
@@ -12,8 +12,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef __H5VarLenType_H
-#define __H5VarLenType_H
+#ifndef H5VarLenType_H
+#define H5VarLenType_H
 
 namespace H5 {
 
@@ -61,4 +61,4 @@ class H5_DLLCPP VarLenType : public DataType {
 }; // end of VarLenType
 } // namespace H5
 
-#endif // __H5VarLenType_H
+#endif // H5VarLenType_H

--- a/c++/test/h5cpputil.h
+++ b/c++/test/h5cpputil.h
@@ -19,8 +19,8 @@
 
  ***************************************************************************/
 
-#ifndef _h5cpputil_h
-#define _h5cpputil_h
+#ifndef H5cpputil_H
+#define H5cpputil_H
 
 #include "h5test.h"
 

--- a/fortran/src/H5f90.h
+++ b/fortran/src/H5f90.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5f90_H
-#define _H5f90_H
+#ifndef H5f90_H
+#define H5f90_H
 
 #include "hdf5.h"
 #include "H5private.h"
@@ -27,4 +27,4 @@
 
 #define H5_MAX(a, b) (((a) > (b)) ? (a) : (b))
 
-#endif /* _H5f90_H */
+#endif /* H5f90_H */

--- a/fortran/src/H5f90i.h
+++ b/fortran/src/H5f90i.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5f90i_H
-#define _H5f90i_H
+#ifndef H5f90i_H
+#define H5f90i_H
 
 /*
  * Include generated header.  This header defines integer types,
@@ -36,4 +36,4 @@ typedef char *_fcd;
 
 #endif
 
-#endif /* _H5f90i_H */
+#endif /* H5f90i_H */

--- a/fortran/src/H5f90proto.h
+++ b/fortran/src/H5f90proto.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5f90proto_H
-#define _H5f90proto_H
+#ifndef H5f90proto_H
+#define H5f90proto_H
 
 #include "H5public.h"
 #include "H5f90.h"
@@ -643,4 +643,4 @@ H5_FCDLL int_f h5literate_by_name_c(hid_t_f *loc_id, _fcd name, size_t_f *namele
                                     int_f *order, hsize_t_f *idx, H5L_iterate2_t op, void *op_data,
                                     hid_t_f *lapl_id);
 
-#endif /* _H5f90proto_H */
+#endif /* H5f90proto_H */

--- a/hl/fortran/src/H5IMcc.h
+++ b/hl/fortran/src/H5IMcc.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5IMCC_H
-#define _H5IMCC_H
+#ifndef H5IMCC_H
+#define H5IMCC_H
 
 #include "H5LTprivate.h"
 #include "H5IMprivate.h"

--- a/hl/fortran/src/H5LTf90proto.h
+++ b/hl/fortran/src/H5LTf90proto.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5LTf90proto_H
-#define _H5LTf90proto_H
+#ifndef H5LTf90proto_H
+#define H5LTf90proto_H
 
 #include "H5public.h"
 #include "H5f90i.h"
@@ -206,4 +206,4 @@ int_f h5tbget_field_info_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, hsize_
                            size_t_f *field_sizes, size_t_f *field_offsets, size_t_f *type_size,
                            size_t_f *namelen2, size_t_f *lenmax, _fcd field_names, size_t_f *maxlen_out);
 
-#endif /* _H5LTf90proto_H */
+#endif /* H5LTf90proto_H */

--- a/hl/src/H5DOpublic.h
+++ b/hl/src/H5DOpublic.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5DOpublic_H
-#define _H5DOpublic_H
+#ifndef H5DOpublic_H
+#define H5DOpublic_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/hl/src/H5DSprivate.h
+++ b/hl/src/H5DSprivate.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5DSprivate_H
-#define _H5DSprivate_H
+#ifndef H5DSprivate_H
+#define H5DSprivate_H
 
 /* High-level library internal header file */
 #include "H5HLprivate2.h"

--- a/hl/src/H5DSpublic.h
+++ b/hl/src/H5DSpublic.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5DSpublic_H
-#define _H5DSpublic_H
+#ifndef H5DSpublic_H
+#define H5DSpublic_H
 
 #define DIMENSION_SCALE_CLASS "DIMENSION_SCALE"
 #define DIMENSION_LIST        "DIMENSION_LIST"

--- a/hl/src/H5HLprivate2.h
+++ b/hl/src/H5HLprivate2.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5HLprivate2_H
-#define _H5HLprivate2_H
+#ifndef H5HLprivate2_H
+#define H5HLprivate2_H
 
 /* Public HDF5 header */
 #include "hdf5.h"
@@ -23,4 +23,4 @@
 /* HDF5 private functions */
 #include "H5private.h"
 
-#endif /* _H5HLprivate2_H */
+#endif /* H5HLprivate2_H */

--- a/hl/src/H5IMprivate.h
+++ b/hl/src/H5IMprivate.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5IMprivate_H
-#define _H5IMprivate_H
+#ifndef H5IMprivate_H
+#define H5IMprivate_H
 
 /* High-level library internal header file */
 #include "H5HLprivate2.h"

--- a/hl/src/H5IMpublic.h
+++ b/hl/src/H5IMpublic.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5IMpublic_H
-#define _H5IMpublic_H
+#ifndef H5IMpublic_H
+#define H5IMpublic_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/hl/src/H5LDprivate.h
+++ b/hl/src/H5LDprivate.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5LDprivate_H
-#define _H5LDprivate_H
+#ifndef H5LDprivate_H
+#define H5LDprivate_H
 
 /* High-level library internal header file */
 #include "H5HLprivate2.h"
@@ -50,4 +50,4 @@ H5_HLDLL int  H5LD_construct_vector(char *fields, H5LD_memb_t *listv[], hid_t pa
 }
 #endif
 
-#endif /* end _H5LDprivate_H */
+#endif /* end H5LDprivate_H */

--- a/hl/src/H5LDpublic.h
+++ b/hl/src/H5LDpublic.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5LDpublic_H
-#define _H5LDpublic_H
+#ifndef H5LDpublic_H
+#define H5LDpublic_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -27,4 +27,4 @@ H5_HLDLL herr_t H5LDget_dset_elmts(hid_t did, const hsize_t *prev_dims, const hs
 }
 #endif
 
-#endif /* _H5LDpublic_H */
+#endif /* H5LDpublic_H */

--- a/hl/src/H5LTprivate.h
+++ b/hl/src/H5LTprivate.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5LTprivate_H
-#define _H5LTprivate_H
+#ifndef H5LTprivate_H
+#define H5LTprivate_H
 
 /* High-level library internal header file */
 #include "H5HLprivate2.h"

--- a/hl/src/H5LTpublic.h
+++ b/hl/src/H5LTpublic.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5LTpublic_H
-#define _H5LTpublic_H
+#ifndef H5LTpublic_H
+#define H5LTpublic_H
 
 /* Flag definitions for H5LTopen_file_image() */
 #define H5LT_FILE_IMAGE_OPEN_RW   0x0001 /* Open image for read-write */

--- a/hl/src/H5PTprivate.h
+++ b/hl/src/H5PTprivate.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5PTprivate_H
-#define _H5PTprivate_H
+#ifndef H5PTprivate_H
+#define H5PTprivate_H
 
 /* High-level library internal header file */
 #include "H5HLprivate2.h"

--- a/hl/src/H5PTpublic.h
+++ b/hl/src/H5PTpublic.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5PTpublic_H
-#define _H5PTpublic_H
+#ifndef H5PTpublic_H
+#define H5PTpublic_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/hl/src/H5TBprivate.h
+++ b/hl/src/H5TBprivate.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5TBprivate_H
-#define _H5TBprivate_H
+#ifndef H5TBprivate_H
+#define H5TBprivate_H
 
 /* High-level library internal header file */
 #include "H5HLprivate2.h"

--- a/hl/src/H5TBpublic.h
+++ b/hl/src/H5TBpublic.h
@@ -11,8 +11,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5TBpublic_H
-#define _H5TBpublic_H
+#ifndef H5TBpublic_H
+#define H5TBpublic_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/hl/test/h5hltest.h
+++ b/hl/test/h5hltest.h
@@ -18,8 +18,8 @@
  * Purpose:     Test support stuff.
  */
 
-#ifndef _H5HLTEST_H
-#define _H5HLTEST_H
+#ifndef H5HLTEST_H
+#define H5HLTEST_H
 
 /* Get the HDF5 test header */
 #include "h5test.h"
@@ -48,4 +48,4 @@
 
 int test_packet_table_with_varlen(void);
 
-#endif /* _H5HLTEST_H */
+#endif /* H5HLTEST_H */

--- a/src/H5ACmodule.h
+++ b/src/H5ACmodule.h
@@ -18,8 +18,8 @@
  *		H5AC package.  Including this header means that the source file
  *		is part of the H5AC package.
  */
-#ifndef _H5ACmodule_H
-#define _H5ACmodule_H
+#ifndef H5ACmodule_H
+#define H5ACmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_CACHE
 #define H5_MY_PKG_INIT YES
 
-#endif /* _H5ACmodule_H */
+#endif /* H5ACmodule_H */

--- a/src/H5ACpkg.h
+++ b/src/H5ACpkg.h
@@ -30,8 +30,8 @@
 #error "Do not include this file outside the H5AC package!"
 #endif
 
-#ifndef _H5ACpkg_H
-#define _H5ACpkg_H
+#ifndef H5ACpkg_H
+#define H5ACpkg_H
 
 /* Get package's private header */
 #include "H5ACprivate.h" /* Metadata cache			*/
@@ -426,4 +426,4 @@ H5_DLL herr_t H5AC__set_sync_point_done_callback(H5C_t *cache_ptr, H5AC_sync_poi
 H5_DLL herr_t H5AC__set_write_done_callback(H5C_t *cache_ptr, H5AC_write_done_cb_t write_done);
 #endif /* H5_HAVE_PARALLEL */
 
-#endif /* _H5ACpkg_H */
+#endif /* H5ACpkg_H */

--- a/src/H5ACprivate.h
+++ b/src/H5ACprivate.h
@@ -23,8 +23,8 @@
  *-------------------------------------------------------------------------
  */
 
-#ifndef _H5ACprivate_H
-#define _H5ACprivate_H
+#ifndef H5ACprivate_H
+#define H5ACprivate_H
 
 #include "H5ACpublic.h" /*public prototypes            */
 

--- a/src/H5ACpublic.h
+++ b/src/H5ACpublic.h
@@ -21,8 +21,8 @@
  *
  *-------------------------------------------------------------------------
  */
-#ifndef _H5ACpublic_H
-#define _H5ACpublic_H
+#ifndef H5ACpublic_H
+#define H5ACpublic_H
 
 /* Public headers needed by this file */
 #include "H5public.h"

--- a/src/H5Amodule.h
+++ b/src/H5Amodule.h
@@ -18,8 +18,8 @@
  *		H5A package.  Including this header means that the source file
  *		is part of the H5A package.
  */
-#ifndef _H5Amodule_H
-#define _H5Amodule_H
+#ifndef H5Amodule_H
+#define H5Amodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -46,4 +46,4 @@
  *
  */
 
-#endif /* _H5Amodule_H */
+#endif /* H5Amodule_H */

--- a/src/H5Apkg.h
+++ b/src/H5Apkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5A package!"
 #endif
 
-#ifndef _H5Apkg_H
-#define _H5Apkg_H
+#ifndef H5Apkg_H
+#define H5Apkg_H
 
 /*
  * Define this to enable debugging.
@@ -262,4 +262,4 @@ H5_DLL htri_t H5A__is_shared_test(hid_t aid);
 H5_DLL herr_t H5A__get_shared_rc_test(hid_t attr_id, hsize_t *ref_count);
 #endif /* H5A_TESTING */
 
-#endif /* _H5Apkg_H */
+#endif /* H5Apkg_H */

--- a/src/H5Aprivate.h
+++ b/src/H5Aprivate.h
@@ -14,8 +14,8 @@
 /*
  * This file contains private information about the H5D module
  */
-#ifndef _H5Aprivate_H
-#define _H5Aprivate_H
+#ifndef H5Aprivate_H
+#define H5Aprivate_H
 
 /* Include package's public header */
 #include "H5Apublic.h"
@@ -78,4 +78,4 @@ H5_DLL herr_t H5O_attr_iterate_real(hid_t loc_id, const H5O_loc_t *loc, H5_index
                                     H5_iter_order_t order, hsize_t skip, hsize_t *last_attr,
                                     const H5A_attr_iter_op_t *attr_op, void *op_data);
 
-#endif /* _H5Aprivate_H */
+#endif /* H5Aprivate_H */

--- a/src/H5Apublic.h
+++ b/src/H5Apublic.h
@@ -14,8 +14,8 @@
 /*
  * This file contains public declarations for the H5A module.
  */
-#ifndef _H5Apublic_H
-#define _H5Apublic_H
+#ifndef H5Apublic_H
+#define H5Apublic_H
 
 /* Public headers needed by this file */
 #include "H5Ipublic.h" /* IDs			  		*/
@@ -1272,4 +1272,4 @@ H5_DLL hid_t H5Aopen_name(hid_t loc_id, const char *name);
 }
 #endif
 
-#endif /* _H5Apublic_H */
+#endif /* H5Apublic_H */

--- a/src/H5B2module.h
+++ b/src/H5B2module.h
@@ -18,8 +18,8 @@
  *		H5B2 package.  Including this header means that the source file
  *		is part of the H5B2 package.
  */
-#ifndef _H5B2module_H
-#define _H5B2module_H
+#ifndef H5B2module_H
+#define H5B2module_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_BTREE
 #define H5_MY_PKG_INIT NO
 
-#endif /* _H5B2module_H */
+#endif /* H5B2module_H */

--- a/src/H5B2pkg.h
+++ b/src/H5B2pkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5B2 package!"
 #endif
 
-#ifndef _H5B2pkg_H
-#define _H5B2pkg_H
+#ifndef H5B2pkg_H
+#define H5B2pkg_H
 
 /* Get package's private header */
 #include "H5B2private.h"
@@ -453,4 +453,4 @@ H5_DLL int    H5B2__get_node_depth_test(H5B2_t *bt2, void *udata);
 H5_DLL herr_t H5B2__get_node_info_test(H5B2_t *bt2, void *udata, H5B2_node_info_test_t *ninfo);
 #endif /* H5B2_TESTING */
 
-#endif /* _H5B2pkg_H */
+#endif /* H5B2pkg_H */

--- a/src/H5B2private.h
+++ b/src/H5B2private.h
@@ -22,8 +22,8 @@
  *-------------------------------------------------------------------------
  */
 
-#ifndef _H5B2private_H
-#define _H5B2private_H
+#ifndef H5B2private_H
+#define H5B2private_H
 
 /* Private headers needed by this file */
 #include "H5ACprivate.h" /* Metadata cache                   */
@@ -149,4 +149,4 @@ H5_DLL herr_t  H5B2_patch_file(H5B2_t *fa, H5F_t *f);
 /* Statistics routines */
 H5_DLL herr_t H5B2_stat_info(H5B2_t *bt2, H5B2_stat_t *info);
 
-#endif /* _H5B2private_H */
+#endif /* H5B2private_H */

--- a/src/H5Bmodule.h
+++ b/src/H5Bmodule.h
@@ -18,8 +18,8 @@
  *		H5B package.  Including this header means that the source file
  *		is part of the H5B package.
  */
-#ifndef _H5Bmodule_H
-#define _H5Bmodule_H
+#ifndef H5Bmodule_H
+#define H5Bmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_BTREE
 #define H5_MY_PKG_INIT NO
 
-#endif /* _H5Bmodule_H */
+#endif /* H5Bmodule_H */

--- a/src/H5Bpkg.h
+++ b/src/H5Bpkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5B package!"
 #endif
 
-#ifndef _H5Bpkg_H
-#define _H5Bpkg_H
+#ifndef H5Bpkg_H
+#define H5Bpkg_H
 
 /* Get package's private header */
 #include "H5Bprivate.h"

--- a/src/H5Bprivate.h
+++ b/src/H5Bprivate.h
@@ -22,8 +22,8 @@
  *-------------------------------------------------------------------------
  */
 
-#ifndef _H5Bprivate_H
-#define _H5Bprivate_H
+#ifndef H5Bprivate_H
+#define H5Bprivate_H
 
 /* Private headers needed by this file */
 #include "H5private.h"   /* Generic Functions			*/
@@ -157,4 +157,4 @@ H5_DLL herr_t        H5B_shared_free(void *_shared);
 H5_DLL herr_t H5B_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth, const H5B_class_t *type,
                         void *udata);
 H5_DLL htri_t H5B_valid(H5F_t *f, const H5B_class_t *type, haddr_t addr);
-#endif /* _H5Bprivate_H */
+#endif /* H5Bprivate_H */

--- a/src/H5CSprivate.h
+++ b/src/H5CSprivate.h
@@ -14,8 +14,8 @@
 /*
  *  Header file for function stacks, etc.
  */
-#ifndef _H5CSprivate_H
-#define _H5CSprivate_H
+#ifndef H5CSprivate_H
+#define H5CSprivate_H
 
 #ifdef NOT_YET
 #include "H5CSpublic.h"
@@ -32,4 +32,4 @@ H5_DLL herr_t         H5CS_print_stack(const struct H5CS_t *stack, FILE *stream)
 H5_DLL struct H5CS_t *H5CS_copy_stack(void);
 H5_DLL herr_t         H5CS_close_stack(struct H5CS_t *stack);
 
-#endif /* _H5CSprivate_H */
+#endif /* H5CSprivate_H */

--- a/src/H5CXmodule.h
+++ b/src/H5CXmodule.h
@@ -18,8 +18,8 @@
  *		H5CX package.  Including this header means that the source file
  *		is part of the H5CX package.
  */
-#ifndef _H5CXmodule_H
-#define _H5CXmodule_H
+#ifndef H5CXmodule_H
+#define H5CXmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_CONTEXT
 #define H5_MY_PKG_INIT YES
 
-#endif /* _H5CXmodule_H */
+#endif /* H5CXmodule_H */

--- a/src/H5CXprivate.h
+++ b/src/H5CXprivate.h
@@ -13,8 +13,8 @@
 /*
  *  Header file for API contexts, etc.
  */
-#ifndef _H5CXprivate_H
-#define _H5CXprivate_H
+#ifndef H5CXprivate_H
+#define H5CXprivate_H
 
 /* Include package's public header */
 #ifdef NOT_YET
@@ -61,10 +61,10 @@ typedef struct H5CX_state_t {
 /***************************************/
 
 /* Library private routines */
-#ifndef _H5private_H
+#ifndef H5private_H
 H5_DLL herr_t H5CX_push(void);
 H5_DLL herr_t H5CX_pop(hbool_t update_dxpl_props);
-#endif /* _H5private_H */
+#endif /* H5private_H */
 H5_DLL void    H5CX_push_special(void);
 H5_DLL hbool_t H5CX_is_def_dxpl(void);
 
@@ -177,4 +177,4 @@ H5_DLL herr_t H5CX_test_set_mpio_coll_rank0_bcast(hbool_t rank0_bcast);
 #endif /* H5_HAVE_INSTRUMENTED_LIBRARY */
 #endif /* H5_HAVE_PARALLEL */
 
-#endif /* _H5CXprivate_H */
+#endif /* H5CXprivate_H */

--- a/src/H5Clog.h
+++ b/src/H5Clog.h
@@ -15,8 +15,8 @@
  * Purpose:     Cache logging header file
  */
 
-#ifndef _H5Clog_H
-#define _H5Clog_H
+#ifndef H5Clog_H
+#define H5Clog_H
 
 /* Get package's private header */
 #include "H5Cprivate.h" /* Cache                                    */
@@ -136,4 +136,4 @@ H5_DLL herr_t H5C_log_write_remove_entry_msg(H5C_t *cache, const H5C_cache_entry
 H5_DLL herr_t H5C_log_json_set_up(H5C_log_info_t *log_info, const char log_location[], int mpi_rank);
 H5_DLL herr_t H5C_log_trace_set_up(H5C_log_info_t *log_info, const char log_location[], int mpi_rank);
 
-#endif /* _H5Clog_H */
+#endif /* H5Clog_H */

--- a/src/H5Cmodule.h
+++ b/src/H5Cmodule.h
@@ -18,8 +18,8 @@
  *		H5C package.  Including this header means that the source file
  *		is part of the H5C package.
  */
-#ifndef _H5Cmodule_H
-#define _H5Cmodule_H
+#ifndef H5Cmodule_H
+#define H5Cmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_CACHE
 #define H5_MY_PKG_INIT NO
 
-#endif /* _H5Cmodule_H */
+#endif /* H5Cmodule_H */

--- a/src/H5Cpkg.h
+++ b/src/H5Cpkg.h
@@ -33,8 +33,8 @@
 #error "Do not include this file outside the H5C package!"
 #endif
 
-#ifndef _H5Cpkg_H
-#define _H5Cpkg_H
+#ifndef H5Cpkg_H
+#define H5Cpkg_H
 
 /* Get package's private header */
 #include "H5Cprivate.h"
@@ -5090,5 +5090,5 @@ H5_DLL herr_t H5C__untag_entry(H5C_t *cache, H5C_cache_entry_t *entry);
 H5_DLL herr_t H5C__verify_cork_tag_test(hid_t fid, H5O_token_t tag_token, hbool_t status);
 #endif /* H5C_TESTING */
 
-#endif /* _H5Cpkg_H */
+#endif /* H5Cpkg_H */
 /* clang-format on */

--- a/src/H5Cprivate.h
+++ b/src/H5Cprivate.h
@@ -23,8 +23,8 @@
  *-------------------------------------------------------------------------
  */
 
-#ifndef _H5Cprivate_H
-#define _H5Cprivate_H
+#ifndef H5Cprivate_H
+#define H5Cprivate_H
 
 #include "H5Cpublic.h" /* public prototypes            */
 

--- a/src/H5Cpublic.h
+++ b/src/H5Cpublic.h
@@ -21,8 +21,8 @@
  *
  *-------------------------------------------------------------------------
  */
-#ifndef _H5Cpublic_H
-#define _H5Cpublic_H
+#ifndef H5Cpublic_H
+#define H5Cpublic_H
 
 /* Public headers needed by this file */
 #include "H5public.h"

--- a/src/H5Dmodule.h
+++ b/src/H5Dmodule.h
@@ -18,8 +18,8 @@
  *		H5D package.  Including this header means that the source file
  *		is part of the H5D package.
  */
-#ifndef _H5Dmodule_H
-#define _H5Dmodule_H
+#ifndef H5Dmodule_H
+#define H5Dmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -40,4 +40,4 @@
  *          which is obtained by either creating or opening the dataset.
  */
 
-#endif /* _H5Dmodule_H */
+#endif /* H5Dmodule_H */

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5D package!"
 #endif
 
-#ifndef _H5Dpkg_H
-#define _H5Dpkg_H
+#ifndef H5Dpkg_H
+#define H5Dpkg_H
 
 /* Get package's private header */
 #include "H5Dprivate.h"

--- a/src/H5Dprivate.h
+++ b/src/H5Dprivate.h
@@ -14,8 +14,8 @@
 /*
  * This file contains private information about the H5D module
  */
-#ifndef _H5Dprivate_H
-#define _H5Dprivate_H
+#ifndef H5Dprivate_H
+#define H5Dprivate_H
 
 /* Include package's public header */
 #include "H5Dpublic.h"
@@ -186,4 +186,4 @@ H5_DLL herr_t H5D_virtual_free_parsed_name(H5O_storage_virtual_name_seg_t *name_
 H5_DLL herr_t H5D_btree_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth, unsigned ndims,
                               const uint32_t *dim);
 
-#endif /* _H5Dprivate_H */
+#endif /* H5Dprivate_H */

--- a/src/H5Dpublic.h
+++ b/src/H5Dpublic.h
@@ -14,8 +14,8 @@
 /*
  * This file contains public declarations for the H5D module.
  */
-#ifndef _H5Dpublic_H
-#define _H5Dpublic_H
+#ifndef H5Dpublic_H
+#define H5Dpublic_H
 
 /* System headers needed by this file */
 
@@ -1618,4 +1618,4 @@ H5_DLL herr_t H5Dvlen_reclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void
 #ifdef __cplusplus
 }
 #endif
-#endif /* _H5Dpublic_H */
+#endif /* H5Dpublic_H */

--- a/src/H5EAmodule.h
+++ b/src/H5EAmodule.h
@@ -18,8 +18,8 @@
  *		H5EA package.  Including this header means that the source file
  *		is part of the H5EA package.
  */
-#ifndef _H5EAmodule_H
-#define _H5EAmodule_H
+#ifndef H5EAmodule_H
+#define H5EAmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_EARRAY
 #define H5_MY_PKG_INIT NO
 
-#endif /* _H5EAmodule_H */
+#endif /* H5EAmodule_H */

--- a/src/H5EApkg.h
+++ b/src/H5EApkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5EA package!"
 #endif
 
-#ifndef _H5EApkg_H
-#define _H5EApkg_H
+#ifndef H5EApkg_H
+#define H5EApkg_H
 
 /* Get package's private header */
 #include "H5EAprivate.h"
@@ -461,4 +461,4 @@ H5_DLL herr_t H5EA__get_cparam_test(const H5EA_t *ea, H5EA_create_t *cparam);
 H5_DLL int    H5EA__cmp_cparam_test(const H5EA_create_t *cparam1, const H5EA_create_t *cparam2);
 #endif /* H5EA_TESTING */
 
-#endif /* _H5EApkg_H */
+#endif /* H5EApkg_H */

--- a/src/H5EAprivate.h
+++ b/src/H5EAprivate.h
@@ -23,8 +23,8 @@
  *-------------------------------------------------------------------------
  */
 
-#ifndef _H5EAprivate_H
-#define _H5EAprivate_H
+#ifndef H5EAprivate_H
+#define H5EAprivate_H
 
 /* Include package's public header */
 #ifdef NOT_YET
@@ -155,4 +155,4 @@ H5_DLL herr_t H5EA_get_stats(const H5EA_t *ea, H5EA_stat_t *stats);
 #ifdef H5EA_DEBUGGING
 #endif /* H5EA_DEBUGGING */
 
-#endif /* _H5EAprivate_H */
+#endif /* H5EAprivate_H */

--- a/src/H5ESmodule.h
+++ b/src/H5ESmodule.h
@@ -18,8 +18,8 @@
  *              H5ES package.  Including this header means that the source file
  *              is part of the H5ES package.
  */
-#ifndef _H5ESmodule_H
-#define _H5ESmodule_H
+#ifndef H5ESmodule_H
+#define H5ESmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_EVENTSET
 #define H5_MY_PKG_INIT YES
 
-#endif /* _H5ESmodule_H */
+#endif /* H5ESmodule_H */

--- a/src/H5ESpkg.h
+++ b/src/H5ESpkg.h
@@ -22,8 +22,8 @@
 #error "Do not include this file outside the H5ES package!"
 #endif
 
-#ifndef _H5ESpkg_H
-#define _H5ESpkg_H
+#ifndef H5ESpkg_H
+#define H5ESpkg_H
 
 /* Get package's private header */
 #include "H5ESprivate.h"
@@ -98,4 +98,4 @@ H5_DLL H5ES_event_t *H5ES__event_new(H5VL_t *connector, void *token);
 H5_DLL herr_t        H5ES__event_free(H5ES_event_t *ev);
 H5_DLL herr_t        H5ES__event_completed(H5ES_event_t *ev, H5ES_event_list_t *el);
 
-#endif /* _H5ESpkg_H */
+#endif /* H5ESpkg_H */

--- a/src/H5ESprivate.h
+++ b/src/H5ESprivate.h
@@ -21,8 +21,8 @@
  *-------------------------------------------------------------------------
  */
 
-#ifndef _H5ESprivate_H
-#define _H5ESprivate_H
+#ifndef H5ESprivate_H
+#define H5ESprivate_H
 
 /* Include package's public header */
 #include "H5ESpublic.h" /* Event Sets                  */
@@ -51,4 +51,4 @@ typedef struct H5ES_t H5ES_t;
 herr_t H5ES_insert(hid_t es_id, H5VL_t *connector, void *token, const char *caller, const char *caller_args,
                    ...);
 
-#endif /* _H5ESprivate_H */
+#endif /* H5ESprivate_H */

--- a/src/H5ESpublic.h
+++ b/src/H5ESpublic.h
@@ -14,8 +14,8 @@
  * This file contains public declarations for the H5ES (event set) module.
  */
 
-#ifndef _H5ESpublic_H
-#define _H5ESpublic_H
+#ifndef H5ESpublic_H
+#define H5ESpublic_H
 
 /* Public headers needed by this file */
 #include "H5public.h" /* Generic Functions                    */
@@ -133,4 +133,4 @@ H5_DLL herr_t H5ESclose(hid_t es_id);
 }
 #endif
 
-#endif /* _H5ESpublic_H */
+#endif /* H5ESpublic_H */

--- a/src/H5Emodule.h
+++ b/src/H5Emodule.h
@@ -18,8 +18,8 @@
  *		H5E package.  Including this header means that the source file
  *		is part of the H5E package.
  */
-#ifndef _H5Emodule_H
-#define _H5Emodule_H
+#ifndef H5Emodule_H
+#define H5Emodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_ERROR
 #define H5_MY_PKG_INIT YES
 
-#endif /* _H5Emodule_H */
+#endif /* H5Emodule_H */

--- a/src/H5Epkg.h
+++ b/src/H5Epkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5E package!"
 #endif
 
-#ifndef _H5Epkg_H
-#define _H5Epkg_H
+#ifndef H5Epkg_H
+#define H5Epkg_H
 
 /* Get package's private header */
 #include "H5Eprivate.h"
@@ -140,4 +140,4 @@ H5_DLL herr_t  H5E__get_auto(const H5E_t *estack, H5E_auto_op_t *op, void **clie
 H5_DLL herr_t  H5E__set_auto(H5E_t *estack, const H5E_auto_op_t *op, void *client_data);
 H5_DLL herr_t  H5E__pop(H5E_t *err_stack, size_t count);
 
-#endif /* _H5Epkg_H */
+#endif /* H5Epkg_H */

--- a/src/H5Eprivate.h
+++ b/src/H5Eprivate.h
@@ -14,8 +14,8 @@
 /*
  *  Header file for error values, etc.
  */
-#ifndef _H5Eprivate_H
-#define _H5Eprivate_H
+#ifndef H5Eprivate_H
+#define H5Eprivate_H
 
 #include "H5Epublic.h"
 
@@ -209,4 +209,4 @@ H5_DLL herr_t H5E_printf_stack(H5E_t *estack, const char *file, const char *func
 H5_DLL herr_t H5E_clear_stack(H5E_t *estack);
 H5_DLL herr_t H5E_dump_api_stack(hbool_t is_api);
 
-#endif /* _H5Eprivate_H */
+#endif /* H5Eprivate_H */

--- a/src/H5Epublic.h
+++ b/src/H5Epublic.h
@@ -14,8 +14,8 @@
 /*
  * This file contains public declarations for the H5E module.
  */
-#ifndef _H5Epublic_H
-#define _H5Epublic_H
+#ifndef H5Epublic_H
+#define H5Epublic_H
 
 #include <stdio.h> /*FILE arg of H5Eprint()                     */
 
@@ -42,11 +42,11 @@ typedef struct H5E_error2_t {
 
 /* When this header is included from a private header, don't make calls to H5open() */
 #undef H5OPEN
-#ifndef _H5private_H
+#ifndef H5private_H
 #define H5OPEN H5open(),
-#else /* _H5private_H */
+#else /* H5private_H */
 #define H5OPEN
-#endif /* _H5private_H */
+#endif /* H5private_H */
 
 /* HDF5 error class */
 #define H5E_ERR_CLS (H5OPEN H5E_ERR_CLS_g)
@@ -219,4 +219,4 @@ H5_DLL char * H5Eget_minor(H5E_minor_t min);
 }
 #endif
 
-#endif /* end _H5Epublic_H */
+#endif /* end H5Epublic_H */

--- a/src/H5FAmodule.h
+++ b/src/H5FAmodule.h
@@ -18,8 +18,8 @@
  *		H5FA package.  Including this header means that the source file
  *		is part of the H5FA package.
  */
-#ifndef _H5FAmodule_H
-#define _H5FAmodule_H
+#ifndef H5FAmodule_H
+#define H5FAmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_FARRAY
 #define H5_MY_PKG_INIT NO
 
-#endif /* _H5FAmodule_H */
+#endif /* H5FAmodule_H */

--- a/src/H5FApkg.h
+++ b/src/H5FApkg.h
@@ -22,8 +22,8 @@
 #error "Do not include this file outside the H5FA package!"
 #endif
 
-#ifndef _H5FApkg_H
-#define _H5FApkg_H
+#ifndef H5FApkg_H
+#define H5FApkg_H
 
 /* Get package's private header */
 #include "H5FAprivate.h"
@@ -299,4 +299,4 @@ H5_DLL herr_t H5FA__get_cparam_test(const H5FA_t *ea, H5FA_create_t *cparam);
 H5_DLL int    H5FA__cmp_cparam_test(const H5FA_create_t *cparam1, const H5FA_create_t *cparam2);
 #endif /* H5FA_TESTING */
 
-#endif /* _H5FApkg_H */
+#endif /* H5FApkg_H */

--- a/src/H5FAprivate.h
+++ b/src/H5FAprivate.h
@@ -21,8 +21,8 @@
  *-------------------------------------------------------------------------
  */
 
-#ifndef _H5FAprivate_H
-#define _H5FAprivate_H
+#ifndef H5FAprivate_H
+#define H5FAprivate_H
 
 /* Include package's public header */
 #ifdef NOT_YET
@@ -137,4 +137,4 @@ H5_DLL herr_t H5FA_get_stats(const H5FA_t *ea, H5FA_stat_t *stats);
 #ifdef H5FA_DEBUGGING
 #endif /* H5FA_DEBUGGING */
 
-#endif /* _H5FAprivate_H */
+#endif /* H5FAprivate_H */

--- a/src/H5FDdrvr_module.h
+++ b/src/H5FDdrvr_module.h
@@ -18,8 +18,8 @@
  *		H5FD driver package.  Including this header means that the source file
  *		is part of the H5FD driver package.
  */
-#ifndef _H5FDdrvr_module_H
-#define _H5FDdrvr_module_H
+#ifndef H5FDdrvr_module_H
+#define H5FDdrvr_module_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_INIT YES
 #define H5_PKG_SINGLE_SOURCE
 
-#endif /* _H5FDdrvr_module_H */
+#endif /* H5FDdrvr_module_H */

--- a/src/H5FDmodule.h
+++ b/src/H5FDmodule.h
@@ -18,8 +18,8 @@
  *		H5FD package.  Including this header means that the source file
  *		is part of the H5FD package.
  */
-#ifndef _H5FDmodule_H
-#define _H5FDmodule_H
+#ifndef H5FDmodule_H
+#define H5FDmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_VFL
 #define H5_MY_PKG_INIT YES
 
-#endif /* _H5FDmodule_H */
+#endif /* H5FDmodule_H */

--- a/src/H5FDpkg.h
+++ b/src/H5FDpkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5FD package!"
 #endif
 
-#ifndef _H5FDpkg_H
-#define _H5FDpkg_H
+#ifndef H5FDpkg_H
+#define H5FDpkg_H
 
 /* Get package's private header */
 #include "H5FDprivate.h" /* File drivers				*/
@@ -55,4 +55,4 @@ H5_DLL herr_t  H5FD__free_real(H5FD_t *file, H5FD_mem_t type, haddr_t addr, hsiz
 H5_DLL hbool_t H5FD__supports_swmr_test(const char *vfd_name);
 #endif /* H5FD_TESTING */
 
-#endif /* _H5FDpkg_H */
+#endif /* H5FDpkg_H */

--- a/src/H5FDprivate.h
+++ b/src/H5FDprivate.h
@@ -15,8 +15,8 @@
  * Programmer:  Robb Matzke
  *              Monday, July 26, 1999
  */
-#ifndef _H5FDprivate_H
-#define _H5FDprivate_H
+#ifndef H5FDprivate_H
+#define H5FDprivate_H
 
 /* Include package's public header */
 #include "H5FDpublic.h"

--- a/src/H5FDpublic.h
+++ b/src/H5FDpublic.h
@@ -15,8 +15,8 @@
  * Programmer:  Robb Matzke
  *              Monday, July 26, 1999
  */
-#ifndef _H5FDpublic_H
-#define _H5FDpublic_H
+#ifndef H5FDpublic_H
+#define H5FDpublic_H
 
 #include "H5public.h"
 #include "H5Fpublic.h" /*for H5F_close_degree_t */

--- a/src/H5FLmodule.h
+++ b/src/H5FLmodule.h
@@ -18,8 +18,8 @@
  *		H5FL package.  Including this header means that the source file
  *		is part of the H5FL package.
  */
-#ifndef _H5FLmodule_H
-#define _H5FLmodule_H
+#ifndef H5FLmodule_H
+#define H5FLmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_RESOURCE
 #define H5_MY_PKG_INIT NO
 
-#endif /* _H5FLmodule_H */
+#endif /* H5FLmodule_H */

--- a/src/H5FLprivate.h
+++ b/src/H5FLprivate.h
@@ -21,8 +21,8 @@
  *
  *-------------------------------------------------------------------------
  */
-#ifndef _H5FLprivate_H
-#define _H5FLprivate_H
+#ifndef H5FLprivate_H
+#define H5FLprivate_H
 
 /* Public headers needed by this file */
 #ifdef LATER

--- a/src/H5FOprivate.h
+++ b/src/H5FOprivate.h
@@ -14,8 +14,8 @@
 /*
  * This file contains library private information about the H5FO module
  */
-#ifndef _H5FOprivate_H
-#define _H5FOprivate_H
+#ifndef H5FOprivate_H
+#define H5FOprivate_H
 
 #ifdef LATER
 #include "H5FOpublic.h"
@@ -47,4 +47,4 @@ H5_DLL herr_t  H5FO_top_decr(const H5F_t *f, haddr_t addr);
 H5_DLL hsize_t H5FO_top_count(const H5F_t *f, haddr_t addr);
 H5_DLL herr_t  H5FO_top_dest(H5F_t *f);
 
-#endif /* _H5FOprivate_H */
+#endif /* H5FOprivate_H */

--- a/src/H5FSmodule.h
+++ b/src/H5FSmodule.h
@@ -18,8 +18,8 @@
  *		H5FS package.  Including this header means that the source file
  *		is part of the H5FS package.
  */
-#ifndef _H5FSmodule_H
-#define _H5FSmodule_H
+#ifndef H5FSmodule_H
+#define H5FSmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_FSPACE
 #define H5_MY_PKG_INIT NO
 
-#endif /* _H5FSmodule_H */
+#endif /* H5FSmodule_H */

--- a/src/H5FSpkg.h
+++ b/src/H5FSpkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5FS package!"
 #endif
 
-#ifndef _H5FSpkg_H
-#define _H5FSpkg_H
+#ifndef H5FSpkg_H
+#define H5FSpkg_H
 
 /* Uncomment this macro to enable debugging output for free space manager */
 /* #define H5FS_DEBUG */
@@ -240,4 +240,4 @@ H5_DLL herr_t H5FS__get_cparam_test(const H5FS_t *fh, H5FS_create_t *cparam);
 H5_DLL int    H5FS__cmp_cparam_test(const H5FS_create_t *cparam1, const H5FS_create_t *cparam2);
 #endif /* H5FS_TESTING */
 
-#endif /* _H5FSpkg_H */
+#endif /* H5FSpkg_H */

--- a/src/H5FSprivate.h
+++ b/src/H5FSprivate.h
@@ -22,8 +22,8 @@
  *-------------------------------------------------------------------------
  */
 
-#ifndef _H5FSprivate_H
-#define _H5FSprivate_H
+#ifndef H5FSprivate_H
+#define H5FSprivate_H
 
 /* Private headers needed by this file */
 #include "H5Fprivate.h"  /* File access				*/
@@ -230,4 +230,4 @@ H5_DLL herr_t H5FS_sects_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent,
 H5_DLL herr_t H5FS_sect_debug(const H5FS_t *fspace, const H5FS_section_info_t *sect, FILE *stream, int indent,
                               int fwidth);
 
-#endif /* _H5FSprivate_H */
+#endif /* H5FSprivate_H */

--- a/src/H5Fmodule.h
+++ b/src/H5Fmodule.h
@@ -18,8 +18,8 @@
  *		H5F package.  Including this header means that the source file
  *		is part of the H5F package.
  */
-#ifndef _H5Fmodule_H
-#define _H5Fmodule_H
+#ifndef H5Fmodule_H
+#define H5Fmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -42,4 +42,4 @@
  * \ingroup H5F
  */
 
-#endif /* _H5Fmodule_H */
+#endif /* H5Fmodule_H */

--- a/src/H5Fpkg.h
+++ b/src/H5Fpkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5F package!"
 #endif
 
-#ifndef _H5Fpkg_H
-#define _H5Fpkg_H
+#ifndef H5Fpkg_H
+#define H5Fpkg_H
 
 /* Get package's private header */
 #include "H5Fprivate.h"
@@ -481,4 +481,4 @@ H5_DLL htri_t H5F__same_file_test(hid_t file_id1, hid_t file_id2);
 H5_DLL herr_t H5F__reparse_file_lock_variable_test(void);
 #endif /* H5F_TESTING */
 
-#endif /* _H5Fpkg_H */
+#endif /* H5Fpkg_H */

--- a/src/H5Fprivate.h
+++ b/src/H5Fprivate.h
@@ -15,8 +15,8 @@
  * This file contains macros & information for file access
  */
 
-#ifndef _H5Fprivate_H
-#define _H5Fprivate_H
+#ifndef H5Fprivate_H
+#define H5Fprivate_H
 
 /* Early typedefs to avoid circular dependencies */
 typedef struct H5F_t H5F_t;
@@ -982,4 +982,4 @@ H5_DLL herr_t H5F_cwfs_remove_heap(H5F_shared_t *shared, struct H5HG_heap_t *hea
 /* Debugging functions */
 H5_DLL herr_t H5F_debug(H5F_t *f, FILE *stream, int indent, int fwidth);
 
-#endif /* _H5Fprivate_H */
+#endif /* H5Fprivate_H */

--- a/src/H5Fpublic.h
+++ b/src/H5Fpublic.h
@@ -14,8 +14,8 @@
 /*
  * This file contains public declarations for the H5F module.
  */
-#ifndef _H5Fpublic_H
-#define _H5Fpublic_H
+#ifndef H5Fpublic_H
+#define H5Fpublic_H
 
 /* Public header files needed by this file */
 #include "H5public.h"
@@ -24,19 +24,19 @@
 
 /* When this header is included from a private header, don't make calls to H5check() */
 #undef H5CHECK
-#ifndef _H5private_H
+#ifndef H5private_H
 #define H5CHECK H5check(),
-#else /* _H5private_H */
+#else /* H5private_H */
 #define H5CHECK
-#endif /* _H5private_H */
+#endif /* H5private_H */
 
 /* When this header is included from a private HDF5 header, don't make calls to H5open() */
 #undef H5OPEN
-#ifndef _H5private_H
+#ifndef H5private_H
 #define H5OPEN H5open(),
-#else /* _H5private_H */
+#else /* H5private_H */
 #define H5OPEN
-#endif /* _H5private_H */
+#endif /* H5private_H */
 
 /*
  * These are the bits that can be passed to the `flags' argument of
@@ -2298,4 +2298,4 @@ H5_DLL htri_t H5Fis_hdf5(const char *file_name);
 #ifdef __cplusplus
 }
 #endif
-#endif /* _H5Fpublic_H */
+#endif /* H5Fpublic_H */

--- a/src/H5Gmodule.h
+++ b/src/H5Gmodule.h
@@ -18,8 +18,8 @@
  *		H5G package.  Including this header means that the source file
  *		is part of the H5G package.
  */
-#ifndef _H5Gmodule_H
-#define _H5Gmodule_H
+#ifndef H5Gmodule_H
+#define H5Gmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -36,4 +36,4 @@
  *          HDF5 groups and their members, which are other HDF5 objects.
  */
 
-#endif /* _H5Gmodule_H */
+#endif /* H5Gmodule_H */

--- a/src/H5Gpkg.h
+++ b/src/H5Gpkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5G package!"
 #endif
 
-#ifndef _H5Gpkg_H
-#define _H5Gpkg_H
+#ifndef H5Gpkg_H
+#define H5Gpkg_H
 
 /* Get package's private header */
 #include "H5Gprivate.h"
@@ -483,4 +483,4 @@ H5_DLL herr_t H5G__verify_cached_stab_test(H5O_loc_t *grp_oloc, H5G_entry_t *ent
 H5_DLL herr_t H5G__verify_cached_stabs_test(hid_t gid);
 #endif /* H5G_TESTING */
 
-#endif /* _H5Gpkg_H */
+#endif /* H5Gpkg_H */

--- a/src/H5Gprivate.h
+++ b/src/H5Gprivate.h
@@ -22,8 +22,8 @@
  *-------------------------------------------------------------------------
  */
 
-#ifndef _H5Gprivate_H
-#define _H5Gprivate_H
+#ifndef H5Gprivate_H
+#define H5Gprivate_H
 
 /* Include package's public header */
 #include "H5Gpublic.h"
@@ -291,4 +291,4 @@ H5_DLL herr_t H5G_root_loc(H5F_t *f, H5G_loc_t *loc);
 H5_DLL herr_t H5G_root_free(H5G_t *grp);
 H5_DLL H5G_t *H5G_rootof(H5F_t *f);
 
-#endif /* _H5Gprivate_H */
+#endif /* H5Gprivate_H */

--- a/src/H5Gpublic.h
+++ b/src/H5Gpublic.h
@@ -21,8 +21,8 @@
  *
  *-------------------------------------------------------------------------
  */
-#ifndef _H5Gpublic_H
-#define _H5Gpublic_H
+#ifndef H5Gpublic_H
+#define H5Gpublic_H
 
 /* System headers needed by this file */
 #include <sys/types.h>
@@ -656,4 +656,4 @@ H5_DLL H5G_obj_t H5Gget_objtype_by_idx(hid_t loc_id, hsize_t idx);
 #ifdef __cplusplus
 }
 #endif
-#endif /* _H5Gpublic_H */
+#endif /* H5Gpublic_H */

--- a/src/H5HFmodule.h
+++ b/src/H5HFmodule.h
@@ -18,8 +18,8 @@
  *		H5HF package.  Including this header means that the source file
  *		is part of the H5HF package.
  */
-#ifndef _H5HFmodule_H
-#define _H5HFmodule_H
+#ifndef H5HFmodule_H
+#define H5HFmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_HEAP
 #define H5_MY_PKG_INIT NO
 
-#endif /* _H5HFmodule_H */
+#endif /* H5HFmodule_H */

--- a/src/H5HFpkg.h
+++ b/src/H5HFpkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5HF package!"
 #endif
 
-#ifndef _H5HFpkg_H
-#define _H5HFpkg_H
+#ifndef H5HFpkg_H
+#define H5HFpkg_H
 
 /* Get package's private header */
 #include "H5HFprivate.h"
@@ -778,4 +778,4 @@ H5_DLL herr_t   H5HF_get_tiny_info_test(const H5HF_t *fh, size_t *max_len, hbool
 H5_DLL herr_t   H5HF_get_huge_info_test(const H5HF_t *fh, hsize_t *next_id, hbool_t *ids_direct);
 #endif /* H5HF_TESTING */
 
-#endif /* _H5HFpkg_H */
+#endif /* H5HFpkg_H */

--- a/src/H5HFprivate.h
+++ b/src/H5HFprivate.h
@@ -22,8 +22,8 @@
  *-------------------------------------------------------------------------
  */
 
-#ifndef _H5HFprivate_H
-#define _H5HFprivate_H
+#ifndef H5HFprivate_H
+#define H5HFprivate_H
 
 /* Private headers needed by this file */
 #include "H5Fprivate.h" /* File access				*/
@@ -138,4 +138,4 @@ H5_DLL void H5HF_iblock_print(const H5HF_indirect_t *iblock, hbool_t dump_intern
 H5_DLL herr_t H5HF_iblock_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth,
                                 haddr_t hdr_addr, unsigned nrows);
 
-#endif /* _H5HFprivate_H */
+#endif /* H5HFprivate_H */

--- a/src/H5HGmodule.h
+++ b/src/H5HGmodule.h
@@ -18,8 +18,8 @@
  *		H5HG package.  Including this header means that the source file
  *		is part of the H5HG package.
  */
-#ifndef _H5HGmodule_H
-#define _H5HGmodule_H
+#ifndef H5HGmodule_H
+#define H5HGmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_HEAP
 #define H5_MY_PKG_INIT NO
 
-#endif /* _H5HGmodule_H */
+#endif /* H5HGmodule_H */

--- a/src/H5HGpkg.h
+++ b/src/H5HGpkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5HG package!"
 #endif
 
-#ifndef _H5HGpkg_H
-#define _H5HGpkg_H
+#ifndef H5HGpkg_H
+#define H5HGpkg_H
 
 /* Get package's private header */
 #include "H5HGprivate.h"
@@ -136,4 +136,4 @@ struct H5HG_heap_t {
 H5_DLL herr_t H5HG__free(H5HG_heap_t *heap);
 H5_DLL H5HG_heap_t *H5HG__protect(H5F_t *f, haddr_t addr, unsigned flags);
 
-#endif /* _H5HGpkg_H */
+#endif /* H5HGpkg_H */

--- a/src/H5HGprivate.h
+++ b/src/H5HGprivate.h
@@ -15,8 +15,8 @@
  * Programmer:  Robb Matzke
  *              Friday, March 27, 1998
  */
-#ifndef _H5HGprivate_H
-#define _H5HGprivate_H
+#ifndef H5HGprivate_H
+#define H5HGprivate_H
 
 /* Private headers needed by this file. */
 #include "H5Fprivate.h" /* File access				*/
@@ -70,4 +70,4 @@ H5_DLL size_t  H5HG_get_free_size(const H5HG_heap_t *h);
 /* Debugging functions */
 H5_DLL herr_t H5HG_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth);
 
-#endif /* _H5HGprivate_H */
+#endif /* H5HGprivate_H */

--- a/src/H5HLmodule.h
+++ b/src/H5HLmodule.h
@@ -18,8 +18,8 @@
  *		H5HL package.  Including this header means that the source file
  *		is part of the H5HL package.
  */
-#ifndef _H5HLmodule_H
-#define _H5HLmodule_H
+#ifndef H5HLmodule_H
+#define H5HLmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_HEAP
 #define H5_MY_PKG_INIT NO
 
-#endif /* _H5HLmodule_H */
+#endif /* H5HLmodule_H */

--- a/src/H5HLpkg.h
+++ b/src/H5HLpkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5HL package!"
 #endif
 
-#ifndef _H5HLpkg_H
-#define _H5HLpkg_H
+#ifndef H5HLpkg_H
+#define H5HLpkg_H
 
 /* Get package's private header */
 #include "H5HLprivate.h"
@@ -145,4 +145,4 @@ H5_DLL H5HL_dblk_t *H5HL__dblk_new(H5HL_t *heap);
 H5_DLL herr_t       H5HL__dblk_dest(H5HL_dblk_t *dblk);
 H5_DLL herr_t       H5HL__dblk_realloc(H5F_t *f, H5HL_t *heap, size_t new_heap_size);
 
-#endif /* _H5HLpkg_H */
+#endif /* H5HLpkg_H */

--- a/src/H5HLprivate.h
+++ b/src/H5HLprivate.h
@@ -21,8 +21,8 @@
  *
  *-------------------------------------------------------------------------
  */
-#ifndef _H5HLprivate_H
-#define _H5HLprivate_H
+#ifndef H5HLprivate_H
+#define H5HLprivate_H
 
 /* Private headers needed by this file. */
 #include "H5private.h"   /* Generic Functions                */

--- a/src/H5HPprivate.h
+++ b/src/H5HPprivate.h
@@ -14,8 +14,8 @@
 /*
  * This file contains private information about the H5HP module
  */
-#ifndef _H5HPprivate_H
-#define _H5HPprivate_H
+#ifndef H5HPprivate_H
+#define H5HPprivate_H
 
 /**************************************/
 /* Public headers needed by this file */
@@ -65,4 +65,4 @@ H5_DLL herr_t  H5HP_incr(H5HP_t *heap, unsigned amt, void *obj);
 H5_DLL herr_t  H5HP_decr(H5HP_t *heap, unsigned amt, void *obj);
 H5_DLL herr_t  H5HP_close(H5HP_t *heap);
 
-#endif /* _H5HPprivate_H */
+#endif /* H5HPprivate_H */

--- a/src/H5Imodule.h
+++ b/src/H5Imodule.h
@@ -18,8 +18,8 @@
  *              H5I package.  Including this header means that the source file
  *              is part of the H5I package.
  */
-#ifndef _H5Imodule_H
-#define _H5Imodule_H
+#ifndef H5Imodule_H
+#define H5Imodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  * reporting macros.
@@ -34,4 +34,4 @@
  * \todo Describe concisely what the functions in this module are about.
  */
 
-#endif /* _H5Imodule_H */
+#endif /* H5Imodule_H */

--- a/src/H5Ipkg.h
+++ b/src/H5Ipkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5I package!"
 #endif
 
-#ifndef _H5Ipkg_H
-#define _H5Ipkg_H
+#ifndef H5Ipkg_H
+#define H5Ipkg_H
 
 /* Get package's private header */
 #include "H5Iprivate.h"

--- a/src/H5Iprivate.h
+++ b/src/H5Iprivate.h
@@ -17,8 +17,8 @@
  *---------------------------------------------------------------------------*/
 
 /* avoid re-inclusion */
-#ifndef _H5Iprivate_H
-#define _H5Iprivate_H
+#ifndef H5Iprivate_H
+#define H5Iprivate_H
 
 /* Include package's public header */
 #include "H5Ipublic.h"
@@ -101,4 +101,4 @@ H5_DLL herr_t H5I_register_using_existing_id(H5I_type_t type, void *object, hboo
 /* Debugging functions */
 H5_DLL herr_t H5I_dump_ids_for_type(H5I_type_t type);
 
-#endif /* _H5Iprivate_H */
+#endif /* H5Iprivate_H */

--- a/src/H5Ipublic.h
+++ b/src/H5Ipublic.h
@@ -15,8 +15,8 @@
  * This file contains function prototypes for each exported function in
  * the H5I module.
  */
-#ifndef _H5Ipublic_H
-#define _H5Ipublic_H
+#ifndef H5Ipublic_H
+#define H5Ipublic_H
 
 /* Public headers needed by this file */
 #include "H5public.h"
@@ -753,4 +753,4 @@ H5_DLL htri_t H5Iis_valid(hid_t id);
 #ifdef __cplusplus
 }
 #endif
-#endif /* _H5Ipublic_H */
+#endif /* H5Ipublic_H */

--- a/src/H5Lmodule.h
+++ b/src/H5Lmodule.h
@@ -18,8 +18,8 @@
  *		H5L package.  Including this header means that the source file
  *		is part of the H5L package.
  */
-#ifndef _H5Lmodule_H
-#define _H5Lmodule_H
+#ifndef H5Lmodule_H
+#define H5Lmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -37,4 +37,4 @@
  * \ingroup H5L
  */
 
-#endif /* _H5Lmodule_H */
+#endif /* H5Lmodule_H */

--- a/src/H5Lpkg.h
+++ b/src/H5Lpkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5L package!"
 #endif
 
-#ifndef _H5Lpkg_H
-#define _H5Lpkg_H
+#ifndef H5Lpkg_H
+#define H5Lpkg_H
 
 /* Get package's private header */
 #include "H5Lprivate.h"
@@ -75,4 +75,4 @@ H5_DLL herr_t  H5L__delete_by_idx(const H5G_loc_t *loc, const char *name, H5_ind
 H5_DLL herr_t  H5L__link_copy_file(H5F_t *dst_file, const H5O_link_t *_src_lnk, const H5O_loc_t *src_oloc,
                                    H5O_link_t *dst_lnk, H5O_copy_t *cpy_info);
 
-#endif /* _H5Lpkg_H */
+#endif /* H5Lpkg_H */

--- a/src/H5Lprivate.h
+++ b/src/H5Lprivate.h
@@ -15,8 +15,8 @@
  * This file contains private information about the H5L module
  * for dealing with links in an HDF5 file.
  */
-#ifndef _H5Lprivate_H
-#define _H5Lprivate_H
+#ifndef H5Lprivate_H
+#define H5Lprivate_H
 
 /* Include package's public header */
 #include "H5Lpublic.h"
@@ -125,4 +125,4 @@ H5_DLL herr_t H5L_register(const H5L_class_t *cls);
 H5_DLL herr_t H5L_unregister(H5L_type_t id);
 H5_DLL const H5L_class_t *H5L_find_class(H5L_type_t id);
 
-#endif /* _H5Lprivate_H */
+#endif /* H5Lprivate_H */

--- a/src/H5Lpublic.h
+++ b/src/H5Lpublic.h
@@ -21,8 +21,8 @@
  *
  *-------------------------------------------------------------------------
  */
-#ifndef _H5Lpublic_H
-#define _H5Lpublic_H
+#ifndef H5Lpublic_H
+#define H5Lpublic_H
 
 /* Public headers needed by this file */
 #include "H5public.h"  /* Generic Functions            */
@@ -2152,4 +2152,4 @@ H5_DLL herr_t H5Lvisit_by_name1(hid_t loc_id, const char *group_name, H5_index_t
 #ifdef __cplusplus
 }
 #endif
-#endif /* _H5Lpublic_H */
+#endif /* H5Lpublic_H */

--- a/src/H5MFmodule.h
+++ b/src/H5MFmodule.h
@@ -18,8 +18,8 @@
  *		H5MF package.  Including this header means that the source file
  *		is part of the H5MF package.
  */
-#ifndef _H5MFmodule_H
-#define _H5MFmodule_H
+#ifndef H5MFmodule_H
+#define H5MFmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_RESOURCE
 #define H5_MY_PKG_INIT NO
 
-#endif /* _H5MFmodule_H */
+#endif /* H5MFmodule_H */

--- a/src/H5MFpkg.h
+++ b/src/H5MFpkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5MF package!"
 #endif
 
-#ifndef _H5MFpkg_H
-#define _H5MFpkg_H
+#ifndef H5MFpkg_H
+#define H5MFpkg_H
 
 /* Get package's private header */
 #include "H5MFprivate.h"
@@ -207,4 +207,4 @@ H5_DLL herr_t H5MF__sects_dump(H5F_t *f, FILE *stream);
 #ifdef H5MF_TESTING
 #endif /* H5MF_TESTING */
 
-#endif /* _H5MFpkg_H */
+#endif /* H5MFpkg_H */

--- a/src/H5MFprivate.h
+++ b/src/H5MFprivate.h
@@ -21,8 +21,8 @@
  *
  *-------------------------------------------------------------------------
  */
-#ifndef _H5MFprivate_H
-#define _H5MFprivate_H
+#ifndef H5MFprivate_H
+#define H5MFprivate_H
 
 /* Private headers needed by this file */
 #include "H5Fprivate.h"  /* File access				*/
@@ -81,4 +81,4 @@ H5_DLL herr_t H5MF_tidy_self_referential_fsm_hack(H5F_t *f);
 H5_DLL herr_t H5MF_sects_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth);
 #endif /* H5MF_DEBUGGING */
 
-#endif /* end _H5MFprivate_H */
+#endif /* end H5MFprivate_H */

--- a/src/H5MMprivate.h
+++ b/src/H5MMprivate.h
@@ -21,8 +21,8 @@
  *
  *-------------------------------------------------------------------------
  */
-#ifndef _H5MMprivate_H
-#define _H5MMprivate_H
+#ifndef H5MMprivate_H
+#define H5MMprivate_H
 
 #include "H5MMpublic.h"
 
@@ -53,4 +53,4 @@ H5_DLL void   H5MM_sanity_check_all(void);
 H5_DLL void   H5MM_final_sanity_check(void);
 #endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
 
-#endif /* _H5MMprivate_H */
+#endif /* H5MMprivate_H */

--- a/src/H5MMpublic.h
+++ b/src/H5MMpublic.h
@@ -22,8 +22,8 @@
  *
  *-------------------------------------------------------------------------
  */
-#ifndef _H5MMpublic_H
-#define _H5MMpublic_H
+#ifndef H5MMpublic_H
+#define H5MMpublic_H
 
 /* Public headers needed by this file */
 #include "H5public.h"
@@ -39,4 +39,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* _H5MMpublic_H */
+#endif /* H5MMpublic_H */

--- a/src/H5MPmodule.h
+++ b/src/H5MPmodule.h
@@ -18,8 +18,8 @@
  *		H5MP package.  Including this header means that the source file
  *		is part of the H5MP package.
  */
-#ifndef _H5MPmodule_H
-#define _H5MPmodule_H
+#ifndef H5MPmodule_H
+#define H5MPmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_RESOURCE
 #define H5_MY_PKG_INIT NO
 
-#endif /* _H5MPmodule_H */
+#endif /* H5MPmodule_H */

--- a/src/H5MPpkg.h
+++ b/src/H5MPpkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5MP package!"
 #endif
 
-#ifndef _H5MPpkg_H
-#define _H5MPpkg_H
+#ifndef H5MPpkg_H
+#define H5MPpkg_H
 
 /* Get package's private header */
 #include "H5MPprivate.h" /* Memory Pools				*/
@@ -96,4 +96,4 @@ H5_DLL herr_t H5MP_get_page_free_size(const H5MP_page_t *mp, size_t *page);
 H5_DLL herr_t H5MP_get_page_next_page(const H5MP_page_t *page, H5MP_page_t **next_page);
 #endif /* H5MP_TESTING */
 
-#endif /* _H5MPpkg_H */
+#endif /* H5MPpkg_H */

--- a/src/H5MPprivate.h
+++ b/src/H5MPprivate.h
@@ -22,8 +22,8 @@
  *-------------------------------------------------------------------------
  */
 
-#ifndef _H5MPprivate_H
-#define _H5MPprivate_H
+#ifndef H5MPprivate_H
+#define H5MPprivate_H
 
 /* Include package's public header (not yet) */
 /* #include "H5MPpublic.h" */
@@ -54,4 +54,4 @@ H5_DLL void *       H5MP_malloc(H5MP_pool_t *mp, size_t request);
 H5_DLL void *       H5MP_free(H5MP_pool_t *mp, void *spc);
 H5_DLL herr_t       H5MP_close(H5MP_pool_t *mp);
 
-#endif /* _H5MPprivate_H */
+#endif /* H5MPprivate_H */

--- a/src/H5Mmodule.h
+++ b/src/H5Mmodule.h
@@ -15,8 +15,8 @@
  *              H5M package.  Including this header means that the source file
  *              is part of the H5M package.
  */
-#ifndef _H5Mmodule_H
-#define _H5Mmodule_H
+#ifndef H5Mmodule_H
+#define H5Mmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -26,4 +26,4 @@
 #define H5_MY_PKG_ERR  H5E_MAP
 #define H5_MY_PKG_INIT YES
 
-#endif /* _H5Dmodule_H */
+#endif /* H5Dmodule_H */

--- a/src/H5Mpkg.h
+++ b/src/H5Mpkg.h
@@ -20,8 +20,8 @@
 #error "Do not include this file outside the H5M package!"
 #endif
 
-#ifndef _H5Mpkg_H
-#define _H5Mpkg_H
+#ifndef H5Mpkg_H
+#define H5Mpkg_H
 
 /* Get package's private header */
 #include "H5Mprivate.h"

--- a/src/H5Mprivate.h
+++ b/src/H5Mprivate.h
@@ -14,8 +14,8 @@
 /*
  * This file contains private information about the H5M module
  */
-#ifndef _H5Mprivate_H
-#define _H5Mprivate_H
+#ifndef H5Mprivate_H
+#define H5Mprivate_H
 
 /* Include package's public header */
 #include "H5Mpublic.h"
@@ -75,4 +75,4 @@ H5_DLL herr_t H5M_init(void);
 /* Library Private Prototypes */
 /******************************/
 
-#endif /* _H5Mprivate_H */
+#endif /* H5Mprivate_H */

--- a/src/H5Mpublic.h
+++ b/src/H5Mpublic.h
@@ -17,8 +17,8 @@
  * NOTE:    This is an experimental API. Everything in the H5M package
  *          is subject to revision in a future release.
  */
-#ifndef _H5Mpublic_H
-#define _H5Mpublic_H
+#ifndef H5Mpublic_H
+#define H5Mpublic_H
 
 /* System headers needed by this file */
 
@@ -147,4 +147,4 @@ H5_DLL herr_t H5Mdelete(hid_t map_id, hid_t key_mem_type_id, const void *key, hi
 }
 #endif
 
-#endif /* _H5Mpublic_H */
+#endif /* H5Mpublic_H */

--- a/src/H5Omodule.h
+++ b/src/H5Omodule.h
@@ -18,8 +18,8 @@
  *		H5O package.  Including this header means that the source file
  *		is part of the H5O package.
  */
-#ifndef _H5Omodule_H
-#define _H5Omodule_H
+#ifndef H5Omodule_H
+#define H5Omodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -35,4 +35,4 @@
  * \todo Describe concisely what the functions in this module are about.
  *
  */
-#endif /* _H5Omodule_H */
+#endif /* H5Omodule_H */

--- a/src/H5Opkg.h
+++ b/src/H5Opkg.h
@@ -15,8 +15,8 @@
 #error "Do not include this file outside the H5O package!"
 #endif
 
-#ifndef _H5Opkg_H
-#define _H5Opkg_H
+#ifndef H5Opkg_H
+#define H5Opkg_H
 
 /* Get package's private header */
 #include "H5Oprivate.h" /* Object headers		  	*/
@@ -644,4 +644,4 @@ H5_DLL herr_t H5O__assert(const H5O_t *oh);
 #endif /* H5O_DEBUG */
 H5_DLL herr_t H5O__debug_real(H5F_t *f, H5O_t *oh, haddr_t addr, FILE *stream, int indent, int fwidth);
 
-#endif /* _H5Opkg_H */
+#endif /* H5Opkg_H */

--- a/src/H5Oprivate.h
+++ b/src/H5Oprivate.h
@@ -21,8 +21,8 @@
  *
  *-------------------------------------------------------------------------
  */
-#ifndef _H5Oprivate_H
-#define _H5Oprivate_H
+#ifndef H5Oprivate_H
+#define H5Oprivate_H
 
 /* Early typedefs to avoid circular dependencies */
 typedef struct H5O_t      H5O_t;
@@ -1032,4 +1032,4 @@ H5_DLL herr_t H5O_pline_set_version(H5F_t *f, H5O_pline_t *pline);
 /* Shared message operators */
 H5_DLL herr_t H5O_set_shared(H5O_shared_t *dst, const H5O_shared_t *src);
 
-#endif /* _H5Oprivate_H */
+#endif /* H5Oprivate_H */

--- a/src/H5Opublic.h
+++ b/src/H5Opublic.h
@@ -22,8 +22,8 @@
  *
  *-------------------------------------------------------------------------
  */
-#ifndef _H5Opublic_H
-#define _H5Opublic_H
+#ifndef H5Opublic_H
+#define H5Opublic_H
 
 /* Public headers needed by this file */
 #include "H5public.h"  /* Generic Functions            */
@@ -2851,4 +2851,4 @@ H5_DLL herr_t H5Ovisit_by_name2(hid_t loc_id, const char *obj_name, H5_index_t i
 #ifdef __cplusplus
 }
 #endif
-#endif /* _H5Opublic_H */
+#endif /* H5Opublic_H */

--- a/src/H5PBmodule.h
+++ b/src/H5PBmodule.h
@@ -18,8 +18,8 @@
  *		H5PB package.  Including this header means that the source file
  *		is part of the H5PB package.
  */
-#ifndef _H5PBmodule_H
-#define _H5PBmodule_H
+#ifndef H5PBmodule_H
+#define H5PBmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_RESOURCE
 #define H5_MY_PKG_INIT NO
 
-#endif /* _H5PBmodule_H */
+#endif /* H5PBmodule_H */

--- a/src/H5PBpkg.h
+++ b/src/H5PBpkg.h
@@ -15,8 +15,8 @@
 #error "Do not include this file outside the H5PB package!"
 #endif
 
-#ifndef _H5PBpkg_H
-#define _H5PBpkg_H
+#ifndef H5PBpkg_H
+#define H5PBpkg_H
 
 /* Get package's private header */
 #include "H5PBprivate.h"
@@ -50,4 +50,4 @@ typedef struct H5PB_entry_t {
 /* Package Private Prototypes */
 /******************************/
 
-#endif /* _H5PBpkg_H */
+#endif /* H5PBpkg_H */

--- a/src/H5PBprivate.h
+++ b/src/H5PBprivate.h
@@ -20,8 +20,8 @@
  *-------------------------------------------------------------------------
  */
 
-#ifndef _H5PBprivate_H
-#define _H5PBprivate_H
+#ifndef H5PBprivate_H
+#define H5PBprivate_H
 
 /* Include package's public header */
 #ifdef NOT_YET

--- a/src/H5PLextern.h
+++ b/src/H5PLextern.h
@@ -14,8 +14,8 @@
  * Purpose:     Header file for writing external HDF5 plugins.
  */
 
-#ifndef _H5PLextern_H
-#define _H5PLextern_H
+#ifndef H5PLextern_H
+#define H5PLextern_H
 
 /* Include HDF5 header */
 #include "hdf5.h"
@@ -40,4 +40,4 @@ H5PLUGIN_DLL const void *H5PLget_plugin_info(void);
 }
 #endif
 
-#endif /* _H5PLextern_H */
+#endif /* H5PLextern_H */

--- a/src/H5PLmodule.h
+++ b/src/H5PLmodule.h
@@ -16,8 +16,8 @@
  *          is part of the H5PL package.
  */
 
-#ifndef _H5PLmodule_H
-#define _H5PLmodule_H
+#ifndef H5PLmodule_H
+#define H5PLmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -32,4 +32,4 @@
  * \todo Describe what programmatically controlling dynamically loaded plugins (H5PL) is all about
  */
 
-#endif /* _H5PLmodule_H */
+#endif /* H5PLmodule_H */

--- a/src/H5PLpkg.h
+++ b/src/H5PLpkg.h
@@ -21,8 +21,8 @@
 #error "Do not include this file outside the H5PL package!"
 #endif
 
-#ifndef _H5PLpkg_H
-#define _H5PLpkg_H
+#ifndef H5PLpkg_H
+#define H5PLpkg_H
 
 /* Include private header file */
 #include "H5PLprivate.h" /* Filter functions                */
@@ -158,4 +158,4 @@ H5_DLL herr_t H5PL__path_table_iterate(H5PL_iterate_type_t iter_type, H5PL_itera
 H5_DLL herr_t H5PL__find_plugin_in_path_table(const H5PL_search_params_t *search_params,
                                               hbool_t *found /*out*/, const void **plugin_info /*out*/);
 
-#endif /* _H5PLpkg_H */
+#endif /* H5PLpkg_H */

--- a/src/H5PLprivate.h
+++ b/src/H5PLprivate.h
@@ -14,8 +14,8 @@
  * This file contains private information about the H5PL module
  */
 
-#ifndef _H5PLprivate_H
-#define _H5PLprivate_H
+#ifndef H5PLprivate_H
+#define H5PLprivate_H
 
 /* Include package's public header */
 #include "H5PLpublic.h"
@@ -68,4 +68,4 @@ typedef herr_t (*H5PL_iterate_t)(H5PL_type_t plugin_type, const void *plugin_inf
 H5_DLL const void *H5PL_load(H5PL_type_t plugin_type, const H5PL_key_t *key);
 H5_DLL herr_t      H5PL_iterate(H5PL_iterate_type_t iter_type, H5PL_iterate_t iter_op, void *op_data);
 
-#endif /* _H5PLprivate_H */
+#endif /* H5PLprivate_H */

--- a/src/H5PLpublic.h
+++ b/src/H5PLpublic.h
@@ -14,8 +14,8 @@
  * This file contains public declarations for the H5PL module.
  */
 
-#ifndef _H5PLpublic_H
-#define _H5PLpublic_H
+#ifndef H5PLpublic_H
+#define H5PLpublic_H
 
 /* Public headers needed by this file */
 #include "H5public.h" /* Generic Functions                    */
@@ -224,4 +224,4 @@ H5_DLL herr_t H5PLsize(unsigned int *num_paths /*out*/);
 }
 #endif
 
-#endif /* _H5PLpublic_H */
+#endif /* H5PLpublic_H */

--- a/src/H5Pmodule.h
+++ b/src/H5Pmodule.h
@@ -18,8 +18,8 @@
  *		H5P package.  Including this header means that the source file
  *		is part of the H5P package.
  */
-#ifndef _H5Pmodule_H
-#define _H5Pmodule_H
+#ifndef H5Pmodule_H
+#define H5Pmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -72,4 +72,4 @@
  * \ingroup H5P
  */
 
-#endif /* _H5Pmodule_H */
+#endif /* H5Pmodule_H */

--- a/src/H5Ppkg.h
+++ b/src/H5Ppkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5P package!"
 #endif
 
-#ifndef _H5Ppkg_H
-#define _H5Ppkg_H
+#ifndef H5Ppkg_H
+#define H5Ppkg_H
 
 /* Get package's private header */
 #include "H5Pprivate.h"
@@ -198,4 +198,4 @@ H5_DLL char *H5P__get_class_path_test(hid_t pclass_id);
 H5_DLL hid_t H5P__open_class_path_test(const char *path);
 #endif /* H5P_TESTING */
 
-#endif /* _H5Ppkg_H */
+#endif /* H5Ppkg_H */

--- a/src/H5Pprivate.h
+++ b/src/H5Pprivate.h
@@ -14,8 +14,8 @@
 /*
  * This file contains private information about the H5P module
  */
-#ifndef _H5Pprivate_H
-#define _H5Pprivate_H
+#ifndef H5Pprivate_H
+#define H5Pprivate_H
 
 /* Early typedefs to avoid circular dependencies */
 typedef struct H5P_genplist_t H5P_genplist_t;
@@ -209,4 +209,4 @@ H5_DLL herr_t H5P_get_fill_value(H5P_genplist_t *plist, const struct H5T_t *type
 H5_DLL int    H5P_ignore_cmp(const void H5_ATTR_UNUSED *val1, const void H5_ATTR_UNUSED *val2,
                              size_t H5_ATTR_UNUSED size);
 
-#endif /* _H5Pprivate_H */
+#endif /* H5Pprivate_H */

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -15,8 +15,8 @@
  * This file contains function prototypes for each exported function in the
  * H5P module.
  */
-#ifndef _H5Ppublic_H
-#define _H5Ppublic_H
+#ifndef H5Ppublic_H
+#define H5Ppublic_H
 
 /* System headers needed by this file */
 
@@ -39,11 +39,11 @@
 
 /* When this header is included from a private HDF5 header, don't make calls to H5open() */
 #undef H5OPEN
-#ifndef _H5private_H
+#ifndef H5private_H
 #define H5OPEN H5open(),
-#else /* _H5private_H */
+#else /* H5private_H */
 #define H5OPEN
-#endif /* _H5private_H */
+#endif /* H5private_H */
 
 /*
  * The library's property list classes
@@ -6989,4 +6989,4 @@ H5_DLL herr_t       H5Pget_file_space(hid_t plist_id, H5F_file_space_type_t *str
 #ifdef __cplusplus
 }
 #endif
-#endif /* _H5Ppublic_H */
+#endif /* H5Ppublic_H */

--- a/src/H5RSmodule.h
+++ b/src/H5RSmodule.h
@@ -18,8 +18,8 @@
  *		H5RS package.  Including this header means that the source file
  *		is part of the H5RS package.
  */
-#ifndef _H5RSmodule_H
-#define _H5RSmodule_H
+#ifndef H5RSmodule_H
+#define H5RSmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_RS
 #define H5_MY_PKG_INIT NO
 
-#endif /* _H5RSmodule_H */
+#endif /* H5RSmodule_H */

--- a/src/H5RSprivate.h
+++ b/src/H5RSprivate.h
@@ -14,8 +14,8 @@
 /*
  * This file contains private information about the H5RS module
  */
-#ifndef _H5RSprivate_H
-#define _H5RSprivate_H
+#ifndef H5RSprivate_H
+#define H5RSprivate_H
 
 /**************************************/
 /* Public headers needed by this file */
@@ -57,4 +57,4 @@ H5_DLL ssize_t     H5RS_len(const H5RS_str_t *rs);
 H5_DLL char *      H5RS_get_str(const H5RS_str_t *rs);
 H5_DLL unsigned    H5RS_get_count(const H5RS_str_t *rs);
 
-#endif /* _H5RSprivate_H */
+#endif /* H5RSprivate_H */

--- a/src/H5Rmodule.h
+++ b/src/H5Rmodule.h
@@ -14,8 +14,8 @@
  *          H5R package.  Including this header means that the source file
  *          is part of the H5R package.
  */
-#ifndef _H5Rmodule_H
-#define _H5Rmodule_H
+#ifndef H5Rmodule_H
+#define H5Rmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -32,4 +32,4 @@
  *          HDF5 referenced objects.
  */
 
-#endif /* _H5Rmodule_H */
+#endif /* H5Rmodule_H */

--- a/src/H5Rpkg.h
+++ b/src/H5Rpkg.h
@@ -19,8 +19,8 @@
 #error "Do not include this file outside the H5R package!"
 #endif
 
-#ifndef _H5Rpkg_H
-#define _H5Rpkg_H
+#ifndef H5Rpkg_H
+#define H5Rpkg_H
 
 /* Get package's private header */
 #include "H5Rprivate.h"
@@ -128,4 +128,4 @@ H5_DLL herr_t H5R__decode_token_obj_compat(const unsigned char *buf, size_t *nby
 H5_DLL herr_t H5R__decode_token_region_compat(H5F_t *f, const unsigned char *buf, size_t *nbytes,
                                               H5O_token_t *obj_token, size_t token_size, H5S_t **space_ptr);
 
-#endif /* _H5Rpkg_H */
+#endif /* H5Rpkg_H */

--- a/src/H5Rprivate.h
+++ b/src/H5Rprivate.h
@@ -14,8 +14,8 @@
 /*
  * This file contains private information about the H5R module
  */
-#ifndef _H5Rprivate_H
-#define _H5Rprivate_H
+#ifndef H5Rprivate_H
+#define H5Rprivate_H
 
 #include "H5Rpublic.h"
 
@@ -39,4 +39,4 @@
 /* Library Private Prototypes */
 /******************************/
 
-#endif /* _H5Rprivate_H */
+#endif /* H5Rprivate_H */

--- a/src/H5Rpublic.h
+++ b/src/H5Rpublic.h
@@ -14,8 +14,8 @@
 /*
  * This file contains public declarations for the H5R module.
  */
-#ifndef _H5Rpublic_H
-#define _H5Rpublic_H
+#ifndef H5Rpublic_H
+#define H5Rpublic_H
 
 /* Public headers needed by this file */
 #include "H5public.h"
@@ -639,4 +639,4 @@ H5_DLL ssize_t H5Rget_name(hid_t loc_id, H5R_type_t ref_type, const void *ref, c
 }
 #endif
 
-#endif /* _H5Rpublic_H */
+#endif /* H5Rpublic_H */

--- a/src/H5SLmodule.h
+++ b/src/H5SLmodule.h
@@ -18,8 +18,8 @@
  *		H5SL package.  Including this header means that the source file
  *		is part of the H5SL package.
  */
-#ifndef _H5SLmodule_H
-#define _H5SLmodule_H
+#ifndef H5SLmodule_H
+#define H5SLmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_SLIST
 #define H5_MY_PKG_INIT YES
 
-#endif /* _H5SLmodule_H */
+#endif /* H5SLmodule_H */

--- a/src/H5SLprivate.h
+++ b/src/H5SLprivate.h
@@ -14,8 +14,8 @@
 /*
  * This file contains private information about the H5SL module
  */
-#ifndef _H5SLprivate_H
-#define _H5SLprivate_H
+#ifndef H5SLprivate_H
+#define H5SLprivate_H
 
 /**************************************/
 /* Public headers needed by this file */
@@ -91,4 +91,4 @@ H5_DLL herr_t       H5SL_close(H5SL_t *slist);
 H5_DLL herr_t       H5SL_destroy(H5SL_t *slist, H5SL_operator_t op, void *op_data);
 H5_DLL int          H5SL_term_interface(void);
 
-#endif /* _H5SLprivate_H */
+#endif /* H5SLprivate_H */

--- a/src/H5SMmodule.h
+++ b/src/H5SMmodule.h
@@ -18,8 +18,8 @@
  *		H5SM package.  Including this header means that the source file
  *		is part of the H5SM package.
  */
-#ifndef _H5SMmodule_H
-#define _H5SMmodule_H
+#ifndef H5SMmodule_H
+#define H5SMmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -29,4 +29,4 @@
 #define H5_MY_PKG_ERR  H5E_SOHM
 #define H5_MY_PKG_INIT NO
 
-#endif /* _H5SMmodule_H */
+#endif /* H5SMmodule_H */

--- a/src/H5SMpkg.h
+++ b/src/H5SMpkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5SM package!"
 #endif
 
-#ifndef _H5SMpkg_H
-#define _H5SMpkg_H
+#ifndef H5SMpkg_H
+#define H5SMpkg_H
 
 /* Get package's private header */
 #include "H5SMprivate.h" /* Shared Object Header Messages	*/
@@ -271,4 +271,4 @@ H5_DLL herr_t H5SM__list_free(H5SM_list_t *list);
 H5_DLL herr_t H5SM__get_mesg_count_test(H5F_t *f, unsigned type_id, size_t *mesg_count);
 #endif /* H5SM_TESTING */
 
-#endif /* _H5SMpkg_H */
+#endif /* H5SMpkg_H */

--- a/src/H5SMprivate.h
+++ b/src/H5SMprivate.h
@@ -18,8 +18,8 @@
  * Purpose:	This file contains private declarations for the H5SM
  *              shared object header messages module.
  */
-#ifndef _H5SMprivate_H
-#define _H5SMprivate_H
+#ifndef H5SMprivate_H
+#define H5SMprivate_H
 
 #include "H5Oprivate.h" /* Object headers			*/
 #include "H5Pprivate.h" /* Property lists			*/

--- a/src/H5STprivate.h
+++ b/src/H5STprivate.h
@@ -14,8 +14,8 @@
 /*
  * This file contains private information about the H5ST module
  */
-#ifndef _H5STprivate_H
-#define _H5STprivate_H
+#ifndef H5STprivate_H
+#define H5STprivate_H
 
 #ifdef LATER
 #include "H5STpublic.h"
@@ -60,4 +60,4 @@ H5_DLL herr_t       H5ST_delete(H5ST_tree_t *root, H5ST_ptr_t p);
 H5_DLL herr_t H5ST_dump(H5ST_tree_t *tree);
 #endif /* H5ST_DEBUG */
 
-#endif /* _H5STprivate_H */
+#endif /* H5STprivate_H */

--- a/src/H5Smodule.h
+++ b/src/H5Smodule.h
@@ -18,8 +18,8 @@
  *		H5S package.  Including this header means that the source file
  *		is part of the H5S package.
  */
-#ifndef _H5Smodule_H
-#define _H5Smodule_H
+#ifndef H5Smodule_H
+#define H5Smodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -56,4 +56,4 @@
  *
  */
 
-#endif /* _H5Smodule_H */
+#endif /* H5Smodule_H */

--- a/src/H5Spkg.h
+++ b/src/H5Spkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5S package!"
 #endif
 
-#ifndef _H5Spkg_H
-#define _H5Spkg_H
+#ifndef H5Spkg_H
+#define H5Spkg_H
 
 /* Get package's private header */
 #include "H5Sprivate.h"

--- a/src/H5Sprivate.h
+++ b/src/H5Sprivate.h
@@ -14,8 +14,8 @@
 /*
  * This file contains private information about the H5S module
  */
-#ifndef _H5Sprivate_H
-#define _H5Sprivate_H
+#ifndef H5Sprivate_H
+#define H5Sprivate_H
 
 /* Include package's public header */
 #include "H5Spublic.h"
@@ -307,4 +307,4 @@ H5_DLL herr_t H5S_mpio_space_type(const H5S_t *space, size_t elmt_size,
                                   hbool_t do_permute, hsize_t **permute_map, hbool_t *is_permuted);
 #endif /* H5_HAVE_PARALLEL */
 
-#endif /* _H5Sprivate_H */
+#endif /* H5Sprivate_H */

--- a/src/H5Spublic.h
+++ b/src/H5Spublic.h
@@ -14,8 +14,8 @@
 /*
  * This file contains public declarations for the H5S module.
  */
-#ifndef _H5Spublic_H
-#define _H5Spublic_H
+#ifndef H5Spublic_H
+#define H5Spublic_H
 
 /* Public headers needed by this file */
 #include "H5public.h"
@@ -1391,4 +1391,4 @@ H5_DLL herr_t H5Sencode1(hid_t obj_id, void *buf, size_t *nalloc);
 #ifdef __cplusplus
 }
 #endif
-#endif /* _H5Spublic_H */
+#endif /* H5Spublic_H */

--- a/src/H5TSpublic.h
+++ b/src/H5TSpublic.h
@@ -14,8 +14,8 @@
  * This file contains public declarations for the H5TS (threadsafety) module.
  */
 
-#ifndef _H5TSpublic_H
-#define _H5TSpublic_H
+#ifndef H5TSpublic_H
+#define H5TSpublic_H
 
 /* Public headers needed by this file */
 #include "H5public.h" /* Generic Functions                    */
@@ -49,4 +49,4 @@ H5_DLL herr_t H5TSmutex_get_attempt_count(unsigned int *count);
 }
 #endif
 
-#endif /* _H5TSpublic_H */
+#endif /* H5TSpublic_H */

--- a/src/H5Tmodule.h
+++ b/src/H5Tmodule.h
@@ -18,8 +18,8 @@
  *		H5T package.  Including this header means that the source file
  *		is part of the H5T package.
  */
-#ifndef _H5Tmodule_H
-#define _H5Tmodule_H
+#ifndef H5Tmodule_H
+#define H5Tmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -105,4 +105,4 @@
  *
  */
 
-#endif /* _H5Tmodule_H */
+#endif /* H5Tmodule_H */

--- a/src/H5Tpkg.h
+++ b/src/H5Tpkg.h
@@ -23,8 +23,8 @@
 #error "Do not include this file outside the H5T package!"
 #endif
 
-#ifndef _H5Tpkg_H
-#define _H5Tpkg_H
+#ifndef H5Tpkg_H
+#define H5Tpkg_H
 
 /*
  * Define this to enable debugging.
@@ -890,4 +890,4 @@ H5_DLL herr_t H5T__sort_name(const H5T_t *dt, int *map);
 /* Debugging functions */
 H5_DLL herr_t H5T__print_stats(H5T_path_t *path, int *nprint /*in,out*/);
 
-#endif /* _H5Tpkg_H */
+#endif /* H5Tpkg_H */

--- a/src/H5Tprivate.h
+++ b/src/H5Tprivate.h
@@ -14,8 +14,8 @@
 /*
  * This file contains private information about the H5T module
  */
-#ifndef _H5Tprivate_H
-#define _H5Tprivate_H
+#ifndef H5Tprivate_H
+#define H5Tprivate_H
 
 /* Early typedefs to avoid circular dependencies */
 typedef struct H5T_t H5T_t;
@@ -173,4 +173,4 @@ H5_DLL int         H5T_get_offset(const H5T_t *dt);
 /* Fixed-point functions */
 H5_DLL H5T_sign_t H5T_get_sign(H5T_t const *dt);
 
-#endif /* _H5Tprivate_H */
+#endif /* H5Tprivate_H */

--- a/src/H5Tpublic.h
+++ b/src/H5Tpublic.h
@@ -14,8 +14,8 @@
 /*
  * This file contains public declarations for the H5T module.
  */
-#ifndef _H5Tpublic_H
-#define _H5Tpublic_H
+#ifndef H5Tpublic_H
+#define H5Tpublic_H
 
 /* Public headers needed by this file */
 #include "H5public.h"
@@ -268,11 +268,11 @@ typedef H5T_conv_ret_t (*H5T_conv_except_func_t)(H5T_conv_except_t except_type, 
 
 /* When this header is included from a private header, don't make calls to H5open() */
 #undef H5OPEN
-#ifndef _H5private_H
+#ifndef H5private_H
 #define H5OPEN H5open(),
-#else /* _H5private_H */
+#else /* H5private_H */
 #define H5OPEN
-#endif /* _H5private_H */
+#endif /* H5private_H */
 
 /*
  * The IEEE floating point types in various byte orders.
@@ -3069,4 +3069,4 @@ H5_DLL int H5Tget_array_dims1(hid_t type_id, hsize_t dims[], int perm[]);
 #ifdef __cplusplus
 }
 #endif
-#endif /* _H5Tpublic_H */
+#endif /* H5Tpublic_H */

--- a/src/H5UCprivate.h
+++ b/src/H5UCprivate.h
@@ -17,8 +17,8 @@
  * conflicting requirement for the use of H5RC.
  */
 
-#ifndef _H5UCprivate_H
-#define _H5UCprivate_H
+#ifndef H5UCprivate_H
+#define H5UCprivate_H
 
 /**************************************/
 /* Public headers needed by this file */
@@ -59,4 +59,4 @@ typedef struct H5UC_t {
 H5_DLL H5UC_t *H5UC_create(void *s, H5UC_free_func_t free_func);
 H5_DLL herr_t  H5UC_decr(H5UC_t *rc);
 
-#endif /* _H5UCprivate_H */
+#endif /* H5UCprivate_H */

--- a/src/H5VLconnector.h
+++ b/src/H5VLconnector.h
@@ -14,8 +14,8 @@
  * This file contains public declarations for authoring VOL connectors.
  */
 
-#ifndef _H5VLconnector_H
-#define _H5VLconnector_H
+#ifndef H5VLconnector_H
+#define H5VLconnector_H
 
 /* Public headers needed by this file */
 #include "H5public.h"   /* Generic Functions                    */
@@ -561,4 +561,4 @@ H5_DLL hid_t H5VLpeek_connector_id_by_value(H5VL_class_value_t value);
 }
 #endif
 
-#endif /* _H5VLconnector_H */
+#endif /* H5VLconnector_H */

--- a/src/H5VLconnector_passthru.h
+++ b/src/H5VLconnector_passthru.h
@@ -23,8 +23,8 @@
  * the H5VLconnector.h header easier to understand.
  */
 
-#ifndef _H5VLconnector_passthru_H
-#define _H5VLconnector_passthru_H
+#ifndef H5VLconnector_passthru_H
+#define H5VLconnector_passthru_H
 
 /* Public headers needed by this file */
 #include "H5public.h"   /* Generic Functions                    */
@@ -234,4 +234,4 @@ H5_DLL herr_t H5VLoptional(void *obj, hid_t connector_id, int op_type, hid_t dxp
 }
 #endif
 
-#endif /* _H5VLconnector_passthru_H */
+#endif /* H5VLconnector_passthru_H */

--- a/src/H5VLmodule.h
+++ b/src/H5VLmodule.h
@@ -16,8 +16,8 @@
  *          is part of the H5VL package.
  */
 
-#ifndef _H5VLmodule_H
-#define _H5VLmodule_H
+#ifndef H5VLmodule_H
+#define H5VLmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -42,4 +42,4 @@
  * \ingroup H5VL
  */
 
-#endif /* _H5VLmodule_H */
+#endif /* H5VLmodule_H */

--- a/src/H5VLnative.h
+++ b/src/H5VLnative.h
@@ -14,8 +14,8 @@
  * Purpose:	The public header file for the native VOL connector.
  */
 
-#ifndef _H5VLnative_H
-#define _H5VLnative_H
+#ifndef H5VLnative_H
+#define H5VLnative_H
 
 /* Public headers needed by this file */
 #include "H5VLpublic.h" /* Virtual Object Layer                 */
@@ -154,4 +154,4 @@ H5_DLL hid_t H5VL_native_register(void);
 }
 #endif
 
-#endif /* _H5VLnative_H */
+#endif /* H5VLnative_H */

--- a/src/H5VLnative_private.h
+++ b/src/H5VLnative_private.h
@@ -14,8 +14,8 @@
  * Purpose:	The private header file for the native VOL connector.
  */
 
-#ifndef _H5VLnative_private_H
-#define _H5VLnative_private_H
+#ifndef H5VLnative_private_H
+#define H5VLnative_private_H
 
 /* Private headers needed by this file */
 #include "H5Fprivate.h" /* Files                                    */
@@ -178,4 +178,4 @@ H5_DLL herr_t H5VL_native_get_file_struct(void *obj, H5I_type_t type, H5F_t **fi
 }
 #endif
 
-#endif /* _H5VLnative_private_H */
+#endif /* H5VLnative_private_H */

--- a/src/H5VLpassthru.h
+++ b/src/H5VLpassthru.h
@@ -14,8 +14,8 @@
  * Purpose:	The public header file for the pass-through VOL connector.
  */
 
-#ifndef _H5VLpassthru_H
-#define _H5VLpassthru_H
+#ifndef H5VLpassthru_H
+#define H5VLpassthru_H
 
 /* Public headers needed by this file */
 #include "H5VLpublic.h" /* Virtual Object Layer                 */
@@ -44,4 +44,4 @@ H5_DLL hid_t H5VL_pass_through_register(void);
 }
 #endif
 
-#endif /* _H5VLpassthru_H */
+#endif /* H5VLpassthru_H */

--- a/src/H5VLpkg.h
+++ b/src/H5VLpkg.h
@@ -20,8 +20,8 @@
 #error "Do not include this file outside the H5VL package!"
 #endif
 
-#ifndef _H5VLpkg_H
-#define _H5VLpkg_H
+#ifndef H5VLpkg_H
+#define H5VLpkg_H
 
 /* Get package's private header */
 #include "H5VLprivate.h" /* Generic Functions                    */
@@ -57,4 +57,4 @@ H5_DLL hid_t   H5VL__peek_connector_id_by_value(H5VL_class_value_t value);
 H5_DLL herr_t  H5VL__connector_str_to_info(const char *str, hid_t connector_id, void **info);
 H5_DLL ssize_t H5VL__get_connector_name(hid_t id, char *name /*out*/, size_t size);
 
-#endif /* _H5VLpkg_H */
+#endif /* H5VLpkg_H */

--- a/src/H5VLprivate.h
+++ b/src/H5VLprivate.h
@@ -10,8 +10,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef _H5VLprivate_H
-#define _H5VLprivate_H
+#ifndef H5VLprivate_H
+#define H5VLprivate_H
 
 /* Include package's public header */
 #include "H5VLpublic.h" /* Generic Functions                    */
@@ -290,4 +290,4 @@ H5_DLL herr_t H5VL_token_from_str(const H5VL_object_t *vol_obj, H5I_type_t obj_t
 /* Generic functions */
 H5_DLL herr_t H5VL_optional(const H5VL_object_t *vol_obj, int op_type, hid_t dxpl_id, void **req, ...);
 
-#endif /* _H5VLprivate_H */
+#endif /* H5VLprivate_H */

--- a/src/H5VLpublic.h
+++ b/src/H5VLpublic.h
@@ -14,8 +14,8 @@
  * This file contains public declarations for the H5VL (VOL) module.
  */
 
-#ifndef _H5VLpublic_H
-#define _H5VLpublic_H
+#ifndef H5VLpublic_H
+#define H5VLpublic_H
 
 /* Public headers needed by this file */
 #include "H5public.h"  /* Generic Functions                    */
@@ -365,4 +365,4 @@ H5_DLL herr_t H5VLquery_optional(hid_t obj_id, H5VL_subclass_t subcls, int opt_t
 #include "H5VLconnector_passthru.h" /* Pass-through VOL connector author routines */
 #include "H5VLnative.h"             /* Native VOL connector macros, for VOL connector authors */
 
-#endif /* _H5VLpublic_H */
+#endif /* H5VLpublic_H */

--- a/src/H5WBprivate.h
+++ b/src/H5WBprivate.h
@@ -22,8 +22,8 @@
  *-------------------------------------------------------------------------
  */
 
-#ifndef _H5WBprivate_H
-#define _H5WBprivate_H
+#ifndef H5WBprivate_H
+#define H5WBprivate_H
 
 /* Include package's public header */
 /* #include "H5WBpublic.h" */
@@ -55,4 +55,4 @@ H5_DLL void *  H5WB_actual(H5WB_t *wb, size_t need);
 H5_DLL void *  H5WB_actual_clear(H5WB_t *wb, size_t need);
 H5_DLL herr_t  H5WB_unwrap(H5WB_t *wb);
 
-#endif /* _H5WBprivate_H */
+#endif /* H5WBprivate_H */

--- a/src/H5Zmodule.h
+++ b/src/H5Zmodule.h
@@ -18,8 +18,8 @@
  *		H5Z package.  Including this header means that the source file
  *		is part of the H5Z package.
  */
-#ifndef _H5Zmodule_H
-#define _H5Zmodule_H
+#ifndef H5Zmodule_H
+#define H5Zmodule_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -96,4 +96,4 @@
  *
  */
 
-#endif /* _H5Zmodule_H */
+#endif /* H5Zmodule_H */

--- a/src/H5Zpkg.h
+++ b/src/H5Zpkg.h
@@ -15,8 +15,8 @@
 #error "Do not include this file outside the H5Z package!"
 #endif
 
-#ifndef _H5Zpkg_H
-#define _H5Zpkg_H
+#ifndef H5Zpkg_H
+#define H5Zpkg_H
 
 /* Include private header file */
 #include "H5Zprivate.h" /* Filter functions                */
@@ -54,4 +54,4 @@ H5_DLLVAR H5Z_class2_t H5Z_SZIP[1];
 /* Package internal routines */
 H5_DLL herr_t H5Z__unregister(H5Z_filter_t filter_id);
 
-#endif /* _H5Zpkg_H */
+#endif /* H5Zpkg_H */

--- a/src/H5Zprivate.h
+++ b/src/H5Zprivate.h
@@ -15,8 +15,8 @@
  *              Thursday, April 16, 1998
  */
 
-#ifndef _H5Zprivate_H
-#define _H5Zprivate_H
+#ifndef H5Zprivate_H
+#define H5Zprivate_H
 
 /* Early typedefs to avoid circular dependencies */
 typedef struct H5Z_filter_info_t H5Z_filter_info_t;

--- a/src/H5Zpublic.h
+++ b/src/H5Zpublic.h
@@ -15,8 +15,8 @@
  *              Thursday, April 16, 1998
  */
 
-#ifndef _H5Zpublic_H
-#define _H5Zpublic_H
+#ifndef H5Zpublic_H
+#define H5Zpublic_H
 
 /* Public headers needed by this file */
 #include "H5public.h"

--- a/src/H5module.h
+++ b/src/H5module.h
@@ -15,8 +15,8 @@
  *		H5 package.  Including this header means that the source file
  *		is part of the H5 package.
  */
-#ifndef _H5module_H
-#define _H5module_H
+#ifndef H5module_H
+#define H5module_H
 
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
@@ -31,4 +31,4 @@
  * \todo Describe concisely what the functions in this module are about.
  */
 
-#endif /* _H5module_H */
+#endif /* H5module_H */

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -21,8 +21,8 @@
  *
  */
 
-#ifndef _H5private_H
-#define _H5private_H
+#ifndef H5private_H
+#define H5private_H
 
 #include "H5public.h" /* Include Public Definitions    */
 
@@ -2980,4 +2980,4 @@ H5_DLL herr_t  H5_mpio_create_large_type(hsize_t num_elements, MPI_Aint stride_b
 H5_DLL herr_t H5_buffer_dump(FILE *stream, int indent, const uint8_t *buf, const uint8_t *marker,
                              size_t buf_offset, size_t buf_size);
 
-#endif /* _H5private_H */
+#endif /* H5private_H */

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -14,16 +14,16 @@
 /*
  * This file contains public declarations for the HDF5 module.
  */
-#ifndef _H5public_H
-#define _H5public_H
+#ifndef H5public_H
+#define H5public_H
 
 /* Include files for public use... */
 /*
  * Since H5pubconf.h is a generated header file, it is messy to try
- * to put a #ifndef _H5pubconf_H ... #endif guard in it.
+ * to put a #ifndef H5pubconf_H ... #endif guard in it.
  * HDF5 has set an internal rule that it is being included here.
  * Source files should NOT include H5pubconf.h directly but include
- * it via H5public.h.  The #ifndef _H5public_H guard above would
+ * it via H5public.h.  The #ifndef H5public_H guard above would
  * prevent repeated include.
  */
 #include "H5pubconf.h" /* From configure */
@@ -849,4 +849,4 @@ H5_DLL void *H5resize_memory(void *mem, size_t size);
 #ifdef __cplusplus
 }
 #endif
-#endif /* _H5public_H */
+#endif /* H5public_H */

--- a/src/hdf5.h
+++ b/src/hdf5.h
@@ -16,8 +16,8 @@
  * a particular header file and include that here, don't fill this file with
  * lots of gunk...
  */
-#ifndef _HDF5_H
-#define _HDF5_H
+#ifndef HDF5_H
+#define HDF5_H
 
 #include "H5public.h"
 #include "H5Apublic.h"  /* Attributes                               */

--- a/test/H5srcdir.h
+++ b/test/H5srcdir.h
@@ -17,8 +17,8 @@
  *
  * Purpose:     srcdir querying support.
  */
-#ifndef _H5SRCDIR_H
-#define _H5SRCDIR_H
+#ifndef H5SRCDIR_H
+#define H5SRCDIR_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,4 +33,4 @@ H5TEST_DLL const char *H5_get_srcdir_filename(const char *filename);
 }
 #endif
 
-#endif /* _H5SRCDIR_H */
+#endif /* H5SRCDIR_H */

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -17,8 +17,8 @@
  *
  * Purpose:     Test support stuff.
  */
-#ifndef _H5TEST_H
-#define _H5TEST_H
+#ifndef H5TEST_H
+#define H5TEST_H
 
 /*
  * Include required headers.  This file tests internal library functions,


### PR DESCRIPTION
Removed leading underscore(s) from header guard spelling.  Used 2 regexes:

` _H5(.*)_H`
` __H5(.*)_H`

Applied case-insensitively to only .h files.