### PR TITLE
Fixes various warnings noticed on Windows

### DIFF
--- a/src/H5private.h
+++ b/src/H5private.h
@@ -675,11 +675,6 @@ typedef struct {
 #ifndef HDacos
 #define HDacos(X) acos(X)
 #endif /* HDacos */
-#ifndef HDvasprintf
-#ifdef H5_HAVE_VASPRINTF
-#define HDvasprintf(RET, FMT, A) vasprintf(RET, FMT, A)
-#endif /* H5_HAVE_VASPRINTF */
-#endif /* HDvasprintf */
 #ifndef HDalarm
 #ifdef H5_HAVE_ALARM
 #define HDalarm(N) alarm(N)
@@ -1647,6 +1642,13 @@ H5_DLL int64_t HDstrtoll(const char *s, const char **rest, int base);
 #ifndef HDutime
 #define HDutime(S, T) utime(S, T)
 #endif /* HDutime */
+#ifndef HDvasprintf
+#ifdef H5_HAVE_VASPRINTF
+#define HDvasprintf(RET, FMT, A) vasprintf(RET, FMT, A)
+#else
+H5_DLL int     HDvasprintf(char **bufp, const char *fmt, va_list _ap);
+#endif /* H5_HAVE_VASPRINTF */
+#endif /* HDvasprintf */
 #ifndef HDva_arg
 #define HDva_arg(A, T) va_arg(A, T)
 #endif /* HDva_arg */

--- a/src/H5system.c
+++ b/src/H5system.c
@@ -66,7 +66,7 @@
 /* Track whether tzset routine was called */
 static hbool_t H5_ntzset = FALSE;
 
-#ifndef HDvasprintf
+#ifndef H5_HAVE_VASPRINTF
 /* HDvasprintf provides vasprintf-like function on targets where it is
  * unavailable.
  */
@@ -94,7 +94,7 @@ HDvasprintf(char **bufp, const char *fmt, va_list _ap)
     }
     return -1;
 }
-#endif
+#endif /* H5_HAVE_VASPRINTF */
 
 /*-------------------------------------------------------------------------
  * Function:  HDstrtoll
@@ -737,7 +737,7 @@ Wroundf(float arg)
  *
  *-------------------------------------------------------------------------
  */
-const wchar_t *
+wchar_t *
 H5_get_utf16_str(const char *s)
 {
     int      nwchars = -1;   /* Length of the UTF-16 buffer */
@@ -833,7 +833,7 @@ int
 Wremove_utf8(const char *path)
 {
     wchar_t *wpath = NULL; /* UTF-16 version of the path */
-    int      ret;
+    int      ret = -1;
 
     /* Convert the input UTF-8 path to UTF-16 */
     if (NULL == (wpath = H5_get_utf16_str(path)))

--- a/src/H5system.c
+++ b/src/H5system.c
@@ -833,7 +833,7 @@ int
 Wremove_utf8(const char *path)
 {
     wchar_t *wpath = NULL; /* UTF-16 version of the path */
-    int      ret = -1;
+    int      ret   = -1;
 
     /* Convert the input UTF-8 path to UTF-16 */
     if (NULL == (wpath = H5_get_utf16_str(path)))

--- a/src/H5win32defs.h
+++ b/src/H5win32defs.h
@@ -176,9 +176,10 @@ H5_DLL int    c99_snprintf(char *str, size_t size, const char *format, ...);
 H5_DLL int    c99_vsnprintf(char *str, size_t size, const char *format, va_list ap);
 H5_DLL int    Wnanosleep(const struct timespec *req, struct timespec *rem);
 H5_DLL herr_t H5_expand_windows_env_vars(char **env_var);
-H5_DLL const wchar_t *H5_get_utf16_str(const char *s);
+H5_DLL wchar_t *H5_get_utf16_str(const char *s);
 H5_DLL int            Wopen_utf8(const char *path, int oflag, ...);
 H5_DLL int            Wremove_utf8(const char *path);
+H5_DLL int            H5_get_win32_times(H5_timevals_t *tvs);
 
 /* Round functions only needed for VS2012 and earlier.
  * They are always built to ensure they don't go stale and

--- a/src/H5win32defs.h
+++ b/src/H5win32defs.h
@@ -177,9 +177,9 @@ H5_DLL int    c99_vsnprintf(char *str, size_t size, const char *format, va_list 
 H5_DLL int    Wnanosleep(const struct timespec *req, struct timespec *rem);
 H5_DLL herr_t H5_expand_windows_env_vars(char **env_var);
 H5_DLL wchar_t *H5_get_utf16_str(const char *s);
-H5_DLL int            Wopen_utf8(const char *path, int oflag, ...);
-H5_DLL int            Wremove_utf8(const char *path);
-H5_DLL int            H5_get_win32_times(H5_timevals_t *tvs);
+H5_DLL int      Wopen_utf8(const char *path, int oflag, ...);
+H5_DLL int      Wremove_utf8(const char *path);
+H5_DLL int      H5_get_win32_times(H5_timevals_t *tvs);
 
 /* Round functions only needed for VS2012 and earlier.
  * They are always built to ensure they don't go stale and

--- a/test/accum.c
+++ b/test/accum.c
@@ -2100,10 +2100,10 @@ test_swmr_write_big(hbool_t newest_format)
     uint8_t *wbuf2 = NULL, *rbuf = NULL; /* Buffers for reading & writing */
     uint8_t  wbuf[1024];                 /* Buffer for reading & writing */
     unsigned u;                          /* Local index variable */
-    pid_t pid;                      /* Process ID */
-    int     status;                 /* Status returned from child process */
-    char *  driver         = NULL;  /* VFD string (from env variable) */
-    hbool_t api_ctx_pushed = FALSE; /* Whether API context pushed */
+    pid_t    pid;                        /* Process ID */
+    int      status;                     /* Status returned from child process */
+    char *   driver         = NULL;      /* VFD string (from env variable) */
+    hbool_t  api_ctx_pushed = FALSE;     /* Whether API context pushed */
 
     if (newest_format)
         TESTING("SWMR write of large metadata: with latest format")

--- a/test/accum.c
+++ b/test/accum.c
@@ -2092,6 +2092,7 @@ error:
 unsigned
 test_swmr_write_big(hbool_t newest_format)
 {
+#if defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID) && defined(H5_HAVE_UNISTD_H)
     hid_t    fid  = -1;   /* File ID */
     hid_t    fapl = -1;   /* File access property list */
     H5F_t *  rf   = NULL; /* File pointer */
@@ -2099,9 +2100,7 @@ test_swmr_write_big(hbool_t newest_format)
     uint8_t *wbuf2 = NULL, *rbuf = NULL; /* Buffers for reading & writing */
     uint8_t  wbuf[1024];                 /* Buffer for reading & writing */
     unsigned u;                          /* Local index variable */
-#ifdef H5_HAVE_UNISTD_H
     pid_t pid;                      /* Process ID */
-#endif                              /* H5_HAVE_UNISTD_H */
     int     status;                 /* Status returned from child process */
     char *  driver         = NULL;  /* VFD string (from env variable) */
     hbool_t api_ctx_pushed = FALSE; /* Whether API context pushed */
@@ -2110,14 +2109,6 @@ test_swmr_write_big(hbool_t newest_format)
         TESTING("SWMR write of large metadata: with latest format")
     else
         TESTING("SWMR write of large metadata: with non-latest-format")
-
-#if !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID))
-
-    SKIPPED();
-    HDputs("    Test skipped due to fork or waitpid not defined.");
-    return 0;
-
-#else /* defined(H5_HAVE_FORK && defined(H5_HAVE_WAITPID) */
 
     /* Skip this test if SWMR I/O is not supported for the VFD specified
      * by the environment variable.
@@ -2296,7 +2287,11 @@ error:
 
     return 1;
 
-#endif
+#else
+    SKIPPED();
+    HDputs("    Test skipped due to fork, waitpid, or pid_t not defined.");
+    return 0;
+#endif /* defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID) && defined(H5_HAVE_UNISTD_H) */
 
 } /* end test_swmr_write_big() */
 

--- a/test/dsets.c
+++ b/test/dsets.c
@@ -6976,6 +6976,7 @@ error:
 static herr_t
 test_filter_delete(hid_t file)
 {
+#ifdef H5_HAVE_FILTER_DEFLATE
     H5Z_filter_t filtn;                    /* filter identification number */
     hid_t        dsid          = -1;       /* dataset ID */
     hid_t        sid           = -1;       /* dataspace ID */
@@ -6987,6 +6988,7 @@ test_filter_delete(hid_t file)
     unsigned     flags;                    /* flags for filter */
     herr_t       ret;                      /* generic return value */
     int          i;
+#endif
 
     TESTING("filter deletion");
 
@@ -7088,9 +7090,7 @@ test_filter_delete(hid_t file)
         goto error;
 
     PASSED();
-#else
-    SKIPPED();
-#endif
+
     return SUCCEED;
 
 error:
@@ -7103,6 +7103,10 @@ error:
     }
     H5E_END_TRY;
     return FAIL;
+#else
+    SKIPPED();
+    return SUCCEED;
+#endif
 } /* end test_filter_delete() */
 
 /*-------------------------------------------------------------------------

--- a/test/trefer.c
+++ b/test/trefer.c
@@ -832,7 +832,7 @@ test_reference_cmpnd_obj(void)
     hsize_t    cmpnd_dims[] = {1};
     hid_t      dapl_id; /* Dataset access property list     */
     unsigned * ibuf, *obuf;
-    unsigned   i, j;     /* Counters                         */
+    unsigned   i;        /* Counter                          */
     H5O_type_t obj_type; /* Object type                      */
     herr_t     ret;      /* Generic return value             */
     s2_t       cmpnd_wbuf, cmpnd_rbuf;


### PR DESCRIPTION
- Adds a prototype for our implementation of vasprintf
- Return type of H5_get_utf16_str() is now non-const
- Fixes possible uninitialized return type in Wremove_utf8
- Better isolation of fork() code in accum.c:test_swmr_write_big()
- Better isolation of non-zlib code in dsets.c:test_filter_delete()
- Removed unused variable in trefer.c:test_reference_cmpnd_obj()