### PR TITLE
Applied clang-tidy readability-delete-null-pointer fixes

### DIFF
--- a/c++/src/H5DaccProp.cpp
+++ b/c++/src/H5DaccProp.cpp
@@ -72,8 +72,7 @@ DSetAccPropList::getConstant()
 void
 DSetAccPropList::deleteConstants()
 {
-    if (DEFAULT_ != 0)
-        delete DEFAULT_;
+    delete DEFAULT_;
 }
 
 //--------------------------------------------------------------------------

--- a/c++/src/H5DataSpace.cpp
+++ b/c++/src/H5DataSpace.cpp
@@ -73,8 +73,7 @@ DataSpace::getConstant()
 void
 DataSpace::deleteConstants()
 {
-    if (ALL_ != 0)
-        delete ALL_;
+    delete ALL_;
 }
 
 //--------------------------------------------------------------------------

--- a/c++/src/H5DcreatProp.cpp
+++ b/c++/src/H5DcreatProp.cpp
@@ -78,8 +78,7 @@ DSetCreatPropList::getConstant()
 void
 DSetCreatPropList::deleteConstants()
 {
-    if (DEFAULT_ != 0)
-        delete DEFAULT_;
+    delete DEFAULT_;
 }
 
 //--------------------------------------------------------------------------

--- a/c++/src/H5DxferProp.cpp
+++ b/c++/src/H5DxferProp.cpp
@@ -72,8 +72,7 @@ DSetMemXferPropList::getConstant()
 void
 DSetMemXferPropList::deleteConstants()
 {
-    if (DEFAULT_ != 0)
-        delete DEFAULT_;
+    delete DEFAULT_;
 }
 
 //--------------------------------------------------------------------------

--- a/c++/src/H5FaccProp.cpp
+++ b/c++/src/H5FaccProp.cpp
@@ -80,8 +80,7 @@ FileAccPropList::getConstant()
 void
 FileAccPropList::deleteConstants()
 {
-    if (DEFAULT_ != 0)
-        delete DEFAULT_;
+    delete DEFAULT_;
 }
 
 //--------------------------------------------------------------------------

--- a/c++/src/H5FcreatProp.cpp
+++ b/c++/src/H5FcreatProp.cpp
@@ -68,8 +68,7 @@ FileCreatPropList::getConstant()
 void
 FileCreatPropList::deleteConstants()
 {
-    if (DEFAULT_ != 0)
-        delete DEFAULT_;
+    delete DEFAULT_;
 }
 
 //--------------------------------------------------------------------------

--- a/c++/src/H5LaccProp.cpp
+++ b/c++/src/H5LaccProp.cpp
@@ -70,8 +70,7 @@ LinkAccPropList::getConstant()
 void
 LinkAccPropList::deleteConstants()
 {
-    if (DEFAULT_ != 0)
-        delete DEFAULT_;
+    delete DEFAULT_;
 }
 
 //--------------------------------------------------------------------------

--- a/c++/src/H5LcreatProp.cpp
+++ b/c++/src/H5LcreatProp.cpp
@@ -70,8 +70,7 @@ LinkCreatPropList::getConstant()
 void
 LinkCreatPropList::deleteConstants()
 {
-    if (DEFAULT_ != 0)
-        delete DEFAULT_;
+    delete DEFAULT_;
 }
 
 //--------------------------------------------------------------------------

--- a/c++/src/H5OcreatProp.cpp
+++ b/c++/src/H5OcreatProp.cpp
@@ -70,8 +70,7 @@ ObjCreatPropList::getConstant()
 void
 ObjCreatPropList::deleteConstants()
 {
-    if (DEFAULT_ != 0)
-        delete DEFAULT_;
+    delete DEFAULT_;
 }
 
 //--------------------------------------------------------------------------

--- a/c++/src/H5PropList.cpp
+++ b/c++/src/H5PropList.cpp
@@ -75,8 +75,7 @@ PropList::getConstant()
 void
 PropList::deleteConstants()
 {
-    if (DEFAULT_ != 0)
-        delete DEFAULT_;
+    delete DEFAULT_;
 }
 
 //--------------------------------------------------------------------------

--- a/c++/test/dsets.cpp
+++ b/c++/test/dsets.cpp
@@ -163,8 +163,7 @@ test_create(H5File &file)
         cerr << "    <<<  " << E.getDetailMsg() << "  >>>" << endl << endl;
 
         // clean up and return with failure
-        if (dataset != NULL)
-            delete dataset;
+        delete dataset;
         return -1;
     }
     // catch all other exceptions
@@ -172,8 +171,7 @@ test_create(H5File &file)
         issue_fail_msg("test_create", __LINE__, __FILE__);
 
         // clean up and return with failure
-        if (dataset != NULL)
-            delete dataset;
+        delete dataset;
         return -1;
     }
 } // test_create
@@ -253,8 +251,7 @@ test_simple_io(H5File &file)
         cerr << "    <<<  " << E.getDetailMsg() << "  >>>" << endl << endl;
 
         // clean up and return with failure
-        if (tconv_buf)
-            delete[] tconv_buf;
+        delete[] tconv_buf;
         return -1;
     }
 } // test_simple_io
@@ -696,10 +693,8 @@ test_compression(H5File &file)
         cerr << "    <<<  " << E.getDetailMsg() << "  >>>" << endl << endl;
 
         // clean up and return with failure
-        if (dataset != NULL)
-            delete dataset;
-        if (tconv_buf)
-            delete[] tconv_buf;
+        delete dataset;
+        delete[] tconv_buf;
         return -1;
     }
 } // test_compression
@@ -889,8 +884,7 @@ test_multiopen(H5File &file)
         cerr << "    <<<  " << E.getDetailMsg() << "  >>>" << endl << endl;
 
         // clean up and return with failure
-        if (space != NULL)
-            delete space;
+        delete space;
         return -1;
     }
 } // test_multiopen
@@ -968,8 +962,7 @@ test_types(H5File &file)
             cerr << "    <<<  "
                  << "bitfield_1: " << E.getFuncName() << " - " << E.getDetailMsg() << "  >>>" << endl
                  << endl;
-            if (dset != NULL)
-                delete dset;
+            delete dset;
             return -1;
         }
 
@@ -1000,8 +993,7 @@ test_types(H5File &file)
             cerr << "    <<<  "
                  << "bitfield_2: " << E.getFuncName() << " - " << E.getDetailMsg() << "  >>>" << endl
                  << endl;
-            if (dset != NULL)
-                delete dset;
+            delete dset;
             throw E; // propagate the exception
         }
 
@@ -1035,10 +1027,8 @@ test_types(H5File &file)
             cerr << "    <<<  "
                  << "opaque_1: " << E.getFuncName() << " - " << E.getDetailMsg() << "  >>>" << endl
                  << endl;
-            if (dset != NULL)
-                delete dset;
-            if (optype != NULL)
-                delete optype;
+            delete dset;
+            delete optype;
             throw E; // propagate the exception
         }
 
@@ -1071,10 +1061,8 @@ test_types(H5File &file)
             cerr << "    <<<  "
                  << "opaque_2: " << E.getFuncName() << " - " << E.getDetailMsg() << "  >>>" << endl
                  << endl;
-            if (dset != NULL)
-                delete dset;
-            if (optype != NULL)
-                delete optype;
+            delete dset;
+            delete optype;
             throw E; // propagate the exception
         }
 

--- a/c++/test/tcompound.cpp
+++ b/c++/test/tcompound.cpp
@@ -180,8 +180,7 @@ test_compound_2()
         issue_fail_msg(E.getCFuncName(), __LINE__, __FILE__, E.getCDetailMsg());
     }
 
-    if (array_dt)
-        delete array_dt;
+    delete array_dt;
 } // test_compound_2()
 
 /*-------------------------------------------------------------------------
@@ -291,8 +290,7 @@ test_compound_3()
         issue_fail_msg(E.getCFuncName(), __LINE__, __FILE__, E.getCDetailMsg());
     }
 
-    if (array_dt)
-        delete array_dt;
+    delete array_dt;
 } // test_compound_3()
 
 /*-------------------------------------------------------------------------
@@ -411,8 +409,7 @@ test_compound_4()
         issue_fail_msg(E.getCFuncName(), __LINE__, __FILE__, E.getCDetailMsg());
     }
 
-    if (array_dt)
-        delete array_dt;
+    delete array_dt;
 } // test_compound_4()
 
 /*-------------------------------------------------------------------------
@@ -508,8 +505,7 @@ test_compound_5()
         issue_fail_msg(E.getCFuncName(), __LINE__, __FILE__, E.getCDetailMsg());
     }
 
-    if (array_dt)
-        delete array_dt;
+    delete array_dt;
 } // test_compound_5()
 
 /*-------------------------------------------------------------------------

--- a/c++/test/tfile.cpp
+++ b/c++/test/tfile.cpp
@@ -179,14 +179,14 @@ test_file_create()
     catch (InvalidActionException &E) {
         cerr << " *FAILED*" << endl;
         cerr << "    <<<  " << E.getDetailMsg() << "  >>>" << endl << endl;
-        if (file1 != NULL) // clean up
-            delete file1;
+        // clean up
+        delete file1;
     }
     // catch all other exceptions
     catch (Exception &E) {
         issue_fail_msg("test_file_create()", __LINE__, __FILE__, E.getCDetailMsg());
-        if (file1 != NULL) // clean up
-            delete file1;
+        // clean up
+        delete file1;
     }
 
     // Setting this to NULL for cleaning up in failure situations
@@ -264,8 +264,8 @@ test_file_create()
     // catch all exceptions
     catch (Exception &E) {
         issue_fail_msg("test_file_create()", __LINE__, __FILE__, E.getCDetailMsg());
-        if (tmpl1 != NULL) // clean up
-            delete tmpl1;
+        // clean up
+        delete tmpl1;
     }
 } // test_file_create()
 

--- a/c++/test/trefer.cpp
+++ b/c++/test/trefer.cpp
@@ -183,8 +183,7 @@ test_reference_params()
         issue_fail_msg("test_reference_param()", __LINE__, __FILE__, E.getCFuncName(), E.getCDetailMsg());
     }
 
-    if (file1)
-        delete file1;
+    delete file1;
 } /* test_reference_param() */
 
 /*-------------------------------------------------------------------------
@@ -378,8 +377,7 @@ test_reference_obj()
         issue_fail_msg("test_reference_obj()", __LINE__, __FILE__, E.getCFuncName(), E.getCDetailMsg());
     }
 
-    if (file1)
-        delete file1;
+    delete file1;
 } // test_reference_obj()
 
 /*-------------------------------------------------------------------------
@@ -522,8 +520,7 @@ test_reference_group()
         issue_fail_msg("test_reference_group()", __LINE__, __FILE__, E.getCFuncName(), E.getCDetailMsg());
     }
 
-    if (file1)
-        delete file1;
+    delete file1;
 } /* test_reference_group() */
 
 /*-------------------------------------------------------------------------

--- a/c++/test/ttypes.cpp
+++ b/c++/test/ttypes.cpp
@@ -806,8 +806,7 @@ test_named()
         issue_fail_msg("test_named", __LINE__, __FILE__, E.getCDetailMsg());
     }
 
-    if (ds_type)
-        delete ds_type;
+    delete ds_type;
 } // test_named
 
 /*-------------------------------------------------------------------------

--- a/c++/test/tvlstr.cpp
+++ b/c++/test/tvlstr.cpp
@@ -317,8 +317,7 @@ test_vlstring_array_dataset()
         issue_fail_msg("test_vlstring_array_dataset()", __LINE__, __FILE__, E.getCDetailMsg());
     }
 
-    if (file1)
-        delete file1;
+    delete file1;
 } // end test_vlstring_array_dataset()
 
 /*-------------------------------------------------------------------------
@@ -531,8 +530,7 @@ test_vlstring_type()
         issue_fail_msg("test_vlstring_type()", __LINE__, __FILE__, E.getCDetailMsg());
     }
 
-    if (file1)
-        delete file1;
+    delete file1;
 } // end test_vlstring_type()
 
 /*-------------------------------------------------------------------------


### PR DESCRIPTION
delete nullptr is well-defined, does not need check.

Manually fixed indentation after automatic changes.