### PR TITLE
Fix example of hyperslab block coordinate printing 

### DIFF
--- a/examples/h5_vds.c
+++ b/examples/h5_vds.c
@@ -60,7 +60,7 @@ main(void)
     hsize_t start_out[2], stride_out[2], count_out[2], block_out[2];
     int     wdata[DIM0],         /* Write buffer for source dataset */
         rdata[VDSDIM0][VDSDIM1], /* Read buffer for virtual dataset */
-        i, j, k, l;
+        i, j, k, l, block_inc;
     int          fill_value = -1; /* Fill value for VDS */
     H5D_layout_t layout;          /* Storage layout */
     size_t       num_map;         /* Number of mappings */
@@ -178,13 +178,14 @@ main(void)
             buf     = (hsize_t *)malloc(sizeof(hsize_t) * 2 * RANK2 * nblocks);
             status  = H5Sget_select_hyper_blocklist(vspace, (hsize_t)0, nblocks, buf);
             for (l = 0; l < nblocks; l++) {
+                block_inc = 2 * RANK2 * l;
                 printf("(");
                 for (k = 0; k < RANK2 - 1; k++)
-                    printf("%d,", (int)buf[k]);
-                printf("%d ) - (", (int)buf[k]);
+                    printf("%d,", (int)buf[block_inc + k]);
+                printf("%d) - (", (int)buf[block_inc + k]);
                 for (k = 0; k < RANK2 - 1; k++)
-                    printf("%d,", (int)buf[RANK2 + k]);
-                printf("%d)\n", (int)buf[RANK2 + k]);
+                    printf("%d,", (int)buf[block_inc + RANK2 + k]);
+                printf("%d)\n", (int)buf[block_inc + RANK2 + k]);
             }
             /* We also can use new APIs to get start, stride, count and block */
             if (H5Sis_regular_hyperslab(vspace)) {


### PR DESCRIPTION
No sure if you welcome community pull requests, but hopefully this is helpful.

I've notice a small bug in the `h5_vds.c` example, where it prints the coordinates of the hyperslab blocks.  This is the current code:

```c
for (l=0; l<nblocks; l++) {
    printf("(");
    for (k=0; k<RANK2-1; k++) 
        printf("%d,", (int)buf[k]);
    printf("%d) - (", (int)buf[k]);
    for (k=0; k<RANK2-1; k++) 
        printf("%d,", (int)buf[RANK2+k]);
     printf("%d)\n", (int)buf[RANK2+k]);
}
```

Although it loops over the number of blocks, it doesn't use the block counter when printing the information, and so will just show the coordinates of the first block over and over.  The patch is intended to enable printing the coordinates for all blocks.

This behaviour isn't obvious in the current example as none of the hyperslabs consist of more than one block. However, I ended up at the example from [H5S_GET_SELECT_HYPER_BLOCKLIST](https://portal.hdfgroup.org/display/HDF5/H5S_GET_SELECT_HYPER_BLOCKLIST) and was trying to use it to understand my own program, where this printing had me confused for a while.  Hopefully this might help anyone else copy/pasting the example into their own code in the future.