### PR TITLE
Applied clang-tidy readability-non-const-parameter warning fixes auto…

### DIFF
--- a/hl/test/test_file_image.c
+++ b/hl/test/test_file_image.c
@@ -51,7 +51,7 @@
  *-------------------------------------------------------------------------
  */
 static int
-test_file_image(size_t open_images, size_t nflags, unsigned *flags)
+test_file_image(size_t open_images, size_t nflags, const unsigned *flags)
 {
     hid_t * file_id, *dset_id, file_space, plist; /* HDF5 ids */
     hsize_t dims1[RANK]    = {2, 3};              /* original dimension of datasets */

--- a/hl/test/test_ld.c
+++ b/hl/test/test_ld.c
@@ -157,7 +157,7 @@ static herr_t test_LD_elmts_invalid(const char *file);
 static herr_t test_LD_elmts_one(const char *file, const char *dname, const char *fields);
 static herr_t test_LD_elmts_two(const char *file, const char *dname, const char *fields);
 
-static herr_t verify_elmts_two(int type, hsize_t *ext_dims, hsize_t *prev_dims, void *_ldbuf, void *_buf);
+static herr_t verify_elmts_two(int type, const hsize_t *ext_dims, const hsize_t *prev_dims, void *_ldbuf, void *_buf);
 
 /* data structures for compound data type */
 typedef struct sub22_t {
@@ -1135,7 +1135,7 @@ error:
  **************************************************************************************
  */
 static herr_t
-verify_elmts_two(int type, hsize_t *ext_dims, hsize_t *prev_dims, void *_ldbuf, void *_buf)
+verify_elmts_two(int type, const hsize_t *ext_dims, const hsize_t *prev_dims, void *_ldbuf, void *_buf)
 {
     int k, m; /* Local index variable */
 

--- a/hl/test/test_ld.c
+++ b/hl/test/test_ld.c
@@ -157,7 +157,8 @@ static herr_t test_LD_elmts_invalid(const char *file);
 static herr_t test_LD_elmts_one(const char *file, const char *dname, const char *fields);
 static herr_t test_LD_elmts_two(const char *file, const char *dname, const char *fields);
 
-static herr_t verify_elmts_two(int type, const hsize_t *ext_dims, const hsize_t *prev_dims, void *_ldbuf, void *_buf);
+static herr_t verify_elmts_two(int type, const hsize_t *ext_dims, const hsize_t *prev_dims, void *_ldbuf,
+                               void *_buf);
 
 /* data structures for compound data type */
 typedef struct sub22_t {

--- a/hl/tools/gif2h5/gif.h
+++ b/hl/tools/gif2h5/gif.h
@@ -157,8 +157,8 @@ int ReadGifApplication(GIFAPPLICATION *, GIFBYTE **);
 int ReadGifComment(GIFCOMMENT *, GIFBYTE **);
 
 /* HDFGIFWR.C */
-int hdfWriteGIF(FILE *fp, GIFBYTE *pic, int ptype, int w, int h, GIFBYTE *rmap, GIFBYTE *gmap, GIFBYTE *bmap,
-                GIFBYTE *pc2ncmap, int numcols, int colorstyle, int BitsPerPixel);
+int hdfWriteGIF(FILE *fp, GIFBYTE *pic, int ptype, int w, int h, const GIFBYTE *rmap, const GIFBYTE *gmap, const GIFBYTE *bmap,
+                const GIFBYTE *pc2ncmap, int numcols, int colorstyle, int BitsPerPixel);
 
 /* WRITEHDF.C */
 int WriteHDF(GIFTOMEM, GIFCHAR *);
@@ -176,7 +176,7 @@ int ReadHDF(GIFBYTE **data, GIFBYTE palette[256][3], hsize_t *image_size, GIFCHA
             GIFCHAR *dset_name, GIFCHAR *pal_name);
 
 GIFBYTE *Decompress(GIFIMAGEDESC *, GIFHEAD *);
-GIFBYTE  GetByte(GIFBYTE *);
+GIFBYTE  GetByte(const GIFBYTE *);
 GIFWORD  GetWord(GIFBYTE *);
 
 void cleanup(GIFBYTE *);

--- a/hl/tools/gif2h5/gif.h
+++ b/hl/tools/gif2h5/gif.h
@@ -157,8 +157,8 @@ int ReadGifApplication(GIFAPPLICATION *, GIFBYTE **);
 int ReadGifComment(GIFCOMMENT *, GIFBYTE **);
 
 /* HDFGIFWR.C */
-int hdfWriteGIF(FILE *fp, GIFBYTE *pic, int ptype, int w, int h, const GIFBYTE *rmap, const GIFBYTE *gmap, const GIFBYTE *bmap,
-                const GIFBYTE *pc2ncmap, int numcols, int colorstyle, int BitsPerPixel);
+int hdfWriteGIF(FILE *fp, GIFBYTE *pic, int ptype, int w, int h, const GIFBYTE *rmap, const GIFBYTE *gmap,
+                const GIFBYTE *bmap, const GIFBYTE *pc2ncmap, int numcols, int colorstyle, int BitsPerPixel);
 
 /* WRITEHDF.C */
 int WriteHDF(GIFTOMEM, GIFCHAR *);

--- a/hl/tools/gif2h5/gifread.c
+++ b/hl/tools/gif2h5/gifread.c
@@ -38,7 +38,7 @@ GetWord(GIFBYTE *MemGif)
 }
 
 GIFBYTE
-GetByte(GIFBYTE *MemGif) { return *MemGif; }
+GetByte(const GIFBYTE *MemGif) { return *MemGif; }
 
 /*
  *  Read a GIF image GIFBYTE Header.

--- a/hl/tools/gif2h5/hdfgifwr.c
+++ b/hl/tools/gif2h5/hdfgifwr.c
@@ -135,8 +135,8 @@ static int EOFCode;
 
 /*************************************************************/
 int
-hdfWriteGIF(FILE *fp, byte *pic, int ptype, int w, int h, const byte *rmap, const byte *gmap, const byte *bmap, const byte *pc2ncmap,
-            int numcols, int colorstyle, int BitsPerPixel)
+hdfWriteGIF(FILE *fp, byte *pic, int ptype, int w, int h, const byte *rmap, const byte *gmap,
+            const byte *bmap, const byte *pc2ncmap, int numcols, int colorstyle, int BitsPerPixel)
 {
     int   InitCodeSize;
     int   i;

--- a/hl/tools/gif2h5/hdfgifwr.c
+++ b/hl/tools/gif2h5/hdfgifwr.c
@@ -135,7 +135,7 @@ static int EOFCode;
 
 /*************************************************************/
 int
-hdfWriteGIF(FILE *fp, byte *pic, int ptype, int w, int h, byte *rmap, byte *gmap, byte *bmap, byte *pc2ncmap,
+hdfWriteGIF(FILE *fp, byte *pic, int ptype, int w, int h, const byte *rmap, const byte *gmap, const byte *bmap, const byte *pc2ncmap,
             int numcols, int colorstyle, int BitsPerPixel)
 {
     int   InitCodeSize;

--- a/hl/tools/h5watch/h5watch.c
+++ b/hl/tools/h5watch/h5watch.c
@@ -43,7 +43,7 @@ static unsigned g_retry = DEFAULT_RETRY;  /* # of times to try opening the file 
 static hbool_t  g_display_hex    = FALSE; /* display data in hexadecimal format : LATER */
 static hbool_t  g_user_interrupt = FALSE; /* Flag to indicate that user interrupted execution */
 
-static herr_t doprint(hid_t did, hsize_t *start, hsize_t *block, int rank);
+static herr_t doprint(hid_t did, const hsize_t *start, const hsize_t *block, int rank);
 static herr_t slicendump(hid_t did, hsize_t *prev_dims, hsize_t *cur_dims, hsize_t *start, hsize_t *block,
                          int rank, int subrank);
 static herr_t monitor_dataset(hid_t fid, char *dsetname);
@@ -95,7 +95,7 @@ static struct long_options l_opts[] = {{"help", no_arg, 'h'},         {"hel", no
  *-------------------------------------------------------------------------
  */
 static herr_t
-doprint(hid_t did, hsize_t *start, hsize_t *block, int rank)
+doprint(hid_t did, const hsize_t *start, const hsize_t *block, int rank)
 {
     h5tools_context_t ctx;                           /* print context  */
     h5tool_format_t   info;                          /* Format info for the tools library */

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -4258,7 +4258,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5D__chunk_allocate(const H5D_io_info_t *io_info, hbool_t full_overwrite, hsize_t old_dim[])
+H5D__chunk_allocate(const H5D_io_info_t *io_info, hbool_t full_overwrite, const hsize_t old_dim[])
 {
     const H5D_t *          dset = io_info->dset;                           /* the dataset pointer */
     H5D_chk_idx_info_t     idx_info;                                       /* Chunked index info */

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -631,7 +631,7 @@ H5_DLL hbool_t H5D__chunk_is_space_alloc(const H5O_storage_t *storage);
 H5_DLL hbool_t H5D__chunk_is_data_cached(const H5D_shared_t *shared_dset);
 H5_DLL herr_t  H5D__chunk_lookup(const H5D_t *dset, const hsize_t *scaled, H5D_chunk_ud_t *udata);
 H5_DLL herr_t  H5D__chunk_allocated(const H5D_t *dset, hsize_t *nbytes);
-H5_DLL herr_t  H5D__chunk_allocate(const H5D_io_info_t *io_info, hbool_t full_overwrite, hsize_t old_dim[]);
+H5_DLL herr_t  H5D__chunk_allocate(const H5D_io_info_t *io_info, hbool_t full_overwrite, const hsize_t old_dim[]);
 H5_DLL herr_t  H5D__chunk_file_alloc(const H5D_chk_idx_info_t *idx_info, const H5F_block_t *old_chunk,
                                      H5F_block_t *new_chunk, hbool_t *need_insert, const hsize_t *scaled);
 H5_DLL herr_t  H5D__chunk_update_old_edge_chunks(H5D_t *dset, hsize_t old_dim[]);

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -631,7 +631,8 @@ H5_DLL hbool_t H5D__chunk_is_space_alloc(const H5O_storage_t *storage);
 H5_DLL hbool_t H5D__chunk_is_data_cached(const H5D_shared_t *shared_dset);
 H5_DLL herr_t  H5D__chunk_lookup(const H5D_t *dset, const hsize_t *scaled, H5D_chunk_ud_t *udata);
 H5_DLL herr_t  H5D__chunk_allocated(const H5D_t *dset, hsize_t *nbytes);
-H5_DLL herr_t  H5D__chunk_allocate(const H5D_io_info_t *io_info, hbool_t full_overwrite, const hsize_t old_dim[]);
+H5_DLL herr_t  H5D__chunk_allocate(const H5D_io_info_t *io_info, hbool_t full_overwrite,
+                                   const hsize_t old_dim[]);
 H5_DLL herr_t  H5D__chunk_file_alloc(const H5D_chk_idx_info_t *idx_info, const H5F_block_t *old_chunk,
                                      H5F_block_t *new_chunk, hbool_t *need_insert, const hsize_t *scaled);
 H5_DLL herr_t  H5D__chunk_update_old_edge_chunks(H5D_t *dset, hsize_t old_dim[]);

--- a/src/H5Tbit.c
+++ b/src/H5Tbit.c
@@ -388,7 +388,7 @@ H5T__bit_set(uint8_t *buf, size_t offset, size_t size, hbool_t value)
  *-------------------------------------------------------------------------
  */
 ssize_t
-H5T__bit_find(uint8_t *buf, size_t offset, size_t size, H5T_sdir_t direction, hbool_t value)
+H5T__bit_find(const uint8_t *buf, size_t offset, size_t size, H5T_sdir_t direction, hbool_t value)
 {
     ssize_t base = (ssize_t)offset;
     ssize_t idx, i;

--- a/src/H5Tpkg.h
+++ b/src/H5Tpkg.h
@@ -852,7 +852,8 @@ H5_DLL herr_t   H5T__bit_shift(uint8_t *buf, ssize_t shift_dist, size_t offset, 
 H5_DLL void     H5T__bit_set(uint8_t *buf, size_t offset, size_t size, hbool_t value);
 H5_DLL uint64_t H5T__bit_get_d(uint8_t *buf, size_t offset, size_t size);
 H5_DLL void     H5T__bit_set_d(uint8_t *buf, size_t offset, size_t size, uint64_t val);
-H5_DLL ssize_t  H5T__bit_find(const uint8_t *buf, size_t offset, size_t size, H5T_sdir_t direction, hbool_t value);
+H5_DLL ssize_t  H5T__bit_find(const uint8_t *buf, size_t offset, size_t size, H5T_sdir_t direction,
+                              hbool_t value);
 H5_DLL hbool_t  H5T__bit_inc(uint8_t *buf, size_t start, size_t size);
 H5_DLL hbool_t  H5T__bit_dec(uint8_t *buf, size_t start, size_t size);
 H5_DLL void     H5T__bit_neg(uint8_t *buf, size_t start, size_t size);

--- a/src/H5Tpkg.h
+++ b/src/H5Tpkg.h
@@ -852,7 +852,7 @@ H5_DLL herr_t   H5T__bit_shift(uint8_t *buf, ssize_t shift_dist, size_t offset, 
 H5_DLL void     H5T__bit_set(uint8_t *buf, size_t offset, size_t size, hbool_t value);
 H5_DLL uint64_t H5T__bit_get_d(uint8_t *buf, size_t offset, size_t size);
 H5_DLL void     H5T__bit_set_d(uint8_t *buf, size_t offset, size_t size, uint64_t val);
-H5_DLL ssize_t  H5T__bit_find(uint8_t *buf, size_t offset, size_t size, H5T_sdir_t direction, hbool_t value);
+H5_DLL ssize_t  H5T__bit_find(const uint8_t *buf, size_t offset, size_t size, H5T_sdir_t direction, hbool_t value);
 H5_DLL hbool_t  H5T__bit_inc(uint8_t *buf, size_t start, size_t size);
 H5_DLL hbool_t  H5T__bit_dec(uint8_t *buf, size_t start, size_t size);
 H5_DLL void     H5T__bit_neg(uint8_t *buf, size_t start, size_t size);

--- a/src/H5Znbit.c
+++ b/src/H5Znbit.c
@@ -52,17 +52,19 @@ static herr_t H5Z__set_parms_array(const H5T_t *type, unsigned *cd_values_index,
 static herr_t H5Z__set_parms_compound(const H5T_t *type, unsigned *cd_values_index, unsigned cd_values[],
                                       hbool_t *need_not_compress);
 
-static void H5Z__nbit_next_byte(size_t *j, size_t *buf_len);
-static void H5Z__nbit_decompress_one_byte(unsigned char *data, size_t data_offset, unsigned k,
-                                          unsigned begin_i, unsigned end_i, const unsigned char *buffer, size_t *j,
+static void   H5Z__nbit_next_byte(size_t *j, size_t *buf_len);
+static void   H5Z__nbit_decompress_one_byte(unsigned char *data, size_t data_offset, unsigned k,
+                                            unsigned begin_i, unsigned end_i, const unsigned char *buffer,
+                                            size_t *j, size_t *buf_len, const parms_atomic *p,
+                                            size_t datatype_len);
+static void   H5Z__nbit_compress_one_byte(const unsigned char *data, size_t data_offset, unsigned k,
+                                          unsigned begin_i, unsigned end_i, unsigned char *buffer, size_t *j,
                                           size_t *buf_len, const parms_atomic *p, size_t datatype_len);
-static void H5Z__nbit_compress_one_byte(const unsigned char *data, size_t data_offset, unsigned k, unsigned begin_i,
-                                        unsigned end_i, unsigned char *buffer, size_t *j, size_t *buf_len,
-                                        const parms_atomic *p, size_t datatype_len);
-static void H5Z__nbit_decompress_one_nooptype(unsigned char *data, size_t data_offset, const unsigned char *buffer,
-                                              size_t *j, size_t *buf_len, unsigned size);
-static void H5Z__nbit_decompress_one_atomic(unsigned char *data, size_t data_offset, unsigned char *buffer,
-                                            size_t *j, size_t *buf_len, const parms_atomic *p);
+static void   H5Z__nbit_decompress_one_nooptype(unsigned char *data, size_t data_offset,
+                                                const unsigned char *buffer, size_t *j, size_t *buf_len,
+                                                unsigned size);
+static void   H5Z__nbit_decompress_one_atomic(unsigned char *data, size_t data_offset, unsigned char *buffer,
+                                              size_t *j, size_t *buf_len, const parms_atomic *p);
 static herr_t H5Z__nbit_decompress_one_array(unsigned char *data, size_t data_offset, unsigned char *buffer,
                                              size_t *j, size_t *buf_len, const unsigned parms[],
                                              unsigned *parms_index);
@@ -71,8 +73,8 @@ static herr_t H5Z__nbit_decompress_one_compound(unsigned char *data, size_t data
                                                 const unsigned parms[], unsigned *parms_index);
 static herr_t H5Z__nbit_decompress(unsigned char *data, unsigned d_nelmts, unsigned char *buffer,
                                    const unsigned parms[]);
-static void   H5Z__nbit_compress_one_nooptype(const unsigned char *data, size_t data_offset, unsigned char *buffer,
-                                              size_t *j, size_t *buf_len, unsigned size);
+static void   H5Z__nbit_compress_one_nooptype(const unsigned char *data, size_t data_offset,
+                                              unsigned char *buffer, size_t *j, size_t *buf_len, unsigned size);
 static void   H5Z__nbit_compress_one_array(unsigned char *data, size_t data_offset, unsigned char *buffer,
                                            size_t *j, size_t *buf_len, const unsigned parms[],
                                            unsigned *parms_index);
@@ -1075,8 +1077,8 @@ H5Z__nbit_decompress_one_byte(unsigned char *data, size_t data_offset, unsigned 
 }
 
 static void
-H5Z__nbit_decompress_one_nooptype(unsigned char *data, size_t data_offset, const unsigned char *buffer, size_t *j,
-                                  size_t *buf_len, unsigned size)
+H5Z__nbit_decompress_one_nooptype(unsigned char *data, size_t data_offset, const unsigned char *buffer,
+                                  size_t *j, size_t *buf_len, unsigned size)
 {
     unsigned      i;       /* index */
     size_t        dat_len; /* dat_len is the number of bits to be copied in each data byte */
@@ -1383,8 +1385,8 @@ H5Z__nbit_compress_one_byte(const unsigned char *data, size_t data_offset, unsig
 }
 
 static void
-H5Z__nbit_compress_one_nooptype(const unsigned char *data, size_t data_offset, unsigned char *buffer, size_t *j,
-                                size_t *buf_len, unsigned size)
+H5Z__nbit_compress_one_nooptype(const unsigned char *data, size_t data_offset, unsigned char *buffer,
+                                size_t *j, size_t *buf_len, unsigned size)
 {
     unsigned      i;       /* index */
     size_t        dat_len; /* dat_len is the number of bits to be copied in each data byte */

--- a/src/H5Znbit.c
+++ b/src/H5Znbit.c
@@ -54,12 +54,12 @@ static herr_t H5Z__set_parms_compound(const H5T_t *type, unsigned *cd_values_ind
 
 static void H5Z__nbit_next_byte(size_t *j, size_t *buf_len);
 static void H5Z__nbit_decompress_one_byte(unsigned char *data, size_t data_offset, unsigned k,
-                                          unsigned begin_i, unsigned end_i, unsigned char *buffer, size_t *j,
+                                          unsigned begin_i, unsigned end_i, const unsigned char *buffer, size_t *j,
                                           size_t *buf_len, const parms_atomic *p, size_t datatype_len);
-static void H5Z__nbit_compress_one_byte(unsigned char *data, size_t data_offset, unsigned k, unsigned begin_i,
+static void H5Z__nbit_compress_one_byte(const unsigned char *data, size_t data_offset, unsigned k, unsigned begin_i,
                                         unsigned end_i, unsigned char *buffer, size_t *j, size_t *buf_len,
                                         const parms_atomic *p, size_t datatype_len);
-static void H5Z__nbit_decompress_one_nooptype(unsigned char *data, size_t data_offset, unsigned char *buffer,
+static void H5Z__nbit_decompress_one_nooptype(unsigned char *data, size_t data_offset, const unsigned char *buffer,
                                               size_t *j, size_t *buf_len, unsigned size);
 static void H5Z__nbit_decompress_one_atomic(unsigned char *data, size_t data_offset, unsigned char *buffer,
                                             size_t *j, size_t *buf_len, const parms_atomic *p);
@@ -71,7 +71,7 @@ static herr_t H5Z__nbit_decompress_one_compound(unsigned char *data, size_t data
                                                 const unsigned parms[], unsigned *parms_index);
 static herr_t H5Z__nbit_decompress(unsigned char *data, unsigned d_nelmts, unsigned char *buffer,
                                    const unsigned parms[]);
-static void   H5Z__nbit_compress_one_nooptype(unsigned char *data, size_t data_offset, unsigned char *buffer,
+static void   H5Z__nbit_compress_one_nooptype(const unsigned char *data, size_t data_offset, unsigned char *buffer,
                                               size_t *j, size_t *buf_len, unsigned size);
 static void   H5Z__nbit_compress_one_array(unsigned char *data, size_t data_offset, unsigned char *buffer,
                                            size_t *j, size_t *buf_len, const unsigned parms[],
@@ -1026,7 +1026,7 @@ H5Z__nbit_next_byte(size_t *j, size_t *buf_len)
 
 static void
 H5Z__nbit_decompress_one_byte(unsigned char *data, size_t data_offset, unsigned k, unsigned begin_i,
-                              unsigned end_i, unsigned char *buffer, size_t *j, size_t *buf_len,
+                              unsigned end_i, const unsigned char *buffer, size_t *j, size_t *buf_len,
                               const parms_atomic *p, size_t datatype_len)
 {
     size_t        dat_len; /* dat_len is the number of bits to be copied in each data byte */
@@ -1075,7 +1075,7 @@ H5Z__nbit_decompress_one_byte(unsigned char *data, size_t data_offset, unsigned 
 }
 
 static void
-H5Z__nbit_decompress_one_nooptype(unsigned char *data, size_t data_offset, unsigned char *buffer, size_t *j,
+H5Z__nbit_decompress_one_nooptype(unsigned char *data, size_t data_offset, const unsigned char *buffer, size_t *j,
                                   size_t *buf_len, unsigned size)
 {
     unsigned      i;       /* index */
@@ -1341,7 +1341,7 @@ done:
 }
 
 static void
-H5Z__nbit_compress_one_byte(unsigned char *data, size_t data_offset, unsigned k, unsigned begin_i,
+H5Z__nbit_compress_one_byte(const unsigned char *data, size_t data_offset, unsigned k, unsigned begin_i,
                             unsigned end_i, unsigned char *buffer, size_t *j, size_t *buf_len,
                             const parms_atomic *p, size_t datatype_len)
 {
@@ -1383,7 +1383,7 @@ H5Z__nbit_compress_one_byte(unsigned char *data, size_t data_offset, unsigned k,
 }
 
 static void
-H5Z__nbit_compress_one_nooptype(unsigned char *data, size_t data_offset, unsigned char *buffer, size_t *j,
+H5Z__nbit_compress_one_nooptype(const unsigned char *data, size_t data_offset, unsigned char *buffer, size_t *j,
                                 size_t *buf_len, unsigned size)
 {
     unsigned      i;       /* index */

--- a/src/H5Zscaleoffset.c
+++ b/src/H5Zscaleoffset.c
@@ -73,9 +73,9 @@ static herr_t H5Z__scaleoffset_postdecompress_fd(void *data, unsigned d_nelmts, 
                                                  uint32_t minbits, unsigned long long minval, double D_val);
 static void   H5Z__scaleoffset_next_byte(size_t *j, unsigned *buf_len);
 static void   H5Z__scaleoffset_decompress_one_byte(unsigned char *data, size_t data_offset, unsigned k,
-                                                   unsigned begin_i, unsigned char *buffer, size_t *j,
+                                                   unsigned begin_i, const unsigned char *buffer, size_t *j,
                                                    unsigned *buf_len, parms_atomic p, unsigned dtype_len);
-static void   H5Z__scaleoffset_compress_one_byte(unsigned char *data, size_t data_offset, unsigned k,
+static void   H5Z__scaleoffset_compress_one_byte(const unsigned char *data, size_t data_offset, unsigned k,
                                                  unsigned begin_i, unsigned char *buffer, size_t *j,
                                                  unsigned *buf_len, parms_atomic p, unsigned dtype_len);
 static void   H5Z__scaleoffset_decompress_one_atomic(unsigned char *data, size_t data_offset,
@@ -1608,7 +1608,7 @@ H5Z__scaleoffset_next_byte(size_t *j, unsigned *buf_len)
 
 static void
 H5Z__scaleoffset_decompress_one_byte(unsigned char *data, size_t data_offset, unsigned k, unsigned begin_i,
-                                     unsigned char *buffer, size_t *j, unsigned *buf_len, parms_atomic p,
+                                     const unsigned char *buffer, size_t *j, unsigned *buf_len, parms_atomic p,
                                      unsigned dtype_len)
 {
     unsigned      dat_len; /* dat_len is the number of bits to be copied in each data byte */
@@ -1694,7 +1694,7 @@ H5Z__scaleoffset_decompress(unsigned char *data, unsigned d_nelmts, unsigned cha
 }
 
 static void
-H5Z__scaleoffset_compress_one_byte(unsigned char *data, size_t data_offset, unsigned k, unsigned begin_i,
+H5Z__scaleoffset_compress_one_byte(const unsigned char *data, size_t data_offset, unsigned k, unsigned begin_i,
                                    unsigned char *buffer, size_t *j, unsigned *buf_len, parms_atomic p,
                                    unsigned dtype_len)
 {

--- a/src/H5Zscaleoffset.c
+++ b/src/H5Zscaleoffset.c
@@ -1608,8 +1608,8 @@ H5Z__scaleoffset_next_byte(size_t *j, unsigned *buf_len)
 
 static void
 H5Z__scaleoffset_decompress_one_byte(unsigned char *data, size_t data_offset, unsigned k, unsigned begin_i,
-                                     const unsigned char *buffer, size_t *j, unsigned *buf_len, parms_atomic p,
-                                     unsigned dtype_len)
+                                     const unsigned char *buffer, size_t *j, unsigned *buf_len,
+                                     parms_atomic p, unsigned dtype_len)
 {
     unsigned      dat_len; /* dat_len is the number of bits to be copied in each data byte */
     unsigned char val;     /* value to be copied in each data byte */
@@ -1694,9 +1694,9 @@ H5Z__scaleoffset_decompress(unsigned char *data, unsigned d_nelmts, unsigned cha
 }
 
 static void
-H5Z__scaleoffset_compress_one_byte(const unsigned char *data, size_t data_offset, unsigned k, unsigned begin_i,
-                                   unsigned char *buffer, size_t *j, unsigned *buf_len, parms_atomic p,
-                                   unsigned dtype_len)
+H5Z__scaleoffset_compress_one_byte(const unsigned char *data, size_t data_offset, unsigned k,
+                                   unsigned begin_i, unsigned char *buffer, size_t *j, unsigned *buf_len,
+                                   parms_atomic p, unsigned dtype_len)
 {
     unsigned      dat_len; /* dat_len is the number of bits to be copied in each data byte */
     unsigned char val;     /* value to be copied in each data byte */

--- a/src/H5Ztrans.c
+++ b/src/H5Ztrans.c
@@ -90,8 +90,7 @@ static void       H5Z__do_op(H5Z_node *tree);
 static hbool_t    H5Z__op_is_numbs(H5Z_node *_tree);
 static hbool_t    H5Z__op_is_numbs2(H5Z_node *_tree);
 static hid_t      H5Z__xform_find_type(const H5T_t *type);
-static herr_t     H5Z__xform_eval_full(H5Z_node *tree, size_t array_size, hid_t array_type,
-                                       H5Z_result *res);
+static herr_t     H5Z__xform_eval_full(H5Z_node *tree, size_t array_size, hid_t array_type, H5Z_result *res);
 static void       H5Z__xform_destroy_parse_tree(H5Z_node *tree);
 static void *     H5Z__xform_parse(const char *expression, H5Z_datval_ptrs *dat_val_pointers);
 static void *     H5Z__xform_copy_tree(H5Z_node *tree, H5Z_datval_ptrs *dat_val_pointers,

--- a/src/H5Ztrans.c
+++ b/src/H5Ztrans.c
@@ -90,7 +90,7 @@ static void       H5Z__do_op(H5Z_node *tree);
 static hbool_t    H5Z__op_is_numbs(H5Z_node *_tree);
 static hbool_t    H5Z__op_is_numbs2(H5Z_node *_tree);
 static hid_t      H5Z__xform_find_type(const H5T_t *type);
-static herr_t     H5Z__xform_eval_full(H5Z_node *tree, const size_t array_size, const hid_t array_type,
+static herr_t     H5Z__xform_eval_full(H5Z_node *tree, size_t array_size, hid_t array_type,
                                        H5Z_result *res);
 static void       H5Z__xform_destroy_parse_tree(H5Z_node *tree);
 static void *     H5Z__xform_parse(const char *expression, H5Z_datval_ptrs *dat_val_pointers);

--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -127,7 +127,7 @@ void reinit_vars(unsigned *read_flt_msk, haddr_t *addr, hsize_t *size);
 static int         verify_idx_nchunks(hid_t dset, hid_t dspace, H5D_chunk_index_t exp_idx_type,
                                       hsize_t exp_num_chunks);
 static int         verify_get_chunk_info(hid_t dset, hid_t dspace, hsize_t chk_index, hsize_t exp_chk_size,
-                                         hsize_t *exp_offset, unsigned exp_flt_msk);
+                                         const hsize_t *exp_offset, unsigned exp_flt_msk);
 static int         verify_get_chunk_info_by_coord(hid_t dset, hsize_t *offset, hsize_t exp_chk_size,
                                                   unsigned exp_flt_msk);
 static int         verify_empty_chunk_info(hid_t dset, hsize_t *offset);
@@ -169,7 +169,7 @@ reinit_vars(unsigned *read_flt_msk, haddr_t *addr, hsize_t *size)
  *-------------------------------------------------------------------------
  */
 static int
-verify_get_chunk_info(hid_t dset, hid_t dspace, hsize_t chk_index, hsize_t exp_chk_size, hsize_t *exp_offset,
+verify_get_chunk_info(hid_t dset, hid_t dspace, hsize_t chk_index, hsize_t exp_chk_size, const hsize_t *exp_offset,
                       unsigned exp_flt_msk)
 {
     unsigned read_flt_msk  = 0;      /* Read filter mask */
@@ -302,7 +302,7 @@ index_type_str(H5D_chunk_index_t idx_type)
  *-------------------------------------------------------------------------
  */
 static int
-verify_selected_chunks(hid_t dset, hid_t plist, hsize_t *start, hsize_t *end)
+verify_selected_chunks(hid_t dset, hid_t plist, const hsize_t *start, const hsize_t *end)
 {
     int      read_buf[CHUNK_NX][CHUNK_NY];
     int      expected_buf[NUM_CHUNKS][CHUNK_NX][CHUNK_NY]; /* Expected data */
@@ -364,7 +364,7 @@ error:
  *-------------------------------------------------------------------------
  */
 static int
-write_selected_chunks(hid_t dset, hid_t plist, hsize_t *start, hsize_t *end, unsigned flt_msk)
+write_selected_chunks(hid_t dset, hid_t plist, const hsize_t *start, const hsize_t *end, unsigned flt_msk)
 {
     int     direct_buf[NUM_CHUNKS][CHUNK_NX][CHUNK_NY]; /* Data in chunks */
     hsize_t offset[2];                                  /* Offset coordinates of a chunk */

--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -169,8 +169,8 @@ reinit_vars(unsigned *read_flt_msk, haddr_t *addr, hsize_t *size)
  *-------------------------------------------------------------------------
  */
 static int
-verify_get_chunk_info(hid_t dset, hid_t dspace, hsize_t chk_index, hsize_t exp_chk_size, const hsize_t *exp_offset,
-                      unsigned exp_flt_msk)
+verify_get_chunk_info(hid_t dset, hid_t dspace, hsize_t chk_index, hsize_t exp_chk_size,
+                      const hsize_t *exp_offset, unsigned exp_flt_msk)
 {
     unsigned read_flt_msk  = 0;      /* Read filter mask */
     hsize_t  out_offset[2] = {0, 0}; /* Buffer to get offset coordinates */

--- a/test/dt_arith.c
+++ b/test/dt_arith.c
@@ -397,8 +397,8 @@ static int without_hardware_g = 0;
 void           some_dummy_func(float x);
 static hbool_t overflows(unsigned char *origin_bits, hid_t src_id, size_t dst_num_bits);
 static int     my_isnan(dtype_t type, void *val);
-static int     my_isinf(int endian, const unsigned char *val, size_t size, size_t mpos, size_t msize, size_t epos,
-                        size_t esize);
+static int my_isinf(int endian, const unsigned char *val, size_t size, size_t mpos, size_t msize, size_t epos,
+                    size_t esize);
 
 /*-------------------------------------------------------------------------
  * Function:    fpe_handler
@@ -2853,7 +2853,8 @@ my_isnan(dtype_t type, void *val)
  *-------------------------------------------------------------------------
  */
 static int
-my_isinf(int endian, const unsigned char *val, size_t size, size_t mpos, size_t msize, size_t epos, size_t esize)
+my_isinf(int endian, const unsigned char *val, size_t size, size_t mpos, size_t msize, size_t epos,
+         size_t esize)
 {
     unsigned char *bits;
     int            retval = 0;

--- a/test/dt_arith.c
+++ b/test/dt_arith.c
@@ -397,7 +397,7 @@ static int without_hardware_g = 0;
 void           some_dummy_func(float x);
 static hbool_t overflows(unsigned char *origin_bits, hid_t src_id, size_t dst_num_bits);
 static int     my_isnan(dtype_t type, void *val);
-static int     my_isinf(int endian, unsigned char *val, size_t size, size_t mpos, size_t msize, size_t epos,
+static int     my_isinf(int endian, const unsigned char *val, size_t size, size_t mpos, size_t msize, size_t epos,
                         size_t esize);
 
 /*-------------------------------------------------------------------------
@@ -2853,7 +2853,7 @@ my_isnan(dtype_t type, void *val)
  *-------------------------------------------------------------------------
  */
 static int
-my_isinf(int endian, unsigned char *val, size_t size, size_t mpos, size_t msize, size_t epos, size_t esize)
+my_isinf(int endian, const unsigned char *val, size_t size, size_t mpos, size_t msize, size_t epos, size_t esize)
 {
     unsigned char *bits;
     int            retval = 0;

--- a/test/dtransform.c
+++ b/test/dtransform.c
@@ -18,12 +18,12 @@
 #define FLOAT_TOL 0.0001F
 
 static int init_test(hid_t file_id);
-static int test_copy(const hid_t dxpl_id_c_to_f_copy, const hid_t dxpl_id_polynomial_copy);
-static int test_trivial(const hid_t dxpl_id_simple);
-static int test_poly(const hid_t dxpl_id_polynomial);
+static int test_copy(hid_t dxpl_id_c_to_f_copy, hid_t dxpl_id_polynomial_copy);
+static int test_trivial(hid_t dxpl_id_simple);
+static int test_poly(hid_t dxpl_id_polynomial);
 static int test_specials(hid_t file);
 static int test_set(void);
-static int test_getset(const hid_t dxpl_id_simple);
+static int test_getset(hid_t dxpl_id_simple);
 
 /* These are needed for multiple tests, so are declared here globally and are init'ed in init_test */
 hid_t dset_id_int         = -1;

--- a/test/fillval.c
+++ b/test/fillval.c
@@ -1586,7 +1586,7 @@ test_extend_release_cmpd_vl(void *_elmt)
  *-------------------------------------------------------------------------
  */
 static int
-test_extend_cases(hid_t file, hid_t _dcpl, const char *dset_name, hsize_t *ch_size, hsize_t *start_size,
+test_extend_cases(hid_t file, hid_t _dcpl, const char *dset_name, const hsize_t *ch_size, hsize_t *start_size,
                   hsize_t *max_size, hid_t dtype, void *fillval)
 {
     hid_t       fspace = -1, mspace = -1; /* File & memory dataspaces */

--- a/test/tselect.c
+++ b/test/tselect.c
@@ -2561,7 +2561,7 @@ test_select_hyper_contig_dr(hid_t dset_type, hid_t xfer_plist)
 static void
 test_select_hyper_checker_board_dr__select_checker_board(hid_t tgt_n_cube_sid, unsigned tgt_n_cube_rank,
                                                          unsigned edge_size, unsigned checker_edge_size,
-                                                         unsigned sel_rank, hsize_t sel_start[])
+                                                         unsigned sel_rank, const hsize_t sel_start[])
 {
     hbool_t  first_selection = TRUE;
     unsigned n_cube_offset;

--- a/test/vfd.c
+++ b/test/vfd.c
@@ -99,7 +99,7 @@ static int splitter_create_single_file_at(const char *filename, hid_t fapl_id,
                                           const struct splitter_dataset_def *data);
 static int splitter_compare_expected_data(hid_t file_id, const struct splitter_dataset_def *data);
 static int run_splitter_test(const struct splitter_dataset_def *data, hbool_t ignore_wo_errors,
-                             hbool_t provide_logfile_path, hid_t sub_fapl_ids[2]);
+                             hbool_t provide_logfile_path, const hid_t sub_fapl_ids[2]);
 static int splitter_RO_test(const struct splitter_dataset_def *data, hid_t child_fapl_id);
 static int splitter_tentative_open_test(hid_t child_fapl_id);
 static int file_exists(const char *filename, hid_t fapl_id);
@@ -2336,7 +2336,7 @@ done:
  */
 static int
 run_splitter_test(const struct splitter_dataset_def *data, hbool_t ignore_wo_errors,
-                  hbool_t provide_logfile_path, hid_t sub_fapl_ids[2])
+                  hbool_t provide_logfile_path, const hid_t sub_fapl_ids[2])
 {
     hid_t                       file_id     = H5I_INVALID_HID;
     hid_t                       fapl_id     = H5I_INVALID_HID;

--- a/tools/lib/h5diff_attr.c
+++ b/tools/lib/h5diff_attr.c
@@ -104,7 +104,7 @@ table_attrs_free(table_attrs_t *table)
  * Date: March 15, 2011
  *------------------------------------------------------------------------*/
 static void
-table_attr_mark_exist(unsigned *exist, char *name, table_attrs_t *table)
+table_attr_mark_exist(const unsigned *exist, char *name, table_attrs_t *table)
 {
     if (table->nattrs == table->size) {
         match_attr_t *new_attrs;

--- a/tools/lib/h5tools.c
+++ b/tools/lib/h5tools.c
@@ -1609,7 +1609,7 @@ h5tools_render_region_element(FILE *stream, const h5tool_format_t *info, h5tools
  *-------------------------------------------------------------------------
  */
 void
-init_acc_pos(unsigned ndims, hsize_t *dims, hsize_t *acc, hsize_t *pos, hsize_t *p_min_idx)
+init_acc_pos(unsigned ndims, const hsize_t *dims, hsize_t *acc, hsize_t *pos, hsize_t *p_min_idx)
 {
     int      i;
     unsigned j;
@@ -1642,7 +1642,7 @@ init_acc_pos(unsigned ndims, hsize_t *dims, hsize_t *acc, hsize_t *pos, hsize_t 
  *-------------------------------------------------------------------------
  */
 hsize_t
-calc_acc_pos(unsigned ndims, hsize_t elmtno, hsize_t *acc, hsize_t *pos)
+calc_acc_pos(unsigned ndims, hsize_t elmtno, const hsize_t *acc, hsize_t *pos)
 {
     int     i;
     hsize_t curr_pos = elmtno;
@@ -1913,7 +1913,7 @@ render_bin_output(FILE *stream, hid_t container, hid_t tid, void *_mem, hsize_t 
  */
 int
 render_bin_output_region_data_blocks(hid_t region_id, FILE *stream, hid_t container, unsigned ndims,
-                                     hid_t type_id, hsize_t nblocks, hsize_t *ptdata)
+                                     hid_t type_id, hsize_t nblocks, const hsize_t *ptdata)
 {
     hsize_t *dims1 = NULL;
     hsize_t *start = NULL;

--- a/tools/lib/h5tools.h
+++ b/tools/lib/h5tools.h
@@ -672,8 +672,8 @@ H5TOOLS_DLL hid_t   h5tools_get_big_endian_type(hid_t type);
 H5TOOLS_DLL htri_t  h5tools_detect_vlen(hid_t tid);
 H5TOOLS_DLL htri_t  h5tools_detect_vlen_str(hid_t tid);
 H5TOOLS_DLL hbool_t h5tools_is_obj_same(hid_t loc_id1, const char *name1, hid_t loc_id2, const char *name2);
-H5TOOLS_DLL void init_acc_pos(unsigned ndims, hsize_t *dims, hsize_t *acc, hsize_t *pos, hsize_t *p_min_idx);
-H5TOOLS_DLL hsize_t calc_acc_pos(unsigned ndims, hsize_t elemtno, hsize_t *acc, hsize_t *pos);
+H5TOOLS_DLL void init_acc_pos(unsigned ndims, const hsize_t *dims, hsize_t *acc, hsize_t *pos, hsize_t *p_min_idx);
+H5TOOLS_DLL hsize_t calc_acc_pos(unsigned ndims, hsize_t elemtno, const hsize_t *acc, hsize_t *pos);
 H5TOOLS_DLL hbool_t h5tools_is_zero(const void *_mem, size_t size);
 H5TOOLS_DLL int     h5tools_canreadf(const char *name, hid_t dcpl_id);
 H5TOOLS_DLL int     h5tools_can_encode(H5Z_filter_t filtn);
@@ -687,7 +687,7 @@ H5TOOLS_DLL void h5tools_region_simple_prefix(FILE *stream, const h5tool_format_
 H5TOOLS_DLL int     render_bin_output(FILE *stream, hid_t container, hid_t tid, void *_mem, hsize_t nelmts);
 H5TOOLS_DLL int     render_bin_output_region_data_blocks(hid_t region_id, FILE *stream, hid_t container,
                                                          unsigned ndims, hid_t type_id, hsize_t nblocks,
-                                                         hsize_t *ptdata);
+                                                         const hsize_t *ptdata);
 H5TOOLS_DLL hbool_t render_bin_output_region_blocks(hid_t region_space, hid_t region_id, FILE *stream,
                                                     hid_t container);
 H5TOOLS_DLL int     render_bin_output_region_data_points(hid_t region_space, hid_t region_id, FILE *stream,

--- a/tools/lib/h5tools.h
+++ b/tools/lib/h5tools.h
@@ -672,7 +672,8 @@ H5TOOLS_DLL hid_t   h5tools_get_big_endian_type(hid_t type);
 H5TOOLS_DLL htri_t  h5tools_detect_vlen(hid_t tid);
 H5TOOLS_DLL htri_t  h5tools_detect_vlen_str(hid_t tid);
 H5TOOLS_DLL hbool_t h5tools_is_obj_same(hid_t loc_id1, const char *name1, hid_t loc_id2, const char *name2);
-H5TOOLS_DLL void init_acc_pos(unsigned ndims, const hsize_t *dims, hsize_t *acc, hsize_t *pos, hsize_t *p_min_idx);
+H5TOOLS_DLL void    init_acc_pos(unsigned ndims, const hsize_t *dims, hsize_t *acc, hsize_t *pos,
+                                 hsize_t *p_min_idx);
 H5TOOLS_DLL hsize_t calc_acc_pos(unsigned ndims, hsize_t elemtno, const hsize_t *acc, hsize_t *pos);
 H5TOOLS_DLL hbool_t h5tools_is_zero(const void *_mem, size_t size);
 H5TOOLS_DLL int     h5tools_canreadf(const char *name, hid_t dcpl_id);

--- a/tools/lib/h5tools_dump.c
+++ b/tools/lib/h5tools_dump.c
@@ -1257,12 +1257,12 @@ done:
 static herr_t
 h5tools_print_simple_subset(FILE *stream, const h5tool_format_t *info, h5tools_context_t *ctx, hid_t dset,
                             hid_t p_type, hid_t f_space, hsize_t hyperslab_count,
-                            hsize_t *    temp_start,  /* start inside offset count loop */
-                            hsize_t *    temp_count,  /* count inside offset count loop  */
-                            hsize_t *    temp_block,  /* block size used in loop  */
-                            hsize_t *    temp_stride, /* stride size used in loop  */
-                            const hsize_t *    total_size,  /* total size of dataset */
-                            unsigned int row_dim)     /* index of row_counter dimension */
+                            hsize_t *      temp_start,  /* start inside offset count loop */
+                            hsize_t *      temp_count,  /* count inside offset count loop  */
+                            hsize_t *      temp_block,  /* block size used in loop  */
+                            hsize_t *      temp_stride, /* stride size used in loop  */
+                            const hsize_t *total_size,  /* total size of dataset */
+                            unsigned int   row_dim)       /* index of row_counter dimension */
 {
     size_t         i;                          /* counters  */
     size_t         j;                          /* counters  */

--- a/tools/lib/h5tools_dump.c
+++ b/tools/lib/h5tools_dump.c
@@ -1261,7 +1261,7 @@ h5tools_print_simple_subset(FILE *stream, const h5tool_format_t *info, h5tools_c
                             hsize_t *    temp_count,  /* count inside offset count loop  */
                             hsize_t *    temp_block,  /* block size used in loop  */
                             hsize_t *    temp_stride, /* stride size used in loop  */
-                            hsize_t *    total_size,  /* total size of dataset */
+                            const hsize_t *    total_size,  /* total size of dataset */
                             unsigned int row_dim)     /* index of row_counter dimension */
 {
     size_t         i;                          /* counters  */

--- a/tools/lib/h5tools_str.c
+++ b/tools/lib/h5tools_str.c
@@ -323,7 +323,7 @@ h5tools_str_prefix(h5tools_str_t *str /*in,out*/, const h5tool_format_t *info, h
  */
 char *
 h5tools_str_region_prefix(h5tools_str_t *str /*in,out*/, const h5tool_format_t *info, hsize_t elmtno,
-                          hsize_t *ptdata, h5tools_context_t *ctx)
+                          const hsize_t *ptdata, h5tools_context_t *ctx)
 {
     size_t i = 0;
 

--- a/tools/lib/h5tools_str.h
+++ b/tools/lib/h5tools_str.h
@@ -36,7 +36,7 @@ H5TOOLS_DLL char * h5tools_str_prefix(h5tools_str_t *str, const h5tool_format_t 
  * new functions needed to display region reference data
  */
 H5TOOLS_DLL char *h5tools_str_region_prefix(h5tools_str_t *str, const h5tool_format_t *info, hsize_t elmtno,
-                                            hsize_t *ptdata, h5tools_context_t *ctx);
+                                            const hsize_t *ptdata, h5tools_context_t *ctx);
 H5TOOLS_DLL void  h5tools_str_dump_space_slabs(h5tools_str_t *, hid_t, const h5tool_format_t *,
                                                h5tools_context_t *ctx);
 H5TOOLS_DLL void  h5tools_str_dump_space_blocks(h5tools_str_t *, hid_t, const h5tool_format_t *);

--- a/tools/lib/h5trav.c
+++ b/tools/lib/h5trav.c
@@ -731,7 +731,7 @@ trav_table_addlink(trav_table_t *table, const H5O_token_t *obj_token, const char
  *-------------------------------------------------------------------------
  */
 void
-trav_table_addflags(unsigned *flags, char *name, h5trav_type_t type, trav_table_t *table)
+trav_table_addflags(const unsigned *flags, char *name, h5trav_type_t type, trav_table_t *table)
 {
     size_t new_obj;
 

--- a/tools/lib/h5trav.h
+++ b/tools/lib/h5trav.h
@@ -187,6 +187,7 @@ H5TOOLS_DLL void trav_table_init(hid_t fid, trav_table_t **table);
 
 H5TOOLS_DLL void trav_table_free(trav_table_t *table);
 
-H5TOOLS_DLL void trav_table_addflags(const unsigned *flags, char *objname, h5trav_type_t type, trav_table_t *table);
+H5TOOLS_DLL void trav_table_addflags(const unsigned *flags, char *objname, h5trav_type_t type,
+                                     trav_table_t *table);
 
 #endif /* H5TRAV_H */

--- a/tools/lib/h5trav.h
+++ b/tools/lib/h5trav.h
@@ -187,6 +187,6 @@ H5TOOLS_DLL void trav_table_init(hid_t fid, trav_table_t **table);
 
 H5TOOLS_DLL void trav_table_free(trav_table_t *table);
 
-H5TOOLS_DLL void trav_table_addflags(unsigned *flags, char *objname, h5trav_type_t type, trav_table_t *table);
+H5TOOLS_DLL void trav_table_addflags(const unsigned *flags, char *objname, h5trav_type_t type, trav_table_t *table);
 
 #endif /* H5TRAV_H */

--- a/tools/src/h5repack/h5repack.h
+++ b/tools/src/h5repack/h5repack.h
@@ -197,7 +197,7 @@ void init_packobject(pack_info_t *obj);
 
 int apply_filters(const char *name,    /* object name from traverse list */
                   int         rank,    /* rank of dataset */
-                  hsize_t *   dims,    /* dimensions of dataset */
+                  const hsize_t *   dims,    /* dimensions of dataset */
                   size_t      msize,   /* size of type */
                   hid_t       dcpl_id, /* dataset creation property list */
                   pack_opt_t *options, /* repack options */

--- a/tools/src/h5repack/h5repack.h
+++ b/tools/src/h5repack/h5repack.h
@@ -195,13 +195,13 @@ void init_packobject(pack_info_t *obj);
  *-------------------------------------------------------------------------
  */
 
-int apply_filters(const char *name,    /* object name from traverse list */
-                  int         rank,    /* rank of dataset */
-                  const hsize_t *   dims,    /* dimensions of dataset */
-                  size_t      msize,   /* size of type */
-                  hid_t       dcpl_id, /* dataset creation property list */
-                  pack_opt_t *options, /* repack options */
-                  int *       has_filter);    /* (OUT) object NAME has a filter */
+int apply_filters(const char *   name,    /* object name from traverse list */
+                  int            rank,    /* rank of dataset */
+                  const hsize_t *dims,    /* dimensions of dataset */
+                  size_t         msize,   /* size of type */
+                  hid_t          dcpl_id, /* dataset creation property list */
+                  pack_opt_t *   options, /* repack options */
+                  int *          has_filter);       /* (OUT) object NAME has a filter */
 
 /*-------------------------------------------------------------------------
  * options table

--- a/tools/src/h5repack/h5repack_copy.c
+++ b/tools/src/h5repack/h5repack_copy.c
@@ -406,8 +406,8 @@ done:
  *-----------------------------------------*/
 
 int
-get_hyperslab(hid_t dcpl_id, int rank_dset, const hsize_t dims_dset[], size_t size_datum, hsize_t dims_hslab[],
-              hsize_t *hslab_nbytes_p)
+get_hyperslab(hid_t dcpl_id, int rank_dset, const hsize_t dims_dset[], size_t size_datum,
+              hsize_t dims_hslab[], hsize_t *hslab_nbytes_p)
 {
     int          k;
     H5D_layout_t dset_layout;

--- a/tools/src/h5repack/h5repack_copy.c
+++ b/tools/src/h5repack/h5repack_copy.c
@@ -37,7 +37,7 @@
  * local functions
  *-------------------------------------------------------------------------
  */
-static int  get_hyperslab(hid_t dcpl_id, int rank_dset, hsize_t dims_dset[], size_t size_datum,
+static int  get_hyperslab(hid_t dcpl_id, int rank_dset, const hsize_t dims_dset[], size_t size_datum,
                           hsize_t dims_hslab[], hsize_t *hslab_nbytes_p);
 static void print_dataset_info(hid_t dcpl_id, char *objname, double per, int pr);
 static int  do_copy_objects(hid_t fidin, hid_t fidout, trav_table_t *travt, pack_opt_t *options);
@@ -406,7 +406,7 @@ done:
  *-----------------------------------------*/
 
 int
-get_hyperslab(hid_t dcpl_id, int rank_dset, hsize_t dims_dset[], size_t size_datum, hsize_t dims_hslab[],
+get_hyperslab(hid_t dcpl_id, int rank_dset, const hsize_t dims_dset[], size_t size_datum, hsize_t dims_hslab[],
               hsize_t *hslab_nbytes_p)
 {
     int          k;

--- a/tools/src/h5repack/h5repack_filters.c
+++ b/tools/src/h5repack/h5repack_filters.c
@@ -238,7 +238,7 @@ aux_assign_obj(const char * name,        /* object name from traverse list */
 int
 apply_filters(const char *name,    /* object name from traverse list */
               int         rank,    /* rank of dataset */
-              hsize_t *   dims,    /* dimensions of dataset */
+              const hsize_t *   dims,    /* dimensions of dataset */
               size_t      msize,   /* size of type */
               hid_t       dcpl_id, /* dataset creation property list */
               pack_opt_t *options, /* repack options */

--- a/tools/src/h5repack/h5repack_filters.c
+++ b/tools/src/h5repack/h5repack_filters.c
@@ -236,13 +236,13 @@ aux_assign_obj(const char * name,        /* object name from traverse list */
  */
 
 int
-apply_filters(const char *name,    /* object name from traverse list */
-              int         rank,    /* rank of dataset */
-              const hsize_t *   dims,    /* dimensions of dataset */
-              size_t      msize,   /* size of type */
-              hid_t       dcpl_id, /* dataset creation property list */
-              pack_opt_t *options, /* repack options */
-              int *       has_filter)     /* (OUT) object NAME has a filter */
+apply_filters(const char *   name,    /* object name from traverse list */
+              int            rank,    /* rank of dataset */
+              const hsize_t *dims,    /* dimensions of dataset */
+              size_t         msize,   /* size of type */
+              hid_t          dcpl_id, /* dataset creation property list */
+              pack_opt_t *   options, /* repack options */
+              int *          has_filter)        /* (OUT) object NAME has a filter */
 {
     int          nfilters;   /* number of filters in DCPL */
     hsize_t      chsize[64]; /* chunk size in elements */


### PR DESCRIPTION
…matically