### PR TITLE
Modified gcc/clang warning suppression macros to account for some warnings flags being supported by one compiler but not the other

### DIFF
--- a/hl/src/H5LT.c
+++ b/hl/src/H5LT.c
@@ -1352,13 +1352,13 @@ find_dataset(H5_ATTR_UNUSED hid_t loc_id, const char *name, H5_ATTR_UNUSED const
  * modify the op_data buffer (i.e.: dset_name) during the traversal, and the
  * library never modifies that buffer.
  */
-H5_GCC_DIAG_OFF("cast-qual")
+H5_GCC_CLANG_DIAG_OFF("cast-qual")
 herr_t
 H5LTfind_dataset(hid_t loc_id, const char *dset_name)
 {
     return H5Literate2(loc_id, H5_INDEX_NAME, H5_ITER_INC, 0, find_dataset, (void *)dset_name);
 }
-H5_GCC_DIAG_ON("cast-qual")
+H5_GCC_CLANG_DIAG_ON("cast-qual")
 
 /*-------------------------------------------------------------------------
  *
@@ -1919,13 +1919,13 @@ H5LTfind_attribute(hid_t loc_id, const char *attr_name)
  * modify the op_data buffer (i.e.: attr_name) during the traversal, and the
  * library never modifies that buffer.
  */
-H5_GCC_DIAG_OFF("cast-qual")
+H5_GCC_CLANG_DIAG_OFF("cast-qual")
 herr_t
 H5LT_find_attribute(hid_t loc_id, const char *attr_name)
 {
     return H5Aiterate2(loc_id, H5_INDEX_NAME, H5_ITER_INC, NULL, find_attr, (void *)attr_name);
 }
-H5_GCC_DIAG_ON("cast-qual")
+H5_GCC_CLANG_DIAG_ON("cast-qual")
 
 /*-------------------------------------------------------------------------
  * Function: H5LTget_attribute_ndims

--- a/java/src/jni/h5Constants.c
+++ b/java/src/jni/h5Constants.c
@@ -26,8 +26,8 @@ extern "C" {
 #include <stdlib.h>
 #include "h5jni.h"
 
-H5_GCC_DIAG_OFF("missing-prototypes")
-H5_GCC_DIAG_OFF("unused-parameter")
+H5_GCC_CLANG_DIAG_OFF("missing-prototypes")
+H5_GCC_CLANG_DIAG_OFF("unused-parameter")
 
 JNIEXPORT jlong JNICALL
 Java_hdf_hdf5lib_HDF5Constants_H5_1QUARTER_1HADDR_1MAX(JNIEnv *env, jclass cls)
@@ -1212,7 +1212,7 @@ Java_hdf_hdf5lib_HDF5Constants_H5ES_1STATUS_1FAIL(JNIEnv *env, jclass cls)
 }
 
 /* Java does not have unsigned native types */
-H5_GCC_DIAG_OFF("sign-conversion")
+H5_GCC_CLANG_DIAG_OFF("sign-conversion")
 JNIEXPORT jint JNICALL
 Java_hdf_hdf5lib_HDF5Constants_H5F_1ACC_1CREAT(JNIEnv *env, jclass cls)
 {
@@ -1253,7 +1253,7 @@ Java_hdf_hdf5lib_HDF5Constants_H5F_1ACC_1SWMR_1WRITE(JNIEnv *env, jclass cls)
 {
     return H5F_ACC_SWMR_WRITE;
 }
-H5_GCC_DIAG_ON("sign-conversion")
+H5_GCC_CLANG_DIAG_ON("sign-conversion")
 
 JNIEXPORT jint JNICALL
 Java_hdf_hdf5lib_HDF5Constants_H5F_1CLOSE_1DEFAULT(JNIEnv *env, jclass cls)
@@ -3724,8 +3724,8 @@ Java_hdf_hdf5lib_HDF5Constants_H5Z_1FILTER_1ALL(JNIEnv *env, jclass cls)
     return H5Z_FILTER_ALL;
 }
 
-H5_GCC_DIAG_ON("missing-prototypes")
-H5_GCC_DIAG_ON("unused-parameter")
+H5_GCC_CLANG_DIAG_ON("missing-prototypes")
+H5_GCC_CLANG_DIAG_ON("unused-parameter")
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/src/H5FDfamily.c
+++ b/src/H5FDfamily.c
@@ -582,7 +582,7 @@ done:
  *      memb_name & temp in the code below, but early (4.4.7, at least) gcc only
  *      allows diagnostic pragmas to be toggled outside of functions.
  */
-H5_GCC_DIAG_OFF("format-nonliteral")
+H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
 static H5FD_t *
 H5FD__family_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr)
 {
@@ -735,7 +735,7 @@ done:
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5FD__family_open() */
-H5_GCC_DIAG_ON("format-nonliteral")
+H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
 /*-------------------------------------------------------------------------
  * Function:    H5FD__family_close
@@ -905,7 +905,7 @@ H5FD__family_get_eoa(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
  *      memb_name in the code below, but early (4.4.7, at least) gcc only
  *      allows diagnostic pragmas to be toggled outside of functions.
  */
-H5_GCC_DIAG_OFF("format-nonliteral")
+H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
 static herr_t
 H5FD__family_set_eoa(H5FD_t *_file, H5FD_mem_t type, haddr_t abs_eoa)
 {
@@ -974,7 +974,7 @@ done:
 
     FUNC_LEAVE_NOAPI(ret_value)
 }
-H5_GCC_DIAG_ON("format-nonliteral")
+H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
 /*-------------------------------------------------------------------------
  * Function:    H5FD__family_get_eof

--- a/src/H5FDmulti.c
+++ b/src/H5FDmulti.c
@@ -44,7 +44,7 @@
 #define my_strdup strdup
 #endif
 
-/* Macros for enabling/disabling particular GCC warnings
+/* Macros for enabling/disabling particular GCC / clang warnings
  *
  * These are (renamed) duplicates of macros in H5private.h. If you make changes
  * here, be sure to update those as well.
@@ -2019,6 +2019,7 @@ open_members(H5FD_multi_t *file)
 
     return 0;
 }
+H5_MULTI_GCC_DIAG_ON("format-nonliteral")
 
 /*-------------------------------------------------------------------------
  * Function:    H5FD_multi_delete
@@ -2029,6 +2030,7 @@ open_members(H5FD_multi_t *file)
  *
  *-------------------------------------------------------------------------
  */
+H5_MULTI_GCC_DIAG_OFF("format-nonliteral")
 static herr_t
 H5FD_multi_delete(const char *filename, hid_t fapl_id)
 {

--- a/src/H5Idbg.c
+++ b/src/H5Idbg.c
@@ -110,9 +110,9 @@ H5I__id_dump_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
         case H5I_DATATYPE: {
             const H5T_t *dt = (const H5T_t *)info->object;
 
-            H5_GCC_DIAG_OFF("cast-qual")
+            H5_GCC_CLANG_DIAG_OFF("cast-qual")
             object = (void *)H5T_get_actual_type((H5T_t *)dt); /* Casting away const OK - QAK */
-            H5_GCC_DIAG_ON("cast-qual")
+            H5_GCC_CLANG_DIAG_ON("cast-qual")
 
             path = H5T_nameof((const H5T_t *)object);
             break;

--- a/src/H5Iint.c
+++ b/src/H5Iint.c
@@ -391,7 +391,7 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
      */
     if (udata->force || (info->count - (!udata->app_ref * info->app_count)) <= 1) {
         /* Check if this is an un-realized future object */
-        H5_GCC_DIAG_OFF("cast-qual")
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
         if (info->is_future) {
             /* Discard the future object */
             if ((info->discard_cb)((void *)info->object) < 0) {
@@ -437,7 +437,7 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
                 mark = TRUE;
             }
         }
-        H5_GCC_DIAG_ON("cast-qual")
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
 
         /* Remove ID if requested */
         if (mark) {
@@ -705,9 +705,9 @@ H5I_subst(hid_t id, const void *new_object)
         HGOTO_ERROR(H5E_ID, H5E_NOTFOUND, NULL, "can't get ID ref count")
 
     /* Get the old object pointer to return */
-    H5_GCC_DIAG_OFF("cast-qual")
+    H5_GCC_CLANG_DIAG_OFF("cast-qual")
     ret_value = (void *)info->object; /* (Casting away const OK -QAK) */
-    H5_GCC_DIAG_ON("cast-qual")
+    H5_GCC_CLANG_DIAG_ON("cast-qual")
 
     /* Set the new object pointer for the ID */
     info->object = new_object;
@@ -739,9 +739,9 @@ H5I_object(hid_t id)
     /* General lookup of the ID */
     if (NULL != (info = H5I__find_id(id))) {
         /* Get the object pointer to return */
-        H5_GCC_DIAG_OFF("cast-qual")
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
         ret_value = (void *)info->object; /* (Casting away const OK -QAK) */
-        H5_GCC_DIAG_ON("cast-qual")
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
     }
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -775,9 +775,9 @@ H5I_object_verify(hid_t id, H5I_type_t type)
     /* Verify that the type of the ID is correct & lookup the ID */
     if (type == H5I_TYPE(id) && NULL != (info = H5I__find_id(id))) {
         /* Get the object pointer to return */
-        H5_GCC_DIAG_OFF("cast-qual")
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
         ret_value = (void *)info->object; /* (Casting away const OK -QAK) */
-        H5_GCC_DIAG_ON("cast-qual")
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
     }
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -938,9 +938,9 @@ H5I__remove_common(H5I_type_info_t *type_info, hid_t id)
     if (type_info->last_id_info == info)
         type_info->last_id_info = NULL;
 
-    H5_GCC_DIAG_OFF("cast-qual")
+    H5_GCC_CLANG_DIAG_OFF("cast-qual")
     ret_value = (void *)info->object; /* (Casting away const OK -QAK) */
-    H5_GCC_DIAG_ON("cast-qual")
+    H5_GCC_CLANG_DIAG_ON("cast-qual")
 
     if (!H5I_marking_g)
         info = H5FL_FREE(H5I_id_info_t, info);
@@ -1040,7 +1040,7 @@ H5I__dec_ref(hid_t id, void **request)
         /* Get the ID's type */
         type_info = H5I_type_info_array_g[H5I_TYPE(id)];
 
-        H5_GCC_DIAG_OFF("cast-qual")
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
         /* (Casting away const OK -QAK) */
         if (!type_info->cls->free_func || (type_info->cls->free_func)((void *)info->object, request) >= 0) {
             /* Remove the node from the type */
@@ -1050,7 +1050,7 @@ H5I__dec_ref(hid_t id, void **request)
         } /* end if */
         else
             ret_value = -1;
-        H5_GCC_DIAG_ON("cast-qual")
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
     } /* end if */
     else {
         --(info->count);
@@ -1529,9 +1529,9 @@ H5I__iterate_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
         /* The stored object pointer might be an H5VL_object_t, in which
          * case we'll need to get the wrapped object struct (H5F_t *, etc.).
          */
-        H5_GCC_DIAG_OFF("cast-qual")
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
         object = H5I__unwrap((void *)info->object, type); /* Casting away const OK */
-        H5_GCC_DIAG_ON("cast-qual")
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
 
         /* Invoke callback function */
         cb_ret_val = (*udata->user_func)((void *)object, info->id, udata->user_udata);
@@ -1654,7 +1654,7 @@ H5I__find_id(hid_t id)
     }
 
     /* Check if this is a future ID */
-    H5_GCC_DIAG_OFF("cast-qual")
+    H5_GCC_CLANG_DIAG_OFF("cast-qual")
     if (id_info && id_info->is_future) {
         hid_t actual_id = H5I_INVALID_HID; /* ID for actual object */
         void *future_object;               /* Pointer to the future object */
@@ -1686,7 +1686,7 @@ H5I__find_id(hid_t id)
         id_info->realize_cb = NULL;
         id_info->discard_cb = NULL;
     }
-    H5_GCC_DIAG_ON("cast-qual")
+    H5_GCC_CLANG_DIAG_ON("cast-qual")
 
     /* Set return value */
     ret_value = id_info;
@@ -1721,9 +1721,9 @@ H5I__find_id_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
     HDassert(udata);
 
     /* Get a pointer to the VOL connector's data */
-    H5_GCC_DIAG_OFF("cast-qual")
+    H5_GCC_CLANG_DIAG_OFF("cast-qual")
     object = H5I__unwrap((void *)info->object, type); /* Casting away const OK */
-    H5_GCC_DIAG_ON("cast-qual")
+    H5_GCC_CLANG_DIAG_ON("cast-qual")
 
     /* Check for a match */
     if (object == udata->object) {

--- a/src/H5PLint.c
+++ b/src/H5PLint.c
@@ -292,7 +292,7 @@ done:
  *       get_plugin_info function pointer, but early (4.4.7, at least) gcc
  *       only allows diagnostic pragmas to be toggled outside of functions.
  */
-H5_GCC_DIAG_OFF("pedantic")
+H5_GCC_CLANG_DIAG_OFF("pedantic")
 herr_t
 H5PL__open(const char *path, H5PL_type_t type, const H5PL_key_t *key, hbool_t *success,
            H5PL_type_t *plugin_type, const void **plugin_info)
@@ -414,7 +414,7 @@ done:
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5PL__open() */
-H5_GCC_DIAG_ON("pedantic")
+H5_GCC_CLANG_DIAG_ON("pedantic")
 
 /*-------------------------------------------------------------------------
  * Function:    H5PL__close

--- a/src/H5PLplugin_cache.c
+++ b/src/H5PLplugin_cache.c
@@ -242,7 +242,7 @@ done:
 /* See the other use of H5PL_GET_LIB_FUNC() for an explanation
  * for why we disable -Wpedantic here.
  */
-H5_GCC_DIAG_OFF("pedantic")
+H5_GCC_CLANG_DIAG_OFF("pedantic")
 herr_t
 H5PL__find_plugin_in_cache(const H5PL_search_params_t *search_params, hbool_t *found,
                            const void **plugin_info)
@@ -320,4 +320,4 @@ H5PL__find_plugin_in_cache(const H5PL_search_params_t *search_params, hbool_t *f
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5PL__find_plugin_in_cache() */
-H5_GCC_DIAG_ON("pedantic")
+H5_GCC_CLANG_DIAG_ON("pedantic")

--- a/src/H5RS.c
+++ b/src/H5RS.c
@@ -349,7 +349,7 @@ done:
  *      format_templ in the code below, but early (4.4.7, at least) gcc only
  *      allows diagnostic pragmas to be toggled outside of functions.
  */
-H5_GCC_DIAG_OFF("format-nonliteral")
+H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
 H5_ATTR_FORMAT(printf, 2, 3)
 herr_t
 H5RS_asprintf_cat(H5RS_str_t *rs, const char *fmt, ...)
@@ -392,7 +392,7 @@ H5RS_asprintf_cat(H5RS_str_t *rs, const char *fmt, ...)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5RS_asprintf_cat() */
-H5_GCC_DIAG_ON("format-nonliteral")
+H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
 /*-------------------------------------------------------------------------
  * Function:    H5RS_acat

--- a/src/H5Tconv.c
+++ b/src/H5Tconv.c
@@ -7725,9 +7725,9 @@ herr_t
 H5T__conv_float_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, SCHAR, float, signed char, SCHAR_MIN, SCHAR_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -7747,9 +7747,9 @@ herr_t
 H5T__conv_float_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, UCHAR, float, unsigned char, 0, UCHAR_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -7769,9 +7769,9 @@ herr_t
 H5T__conv_double_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, SCHAR, double, signed char, SCHAR_MIN, SCHAR_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -7791,9 +7791,9 @@ herr_t
 H5T__conv_double_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, UCHAR, double, unsigned char, 0, UCHAR_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -7813,9 +7813,9 @@ herr_t
 H5T__conv_ldouble_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                         size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, SCHAR, long double, signed char, SCHAR_MIN, SCHAR_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -7835,9 +7835,9 @@ herr_t
 H5T__conv_ldouble_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                         size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, UCHAR, long double, unsigned char, 0, UCHAR_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -7857,9 +7857,9 @@ herr_t
 H5T__conv_float_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, SHORT, float, short, SHRT_MIN, SHRT_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -7879,9 +7879,9 @@ herr_t
 H5T__conv_float_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, USHORT, float, unsigned short, 0, USHRT_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -7901,9 +7901,9 @@ herr_t
 H5T__conv_double_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, SHORT, double, short, SHRT_MIN, SHRT_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -7923,9 +7923,9 @@ herr_t
 H5T__conv_double_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                         size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, USHORT, double, unsigned short, 0, USHRT_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -7945,9 +7945,9 @@ herr_t
 H5T__conv_ldouble_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                         size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, SHORT, long double, short, SHRT_MIN, SHRT_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -7967,9 +7967,9 @@ herr_t
 H5T__conv_ldouble_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                          size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, USHORT, long double, unsigned short, 0, USHRT_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -7989,9 +7989,9 @@ herr_t
 H5T__conv_float_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, INT, float, int, INT_MIN, INT_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -8011,9 +8011,9 @@ herr_t
 H5T__conv_float_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, UINT, float, unsigned int, 0, UINT_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -8033,9 +8033,9 @@ herr_t
 H5T__conv_double_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, INT, double, int, INT_MIN, INT_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -8055,9 +8055,9 @@ herr_t
 H5T__conv_double_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, UINT, double, unsigned int, 0, UINT_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -8077,9 +8077,9 @@ herr_t
 H5T__conv_ldouble_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, INT, long double, int, INT_MIN, INT_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -8099,9 +8099,9 @@ herr_t
 H5T__conv_ldouble_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, UINT, long double, unsigned int, 0, UINT_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -8121,9 +8121,9 @@ herr_t
 H5T__conv_float_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, LONG, float, long, LONG_MIN, LONG_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -8143,9 +8143,9 @@ herr_t
 H5T__conv_float_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, ULONG, float, unsigned long, 0, ULONG_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -8165,9 +8165,9 @@ herr_t
 H5T__conv_double_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, LONG, double, long, LONG_MIN, LONG_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -8187,9 +8187,9 @@ herr_t
 H5T__conv_double_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, ULONG, double, unsigned long, 0, ULONG_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -8209,9 +8209,9 @@ herr_t
 H5T__conv_ldouble_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, LONG, long double, long, LONG_MIN, LONG_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -8231,9 +8231,9 @@ herr_t
 H5T__conv_ldouble_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                         size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, ULONG, long double, unsigned long, 0, ULONG_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -8253,9 +8253,9 @@ herr_t
 H5T__conv_float_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, LLONG, float, long long, LLONG_MIN, LLONG_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -8275,9 +8275,9 @@ herr_t
 H5T__conv_float_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, ULLONG, float, unsigned long long, 0, ULLONG_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -8297,9 +8297,9 @@ herr_t
 H5T__conv_double_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, LLONG, double, long long, LLONG_MIN, LLONG_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -8319,9 +8319,9 @@ herr_t
 H5T__conv_double_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                         size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, ULLONG, double, unsigned long long, 0, ULLONG_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 
 /*-------------------------------------------------------------------------
@@ -8342,9 +8342,9 @@ herr_t
 H5T__conv_ldouble_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                         size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, LLONG, long double, long long, LLONG_MIN, LLONG_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 #endif /*H5T_CONV_INTERNAL_LDOUBLE_LLONG*/
 
@@ -8366,9 +8366,9 @@ herr_t
 H5T__conv_ldouble_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
                          size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5_GCC_DIAG_OFF("float-equal")
+    H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, ULLONG, long double, unsigned long long, 0, ULLONG_MAX);
-    H5_GCC_DIAG_ON("float-equal")
+    H5_GCC_CLANG_DIAG_ON("float-equal")
 }
 #endif /*H5T_CONV_INTERNAL_LDOUBLE_ULLONG*/
 

--- a/src/H5detect.c
+++ b/src/H5detect.c
@@ -52,7 +52,7 @@ static const char *FileHeader = "\n\
 /* Disable warning about cast increasing the alignment of the target type,
  * that's _exactly_ what this code is probing.  -QAK
  */
-H5_GCC_DIAG_OFF("cast-align")
+H5_GCC_CLANG_DIAG_OFF("cast-align")
 
 #if defined(__has_attribute)
 #if __has_attribute(no_sanitize_address)
@@ -300,10 +300,10 @@ precision(detected_t *d)
             for (_byte_mask = (unsigned char)1; _byte_mask; _byte_mask = (unsigned char)(_byte_mask << 1)) { \
                 _buf1[_i] ^= _byte_mask;                                                                     \
                 HDmemcpy((void *)&_v2, (const void *)_buf1, sizeof(TYPE));                                   \
-                H5_GCC_DIAG_OFF("float-equal")                                                               \
+                H5_GCC_CLANG_DIAG_OFF("float-equal")                                                         \
                 if (_v1 != _v2)                                                                              \
                     _pad_mask[_i] |= _byte_mask;                                                             \
-                H5_GCC_DIAG_ON("float-equal")                                                                \
+                H5_GCC_CLANG_DIAG_ON("float-equal")                                                          \
                 _buf1[_i] ^= _byte_mask;                                                                     \
             } /* end for */                                                                                  \
                                                                                                              \
@@ -414,10 +414,10 @@ precision(detected_t *d)
                 HDmemcpy(_buf + align_g[_ano] + (INFO.offset / 8), ((char *)&_val) + (INFO.offset / 8),      \
                          (size_t)(INFO.precision / 8));                                                      \
             _val2 = *((TYPE *)(_buf + align_g[_ano]));                                                       \
-            H5_GCC_DIAG_OFF("float-equal")                                                                   \
+            H5_GCC_CLANG_DIAG_OFF("float-equal")                                                                   \
             if (_val != _val2)                                                                               \
                 H5LONGJMP(jbuf_g, 1);                                                                        \
-            H5_GCC_DIAG_ON("float-equal")                                                                    \
+            H5_GCC_CLANG_DIAG_ON("float-equal")                                                                    \
             /* End Cray Check */                                                                             \
             (INFO.align) = align_g[_ano];                                                                    \
         }                                                                                                    \
@@ -1567,4 +1567,4 @@ main(int argc, char *argv[])
     return EXIT_SUCCESS;
 }
 
-H5_GCC_DIAG_ON("cast-align")
+H5_GCC_CLANG_DIAG_ON("cast-align")

--- a/src/H5detect.c
+++ b/src/H5detect.c
@@ -414,10 +414,10 @@ precision(detected_t *d)
                 HDmemcpy(_buf + align_g[_ano] + (INFO.offset / 8), ((char *)&_val) + (INFO.offset / 8),      \
                          (size_t)(INFO.precision / 8));                                                      \
             _val2 = *((TYPE *)(_buf + align_g[_ano]));                                                       \
-            H5_GCC_CLANG_DIAG_OFF("float-equal")                                                                   \
+            H5_GCC_CLANG_DIAG_OFF("float-equal")                                                             \
             if (_val != _val2)                                                                               \
                 H5LONGJMP(jbuf_g, 1);                                                                        \
-            H5_GCC_CLANG_DIAG_ON("float-equal")                                                                    \
+            H5_GCC_CLANG_DIAG_ON("float-equal")                                                              \
             /* End Cray Check */                                                                             \
             (INFO.align) = align_g[_ano];                                                                    \
         }                                                                                                    \

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -451,7 +451,7 @@
 #define LOCK_UN 0x08
 #endif /* H5_HAVE_FLOCK */
 
-/* Macros for enabling/disabling particular GCC warnings
+/* Macros for enabling/disabling particular GCC / clang warnings
  *
  * These are duplicated in H5FDmulti.c (we don't want to put them in the
  * public header and the multi VFD can't use private headers). If you make
@@ -461,17 +461,43 @@
  *      http://www.dbp-consulting.com/tutorials/SuppressingGCCWarnings.html
  *      http://gcc.gnu.org/onlinedocs/gcc/Diagnostic-Pragmas.html#Diagnostic-Pragmas
  */
-/* These pragmas are only implemented usefully in gcc 4.6+ */
-#if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 406
-#define H5_GCC_DIAG_JOINSTR(x, y) x y
-#define H5_GCC_DIAG_DO_PRAGMA(x)  _Pragma(#x)
-#define H5_GCC_DIAG_PRAGMA(x)     H5_GCC_DIAG_DO_PRAGMA(GCC diagnostic x)
+#define H5_DIAG_JOINSTR(x, y) x y
+#define H5_DIAG_DO_PRAGMA(x)  _Pragma(#x)
+#define H5_DIAG_PRAGMA(x)     H5_DIAG_DO_PRAGMA(GCC diagnostic x)
 
-#define H5_GCC_DIAG_OFF(x) H5_GCC_DIAG_PRAGMA(push) H5_GCC_DIAG_PRAGMA(ignored H5_GCC_DIAG_JOINSTR("-W", x))
-#define H5_GCC_DIAG_ON(x)  H5_GCC_DIAG_PRAGMA(pop)
+#define H5_DIAG_OFF(x) H5_DIAG_PRAGMA(push) H5_DIAG_PRAGMA(ignored H5_DIAG_JOINSTR("-W", x))
+#define H5_DIAG_ON(x)  H5_DIAG_PRAGMA(pop)
+
+/* Macros for enabling/disabling particular GCC-only warnings.
+ * These pragmas are only implemented usefully in gcc 4.6+
+ */
+#if (((__GNUC__ * 100) + __GNUC_MINOR__) >= 406)
+#define H5_GCC_DIAG_OFF(x) H5_DIAG_OFF(x)
+#define H5_GCC_DIAG_ON(x)  H5_DIAG_ON(x)
 #else
 #define H5_GCC_DIAG_OFF(x)
 #define H5_GCC_DIAG_ON(x)
+#endif
+
+/* Macros for enabling/disabling particular clang-only warnings.
+ */
+#if defined(__clang__)
+#define H5_CLANG_DIAG_OFF(x) H5_DIAG_OFF(x)
+#define H5_CLANG_DIAG_ON(x)  H5_DIAG_ON(x)
+#else
+#define H5_CLANG_DIAG_OFF(x)
+#define H5_CLANG_DIAG_ON(x)
+#endif
+
+/* Macros for enabling/disabling particular GCC / clang warnings.
+ * These macros should be used for warnings supported by both gcc and clang.
+ */
+#if (((__GNUC__ * 100) + __GNUC_MINOR__) >= 406) || defined(__clang__)
+#define H5_GCC_CLANG_DIAG_OFF(x) H5_DIAG_OFF(x)
+#define H5_GCC_CLANG_DIAG_ON(x)  H5_DIAG_ON(x)
+#else
+#define H5_GCC_CLANG_DIAG_OFF(x)
+#define H5_GCC_CLANG_DIAG_ON(x)
 #endif
 
 /* Typedefs and functions for timing certain parts of the library. */

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -60,7 +60,7 @@
 #define MPICH_SKIP_MPICXX 1
 #endif
 #ifndef OMPI_SKIP_MPICXX
-#define OMPI_SKIP_MPICXX  1
+#define OMPI_SKIP_MPICXX 1
 #endif
 #include <mpi.h>
 #ifndef MPI_FILE_NULL /* MPIO may be defined in mpi.h already */

--- a/test/big.c
+++ b/test/big.c
@@ -277,7 +277,7 @@ error:
  *      'name' in the code below, but early (4.4.7, at least) gcc only
  *      allows diagnostic pragmas to be toggled outside of functions.
  */
-H5_GCC_DIAG_OFF("format-nonliteral")
+H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
 static int
 enough_room(hid_t fapl)
 {
@@ -319,7 +319,7 @@ done:
 
     return ret_value;
 }
-H5_GCC_DIAG_ON("format-nonliteral")
+H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
 /*-------------------------------------------------------------------------
  * Function:    writer

--- a/test/error_test.c
+++ b/test/error_test.c
@@ -319,7 +319,7 @@ long_desc_cb(unsigned H5_ATTR_UNUSED n, const H5E_error2_t *err_desc, void *clie
  *      'full_desc' in the code below, but early (4.4.7, at least) gcc only
  *      allows diagnostic pragmas to be toggled outside of functions.
  */
-H5_GCC_DIAG_OFF("format-nonliteral")
+H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
 static herr_t
 test_long_desc(void)
 {
@@ -375,7 +375,7 @@ error:
 
     return -1;
 } /* end test_long_desc() */
-H5_GCC_DIAG_ON("format-nonliteral")
+H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
 /*-------------------------------------------------------------------------
  * Function:    dump_error

--- a/test/fheap.c
+++ b/test/fheap.c
@@ -553,7 +553,7 @@ get_fill_size(const fheap_test_param_t *tparam)
  *      test_desc in the code below, but early (4.4.7, at least) gcc only
  *      allows diagnostic pragmas to be toggled outside of functions.
  */
-H5_GCC_DIAG_OFF("format-nonliteral")
+H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
 static int
 begin_test(fheap_test_param_t *tparam, const char *base_desc, fheap_heap_ids_t *keep_ids, size_t *fill_size)
 {
@@ -581,7 +581,7 @@ begin_test(fheap_test_param_t *tparam, const char *base_desc, fheap_heap_ids_t *
     /* Success */
     return (0);
 } /* end begin_test() */
-H5_GCC_DIAG_ON("format-nonliteral")
+H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
 /*-------------------------------------------------------------------------
  * Function:  reopen_file

--- a/test/file_image.c
+++ b/test/file_image.c
@@ -712,7 +712,7 @@ error:
  *      'member_file_name' in the code below, but early (4.4.7, at least) gcc only
  *      allows diagnostic pragmas to be toggled outside of functions.
  */
-H5_GCC_DIAG_OFF("format-nonliteral")
+H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
 static int
 test_get_file_image(const char *test_banner, const int file_name_num, hid_t fapl, hbool_t user)
 {
@@ -976,7 +976,7 @@ test_get_file_image(const char *test_banner, const int file_name_num, hid_t fapl
 error:
     return 1;
 } /* end test_get_file_image() */
-H5_GCC_DIAG_ON("format-nonliteral")
+H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
 /******************************************************************************
  * Function:    test_get_file_image_error_rejection

--- a/test/h5test.c
+++ b/test/h5test.c
@@ -1305,7 +1305,7 @@ h5_dump_info_object(MPI_Info info)
  *      temp in the code below, but early (4.4.7, at least) gcc only
  *      allows diagnostic pragmas to be toggled outside of functions.
  */
-H5_GCC_DIAG_OFF("format-nonliteral")
+H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
 h5_stat_size_t
 h5_get_file_size(const char *filename, hid_t fapl)
 {
@@ -1410,7 +1410,7 @@ h5_get_file_size(const char *filename, hid_t fapl)
 
     return (-1);
 } /* end get_file_size() */
-H5_GCC_DIAG_ON("format-nonliteral")
+H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
 /*
  * This routine is designed to provide equivalent functionality to 'printf'

--- a/test/vfd.c
+++ b/test/vfd.c
@@ -859,7 +859,7 @@ error:
  *      'first_name' in the code below, but early (4.4.7, at least) gcc only
  *      allows diagnostic pragmas to be toggled outside of functions.
  */
-H5_GCC_DIAG_OFF("format-nonliteral")
+H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
 static herr_t
 test_family_opens(char *fname, hid_t fa_pl)
 {
@@ -924,7 +924,7 @@ test_family_opens(char *fname, hid_t fa_pl)
 error:
     return -1;
 } /* end test_family_opens() */
-H5_GCC_DIAG_ON("format-nonliteral")
+H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
 /*-------------------------------------------------------------------------
  * Function:    test_family
@@ -1150,7 +1150,7 @@ error:
  *      'newname_individual', etc. in the code below, but early (4.4.7, at least) gcc only
  *      allows diagnostic pragmas to be toggled outside of functions.
  */
-H5_GCC_DIAG_OFF("format-nonliteral")
+H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
 static herr_t
 test_family_compat(void)
 {
@@ -1236,7 +1236,7 @@ error:
 
     return -1;
 } /* end test_family_compat() */
-H5_GCC_DIAG_ON("format-nonliteral")
+H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
 /*-------------------------------------------------------------------------
  * Function:    test_family_member_fapl
@@ -1376,7 +1376,7 @@ error:
  *      'sf_name' in the code below, but early (4.4.7, at least) gcc only
  *      allows diagnostic pragmas to be toggled outside of functions.
  */
-H5_GCC_DIAG_OFF("format-nonliteral")
+H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
 static herr_t
 test_multi_opens(char *fname)
 {
@@ -1396,7 +1396,7 @@ test_multi_opens(char *fname)
 
     return (fid >= 0 ? FAIL : SUCCEED);
 } /* end test_multi_opens() */
-H5_GCC_DIAG_ON("format-nonliteral")
+H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
 /*-------------------------------------------------------------------------
  * Function:    test_multi

--- a/tools/libtest/h5tools_test_utils.c
+++ b/tools/libtest/h5tools_test_utils.c
@@ -69,7 +69,7 @@
  *
  *****************************************************************************/
 
-H5_GCC_DIAG_OFF("format")
+H5_GCC_CLANG_DIAG_OFF("format")
 
 /*----------------------------------------------------------------------------
  *
@@ -1254,7 +1254,7 @@ error:
 #undef UTIL_TEST_DEFAULT
 #undef UTIL_TEST_CREATE
 } /* test_set_configured_fapl */
-H5_GCC_DIAG_ON("format")
+H5_GCC_CLANG_DIAG_ON("format")
 
 /*----------------------------------------------------------------------------
  *


### PR DESCRIPTION
Added const where possible, then removed casts.