### PR TITLE
Fixed all clang-tidy bugprone-suspicious-string-compare warnings

### DIFF
--- a/c++/test/tattr.cpp
+++ b/c++/test/tattr.cpp
@@ -775,7 +775,7 @@ test_attr_compound_read()
         hsize_t ii, jj;
         for (ii = 0; ii < ATTR4_DIM1; ii++)
             for (jj = 0; jj < ATTR4_DIM2; jj++)
-                if (HDmemcmp(&attr_data4[ii][jj], &read_data4[ii][jj], sizeof(struct attr4_struct))) {
+                if (HDmemcmp(&attr_data4[ii][jj], &read_data4[ii][jj], sizeof(struct attr4_struct)) != 0) {
                     TestErrPrintf("%d:attribute data different: attr_data4[%llu][%llu].i=%d, "
                                   "read_data4[%llu][%llu].i=%d\n",
                                   __LINE__, ii, jj, attr_data4[ii][jj].i, ii, jj, read_data4[ii][jj].i);

--- a/c++/test/tcompound.cpp
+++ b/c++/test/tcompound.cpp
@@ -491,7 +491,7 @@ test_compound_5()
         int_array.close();
 
         /* Check results */
-        if (memcmp(src[1].name, dst[1].name, sizeof(src[1].name)) || src[1].tdim != dst[1].tdim ||
+        if (memcmp(src[1].name, dst[1].name, sizeof(src[1].name)) != 0 || src[1].tdim != dst[1].tdim ||
             src[1].coll_ids[0] != dst[1].coll_ids[0] || src[1].coll_ids[1] != dst[1].coll_ids[1] ||
             src[1].coll_ids[2] != dst[1].coll_ids[2] || src[1].coll_ids[3] != dst[1].coll_ids[3]) {
             H5_FAILED();

--- a/c++/test/th5s.cpp
+++ b/c++/test/th5s.cpp
@@ -516,7 +516,7 @@ test_h5s_compound_scalar_read()
         dataset.read(&rdata, type);
 
         // Verify read data
-        if (HDmemcmp(&space4_data, &rdata, sizeof(struct space4_struct))) {
+        if (HDmemcmp(&space4_data, &rdata, sizeof(struct space4_struct)) != 0) {
             cerr << "scalar data different: space4_data.c1=" << space4_data.c1
                  << ", read_data4.c1=" << rdata.c1 << endl;
             cerr << "scalar data different: space4_data.u=" << space4_data.u << ", read_data4.u=" << rdata.u

--- a/c++/test/tlinks.cpp
+++ b/c++/test/tlinks.cpp
@@ -593,7 +593,7 @@ visit_obj_cb(H5Object &obj, const H5std_string name, const H5O_info2_t *oinfo, v
     ovisit_ud_t *op_data = static_cast<ovisit_ud_t *>(_op_data);
 
     // Check for correct object information
-    if (strcmp(op_data->info[op_data->idx].path, name.c_str()))
+    if (strcmp(op_data->info[op_data->idx].path, name.c_str()) != 0)
         return (H5_ITER_ERROR);
     if (op_data->info[op_data->idx].type != oinfo->type)
         return (H5_ITER_ERROR);

--- a/c++/test/tvlstr.cpp
+++ b/c++/test/tvlstr.cpp
@@ -865,7 +865,7 @@ read_scalar_dset(H5File &file, DataType &type, DataSpace &space, char *name, cha
         dset.read(&data_read, type, space, space);
         dset.close();
 
-        if (HDstrcmp(data, data_read))
+        if (HDstrcmp(data, data_read) != 0)
             TestErrPrintf("Expected %s for dataset %s but read %s\n", data, name, data_read);
 
         HDfree(data_read);

--- a/hl/c++/test/ptableTest.cpp
+++ b/hl/c++/test/ptableTest.cpp
@@ -690,7 +690,7 @@ TestHDFFV_9758()
 
             if (s2.a != s1[i].a || s2.e != s1[i].e)
                 goto error;
-            else if (HDstrcmp(s2.d, s1[i].d))
+            else if (HDstrcmp(s2.d, s1[i].d) != 0)
                 goto error;
         }
     } // end of ptable block

--- a/hl/test/test_lite.c
+++ b/hl/test/test_lite.c
@@ -1054,7 +1054,7 @@ test_integers(void)
         HDfree(dt_str);
         goto out;
     }
-    if (HDstrcmp(dt_str, "H5T_STD_I8BE")) {
+    if (HDstrcmp(dt_str, "H5T_STD_I8BE") != 0) {
         HDfree(dt_str);
         goto out;
     }
@@ -1112,7 +1112,7 @@ test_fps(void)
         HDfree(dt_str);
         goto out;
     }
-    if (HDstrcmp(dt_str, "H5T_IEEE_F32BE")) {
+    if (HDstrcmp(dt_str, "H5T_IEEE_F32BE") != 0) {
         HDfree(dt_str);
         goto out;
     }
@@ -1184,7 +1184,7 @@ test_strings(void)
         goto out;
     }
     if (HDstrcmp(dt_str, "H5T_STRING {\n      STRSIZE 13;\n      STRPAD H5T_STR_NULLTERM;\n      CSET "
-                         "H5T_CSET_ASCII;\n      CTYPE H5T_C_S1;\n   }")) {
+                         "H5T_CSET_ASCII;\n      CTYPE H5T_C_S1;\n   }") != 0) {
         HDprintf("dt=\n%s\n", dt_str);
         HDfree(dt_str);
         goto out;
@@ -1219,7 +1219,7 @@ test_strings(void)
         goto out;
     }
     if (HDstrcmp(dt_str, "H5T_STRING {\n      STRSIZE H5T_VARIABLE;\n      STRPAD H5T_STR_NULLPAD;\n      "
-                         "CSET H5T_CSET_ASCII;\n      CTYPE H5T_C_S1;\n   }")) {
+                         "CSET H5T_CSET_ASCII;\n      CTYPE H5T_C_S1;\n   }") != 0) {
         HDprintf("dt=\n%s\n", dt_str);
         HDfree(dt_str);
         goto out;
@@ -1238,7 +1238,7 @@ test_strings(void)
     if (HDstrncmp(dt_str,
                   "H5T_STRING {\n      STRSIZE H5T_VARIABLE;\n      STRPAD H5T_STR_NULLPAD;\n      CSET "
                   "H5T_CSET_ASCII;\n      CTYPE H5T_C_S1;\n   }",
-                  str_len - 1)) {
+                  str_len - 1) != 0) {
         HDprintf("dt=\n%s\n", dt_str);
         HDfree(dt_str);
         goto out;
@@ -1261,7 +1261,7 @@ test_strings(void)
     if (HDstrncmp(dt_str,
                   "H5T_STRING {\n      STRSIZE H5T_VARIABLE;\n      STRPAD H5T_STR_NULLPAD;\n      CSET "
                   "H5T_CSET_ASCII;\n      CTYPE H5T_C_S1;\n   }",
-                  str_len)) {
+                  str_len) != 0) {
         HDprintf("dt=\n%s\n", dt_str);
         HDfree(dt_str);
         goto out;
@@ -1322,7 +1322,7 @@ test_opaques(void)
     }
     if (HDstrcmp(
             dt_str,
-            "H5T_OPAQUE {\n      OPQ_SIZE 19;\n      OPQ_TAG \"This is a tag for opaque type\";\n   }")) {
+            "H5T_OPAQUE {\n      OPQ_SIZE 19;\n      OPQ_TAG \"This is a tag for opaque type\";\n   }") != 0) {
         HDprintf("dt=\n%s\n", dt_str);
         HDfree(dt_str);
         goto out;
@@ -1376,7 +1376,7 @@ test_enums(void)
 
     if (H5Tenum_nameof(dtype, &value1, name1, size) < 0)
         goto out;
-    if (HDstrcmp(name1, "BLUE"))
+    if (HDstrcmp(name1, "BLUE") != 0)
         goto out;
 
     if (H5Tenum_valueof(dtype, name2, &value2) < 0)
@@ -1400,7 +1400,7 @@ test_enums(void)
         goto out;
     }
     if (HDstrcmp(dt_str, "H5T_ENUM {\n      H5T_STD_I32LE;\n      \"RED\"              5;\n      \"GREEN\"   "
-                         "         6;\n      \"BLUE\"             7;\n      \"WHITE\"            8;\n   }")) {
+                         "         6;\n      \"BLUE\"             7;\n      \"WHITE\"            8;\n   }") != 0) {
 
         HDprintf("dt=\n%s\n", dt_str);
         HDfree(dt_str);
@@ -1462,7 +1462,7 @@ test_variables(void)
         HDfree(dt_str);
         goto out;
     }
-    if (HDstrcmp(dt_str, "H5T_VLEN {\n      H5T_VLEN {\n         H5T_STD_I32BE\n      }\n   }")) {
+    if (HDstrcmp(dt_str, "H5T_VLEN {\n      H5T_VLEN {\n         H5T_STD_I32BE\n      }\n   }") != 0) {
         HDprintf("dt=\n%s\n", dt_str);
         HDfree(dt_str);
         goto out;
@@ -1526,7 +1526,7 @@ test_arrays(void)
     }
     if (HDstrcmp(dt_str, "H5T_ARRAY {\n      [5][7][13] H5T_ARRAY {\n         [17][19] H5T_COMPOUND {\n      "
                          "      H5T_STD_I8BE \"arr_compound_1\" : 0;\n            H5T_STD_I32BE "
-                         "\"arr_compound_2\" : 1;\n         }\n      }\n   }")) {
+                         "\"arr_compound_2\" : 1;\n         }\n      }\n   }") != 0) {
         HDprintf("dt=\n%s\n", dt_str);
         HDfree(dt_str);
         goto out;
@@ -1586,7 +1586,7 @@ test_compounds(void)
         goto out;
     }
     if (HDstrcmp(dt_str, "H5T_COMPOUND {\n      H5T_STD_I16BE \"one_field\" : 2;\n      H5T_STD_U8LE "
-                         "\"two_field\" : 6;\n   }")) {
+                         "\"two_field\" : 6;\n   }") != 0) {
         HDprintf("dt=\n%s\n", dt_str);
         HDfree(dt_str);
         goto out;
@@ -1605,7 +1605,7 @@ test_compounds(void)
 
     if ((memb_name = H5Tget_member_name(dtype, 1)) == NULL)
         goto out;
-    if (HDstrcmp(memb_name, "i16_field")) {
+    if (HDstrcmp(memb_name, "i16_field") != 0) {
         H5free_memory(memb_name);
         goto out;
     }
@@ -1683,7 +1683,7 @@ test_compound_bug(void)
 
     if ((memb_name = H5Tget_member_name(dtype, 2)) == NULL)
         goto out;
-    if (HDstrcmp(memb_name, "sub")) {
+    if (HDstrcmp(memb_name, "sub") != 0) {
         H5free_memory(memb_name);
         goto out;
     }
@@ -1720,7 +1720,7 @@ test_compound_bug(void)
     if ((memb_name = H5Tget_member_name(dtype, 1)) == NULL)
         goto out;
     if (HDstrcmp(memb_name, "desc____________________________________________________________________________"
-                            "_____________")) {
+                            "_____________") != 0) {
         H5free_memory(memb_name);
         goto out;
     }

--- a/hl/test/test_lite.c
+++ b/hl/test/test_lite.c
@@ -1322,7 +1322,8 @@ test_opaques(void)
     }
     if (HDstrcmp(
             dt_str,
-            "H5T_OPAQUE {\n      OPQ_SIZE 19;\n      OPQ_TAG \"This is a tag for opaque type\";\n   }") != 0) {
+            "H5T_OPAQUE {\n      OPQ_SIZE 19;\n      OPQ_TAG \"This is a tag for opaque type\";\n   }") !=
+        0) {
         HDprintf("dt=\n%s\n", dt_str);
         HDfree(dt_str);
         goto out;
@@ -1399,8 +1400,9 @@ test_enums(void)
         HDfree(dt_str);
         goto out;
     }
-    if (HDstrcmp(dt_str, "H5T_ENUM {\n      H5T_STD_I32LE;\n      \"RED\"              5;\n      \"GREEN\"   "
-                         "         6;\n      \"BLUE\"             7;\n      \"WHITE\"            8;\n   }") != 0) {
+    if (HDstrcmp(dt_str,
+                 "H5T_ENUM {\n      H5T_STD_I32LE;\n      \"RED\"              5;\n      \"GREEN\"   "
+                 "         6;\n      \"BLUE\"             7;\n      \"WHITE\"            8;\n   }") != 0) {
 
         HDprintf("dt=\n%s\n", dt_str);
         HDfree(dt_str);

--- a/hl/tools/gif2h5/gifread.c
+++ b/hl/tools/gif2h5/gifread.c
@@ -62,7 +62,7 @@ ReadGifHeader(GIFHEAD * GifHead, /* Pointer to GIF header structure  */
         GifHead->HeaderDump[i] = *(*MemGif2)++;
     }
 
-    if (strncmp((const char *)GifHead->HeaderDump, "GIF", (size_t)3)) {
+    if (strncmp((const char *)GifHead->HeaderDump, "GIF", (size_t)3) != 0) {
         printf("The file does not appear to be a valid GIF file.\n");
         exit(EXIT_FAILURE);
     }

--- a/src/H5.c
+++ b/src/H5.c
@@ -970,7 +970,7 @@ H5check_version(unsigned majnum, unsigned minnum, unsigned relnum)
             HDstrncat(lib_str, "-", (size_t)1);
             HDstrncat(lib_str, substr, (sizeof(lib_str) - HDstrlen(lib_str)) - 1);
         } /* end if */
-        if (HDstrcmp(lib_str, H5_lib_vers_info_g)) {
+        if (HDstrcmp(lib_str, H5_lib_vers_info_g) != 0) {
             HDfputs("Warning!  Library version information error.\n"
                     "The HDF5 library version information are not "
                     "consistent in its source code.\nThis is NOT a fatal error "

--- a/src/H5A.c
+++ b/src/H5A.c
@@ -1541,7 +1541,7 @@ H5A__rename_common(H5VL_object_t *vol_obj, H5VL_loc_params_t *loc_params, const 
     HDassert(new_name);
 
     /* Avoid thrashing things if the names are the same */
-    if (HDstrcmp(old_name, new_name))
+    if (HDstrcmp(old_name, new_name) != 0)
         /* Rename the attribute */
         if (H5VL_attr_specific(vol_obj, loc_params, H5VL_ATTR_RENAME, H5P_DATASET_XFER_DEFAULT, token_ptr,
                                old_name, new_name) < 0)

--- a/src/H5Aint.c
+++ b/src/H5Aint.c
@@ -2661,7 +2661,7 @@ H5A__rename_by_name(H5G_loc_t loc, const char *obj_name, const char *old_attr_na
     FUNC_ENTER_PACKAGE
 
     /* Avoid thrashing things if the names are the same */
-    if (HDstrcmp(old_attr_name, new_attr_name)) {
+    if (HDstrcmp(old_attr_name, new_attr_name) != 0) {
         /* Set up opened group location to fill in */
         obj_loc.oloc = &obj_oloc;
         obj_loc.path = &obj_path;

--- a/src/H5B2cache.c
+++ b/src/H5B2cache.c
@@ -250,7 +250,7 @@ H5B2__cache_hdr_deserialize(const void *_image, size_t H5_ATTR_UNUSED len, void 
         HGOTO_ERROR(H5E_BTREE, H5E_CANTALLOC, NULL, "allocation failed for B-tree header")
 
     /* Magic number */
-    if (HDmemcmp(image, H5B2_HDR_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5B2_HDR_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         HGOTO_ERROR(H5E_BTREE, H5E_BADVALUE, NULL, "wrong B-tree header signature")
     image += H5_SIZEOF_MAGIC;
 
@@ -648,7 +648,7 @@ H5B2__cache_int_deserialize(const void *_image, size_t H5_ATTR_UNUSED len, void 
     internal->shadow_epoch = udata->hdr->shadow_epoch;
 
     /* Magic number */
-    if (HDmemcmp(image, H5B2_INT_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5B2_INT_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         HGOTO_ERROR(H5E_BTREE, H5E_BADVALUE, NULL, "wrong B-tree internal node signature")
     image += H5_SIZEOF_MAGIC;
 
@@ -1064,7 +1064,7 @@ H5B2__cache_leaf_deserialize(const void *_image, size_t H5_ATTR_UNUSED len, void
     leaf->shadow_epoch = udata->hdr->shadow_epoch;
 
     /* Magic number */
-    if (HDmemcmp(image, H5B2_LEAF_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5B2_LEAF_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         HGOTO_ERROR(H5E_BTREE, H5E_BADVALUE, NULL, "wrong B-tree leaf node signature")
     image += H5_SIZEOF_MAGIC;
 

--- a/src/H5Bcache.c
+++ b/src/H5Bcache.c
@@ -166,7 +166,7 @@ H5B__cache_deserialize(const void *_image, size_t H5_ATTR_UNUSED len, void *_uda
         HGOTO_ERROR(H5E_BTREE, H5E_CANTALLOC, NULL, "can't allocate buffer for child addresses")
 
     /* magic number */
-    if (HDmemcmp(image, H5B_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5B_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         HGOTO_ERROR(H5E_BTREE, H5E_BADVALUE, NULL, "wrong B-tree signature")
     image += H5_SIZEOF_MAGIC;
 

--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -1773,7 +1773,7 @@ H5C__decode_cache_image_header(const H5F_t *f, H5C_t *cache_ptr, const uint8_t *
     p = *buf;
 
     /* Check signature */
-    if (HDmemcmp(p, H5C__MDCI_BLOCK_SIGNATURE, (size_t)H5C__MDCI_BLOCK_SIGNATURE_LEN))
+    if (HDmemcmp(p, H5C__MDCI_BLOCK_SIGNATURE, (size_t)H5C__MDCI_BLOCK_SIGNATURE_LEN) != 0)
         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "Bad metadata cache image header signature")
     p += H5C__MDCI_BLOCK_SIGNATURE_LEN;
 

--- a/src/H5Dvirtual.c
+++ b/src/H5Dvirtual.c
@@ -895,7 +895,7 @@ H5D__virtual_open_source_dset(const H5D_t *vdset, H5O_storage_virtual_ent_t *vir
     HDassert(source_dset->dset_name);
 
     /* Check if we need to open the source file */
-    if (HDstrcmp(source_dset->file_name, ".")) {
+    if (HDstrcmp(source_dset->file_name, ".") != 0) {
         unsigned intent; /* File access permissions */
 
         /* Get the virtual dataset's file open flags ("intent") */

--- a/src/H5EAcache.c
+++ b/src/H5EAcache.c
@@ -307,7 +307,7 @@ BEGIN_FUNC(STATIC, ERR, void *, NULL, NULL,
     hdr->addr = udata->addr;
 
     /* Magic number */
-    if (HDmemcmp(image, H5EA_HDR_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5EA_HDR_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         H5E_THROW(H5E_BADVALUE, "wrong extensible array header signature")
     image += H5_SIZEOF_MAGIC;
 
@@ -697,7 +697,7 @@ BEGIN_FUNC(STATIC, ERR, void *, NULL, NULL,
     iblock->addr = hdr->idx_blk_addr;
 
     /* Magic number */
-    if (HDmemcmp(image, H5EA_IBLOCK_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5EA_IBLOCK_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         H5E_THROW(H5E_BADVALUE, "wrong extensible array index block signature")
     image += H5_SIZEOF_MAGIC;
 
@@ -1100,7 +1100,7 @@ BEGIN_FUNC(STATIC, ERR, void *, NULL, NULL,
     sblock->addr = udata->sblk_addr;
 
     /* Magic number */
-    if (HDmemcmp(image, H5EA_SBLOCK_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5EA_SBLOCK_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         H5E_THROW(H5E_BADVALUE, "wrong extensible array super block signature")
     image += H5_SIZEOF_MAGIC;
 
@@ -1510,7 +1510,7 @@ BEGIN_FUNC(STATIC, ERR, void *, NULL, NULL,
     dblock->addr = udata->dblk_addr;
 
     /* Magic number */
-    if (HDmemcmp(image, H5EA_DBLOCK_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5EA_DBLOCK_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         H5E_THROW(H5E_BADVALUE, "wrong extensible array data block signature")
     image += H5_SIZEOF_MAGIC;
 

--- a/src/H5Eint.c
+++ b/src/H5Eint.c
@@ -218,7 +218,7 @@ H5E__walk1_cb(int n, H5E_error1_t *err_desc, void *client_data)
     cls_ptr = maj_ptr->cls;
 
     /* Print error class header if new class */
-    if (eprint->cls.lib_name == NULL || HDstrcmp(cls_ptr->lib_name, eprint->cls.lib_name)) {
+    if (eprint->cls.lib_name == NULL || HDstrcmp(cls_ptr->lib_name, eprint->cls.lib_name) != 0) {
         /* update to the new class information */
         if (cls_ptr->cls_name)
             eprint->cls.cls_name = cls_ptr->cls_name;
@@ -346,7 +346,7 @@ H5E__walk2_cb(unsigned n, const H5E_error2_t *err_desc, void *client_data)
         HGOTO_DONE(FAIL)
 
     /* Print error class header if new class */
-    if (eprint->cls.lib_name == NULL || HDstrcmp(cls_ptr->lib_name, eprint->cls.lib_name)) {
+    if (eprint->cls.lib_name == NULL || HDstrcmp(cls_ptr->lib_name, eprint->cls.lib_name) != 0) {
         /* update to the new class information */
         if (cls_ptr->cls_name)
             eprint->cls.cls_name = cls_ptr->cls_name;

--- a/src/H5FAcache.c
+++ b/src/H5FAcache.c
@@ -252,7 +252,7 @@ BEGIN_FUNC(STATIC, ERR, void *, NULL, NULL,
     hdr->addr = udata->addr;
 
     /* Magic number */
-    if (HDmemcmp(image, H5FA_HDR_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5FA_HDR_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         H5E_THROW(H5E_BADVALUE, "wrong fixed array header signature")
     image += H5_SIZEOF_MAGIC;
 
@@ -637,7 +637,7 @@ BEGIN_FUNC(STATIC, ERR, void *, NULL, NULL,
     dblock->addr = udata->dblk_addr;
 
     /* Magic number */
-    if (HDmemcmp(image, H5FA_DBLOCK_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5FA_DBLOCK_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         H5E_THROW(H5E_BADVALUE, "wrong fixed array data block signature")
     image += H5_SIZEOF_MAGIC;
 

--- a/src/H5FD.c
+++ b/src/H5FD.c
@@ -496,9 +496,9 @@ H5FD_sb_load(H5FD_t *file, const char *name, const uint8_t *buf)
     /* Check if driver matches driver information saved. Unfortunately, we can't push this
      * function to each specific driver because we're checking if the driver is correct.
      */
-    if (!HDstrncmp(name, "NCSAfami", (size_t)8) && HDstrcmp(file->cls->name, "family"))
+    if (!HDstrncmp(name, "NCSAfami", (size_t)8) && HDstrcmp(file->cls->name, "family") != 0)
         HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "family driver should be used")
-    if (!HDstrncmp(name, "NCSAmult", (size_t)8) && HDstrcmp(file->cls->name, "multi"))
+    if (!HDstrncmp(name, "NCSAmult", (size_t)8) && HDstrcmp(file->cls->name, "multi") != 0)
         HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "multi driver should be used")
 
     /* Decode driver information */

--- a/src/H5FDmulti.c
+++ b/src/H5FDmulti.c
@@ -731,7 +731,7 @@ H5FD_multi_sb_decode(H5FD_t *_file, const char *name, const unsigned char *buf)
     H5Eclear2(H5E_DEFAULT);
 
     /* Make sure the name/version number is correct */
-    if (strcmp(name, "NCSAmult"))
+    if (strcmp(name, "NCSAmult") != 0)
         H5Epush_ret(func, H5E_ERR_CLS, H5E_FILE, H5E_BADVALUE, "invalid multi superblock", -1);
 
     /* Set default values */

--- a/src/H5FScache.c
+++ b/src/H5FScache.c
@@ -248,7 +248,7 @@ H5FS__cache_hdr_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED len
     fspace->addr = udata->addr;
 
     /* Magic number */
-    if (HDmemcmp(image, H5FS_HDR_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5FS_HDR_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         HGOTO_ERROR(H5E_FSPACE, H5E_CANTLOAD, NULL, "wrong free space header signature")
     image += H5_SIZEOF_MAGIC;
 
@@ -988,7 +988,7 @@ H5FS__cache_sinfo_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED l
     H5_CHECKED_ASSIGN(old_sect_size, size_t, fspace->sect_size, hsize_t);
 
     /* Magic number */
-    if (HDmemcmp(image, H5FS_SINFO_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5FS_SINFO_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         HGOTO_ERROR(H5E_FSPACE, H5E_CANTLOAD, NULL, "wrong free space sections signature")
     image += H5_SIZEOF_MAGIC;
 

--- a/src/H5Gcache.c
+++ b/src/H5Gcache.c
@@ -176,7 +176,7 @@ H5G__cache_node_deserialize(const void *_image, size_t len, void *_udata, hbool_
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed")
 
     /* magic */
-    if (HDmemcmp(image, H5G_NODE_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5G_NODE_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         HGOTO_ERROR(H5E_SYM, H5E_BADVALUE, NULL, "bad symbol table node signature")
     image += H5_SIZEOF_MAGIC;
 

--- a/src/H5HFcache.c
+++ b/src/H5HFcache.c
@@ -209,7 +209,7 @@ H5HF__hdr_prefix_decode(H5HF_hdr_t *hdr, const uint8_t **image_ref)
     HDassert(image);
 
     /* Magic number */
-    if (HDmemcmp(image, H5HF_HDR_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5HF_HDR_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         HGOTO_ERROR(H5E_HEAP, H5E_BADVALUE, FAIL, "wrong fractal heap header signature")
     image += H5_SIZEOF_MAGIC;
 
@@ -992,7 +992,7 @@ H5HF__cache_iblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED 
     HDassert(iblock->size == len);
 
     /* Magic number */
-    if (HDmemcmp(image, H5HF_IBLOCK_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5HF_IBLOCK_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         HGOTO_ERROR(H5E_HEAP, H5E_BADVALUE, NULL, "wrong fractal heap indirect block signature")
     image += H5_SIZEOF_MAGIC;
 
@@ -1831,7 +1831,7 @@ H5HF__cache_dblock_deserialize(const void *_image, size_t len, void *_udata, hbo
     image = dblock->blk;
 
     /* Magic number */
-    if (HDmemcmp(image, H5HF_DBLOCK_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5HF_DBLOCK_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         HGOTO_ERROR(H5E_HEAP, H5E_BADVALUE, NULL, "wrong fractal heap direct block signature")
     image += H5_SIZEOF_MAGIC;
 

--- a/src/H5HGcache.c
+++ b/src/H5HGcache.c
@@ -122,7 +122,7 @@ H5HG__hdr_deserialize(H5HG_heap_t *heap, const uint8_t *image, const H5F_t *f)
     HDassert(f);
 
     /* Magic number */
-    if (HDmemcmp(image, H5HG_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5HG_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         HGOTO_ERROR(H5E_HEAP, H5E_BADVALUE, FAIL, "bad global heap collection signature")
     image += H5_SIZEOF_MAGIC;
 

--- a/src/H5HLcache.c
+++ b/src/H5HLcache.c
@@ -161,7 +161,7 @@ H5HL__hdr_deserialize(H5HL_t *heap, const uint8_t *image, H5HL_cache_prfx_ud_t *
     HDassert(udata);
 
     /* Check magic number */
-    if (HDmemcmp(image, H5HL_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5HL_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         HGOTO_ERROR(H5E_HEAP, H5E_BADVALUE, FAIL, "bad local heap signature")
     image += H5_SIZEOF_MAGIC;
 

--- a/src/H5Ocache.c
+++ b/src/H5Ocache.c
@@ -1335,7 +1335,7 @@ H5O__chunk_deserialize(H5O_t *oh, haddr_t addr, size_t len, const uint8_t *image
     /* Check for magic # on chunks > 0 in later versions of the format */
     else if (chunkno > 0 && oh->version > H5O_VERSION_1) {
         /* Magic number */
-        if (HDmemcmp(chunk_image, H5O_CHK_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+        if (HDmemcmp(chunk_image, H5O_CHK_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
             HGOTO_ERROR(H5E_OHDR, H5E_CANTLOAD, FAIL, "wrong object header chunk signature")
         chunk_image += H5_SIZEOF_MAGIC;
     } /* end if */

--- a/src/H5SMcache.c
+++ b/src/H5SMcache.c
@@ -238,7 +238,7 @@ H5SM__cache_table_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED l
     HDassert(table->table_size == len);
 
     /* Check magic number */
-    if (HDmemcmp(image, H5SM_TABLE_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5SM_TABLE_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         HGOTO_ERROR(H5E_SOHM, H5E_CANTLOAD, NULL, "bad SOHM table signature")
     image += H5_SIZEOF_MAGIC;
 
@@ -580,7 +580,7 @@ H5SM__cache_list_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED le
     list->header = udata->header;
 
     /* Check magic number */
-    if (HDmemcmp(image, H5SM_LIST_MAGIC, (size_t)H5_SIZEOF_MAGIC))
+    if (HDmemcmp(image, H5SM_LIST_MAGIC, (size_t)H5_SIZEOF_MAGIC) != 0)
         HGOTO_ERROR(H5E_SOHM, H5E_CANTLOAD, NULL, "bad SOHM list signature")
     image += H5_SIZEOF_MAGIC;
 

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -2834,7 +2834,7 @@ H5T__unregister(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_c
         for (i = H5T_g.nsoft - 1; i >= 0; --i) {
             soft = H5T_g.soft + i;
             HDassert(soft);
-            if (name && *name && HDstrcmp(name, soft->name))
+            if (name && *name && HDstrcmp(name, soft->name) != 0)
                 continue;
             if (src && src->shared->type != soft->src)
                 continue;
@@ -2856,7 +2856,7 @@ H5T__unregister(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_c
 
         /* Not a match */
         if (((H5T_PERS_SOFT == pers && path->is_hard) || (H5T_PERS_HARD == pers && !path->is_hard)) ||
-            (name && *name && HDstrcmp(name, path->name)) || (src && H5T_cmp(src, path->src, FALSE)) ||
+            (name && *name && HDstrcmp(name, path->name) != 0) || (src && H5T_cmp(src, path->src, FALSE)) ||
             (dst && H5T_cmp(dst, path->dst, FALSE)) || (func && func != path->conv.u.app_func)) {
             /*
              * Notify all other functions to recalculate private data since some

--- a/src/H5Tconv.c
+++ b/src/H5Tconv.c
@@ -2699,7 +2699,7 @@ H5T__conv_enum_init(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata)
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed")
     for (i = 0, j = 0; i < src->shared->u.enumer.nmembs && j < dst->shared->u.enumer.nmembs; i++, j++) {
         while (j < dst->shared->u.enumer.nmembs &&
-               HDstrcmp(src->shared->u.enumer.name[i], dst->shared->u.enumer.name[j]))
+               HDstrcmp(src->shared->u.enumer.name[i], dst->shared->u.enumer.name[j]) != 0)
             j++;
         if (j >= dst->shared->u.enumer.nmembs)
             HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, FAIL,

--- a/test/btree2.c
+++ b/test/btree2.c
@@ -8801,8 +8801,8 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
         TEST_ERROR
 
     /* Check for VFD which stores data in multiple files */
-    single_file_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi") &&
-                                HDstrcmp(env_h5_drvr, "family"));
+    single_file_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
+                                HDstrcmp(env_h5_drvr, "family") != 0);
     if (single_file_vfd) {
         /* Make a copy of the file in memory, in order to speed up deletion testing */
 

--- a/test/cache_image.c
+++ b/test/cache_image.c
@@ -7850,8 +7850,8 @@ main(void)
     HDprintf("=========================================\n");
 
     /* Check for VFD which stores data in multiple files */
-    single_file_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi") &&
-                                HDstrcmp(env_h5_drvr, "family"));
+    single_file_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
+                                HDstrcmp(env_h5_drvr, "family") != 0);
 
     nerrs += check_cache_image_ctl_flow_1(single_file_vfd);
     nerrs += check_cache_image_ctl_flow_2(single_file_vfd);

--- a/test/cache_logging.c
+++ b/test/cache_logging.c
@@ -76,7 +76,7 @@ test_logging_api(void)
     if (H5Pget_mdc_log_options(fapl, &is_enabled_out, location, &size, &start_on_access_out) < 0)
         TEST_ERROR;
     if ((is_enabled != is_enabled_out) || (start_on_access != start_on_access_out) ||
-        HDstrcmp(LOG_LOCATION, location))
+        HDstrcmp(LOG_LOCATION, location) != 0)
         TEST_ERROR;
 
     /* Create a file */

--- a/test/cmpd_dset.c
+++ b/test/cmpd_dset.c
@@ -2233,7 +2233,7 @@ main(int argc, char *argv[])
 
     /* Turn off optimized compound converter? */
     if (argc > 1) {
-        if (argc > 2 || HDstrcmp("--noopt", argv[1])) {
+        if (argc > 2 || HDstrcmp("--noopt", argv[1]) != 0) {
             HDfprintf(stderr, "usage: %s [--noopt]\n", argv[0]);
             HDexit(EXIT_FAILURE);
         }

--- a/test/dsets.c
+++ b/test/dsets.c
@@ -539,7 +539,8 @@ test_simple_io(const char *env_h5_drvr, hid_t fapl)
     TESTING("simple I/O");
 
     /* Can't run this test with multi-file VFDs because of HDopen/read/seek the file directly */
-    if (HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 && HDstrcmp(env_h5_drvr, "family") != 0) {
+    if (HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
+        HDstrcmp(env_h5_drvr, "family") != 0) {
         h5_fixname(FILENAME[4], fapl, filename, sizeof filename);
 
         /* Set up data array */
@@ -699,7 +700,8 @@ test_userblock_offset(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
     TESTING("dataset offset with user block");
 
     /* Can't run this test with multi-file VFDs because of HDopen/read/seek the file directly */
-    if (HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 && HDstrcmp(env_h5_drvr, "family") != 0) {
+    if (HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
+        HDstrcmp(env_h5_drvr, "family") != 0) {
         h5_fixname(FILENAME[2], fapl, filename, sizeof filename);
 
         /* Set up data array */

--- a/test/dsets.c
+++ b/test/dsets.c
@@ -539,7 +539,7 @@ test_simple_io(const char *env_h5_drvr, hid_t fapl)
     TESTING("simple I/O");
 
     /* Can't run this test with multi-file VFDs because of HDopen/read/seek the file directly */
-    if (HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi") && HDstrcmp(env_h5_drvr, "family")) {
+    if (HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 && HDstrcmp(env_h5_drvr, "family") != 0) {
         h5_fixname(FILENAME[4], fapl, filename, sizeof filename);
 
         /* Set up data array */
@@ -699,7 +699,7 @@ test_userblock_offset(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
     TESTING("dataset offset with user block");
 
     /* Can't run this test with multi-file VFDs because of HDopen/read/seek the file directly */
-    if (HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi") && HDstrcmp(env_h5_drvr, "family")) {
+    if (HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 && HDstrcmp(env_h5_drvr, "family") != 0) {
         h5_fixname(FILENAME[2], fapl, filename, sizeof filename);
 
         /* Set up data array */
@@ -15081,7 +15081,7 @@ main(void)
         envval = "nomatch";
 
     /* Current VFD that does not support contigous address space */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(envval, "split") && HDstrcmp(envval, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(envval, "split") != 0 && HDstrcmp(envval, "multi") != 0);
 
     /* Set the random # seed */
     HDsrandom((unsigned)HDtime(NULL));

--- a/test/dtypes.c
+++ b/test/dtypes.c
@@ -1141,7 +1141,7 @@ test_compound_5(void)
     H5Tclose(int_array);
 
     /* Check results */
-    if (HDmemcmp(src[1].name, dst[1].name, sizeof(src[1].name)) || src[1].tdim != dst[1].tdim ||
+    if (HDmemcmp(src[1].name, dst[1].name, sizeof(src[1].name)) != 0 || src[1].tdim != dst[1].tdim ||
         src[1].coll_ids[0] != dst[1].coll_ids[0] || src[1].coll_ids[1] != dst[1].coll_ids[1] ||
         src[1].coll_ids[2] != dst[1].coll_ids[2] || src[1].coll_ids[3] != dst[1].coll_ids[3]) {
         H5_FAILED();
@@ -1817,7 +1817,7 @@ test_compound_9(void)
         goto error;
     } /* end if */
 
-    if (rdata.i1 != wdata.i1 || rdata.i2 != wdata.i2 || HDstrcmp(rdata.str, wdata.str)) {
+    if (rdata.i1 != wdata.i1 || rdata.i2 != wdata.i2 || HDstrcmp(rdata.str, wdata.str) != 0) {
         H5_FAILED();
         AT();
         HDprintf("incorrect read data\n");
@@ -1891,7 +1891,7 @@ test_compound_9(void)
         goto error;
     } /* end if */
 
-    if (rdata.i1 != wdata.i1 || rdata.i2 != wdata.i2 || HDstrcmp(rdata.str, wdata.str)) {
+    if (rdata.i1 != wdata.i1 || rdata.i2 != wdata.i2 || HDstrcmp(rdata.str, wdata.str) != 0) {
         H5_FAILED();
         AT();
         HDprintf("incorrect read data\n");
@@ -2081,7 +2081,7 @@ test_compound_10(void)
 
     for (i = 0; i < ARRAY_DIM; i++) {
         if (rdata[i].i1 != wdata[i].i1 || rdata[i].i2 != wdata[i].i2 ||
-            HDstrcmp(rdata[i].str, wdata[i].str)) {
+            HDstrcmp(rdata[i].str, wdata[i].str) != 0) {
             H5_FAILED();
             AT();
             HDprintf("incorrect read data\n");
@@ -2097,7 +2097,7 @@ test_compound_10(void)
 
         t1 = rdata[i].text.p;
         t2 = wdata[i].text.p;
-        if (HDstrcmp((char *)t1, (char *)t2)) {
+        if (HDstrcmp((char *)t1, (char *)t2) != 0) {
             H5_FAILED();
             AT();
             HDprintf("incorrect VL read data\n");
@@ -2282,7 +2282,7 @@ test_compound_11(void)
                      ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
             TEST_ERROR
         } /* end if */
-        else if (HDstrcmp(((big_t *)buf_orig)[u].s1, ((little_t *)buf)[u].s1)) {
+        else if (HDstrcmp(((big_t *)buf_orig)[u].s1, ((little_t *)buf)[u].s1) != 0) {
             HDprintf("Error, line #%d: buf_orig[%u].s1=%s, buf[%u].s1=%s\n", __LINE__, (unsigned)u,
                      ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
             TEST_ERROR
@@ -2333,7 +2333,7 @@ test_compound_11(void)
                      ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
             TEST_ERROR
         } /* end if */
-        else if (HDstrcmp(((big_t *)buf_orig)[u].s1, ((little_t *)buf)[u].s1)) {
+        else if (HDstrcmp(((big_t *)buf_orig)[u].s1, ((little_t *)buf)[u].s1) != 0) {
             HDprintf("Error, line #%d: buf_orig[%u].s1=%s, buf[%u].s1=%s\n", __LINE__, (unsigned)u,
                      ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
             TEST_ERROR
@@ -2374,7 +2374,7 @@ test_compound_11(void)
                      ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
             TEST_ERROR
         } /* end if */
-        else if (HDstrcmp(((big_t *)buf_orig)[u].s1, ((little_t *)buf)[u].s1)) {
+        else if (HDstrcmp(((big_t *)buf_orig)[u].s1, ((little_t *)buf)[u].s1) != 0) {
             HDprintf("Error, line #%d: buf_orig[%u].s1=%s, buf[%u].s1=%s\n", __LINE__, (unsigned)u,
                      ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
             TEST_ERROR
@@ -2956,14 +2956,14 @@ test_compound_14(void)
         goto error;
     } /* end if */
 
-    if (rdata1.c1 != wdata1.c1 || rdata1.c2 != wdata1.c2 || HDstrcmp(rdata1.str, wdata1.str)) {
+    if (rdata1.c1 != wdata1.c1 || rdata1.c2 != wdata1.c2 || HDstrcmp(rdata1.str, wdata1.str) != 0) {
         H5_FAILED();
         AT();
         HDprintf("incorrect read data\n");
         goto error;
     } /* end if */
 
-    if (rdata2.c1 != wdata2.c1 || rdata2.c2 != wdata2.c2 || HDstrcmp(rdata2.str, wdata2.str) ||
+    if (rdata2.c1 != wdata2.c1 || rdata2.c2 != wdata2.c2 || HDstrcmp(rdata2.str, wdata2.str) != 0 ||
         rdata2.l1 != wdata2.l1 || rdata2.l2 != wdata2.l2 || rdata2.l3 != wdata2.l3 ||
         rdata2.l4 != wdata2.l4) {
         H5_FAILED();
@@ -3054,14 +3054,14 @@ test_compound_14(void)
         goto error;
     } /* end if */
 
-    if (rdata1.c1 != wdata1.c1 || rdata1.c2 != wdata1.c2 || HDstrcmp(rdata1.str, wdata1.str)) {
+    if (rdata1.c1 != wdata1.c1 || rdata1.c2 != wdata1.c2 || HDstrcmp(rdata1.str, wdata1.str) != 0) {
         H5_FAILED();
         AT();
         HDprintf("incorrect read data\n");
         goto error;
     } /* end if */
 
-    if (rdata2.c1 != wdata2.c1 || rdata2.c2 != wdata2.c2 || HDstrcmp(rdata2.str, wdata2.str) ||
+    if (rdata2.c1 != wdata2.c1 || rdata2.c2 != wdata2.c2 || HDstrcmp(rdata2.str, wdata2.str) != 0 ||
         rdata2.l1 != wdata2.l1 || rdata2.l2 != wdata2.l2 || rdata2.l3 != wdata2.l3 ||
         rdata2.l4 != wdata2.l4) {
         H5_FAILED();
@@ -3885,7 +3885,7 @@ test_query(void)
         HDprintf("Can't get name for enum member\n");
         goto error;
     } /* end if */
-    if (HDstrcmp("YELLOW", enum_name)) {
+    if (HDstrcmp("YELLOW", enum_name) != 0) {
         H5_FAILED();
         HDprintf("Incorrect name for enum member\n");
         goto error;
@@ -4504,14 +4504,14 @@ test_conv_str_1(void)
     HDmemcpy(buf, "abcdefghi\0abcdefghi\0", (size_t)20);
     if (H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcd\0abcd\0abcdefghi\0", (size_t)20)) {
+    if (HDmemcmp(buf, "abcd\0abcd\0abcdefghi\0", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    Truncated C-string test failed");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcd\0\0\0\0\0\0abcd\0\0\0\0\0\0", (size_t)20)) {
+    if (HDmemcmp(buf, "abcd\0\0\0\0\0\0abcd\0\0\0\0\0\0", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    Extended C-string test failed");
         goto error;
@@ -4535,14 +4535,14 @@ test_conv_str_1(void)
     HDmemcpy(buf, "abcdefghijabcdefghij", (size_t)20);
     if (H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcdeabcdeabcdefghij", (size_t)20)) {
+    if (HDmemcmp(buf, "abcdeabcdeabcdefghij", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    Truncated C buffer test failed");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcde\0\0\0\0\0abcde\0\0\0\0\0", (size_t)20)) {
+    if (HDmemcmp(buf, "abcde\0\0\0\0\0abcde\0\0\0\0\0", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    Extended C buffer test failed");
         goto error;
@@ -4566,14 +4566,14 @@ test_conv_str_1(void)
     HDmemcpy(buf, "abcdefghijabcdefghij", (size_t)20);
     if (H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcdeabcdeabcdefghij", (size_t)20)) {
+    if (HDmemcmp(buf, "abcdeabcdeabcdefghij", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    Truncated Fortran-string test failed");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcde     abcde     ", (size_t)20)) {
+    if (HDmemcmp(buf, "abcde     abcde     ", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    Extended Fortran-string test failed");
         goto error;
@@ -4600,7 +4600,7 @@ test_conv_str_1(void)
     HDmemcpy(buf, "abcdefghijabcdefghij", (size_t)20);
     if (H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcdefghijabcdefghij", (size_t)20)) {
+    if (HDmemcmp(buf, "abcdefghijabcdefghij", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    Non-terminated string test 1");
         goto error;
@@ -4611,7 +4611,7 @@ test_conv_str_1(void)
     HDmemcpy(buf, "abcdefghijabcdefghij", (size_t)20);
     if (H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcd\0abcd\0abcdefghij", (size_t)20)) {
+    if (HDmemcmp(buf, "abcd\0abcd\0abcdefghij", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    Non-terminated string test 2");
         goto error;
@@ -4619,7 +4619,7 @@ test_conv_str_1(void)
     HDmemcpy(buf, "abcdeabcdexxxxxxxxxx", (size_t)20);
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcde\0\0\0\0\0abcde\0\0\0\0\0", (size_t)20)) {
+    if (HDmemcmp(buf, "abcde\0\0\0\0\0abcde\0\0\0\0\0", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    Non-terminated string test 2");
         goto error;
@@ -4643,14 +4643,14 @@ test_conv_str_1(void)
     HDmemcpy(buf, "abcdefghi\0abcdefghi\0", (size_t)20);
     if (H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcdefghi abcdefghi ", (size_t)20)) {
+    if (HDmemcmp(buf, "abcdefghi abcdefghi ", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    C string to Fortran test 1");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcdefghi\0abcdefghi\0", (size_t)20)) {
+    if (HDmemcmp(buf, "abcdefghi\0abcdefghi\0", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    Fortran to C string test 1");
         goto error;
@@ -4662,14 +4662,14 @@ test_conv_str_1(void)
     HDmemcpy(buf, "abcdefgh\0\0abcdefgh\0\0", (size_t)20);
     if (H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcdeabcdeabcdefgh\0\0", (size_t)20)) {
+    if (HDmemcmp(buf, "abcdeabcdeabcdefgh\0\0", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    C string to Fortran test 2");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcde\0\0\0\0\0abcde\0\0\0\0\0", (size_t)20)) {
+    if (HDmemcmp(buf, "abcde\0\0\0\0\0abcde\0\0\0\0\0", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    Fortran to C string test 2");
         goto error;
@@ -4685,14 +4685,14 @@ test_conv_str_1(void)
     HDmemcpy(buf, "abcd\0abcd\0xxxxxxxxxx", (size_t)20);
     if (H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcd      abcd      ", (size_t)20)) {
+    if (HDmemcmp(buf, "abcd      abcd      ", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    C string to Fortran test 3");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcd\0abcd\0abcd      ", (size_t)20)) {
+    if (HDmemcmp(buf, "abcd\0abcd\0abcd      ", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    Fortran to C string test 3");
         goto error;
@@ -4716,14 +4716,14 @@ test_conv_str_1(void)
     HDmemcpy(buf, "abcdefghijabcdefghij", (size_t)20);
     if (H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcdefghijabcdefghij", (size_t)20)) {
+    if (HDmemcmp(buf, "abcdefghijabcdefghij", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    C buffer to Fortran test 1");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcdefghijabcdefghij", (size_t)20)) {
+    if (HDmemcmp(buf, "abcdefghijabcdefghij", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    Fortran to C buffer test 1");
         goto error;
@@ -4735,14 +4735,14 @@ test_conv_str_1(void)
     HDmemcpy(buf, "abcdefgh\0\0abcdefgh\0\0", (size_t)20);
     if (H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcdeabcdeabcdefgh\0\0", (size_t)20)) {
+    if (HDmemcmp(buf, "abcdeabcdeabcdefgh\0\0", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    C buffer to Fortran test 2");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcde\0\0\0\0\0abcde\0\0\0\0\0", (size_t)20)) {
+    if (HDmemcmp(buf, "abcde\0\0\0\0\0abcde\0\0\0\0\0", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    Fortran to C buffer test 2");
         goto error;
@@ -4758,14 +4758,14 @@ test_conv_str_1(void)
     HDmemcpy(buf, "abcd\0abcd\0xxxxxxxxxx", (size_t)20);
     if (H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcd      abcd      ", (size_t)20)) {
+    if (HDmemcmp(buf, "abcd      abcd      ", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    C buffer to Fortran test 3");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
-    if (HDmemcmp(buf, "abcd\0abcd\0abcd      ", (size_t)20)) {
+    if (HDmemcmp(buf, "abcd\0abcd\0abcd      ", (size_t)20) != 0) {
         H5_FAILED();
         HDputs("    Fortran to C buffer test 3");
         goto error;
@@ -7193,7 +7193,7 @@ test_named_indirect_reopen(hid_t fapl)
         TEST_ERROR
     if (NULL == (tag_ret = H5Tget_tag(type)))
         TEST_ERROR
-    if (HDstrcmp(tag, tag_ret))
+    if (HDstrcmp(tag, tag_ret) != 0)
         TEST_ERROR
     H5free_memory(tag_ret);
     tag_ret = NULL;
@@ -7209,7 +7209,7 @@ test_named_indirect_reopen(hid_t fapl)
         TEST_ERROR
     if (NULL == (tag_ret = H5Tget_tag(type)))
         TEST_ERROR
-    if (HDstrcmp(tag, tag_ret))
+    if (HDstrcmp(tag, tag_ret) != 0)
         TEST_ERROR
     H5free_memory(tag_ret);
     tag_ret = NULL;

--- a/test/error_test.c
+++ b/test/error_test.c
@@ -200,7 +200,7 @@ init_error(void)
 
     if (cls_size != H5Eget_class_name(ERR_CLS, cls_name, (size_t)cls_size) + 1)
         TEST_ERROR;
-    if (HDstrcmp(ERR_CLS_NAME, cls_name))
+    if (HDstrcmp(ERR_CLS_NAME, cls_name) != 0)
         TEST_ERROR;
 
     if ((ERR_MAJ_TEST = H5Ecreate_msg(ERR_CLS, H5E_MAJOR, ERR_MAJ_TEST_MSG)) < 0)
@@ -225,7 +225,7 @@ init_error(void)
         TEST_ERROR;
     if (msg_type != H5E_MINOR)
         TEST_ERROR;
-    if (HDstrcmp(msg, ERR_MIN_SUBROUTINE_MSG))
+    if (HDstrcmp(msg, ERR_MIN_SUBROUTINE_MSG) != 0)
         TEST_ERROR;
 
     /* Register another class for later testing. */

--- a/test/external.c
+++ b/test/external.c
@@ -72,7 +72,7 @@ files_have_same_contents(const char *name1, const char *name2)
             break;
         }
 
-        if (HDmemcmp(buf1, buf2, (size_t)n1))
+        if (HDmemcmp(buf1, buf2, (size_t)n1) != 0)
             break;
 
     } /* end while */

--- a/test/fheap.c
+++ b/test/fheap.c
@@ -424,7 +424,7 @@ add_obj(H5HF_t *fh, size_t obj_off, size_t obj_size, fheap_heap_state_t *state, 
         TEST_ERROR
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(obj, shared_robj_g, obj_size))
+    if (HDmemcmp(obj, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* If the heap IDs are to be retained, append them to the list */
@@ -1192,7 +1192,7 @@ fill_heap(H5HF_t *fh, unsigned block_row, size_t obj_size, fheap_heap_state_t *s
 
         /* Check that object is correct */
         wobj = &shared_wobj_g[*curr_off_ptr];
-        if (HDmemcmp(wobj, shared_robj_g, *curr_len_ptr))
+        if (HDmemcmp(wobj, shared_robj_g, *curr_len_ptr) != 0)
             TEST_ERROR
 
         /* Adjust object & ID pointers */
@@ -12698,7 +12698,7 @@ test_huge_insert_one(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
@@ -12851,7 +12851,7 @@ test_huge_insert_two(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Insert second object too large for managed heap blocks */
@@ -12881,7 +12881,7 @@ test_huge_insert_two(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id2, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
@@ -13084,7 +13084,7 @@ test_huge_insert_three(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tp
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Insert second object too large for managed heap blocks */
@@ -13114,7 +13114,7 @@ test_huge_insert_three(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tp
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id2, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Insert third object too large for managed heap blocks */
@@ -13144,7 +13144,7 @@ test_huge_insert_three(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tp
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id3, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
@@ -13395,7 +13395,7 @@ test_huge_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Insert second object too large for managed heap blocks */
@@ -13425,7 +13425,7 @@ test_huge_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id2, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Insert third object too large for managed heap blocks */
@@ -13455,7 +13455,7 @@ test_huge_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id3, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Insert fourth object small enough to fit into 'normal' heap blocks */
@@ -13492,7 +13492,7 @@ test_huge_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id4, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Insert fifth object small enough to fit into 'normal' heap blocks */
@@ -13530,7 +13530,7 @@ test_huge_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id5, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
@@ -13868,7 +13868,7 @@ test_filtered_huge(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
@@ -14019,7 +14019,7 @@ test_tiny_insert_one(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
@@ -14172,7 +14172,7 @@ test_tiny_insert_two(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Insert second object small enough to encode in heap ID */
@@ -14202,7 +14202,7 @@ test_tiny_insert_two(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id2, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
@@ -14418,14 +14418,14 @@ test_tiny_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Check 'op' functionality on first huge object */
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_op(fh, heap_id, op_memcpy, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Insert second object too large for managed heap blocks */
@@ -14455,14 +14455,14 @@ test_tiny_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id2, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Check 'op' functionality on second huge object */
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_op(fh, heap_id2, op_memcpy, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Insert third object too large for managed heap blocks */
@@ -14492,14 +14492,14 @@ test_tiny_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id3, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Check 'op' functionality on third huge object */
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_op(fh, heap_id3, op_memcpy, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Insert fourth object small enough to fit into 'normal' heap blocks */
@@ -14536,14 +14536,14 @@ test_tiny_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id4, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Check 'op' functionality on fourth ('normal') object */
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_op(fh, heap_id4, op_memcpy, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Insert fifth object small enough to fit into 'normal' heap blocks */
@@ -14581,14 +14581,14 @@ test_tiny_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id5, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Check 'op' functionality on fifth ('normal') object */
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_op(fh, heap_id5, op_memcpy, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Insert sixth object small enough to encode in heap ID */
@@ -14618,14 +14618,14 @@ test_tiny_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id6, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Check 'op' functionality on sixth ('tiny') object */
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_op(fh, heap_id6, op_memcpy, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Insert seventh object small enough to encode in heap ID */
@@ -14655,14 +14655,14 @@ test_tiny_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id7, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Check 'op' functionality on seventh ('tiny') object */
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_op(fh, heap_id7, op_memcpy, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
@@ -15032,7 +15032,7 @@ test_filtered_man_root_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_para
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
@@ -15215,7 +15215,7 @@ test_filtered_man_root_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_test_pa
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id1, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Read in ('normal') object #2 */
@@ -15226,7 +15226,7 @@ test_filtered_man_root_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_test_pa
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id2, shared_robj_g) < 0)
         FAIL_STACK_ERROR
-    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size))
+    if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
         TEST_ERROR
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
@@ -16032,7 +16032,7 @@ test_write(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
             FAIL_STACK_ERROR
 
         /* Compare data read in */
-        if (HDmemcmp(rewrite_obj, shared_robj_g, obj_size))
+        if (HDmemcmp(rewrite_obj, shared_robj_g, obj_size) != 0)
             TEST_ERROR
 
         /* Change size of data to write */
@@ -16081,7 +16081,7 @@ test_write(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
             FAIL_STACK_ERROR
 
         /* Compare data read in */
-        if (HDmemcmp(rewrite_obj, shared_robj_g, obj_size))
+        if (HDmemcmp(rewrite_obj, shared_robj_g, obj_size) != 0)
             TEST_ERROR
 
         /* Change size of data to write */
@@ -16340,7 +16340,7 @@ main(void)
         envval = "nomatch";
 
     /* Current VFD that does not support contigous address space */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(envval, "split") && HDstrcmp(envval, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(envval, "split") != 0 && HDstrcmp(envval, "multi") != 0);
 
     /* Reset library */
     h5_reset();

--- a/test/filenotclosed.c
+++ b/test/filenotclosed.c
@@ -77,7 +77,7 @@ main(void)
      * Further investigation is needed to resolve the test failure with the
      * split/multi driver.  Please see HDFFV-10160.
      */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
     if (!contig_addr_vfd) {
         SKIPPED();
         HDputs("    Temporary skipped for a spilt/multi driver");

--- a/test/fillval.c
+++ b/test/fillval.c
@@ -318,7 +318,7 @@ test_getset_vl(hid_t fapl)
         TEST_ERROR
 
     /* Verify that the fill value is the original value */
-    if (HDstrcmp(f2, orig_fill_value))
+    if (HDstrcmp(f2, orig_fill_value) != 0)
         TEST_ERROR
 
     /* Release the fill value retrieved */
@@ -360,7 +360,7 @@ test_getset_vl(hid_t fapl)
         TEST_ERROR
 
     /* Verify that the fill value is the original value */
-    if (HDstrcmp(f2, orig_fill_value))
+    if (HDstrcmp(f2, orig_fill_value) != 0)
         TEST_ERROR
 
     /* Release the fill value retrieved */
@@ -1529,8 +1529,8 @@ test_extend_verify_cmpd_vl(unsigned lineno, const hsize_t *offset, const void *_
         (const comp_vl_datatype *)_compare_val; /* Value to compare against */
 
     /* Verify value */
-    if ((test_val->x != compare_val->x) || HDstrcmp(test_val->a, compare_val->a) ||
-        HDstrcmp(test_val->b, compare_val->b) || (test_val->y != compare_val->y)) {
+    if ((test_val->x != compare_val->x) || HDstrcmp(test_val->a, compare_val->a) != 0 ||
+        HDstrcmp(test_val->b, compare_val->b) != 0 || (test_val->y != compare_val->y)) {
         HDfprintf(stdout, "%u: Value read was not expected.\n", lineno);
         HDfprintf(stdout,
                   "    Elmt = {%" PRIuHSIZE ", %" PRIuHSIZE ", %" PRIuHSIZE ", %" PRIuHSIZE ", %" PRIuHSIZE

--- a/test/getname.c
+++ b/test/getname.c
@@ -68,11 +68,11 @@ check_name(hid_t id, const char *chk_name, const char *chk_user_path)
         TEST_ERROR
 
     /* Check on name from H5Iget_name() */
-    if (HDstrcmp(name, chk_name))
+    if (HDstrcmp(name, chk_name) != 0)
         goto error;
 
     /* Check on user path */
-    if (HDstrcmp(user_path, chk_user_path))
+    if (HDstrcmp(user_path, chk_user_path) != 0)
         goto error;
 
     /* Check that if user path is hidden, the name from H5Iget_name() and the user path should be different */
@@ -1439,7 +1439,7 @@ test_main(hid_t file_id, hid_t fapl)
             /* Check that name is longer */
             if (name_len <= SMALL_NAME_BUF_SIZE)
                 TEST_ERROR
-            if (HDstrcmp(name2, "/"))
+            if (HDstrcmp(name2, "/") != 0)
                 TEST_ERROR
         }
 
@@ -1481,7 +1481,7 @@ test_main(hid_t file_id, hid_t fapl)
             TEST_ERROR
 
         /* Verify */
-        if (HDstrcmp(name3, "/g17"))
+        if (HDstrcmp(name3, "/g17") != 0)
             TEST_ERROR
         *name3 = '\0';
 
@@ -1491,7 +1491,7 @@ test_main(hid_t file_id, hid_t fapl)
             TEST_ERROR
 
         /* Verify */
-        if (HDstrcmp(name3, "/g"))
+        if (HDstrcmp(name3, "/g") != 0)
             TEST_ERROR
 
         HDfree(name3);

--- a/test/gheap.c
+++ b/test/gheap.c
@@ -129,7 +129,7 @@ test_1(hid_t fapl)
             HDputs("    Unable to read object");
             nerrors++;
         }
-        else if (HDmemcmp(in, out, size)) {
+        else if (HDmemcmp(in, out, size) != 0) {
             H5_FAILED();
             HDputs("    Value read doesn't match value written");
             nerrors++;
@@ -226,7 +226,7 @@ test_2(hid_t fapl)
             HDputs("    Unable to read object");
             nerrors++;
         }
-        else if (HDmemcmp(in, out, size)) {
+        else if (HDmemcmp(in, out, size) != 0) {
             H5_FAILED();
             HDputs("    Value read doesn't match value written");
             nerrors++;

--- a/test/istore.c
+++ b/test/istore.c
@@ -376,7 +376,7 @@ test_extend(hid_t f, const char *prefix, size_t nx, size_t ny, size_t nz)
             HDfprintf(stderr, "    Read failed: ctr=%lu\n", (unsigned long)ctr);
             goto error;
         }
-        if (HDmemcmp(buf, check, (size_t)nelmts)) {
+        if (HDmemcmp(buf, check, (size_t)nelmts) != 0) {
             H5_FAILED();
             HDfprintf(stderr, "    Read check failed: ctr=%lu\n", (unsigned long)ctr);
             HDfprintf(stderr, "    Wrote:\n");

--- a/test/lheap.c
+++ b/test/lheap.c
@@ -155,7 +155,7 @@ main(void)
             goto error;
         }
 
-        if (HDstrcmp(s, buf)) {
+        if (HDstrcmp(s, buf) != 0) {
             H5_FAILED();
             HDprintf("    i=%d, heap offset=%lu\n", i, (unsigned long)(obj[i]));
             HDprintf("    got: \"%s\"\n", s);

--- a/test/links.c
+++ b/test/links.c
@@ -697,7 +697,7 @@ cklinks(hid_t fapl, hbool_t new_format)
     } /* end if */
     if (H5Lget_val(file, "grp1/soft", linkval, sizeof linkval, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp(linkval, "/d1")) {
+    if (HDstrcmp(linkval, "/d1") != 0) {
         H5_FAILED();
         HDputs("    Soft link test failed. Wrong link value");
         TEST_ERROR
@@ -728,7 +728,7 @@ cklinks(hid_t fapl, hbool_t new_format)
         HDprintf("    %d: Can't retrieve link value\n", __LINE__);
         TEST_ERROR
     } /* end if */
-    if (HDstrcmp(linkval, "foobar")) {
+    if (HDstrcmp(linkval, "foobar") != 0) {
         H5_FAILED();
         HDputs("    Dangling link test failed. Wrong link value");
         TEST_ERROR
@@ -759,7 +759,7 @@ cklinks(hid_t fapl, hbool_t new_format)
         HDprintf("    %d: Can't retrieve link value\n", __LINE__);
         TEST_ERROR
     } /* end if */
-    if (HDstrcmp(linkval, "/grp1/recursive")) {
+    if (HDstrcmp(linkval, "/grp1/recursive") != 0) {
         H5_FAILED();
         HDputs("   Recursive link test failed. Wrong link value");
         TEST_ERROR
@@ -1058,7 +1058,7 @@ toomany(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/hard21"))
+    if (HDstrcmp(objname, "/hard21") != 0)
         TEST_ERROR
 
     /* Create object in hard-linked group */
@@ -1089,7 +1089,7 @@ toomany(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/soft16"))
+    if (HDstrcmp(objname, "/soft16") != 0)
         TEST_ERROR
 
     /* Create object using soft links */
@@ -1955,7 +1955,7 @@ test_deprec(hid_t fapl, hbool_t new_format)
         FAIL_STACK_ERROR
     if (H5Gget_comment(file_id, "group1", sizeof(tmpstr), tmpstr) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp(tmpstr, "comment"))
+    if (HDstrcmp(tmpstr, "comment") != 0)
         TEST_ERROR
 
     /* Create links using H5Glink and H5Glink2 */
@@ -1971,7 +1971,7 @@ test_deprec(hid_t fapl, hbool_t new_format)
     /* Test getting the names for objects */
     if (H5Gget_objname_by_idx(group1_id, (hsize_t)0, tmpstr, sizeof(tmpstr)) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp(tmpstr, "link_to_group2"))
+    if (HDstrcmp(tmpstr, "link_to_group2") != 0)
         TEST_ERROR
     H5E_BEGIN_TRY
     {
@@ -2008,7 +2008,7 @@ test_deprec(hid_t fapl, hbool_t new_format)
     if (H5Gget_objinfo(file_id, "/group1/link_to_group2", TRUE, &sb_hard2) < 0)
         FAIL_STACK_ERROR
 
-    if (HDmemcmp(&sb_hard1.objno, sb_hard2.objno, sizeof(sb_hard1.objno))) {
+    if (HDmemcmp(&sb_hard1.objno, sb_hard2.objno, sizeof(sb_hard1.objno)) != 0) {
         H5_FAILED();
         HDputs("    Hard link test failed.  Link seems not to point to the ");
         HDputs("    expected file location.");
@@ -2021,7 +2021,7 @@ test_deprec(hid_t fapl, hbool_t new_format)
     if (H5Gget_objinfo(file_id, "/group2/link_to_group1", TRUE, &sb_hard2) < 0)
         FAIL_STACK_ERROR
 
-    if (HDmemcmp(&sb_hard1.objno, sb_hard2.objno, sizeof(sb_hard1.objno))) {
+    if (HDmemcmp(&sb_hard1.objno, sb_hard2.objno, sizeof(sb_hard1.objno)) != 0) {
         H5_FAILED();
         HDputs("    Hard link test failed.  Link seems not to point to the ");
         HDputs("    expected file location.");
@@ -2038,7 +2038,7 @@ test_deprec(hid_t fapl, hbool_t new_format)
 
     if (H5Gget_linkval(group2_id, "soft_link_to_group1", sb_soft1.linklen, tmpstr) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp("link_to_group1", tmpstr))
+    if (HDstrcmp("link_to_group1", tmpstr) != 0)
         TEST_ERROR
 
     /* Test non-existing links with H5Gget_objinfo */
@@ -2059,7 +2059,7 @@ test_deprec(hid_t fapl, hbool_t new_format)
 
     if (H5Gget_linkval(group2_id, "dangle_soft_link", sb_soft2.linklen, tmpstr) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp("dangle", tmpstr))
+    if (HDstrcmp("dangle", tmpstr) != 0)
         TEST_ERROR
 
     /* Test H5Gmove and H5Gmove2 */
@@ -2200,7 +2200,7 @@ cklinks_deprec(hid_t fapl, hbool_t new_format)
     } /* end if */
     if (H5Lget_val(file, "grp1/soft", linkval, sizeof linkval, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp(linkval, "/d1")) {
+    if (HDstrcmp(linkval, "/d1") != 0) {
         H5_FAILED();
         HDputs("    Soft link test failed. Wrong link value");
         TEST_ERROR
@@ -2231,7 +2231,7 @@ cklinks_deprec(hid_t fapl, hbool_t new_format)
         HDprintf("    %d: Can't retrieve link value\n", __LINE__);
         TEST_ERROR
     } /* end if */
-    if (HDstrcmp(linkval, "foobar")) {
+    if (HDstrcmp(linkval, "foobar") != 0) {
         H5_FAILED();
         HDputs("    Dangling link test failed. Wrong link value");
         TEST_ERROR
@@ -2262,7 +2262,7 @@ cklinks_deprec(hid_t fapl, hbool_t new_format)
         HDprintf("    %d: Can't retrieve link value\n", __LINE__);
         TEST_ERROR
     } /* end if */
-    if (HDstrcmp(linkval, "/grp1/recursive")) {
+    if (HDstrcmp(linkval, "/grp1/recursive") != 0) {
         H5_FAILED();
         HDputs("   Recursive link test failed. Wrong link value");
         TEST_ERROR
@@ -2799,12 +2799,12 @@ external_link_root_deprec(hid_t fapl, hbool_t new_format)
         TEST_ERROR
     if (H5Lunpack_elink_val(objname, linfo.u.val_size, NULL, &file, &path) < 0)
         TEST_ERROR
-    if (HDstrcmp(file, filename1)) {
+    if (HDstrcmp(file, filename1) != 0) {
         H5_FAILED();
         HDputs("    External link file name incorrect");
         goto error;
     }
-    if (HDstrcmp(path, "/")) {
+    if (HDstrcmp(path, "/") != 0) {
         H5_FAILED();
         HDputs("    External link path incorrect");
         goto error;
@@ -2827,12 +2827,12 @@ external_link_root_deprec(hid_t fapl, hbool_t new_format)
         TEST_ERROR
     if (H5Lunpack_elink_val(objname, linfo.u.val_size, NULL, &file, &path) < 0)
         TEST_ERROR
-    if (HDstrcmp(file, filename1)) {
+    if (HDstrcmp(file, filename1) != 0) {
         H5_FAILED();
         HDputs("    External link file name incorrect");
         goto error;
     }
-    if (HDstrcmp(path, "/")) {
+    if (HDstrcmp(path, "/") != 0) {
         H5_FAILED();
         HDputs("    External link path incorrect");
         goto error;
@@ -2851,7 +2851,7 @@ external_link_root_deprec(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/"))
+    if (HDstrcmp(objname, "/") != 0)
         TEST_ERROR
 
     /* Create object in external file */
@@ -2896,11 +2896,11 @@ external_link_root_deprec(hid_t fapl, hbool_t new_format)
     /* Check names */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/new_group"))
+    if (HDstrcmp(objname, "/new_group") != 0)
         TEST_ERROR
     if (H5Iget_name(gid2, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/newer_group"))
+    if (HDstrcmp(objname, "/newer_group") != 0)
         TEST_ERROR
 
     /* Close opened objects */
@@ -3045,9 +3045,9 @@ external_link_query_deprec(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Compare the file and object names */
-    if (HDstrcmp(file_name, filename2))
+    if (HDstrcmp(file_name, filename2) != 0)
         TEST_ERROR
-    if (HDstrcmp(object_name, "/dst"))
+    if (HDstrcmp(object_name, "/dst") != 0)
         TEST_ERROR
 
     /* Query information about object that external link points to */
@@ -3241,7 +3241,7 @@ external_link_closing_deprec(hid_t fapl, hbool_t new_format)
         FAIL_STACK_ERROR
     if (H5Oget_comment_by_name(fid1, "elink/elink/elink/group1_moved", buf, sizeof(buf), H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp(buf, "comment"))
+    if (HDstrcmp(buf, "comment") != 0)
         TEST_ERROR
 
     /* Test H5*open */
@@ -3658,7 +3658,7 @@ ud_hard_links_deprec(hid_t fapl)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/group"))
+    if (HDstrcmp(objname, "/group") != 0)
         TEST_ERROR
 
     /* Create object in group */
@@ -3678,7 +3678,7 @@ ud_hard_links_deprec(hid_t fapl)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/group/new_group"))
+    if (HDstrcmp(objname, "/group/new_group") != 0)
         TEST_ERROR
 
     /* Close opened object */
@@ -3841,7 +3841,7 @@ ud_link_reregister_deprec(hid_t fapl)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/" REREG_TARGET_NAME))
+    if (HDstrcmp(objname, "/" REREG_TARGET_NAME) != 0)
         TEST_ERROR
 
     /* Create object in group */
@@ -3861,7 +3861,7 @@ ud_link_reregister_deprec(hid_t fapl)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/rereg_target/new_group"))
+    if (HDstrcmp(objname, "/rereg_target/new_group") != 0)
         TEST_ERROR
 
     /* Close opened object */
@@ -4205,7 +4205,7 @@ lapl_nlinks_deprec(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/soft17"))
+    if (HDstrcmp(objname, "/soft17") != 0)
         TEST_ERROR
 
     /* Create group using soft link */
@@ -4246,7 +4246,7 @@ lapl_nlinks_deprec(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/soft4"))
+    if (HDstrcmp(objname, "/soft4") != 0)
         TEST_ERROR
 
     /* Test other functions that should use a LAPL */
@@ -4861,7 +4861,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, h
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
             TEST_ERROR
-        if (HDstrcmp(valname, tmpval))
+        if (HDstrcmp(valname, tmpval) != 0)
             TEST_ERROR
     } /* end if */
 
@@ -4870,7 +4870,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, h
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, tmpname, (size_t)NAME_BUF_SIZE,
                            H5P_DEFAULT) < 0)
         TEST_ERROR
-    if (HDstrcmp(linkname, tmpname))
+    if (HDstrcmp(linkname, tmpname) != 0)
         TEST_ERROR
 
     /* Don't test "native" order if there is no creation order index, since
@@ -4900,7 +4900,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, h
             if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, n, tmpval,
                                   (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR
-            if (HDstrcmp(valname, tmpval))
+            if (HDstrcmp(valname, tmpval) != 0)
                 TEST_ERROR
         } /* end if */
 
@@ -4909,7 +4909,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, h
         if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, n, tmpname,
                                (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
             TEST_ERROR
-        if (HDstrcmp(linkname, tmpname))
+        if (HDstrcmp(linkname, tmpname) != 0)
             TEST_ERROR
     } /* end if */
 
@@ -4934,7 +4934,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, h
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
             TEST_ERROR
-        if (HDstrcmp(valname, tmpval))
+        if (HDstrcmp(valname, tmpval) != 0)
             TEST_ERROR
     } /* end if */
 
@@ -4943,7 +4943,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, h
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, tmpname,
                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
         TEST_ERROR
-    if (HDstrcmp(linkname, tmpname))
+    if (HDstrcmp(linkname, tmpname) != 0)
         TEST_ERROR
 
     /* Verify the link information for first link, in increasing link name order */
@@ -4966,7 +4966,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, h
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, tmpval, (size_t)NAME_BUF_SIZE,
                               H5P_DEFAULT) < 0)
             TEST_ERROR
-        if (HDstrcmp(valname, tmpval))
+        if (HDstrcmp(valname, tmpval) != 0)
             TEST_ERROR
     } /* end if */
 
@@ -4975,7 +4975,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, h
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, tmpname, (size_t)NAME_BUF_SIZE,
                            H5P_DEFAULT) < 0)
         TEST_ERROR
-    if (HDstrcmp(linkname, tmpname))
+    if (HDstrcmp(linkname, tmpname) != 0)
         TEST_ERROR
 
     /* Don't test "native" order queries on link name order, since there's not
@@ -5002,7 +5002,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, h
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
             TEST_ERROR
-        if (HDstrcmp(valname, tmpval))
+        if (HDstrcmp(valname, tmpval) != 0)
             TEST_ERROR
     } /* end if */
 
@@ -5011,7 +5011,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, h
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, tmpname,
                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
         TEST_ERROR
-    if (HDstrcmp(linkname, tmpname))
+    if (HDstrcmp(linkname, tmpname) != 0)
         TEST_ERROR
 
     /* Success */
@@ -5358,7 +5358,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                     TEST_ERROR
-                if (HDstrcmp(valname, tmpval))
+                if (HDstrcmp(valname, tmpval) != 0)
                     TEST_ERROR
             } /* end else */
 
@@ -5366,7 +5366,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR
-            if (HDstrcmp(objname, tmpname))
+            if (HDstrcmp(objname, tmpname) != 0)
                 TEST_ERROR
 
             /* Verify link information (in native order - native is increasing) */
@@ -5381,7 +5381,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                     TEST_ERROR
-                if (HDstrcmp(valname, tmpval))
+                if (HDstrcmp(valname, tmpval) != 0)
                     TEST_ERROR
             } /* end else */
 
@@ -5389,7 +5389,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR
-            if (HDstrcmp(objname, tmpname))
+            if (HDstrcmp(objname, tmpname) != 0)
                 TEST_ERROR
 
             /* Make link name for decreasing order queries */
@@ -5410,7 +5410,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                     TEST_ERROR
-                if (HDstrcmp(valname, tmpval))
+                if (HDstrcmp(valname, tmpval) != 0)
                     TEST_ERROR
             } /* end else */
 
@@ -5418,7 +5418,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR
-            if (HDstrcmp(objname, tmpname))
+            if (HDstrcmp(objname, tmpname) != 0)
                 TEST_ERROR
         } /* end for */
 
@@ -5644,7 +5644,7 @@ delete_by_idx_deprec(hid_t fapl)
                         HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
                     else
                         HDsnprintf(objname, sizeof(objname), "filler %02u", (max_compact - (u + 2)));
-                    if (HDstrcmp(objname, tmpname))
+                    if (HDstrcmp(objname, tmpname) != 0)
                         TEST_ERROR
                 } /* end for */
 
@@ -5718,7 +5718,7 @@ delete_by_idx_deprec(hid_t fapl)
                         HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
                     else
                         HDsnprintf(objname, sizeof(objname), "filler %02u", ((max_compact * 2) - (u + 2)));
-                    if (HDstrcmp(objname, tmpname))
+                    if (HDstrcmp(objname, tmpname) != 0)
                         TEST_ERROR
                 } /* end for */
 
@@ -5797,7 +5797,7 @@ delete_by_idx_deprec(hid_t fapl)
                     else
                         HDsnprintf(objname, sizeof(objname), "filler %02u",
                                    ((max_compact * 2) - ((u * 2) + 2)));
-                    if (HDstrcmp(objname, tmpname))
+                    if (HDstrcmp(objname, tmpname) != 0)
                         TEST_ERROR
                 } /* end for */
 
@@ -5831,7 +5831,7 @@ delete_by_idx_deprec(hid_t fapl)
                     else
                         HDsnprintf(objname, sizeof(objname), "filler %02u",
                                    ((max_compact * 2) - ((u * 2) + 4)));
-                    if (HDstrcmp(objname, tmpname))
+                    if (HDstrcmp(objname, tmpname) != 0)
                         TEST_ERROR
                 } /* end for */
 
@@ -5998,7 +5998,7 @@ delete_by_idx_old_deprec(hid_t fapl)
                 HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
             else
                 HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
-            if (HDstrcmp(objname, tmpname))
+            if (HDstrcmp(objname, tmpname) != 0)
                 TEST_ERROR
         } /* end for */
 
@@ -6072,7 +6072,7 @@ delete_by_idx_old_deprec(hid_t fapl)
                 HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 1));
             else
                 HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
-            if (HDstrcmp(objname, tmpname))
+            if (HDstrcmp(objname, tmpname) != 0)
                 TEST_ERROR
         } /* end for */
 
@@ -6106,7 +6106,7 @@ delete_by_idx_old_deprec(hid_t fapl)
                 HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 3));
             else
                 HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
-            if (HDstrcmp(objname, tmpname))
+            if (HDstrcmp(objname, tmpname) != 0)
                 TEST_ERROR
         } /* end for */
 
@@ -6188,7 +6188,7 @@ link_iterate_deprec_cb(hid_t group_id, const char *link_name, const H5L_info1_t 
 
     /* Verify name of link */
     HDsnprintf(objname, sizeof(objname), "filler %02u", (unsigned)my_info.corder);
-    if (HDstrcmp(link_name, objname))
+    if (HDstrcmp(link_name, objname) != 0)
         return H5_ITER_ERROR;
 
     /* Check if we've visited this link before */
@@ -6685,7 +6685,7 @@ link_iterate_old_deprec_cb(hid_t group_id, const char *link_name, const H5L_info
     /* Verify name of link */
     HDsnprintf(objname, sizeof(objname), "filler %02u",
                (info ? (unsigned)op_data->curr : (unsigned)((op_data->ncalled - 1) + op_data->nskipped)));
-    if (HDstrcmp(link_name, objname))
+    if (HDstrcmp(link_name, objname) != 0)
         return H5_ITER_ERROR;
 
     /* Check if we've visited this link before */
@@ -7105,12 +7105,12 @@ external_link_root(hid_t fapl, hbool_t new_format)
         TEST_ERROR
     if (H5Lunpack_elink_val(objname, linfo.u.val_size, NULL, &file, &path) < 0)
         TEST_ERROR
-    if (HDstrcmp(file, filename1)) {
+    if (HDstrcmp(file, filename1) != 0) {
         H5_FAILED();
         HDputs("    External link file name incorrect");
         goto error;
     }
-    if (HDstrcmp(path, "/")) {
+    if (HDstrcmp(path, "/") != 0) {
         H5_FAILED();
         HDputs("    External link path incorrect");
         goto error;
@@ -7133,12 +7133,12 @@ external_link_root(hid_t fapl, hbool_t new_format)
         TEST_ERROR
     if (H5Lunpack_elink_val(objname, linfo.u.val_size, NULL, &file, &path) < 0)
         TEST_ERROR
-    if (HDstrcmp(file, filename1)) {
+    if (HDstrcmp(file, filename1) != 0) {
         H5_FAILED();
         HDputs("    External link file name incorrect");
         goto error;
     }
-    if (HDstrcmp(path, "/")) {
+    if (HDstrcmp(path, "/") != 0) {
         H5_FAILED();
         HDputs("    External link path incorrect");
         goto error;
@@ -7157,7 +7157,7 @@ external_link_root(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/"))
+    if (HDstrcmp(objname, "/") != 0)
         TEST_ERROR
 
     /* Create object in external file */
@@ -7202,11 +7202,11 @@ external_link_root(hid_t fapl, hbool_t new_format)
     /* Check names */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/new_group"))
+    if (HDstrcmp(objname, "/new_group") != 0)
         TEST_ERROR
     if (H5Iget_name(gid2, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/newer_group"))
+    if (HDstrcmp(objname, "/newer_group") != 0)
         TEST_ERROR
 
     /* Close opened objects */
@@ -7325,7 +7325,7 @@ external_link_path(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/A/B/C"))
+    if (HDstrcmp(objname, "/A/B/C") != 0)
         TEST_ERROR
 
     /* Create object in external file */
@@ -7355,7 +7355,7 @@ external_link_path(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/A/B/C/new_group"))
+    if (HDstrcmp(objname, "/A/B/C/new_group") != 0)
         TEST_ERROR
 
     /* Close opened object */
@@ -7497,7 +7497,7 @@ external_link_mult(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/A/B/C"))
+    if (HDstrcmp(objname, "/A/B/C") != 0)
         TEST_ERROR
 
     /* Create object in external file */
@@ -7527,7 +7527,7 @@ external_link_mult(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/A/B/C/new_group"))
+    if (HDstrcmp(objname, "/A/B/C/new_group") != 0)
         TEST_ERROR
 
     /* Close opened object */
@@ -7643,7 +7643,7 @@ external_link_self(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/X"))
+    if (HDstrcmp(objname, "/X") != 0)
         TEST_ERROR
 
     /* Create object through external link */
@@ -7665,7 +7665,7 @@ external_link_self(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/X/new_group"))
+    if (HDstrcmp(objname, "/X/new_group") != 0)
         TEST_ERROR
 
     /* Close opened object */
@@ -7850,7 +7850,7 @@ external_link_pingpong(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/final"))
+    if (HDstrcmp(objname, "/final") != 0)
         TEST_ERROR
 
     /* Create object in external file */
@@ -7880,7 +7880,7 @@ external_link_pingpong(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/final/new_group"))
+    if (HDstrcmp(objname, "/final/new_group") != 0)
         TEST_ERROR
 
     /* Close opened object */
@@ -8039,7 +8039,7 @@ external_link_toomany(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/final"))
+    if (HDstrcmp(objname, "/final") != 0)
         TEST_ERROR
 
     /* Create object in external file */
@@ -9753,13 +9753,13 @@ external_set_elink_cb_cb(const char *parent_file, const char *parent_group, cons
     set_elink_cb_t *op_data = (set_elink_cb_t *)_op_data;
 
     /* Verify file and object names are correct */
-    if (HDstrcmp(parent_file, op_data->parent_file))
+    if (HDstrcmp(parent_file, op_data->parent_file) != 0)
         return FAIL;
-    if (HDstrcmp(parent_group, "/group1"))
+    if (HDstrcmp(parent_group, "/group1") != 0)
         return FAIL;
-    if (HDstrcmp(target_file, op_data->target_file))
+    if (HDstrcmp(target_file, op_data->target_file) != 0)
         return FAIL;
-    if (HDstrcmp(target_obj, "/"))
+    if (HDstrcmp(target_obj, "/") != 0)
         return FAIL;
 
     /* Set flags to be read-write */
@@ -10983,9 +10983,9 @@ external_link_query(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Compare the file and object names */
-    if (HDstrcmp(file_name, filename2))
+    if (HDstrcmp(file_name, filename2) != 0)
         TEST_ERROR
-    if (HDstrcmp(object_name, "/dst"))
+    if (HDstrcmp(object_name, "/dst") != 0)
         TEST_ERROR
 
     /* Query information about object that external link points to */
@@ -11382,7 +11382,7 @@ external_link_move(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp(objname, "/dst"))
+    if (HDstrcmp(objname, "/dst") != 0)
         TEST_ERROR
 
     /* Create object in external file */
@@ -11442,7 +11442,7 @@ external_link_move(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp(objname, "/dst"))
+    if (HDstrcmp(objname, "/dst") != 0)
         TEST_ERROR
 
     /* Create object in external file */
@@ -11489,7 +11489,7 @@ external_link_move(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp(objname, "/dst"))
+    if (HDstrcmp(objname, "/dst") != 0)
         TEST_ERROR
 
     /* Move external link back to original location */
@@ -11499,7 +11499,7 @@ external_link_move(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp(objname, "/dst"))
+    if (HDstrcmp(objname, "/dst") != 0)
         TEST_ERROR
 
     /* Create object in external file */
@@ -11673,7 +11673,7 @@ external_link_ride(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/dst"))
+    if (HDstrcmp(objname, "/dst") != 0)
         TEST_ERROR
 
     /* Create object in external file */
@@ -11722,7 +11722,7 @@ external_link_ride(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/dst"))
+    if (HDstrcmp(objname, "/dst") != 0)
         TEST_ERROR
 
     /* Create object in external file */
@@ -11915,7 +11915,7 @@ external_link_closing(hid_t fapl, hbool_t new_format)
         FAIL_STACK_ERROR
     if (H5Oget_comment_by_name(fid1, "elink/elink/elink/group1_moved", buf, sizeof(buf), H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp(buf, "comment"))
+    if (HDstrcmp(buf, "comment") != 0)
         TEST_ERROR
 
     /* Test H5*open */
@@ -12258,7 +12258,7 @@ external_link_strong(hid_t fapl, hbool_t new_format)
         FAIL_STACK_ERROR
     if (H5Iget_name(gid2, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/A/B/C"))
+    if (HDstrcmp(objname, "/A/B/C") != 0)
         TEST_ERROR
     if (H5Gclose(gid2) < 0)
         TEST_ERROR
@@ -13823,7 +13823,7 @@ ud_hard_links(hid_t fapl)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/group"))
+    if (HDstrcmp(objname, "/group") != 0)
         TEST_ERROR
 
     /* Create object in group */
@@ -13843,7 +13843,7 @@ ud_hard_links(hid_t fapl)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/group/new_group"))
+    if (HDstrcmp(objname, "/group/new_group") != 0)
         TEST_ERROR
 
     /* Close opened object */
@@ -14034,7 +14034,7 @@ ud_link_reregister(hid_t fapl)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/" REREG_TARGET_NAME))
+    if (HDstrcmp(objname, "/" REREG_TARGET_NAME) != 0)
         TEST_ERROR
 
     /* Create object in group */
@@ -14054,7 +14054,7 @@ ud_link_reregister(hid_t fapl)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/rereg_target/new_group"))
+    if (HDstrcmp(objname, "/rereg_target/new_group") != 0)
         TEST_ERROR
 
     /* Close opened object */
@@ -14143,9 +14143,9 @@ UD_cb_create(const char *link_name, hid_t loc_group, const void *udata, size_t u
     if (lcpl_id < 0)
         TEST_ERROR
 
-    if (HDstrcmp(link_name, UD_CB_LINK_NAME) && HDstrcmp(link_name, NEW_UD_CB_LINK_NAME))
+    if (HDstrcmp(link_name, UD_CB_LINK_NAME) != 0 && HDstrcmp(link_name, NEW_UD_CB_LINK_NAME) != 0)
         TEST_ERROR
-    if (HDstrcmp((const char *)udata, UD_CB_TARGET))
+    if (HDstrcmp((const char *)udata, UD_CB_TARGET) != 0)
         TEST_ERROR
     if (udata_size != UD_CB_TARGET_LEN)
         TEST_ERROR
@@ -14170,9 +14170,9 @@ UD_cb_traverse(const char *link_name, hid_t cur_group, const void *udata, size_t
     if (udata_size > 0 && !udata)
         TEST_ERROR
 
-    if (HDstrcmp(link_name, UD_CB_LINK_NAME) && HDstrcmp(link_name, NEW_UD_CB_LINK_NAME))
+    if (HDstrcmp(link_name, UD_CB_LINK_NAME) != 0 && HDstrcmp(link_name, NEW_UD_CB_LINK_NAME) != 0)
         TEST_ERROR
-    if (HDstrcmp((const char *)udata, UD_CB_TARGET))
+    if (HDstrcmp((const char *)udata, UD_CB_TARGET) != 0)
         TEST_ERROR
     if (udata_size != UD_CB_TARGET_LEN)
         TEST_ERROR
@@ -14197,9 +14197,9 @@ UD_cb_move(const char *new_name, hid_t new_loc, const void *udata, size_t udata_
     if (udata_size > 0 && !udata)
         TEST_ERROR
 
-    if (HDstrcmp(new_name, NEW_UD_CB_LINK_NAME))
+    if (HDstrcmp(new_name, NEW_UD_CB_LINK_NAME) != 0)
         TEST_ERROR
-    if (HDstrcmp((const char *)udata, UD_CB_TARGET))
+    if (HDstrcmp((const char *)udata, UD_CB_TARGET) != 0)
         TEST_ERROR
     if (udata_size != UD_CB_TARGET_LEN)
         TEST_ERROR
@@ -14221,9 +14221,9 @@ UD_cb_delete(const char *link_name, hid_t file, const void *udata, size_t udata_
     if (udata_size > 0 && !udata)
         TEST_ERROR
 
-    if (HDstrcmp(link_name, UD_CB_LINK_NAME) && HDstrcmp(link_name, NEW_UD_CB_LINK_NAME))
+    if (HDstrcmp(link_name, UD_CB_LINK_NAME) != 0 && HDstrcmp(link_name, NEW_UD_CB_LINK_NAME) != 0)
         TEST_ERROR
-    if (HDstrcmp((const char *)udata, UD_CB_TARGET))
+    if (HDstrcmp((const char *)udata, UD_CB_TARGET) != 0)
         TEST_ERROR
     if (udata_size != UD_CB_TARGET_LEN)
         TEST_ERROR
@@ -14243,9 +14243,9 @@ UD_cb_query(const char *link_name, const void *udata, size_t udata_size, void *b
     if (udata_size > 0 && !udata)
         TEST_ERROR
 
-    if (HDstrcmp(link_name, UD_CB_LINK_NAME))
+    if (HDstrcmp(link_name, UD_CB_LINK_NAME) != 0)
         TEST_ERROR
-    if (HDstrcmp((const char *)udata, UD_CB_TARGET))
+    if (HDstrcmp((const char *)udata, UD_CB_TARGET) != 0)
         TEST_ERROR
     if (udata_size != UD_CB_TARGET_LEN)
         TEST_ERROR
@@ -15077,7 +15077,7 @@ lapl_nlinks(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/soft17"))
+    if (HDstrcmp(objname, "/soft17") != 0)
         TEST_ERROR
 
     /* Create group using soft link */
@@ -15118,7 +15118,7 @@ lapl_nlinks(hid_t fapl, hbool_t new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/soft4"))
+    if (HDstrcmp(objname, "/soft4") != 0)
         TEST_ERROR
 
     /* Test other functions that should use a LAPL */
@@ -15572,7 +15572,7 @@ visit_link_cb(hid_t H5_ATTR_UNUSED group_id, const char *name, const H5L_info2_t
     lvisit_ud_t *op_data = (lvisit_ud_t *)_op_data;
 
     /* Check for correct link information */
-    if (HDstrcmp(op_data->info[op_data->idx].path, name))
+    if (HDstrcmp(op_data->info[op_data->idx].path, name) != 0)
         return (H5_ITER_ERROR);
     if (op_data->info[op_data->idx].type != linfo->type)
         return (H5_ITER_ERROR);
@@ -15763,7 +15763,7 @@ visit_obj_cb(hid_t H5_ATTR_UNUSED group_id, const char *name, const H5O_info2_t 
     ovisit_ud_t *op_data = (ovisit_ud_t *)_op_data;
 
     /* Check for correct object information */
-    if (HDstrcmp(op_data->info[op_data->idx].path, name))
+    if (HDstrcmp(op_data->info[op_data->idx].path, name) != 0)
         return (H5_ITER_ERROR);
     if (op_data->info[op_data->idx].type != oinfo->type)
         return (H5_ITER_ERROR);
@@ -16297,13 +16297,13 @@ link_filters(hid_t fapl, hbool_t new_format)
     if (H5Pget_filter_by_id2(gcpl2, H5Z_FILTER_RESERVED + 42, &flags_out, &cd_nelmts, &cd_value_out,
                              (size_t)24, name_out, &filter_config_out) < 0)
         TEST_ERROR
-    if (flags_out != 0 || cd_value_out != cd_value || HDstrcmp(filter_class.name, name_out) ||
+    if (flags_out != 0 || cd_value_out != cd_value || HDstrcmp(filter_class.name, name_out) != 0 ||
         filter_config_out != (H5Z_FILTER_CONFIG_ENCODE_ENABLED | H5Z_FILTER_CONFIG_DECODE_ENABLED))
         TEST_ERROR
     if (H5Pget_filter2(gcpl2, (unsigned)(nfilters - 1), &flags_out, &cd_nelmts, &cd_value_out, (size_t)24,
                        name_out, &filter_config_out) < 0)
         TEST_ERROR
-    if (flags_out != 0 || cd_value_out != cd_value || HDstrcmp(filter_class.name, name_out) ||
+    if (flags_out != 0 || cd_value_out != cd_value || HDstrcmp(filter_class.name, name_out) != 0 ||
         filter_config_out != (H5Z_FILTER_CONFIG_ENCODE_ENABLED | H5Z_FILTER_CONFIG_DECODE_ENABLED))
         TEST_ERROR
 
@@ -16314,7 +16314,7 @@ link_filters(hid_t fapl, hbool_t new_format)
     if (H5Pget_filter_by_id2(gcpl2, H5Z_FILTER_RESERVED + 42, &flags_out, &cd_nelmts, &cd_value_out,
                              (size_t)24, name_out, &filter_config_out) < 0)
         TEST_ERROR
-    if (flags_out != 0 || cd_value_out != cd_value || HDstrcmp(filter_class.name, name_out) ||
+    if (flags_out != 0 || cd_value_out != cd_value || HDstrcmp(filter_class.name, name_out) != 0 ||
         filter_config_out != (H5Z_FILTER_CONFIG_ENCODE_ENABLED | H5Z_FILTER_CONFIG_DECODE_ENABLED))
         TEST_ERROR
 
@@ -17753,7 +17753,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, hbool_t 
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
             TEST_ERROR
-        if (HDstrcmp(valname, tmpval))
+        if (HDstrcmp(valname, tmpval) != 0)
             TEST_ERROR
     } /* end if */
 
@@ -17762,7 +17762,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, hbool_t 
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, tmpname, (size_t)NAME_BUF_SIZE,
                            H5P_DEFAULT) < 0)
         TEST_ERROR
-    if (HDstrcmp(linkname, tmpname))
+    if (HDstrcmp(linkname, tmpname) != 0)
         TEST_ERROR
 
     /* Don't test "native" order if there is no creation order index, since
@@ -17792,7 +17792,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, hbool_t 
             if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, n, tmpval,
                                   (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR
-            if (HDstrcmp(valname, tmpval))
+            if (HDstrcmp(valname, tmpval) != 0)
                 TEST_ERROR
         } /* end if */
 
@@ -17801,7 +17801,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, hbool_t 
         if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, n, tmpname,
                                (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
             TEST_ERROR
-        if (HDstrcmp(linkname, tmpname))
+        if (HDstrcmp(linkname, tmpname) != 0)
             TEST_ERROR
     } /* end if */
 
@@ -17826,7 +17826,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, hbool_t 
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
             TEST_ERROR
-        if (HDstrcmp(valname, tmpval))
+        if (HDstrcmp(valname, tmpval) != 0)
             TEST_ERROR
     } /* end if */
 
@@ -17835,7 +17835,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, hbool_t 
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, tmpname,
                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
         TEST_ERROR
-    if (HDstrcmp(linkname, tmpname))
+    if (HDstrcmp(linkname, tmpname) != 0)
         TEST_ERROR
 
     /* Verify the link information for first link, in increasing link name order */
@@ -17858,7 +17858,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, hbool_t 
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, tmpval, (size_t)NAME_BUF_SIZE,
                               H5P_DEFAULT) < 0)
             TEST_ERROR
-        if (HDstrcmp(valname, tmpval))
+        if (HDstrcmp(valname, tmpval) != 0)
             TEST_ERROR
     } /* end if */
 
@@ -17867,7 +17867,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, hbool_t 
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, tmpname, (size_t)NAME_BUF_SIZE,
                            H5P_DEFAULT) < 0)
         TEST_ERROR
-    if (HDstrcmp(linkname, tmpname))
+    if (HDstrcmp(linkname, tmpname) != 0)
         TEST_ERROR
 
     /* Don't test "native" order queries on link name order, since there's not
@@ -17894,7 +17894,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, hbool_t 
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
             TEST_ERROR
-        if (HDstrcmp(valname, tmpval))
+        if (HDstrcmp(valname, tmpval) != 0)
             TEST_ERROR
     } /* end if */
 
@@ -17903,7 +17903,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, hbool_t 
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, tmpname,
                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
         TEST_ERROR
-    if (HDstrcmp(linkname, tmpname))
+    if (HDstrcmp(linkname, tmpname) != 0)
         TEST_ERROR
 
     /* Success */
@@ -18260,7 +18260,7 @@ link_info_by_idx_old(hid_t fapl)
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                     TEST_ERROR
-                if (HDstrcmp(valname, tmpval))
+                if (HDstrcmp(valname, tmpval) != 0)
                     TEST_ERROR
             } /* end else */
 
@@ -18268,7 +18268,7 @@ link_info_by_idx_old(hid_t fapl)
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR
-            if (HDstrcmp(objname, tmpname))
+            if (HDstrcmp(objname, tmpname) != 0)
                 TEST_ERROR
 
             /* Verify link information (in native order - native is increasing) */
@@ -18285,7 +18285,7 @@ link_info_by_idx_old(hid_t fapl)
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                     TEST_ERROR
-                if (HDstrcmp(valname, tmpval))
+                if (HDstrcmp(valname, tmpval) != 0)
                     TEST_ERROR
             } /* end else */
 
@@ -18293,7 +18293,7 @@ link_info_by_idx_old(hid_t fapl)
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR
-            if (HDstrcmp(objname, tmpname))
+            if (HDstrcmp(objname, tmpname) != 0)
                 TEST_ERROR
 
             /* Make link name for decreasing order queries */
@@ -18316,7 +18316,7 @@ link_info_by_idx_old(hid_t fapl)
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                     TEST_ERROR
-                if (HDstrcmp(valname, tmpval))
+                if (HDstrcmp(valname, tmpval) != 0)
                     TEST_ERROR
             } /* end else */
 
@@ -18324,7 +18324,7 @@ link_info_by_idx_old(hid_t fapl)
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR
-            if (HDstrcmp(objname, tmpname))
+            if (HDstrcmp(objname, tmpname) != 0)
                 TEST_ERROR
         } /* end for */
 
@@ -18548,7 +18548,7 @@ delete_by_idx(hid_t fapl)
                         HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
                     else
                         HDsnprintf(objname, sizeof(objname), "filler %02u", (max_compact - (u + 2)));
-                    if (HDstrcmp(objname, tmpname))
+                    if (HDstrcmp(objname, tmpname) != 0)
                         TEST_ERROR
                 } /* end for */
 
@@ -18622,7 +18622,7 @@ delete_by_idx(hid_t fapl)
                         HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
                     else
                         HDsnprintf(objname, sizeof(objname), "filler %02u", ((max_compact * 2) - (u + 2)));
-                    if (HDstrcmp(objname, tmpname))
+                    if (HDstrcmp(objname, tmpname) != 0)
                         TEST_ERROR
                 } /* end for */
 
@@ -18701,7 +18701,7 @@ delete_by_idx(hid_t fapl)
                     else
                         HDsnprintf(objname, sizeof(objname), "filler %02u",
                                    ((max_compact * 2) - ((u * 2) + 2)));
-                    if (HDstrcmp(objname, tmpname))
+                    if (HDstrcmp(objname, tmpname) != 0)
                         TEST_ERROR
                 } /* end for */
 
@@ -18735,7 +18735,7 @@ delete_by_idx(hid_t fapl)
                     else
                         HDsnprintf(objname, sizeof(objname), "filler %02u",
                                    ((max_compact * 2) - ((u * 2) + 4)));
-                    if (HDstrcmp(objname, tmpname))
+                    if (HDstrcmp(objname, tmpname) != 0)
                         TEST_ERROR
                 } /* end for */
 
@@ -18916,7 +18916,7 @@ delete_by_idx_old(hid_t fapl)
                 HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
             else
                 HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
-            if (HDstrcmp(objname, tmpname))
+            if (HDstrcmp(objname, tmpname) != 0)
                 TEST_ERROR
         } /* end for */
 
@@ -18995,7 +18995,7 @@ delete_by_idx_old(hid_t fapl)
                 HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 1));
             else
                 HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
-            if (HDstrcmp(objname, tmpname))
+            if (HDstrcmp(objname, tmpname) != 0)
                 TEST_ERROR
         } /* end for */
 
@@ -19033,7 +19033,7 @@ delete_by_idx_old(hid_t fapl)
                 HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 3));
             else
                 HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
-            if (HDstrcmp(objname, tmpname))
+            if (HDstrcmp(objname, tmpname) != 0)
                 TEST_ERROR
         } /* end for */
 
@@ -19119,7 +19119,7 @@ link_iterate_cb(hid_t group_id, const char *link_name, const H5L_info2_t *info, 
 
     /* Verify name of link */
     HDsnprintf(objname, sizeof(objname), "filler %02u", (unsigned)my_info.corder);
-    if (HDstrcmp(link_name, objname))
+    if (HDstrcmp(link_name, objname) != 0)
         return H5_ITER_ERROR;
 
     /* Check if we've visited this link before */
@@ -19625,7 +19625,7 @@ link_iterate_old_cb(hid_t group_id, const char *link_name, const H5L_info2_t *in
     /* Verify name of link */
     HDsnprintf(objname, sizeof(objname), "filler %02u",
                (info ? (unsigned)op_data->curr : (unsigned)((op_data->ncalled - 1) + op_data->nskipped)));
-    if (HDstrcmp(link_name, objname))
+    if (HDstrcmp(link_name, objname) != 0)
         return H5_ITER_ERROR;
 
     /* Check if we've visited this link before */

--- a/test/links_env.c
+++ b/test/links_env.c
@@ -69,7 +69,7 @@ external_link_env(hid_t fapl, hbool_t new_format)
 
     if ((envval = HDgetenv("HDF5_EXT_PREFIX")) == NULL)
         envval = "nomatch";
-    if (HDstrcmp(envval, ".:tmp_links_env"))
+    if (HDstrcmp(envval, ".:tmp_links_env") != 0)
         TEST_ERROR
 
     /* Set up name for main file:"extlinks_env0" */

--- a/test/mf.c
+++ b/test/mf.c
@@ -872,7 +872,8 @@ test_mf_tmp(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
         TESTING("'temporary' file space allocation with old library format")
 
     /* Can't run this test with multi-file VFDs */
-    if (HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 && HDstrcmp(env_h5_drvr, "family") != 0) {
+    if (HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
+        HDstrcmp(env_h5_drvr, "family") != 0) {
         char           filename[FILENAME_LEN];   /* Filename to use */
         H5F_t *        f = NULL;                 /* Internal file object pointer */
         h5_stat_size_t file_size, new_file_size; /* file size */

--- a/test/mf.c
+++ b/test/mf.c
@@ -230,7 +230,7 @@ test_mf_eoa(const char *env_h5_drvr, hid_t fapl)
     /* Skip test when using VFDs that has different address spaces for each
      *  type of metadata allocation.
      */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -378,7 +378,7 @@ test_mf_eoa_shrink(const char *env_h5_drvr, hid_t fapl)
     /* Skip test when using VFDs that has different address spaces for each
      *  type of metadata allocation.
      */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -665,7 +665,7 @@ test_mf_eoa_extend(const char *env_h5_drvr, hid_t fapl)
     /* Skip test when using VFDs that has different address spaces for each
      *  type of metadata allocation.
      */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -872,7 +872,7 @@ test_mf_tmp(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
         TESTING("'temporary' file space allocation with old library format")
 
     /* Can't run this test with multi-file VFDs */
-    if (HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi") && HDstrcmp(env_h5_drvr, "family")) {
+    if (HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 && HDstrcmp(env_h5_drvr, "family") != 0) {
         char           filename[FILENAME_LEN];   /* Filename to use */
         H5F_t *        f = NULL;                 /* Internal file object pointer */
         h5_stat_size_t file_size, new_file_size; /* file size */
@@ -1998,7 +1998,7 @@ test_mf_fs_absorb(const char *env_h5_drvr, hid_t fapl)
     TESTING("A free-space section absorbs an aggregator: test 1");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -2171,7 +2171,7 @@ test_mf_aggr_alloc1(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_alloc() of meta/sdata aggregator:test 1");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -2322,7 +2322,7 @@ test_mf_aggr_alloc2(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_alloc() of meta/sdata aggregator:test 2");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -2477,7 +2477,7 @@ test_mf_aggr_alloc3(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_alloc() of meta/sdata aggregator: test 3");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -2642,7 +2642,7 @@ test_mf_aggr_alloc4(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_alloc() of meta/sdata aggregator:test 4");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -2788,7 +2788,7 @@ test_mf_aggr_alloc5(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_alloc() of meta/sdata aggregator:test 5");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -2923,7 +2923,7 @@ test_mf_aggr_alloc6(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_alloc() of meta/sdata aggregator:test 6");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -3094,7 +3094,7 @@ test_mf_aggr_alloc7(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_alloc() of meta/sdata aggregator:test 7");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -3262,7 +3262,7 @@ test_mf_aggr_extend(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_try_extend() of meta/sdata aggregator: test 1");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -3557,7 +3557,7 @@ test_mf_aggr_absorb(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_try_shrink() of meta/sdata aggregator: test 1");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -3808,8 +3808,8 @@ test_mf_align_eoa(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     /* Skip test when using VFDs that have their own 'alloc' callback, which
      *  don't push mis-aligned space fragments on the file free space list
      */
-    have_alloc_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "stdio") && HDstrcmp(env_h5_drvr, "split") &&
-                               HDstrcmp(env_h5_drvr, "multi"));
+    have_alloc_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "stdio") != 0 && HDstrcmp(env_h5_drvr, "split") != 0 &&
+                               HDstrcmp(env_h5_drvr, "multi") != 0);
     if (have_alloc_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -4249,8 +4249,8 @@ test_mf_align_fs(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     /* Skip test when using VFDs that have their own 'alloc' callback, which
      *  don't push mis-aligned space fragments on the file free space list
      */
-    have_alloc_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "stdio") && HDstrcmp(env_h5_drvr, "split") &&
-                               HDstrcmp(env_h5_drvr, "multi"));
+    have_alloc_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "stdio") != 0 && HDstrcmp(env_h5_drvr, "split") != 0 &&
+                               HDstrcmp(env_h5_drvr, "multi") != 0);
     if (have_alloc_vfd) {
         if ((file_size = h5_get_file_size(filename, new_fapl)) < 0)
             TEST_ERROR
@@ -4452,8 +4452,8 @@ test_mf_align_alloc1(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     /* Skip test when using VFDs that have their own 'alloc' callback, which
      *  don't push mis-aligned space fragments on the file free space list
      */
-    have_alloc_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "stdio") && HDstrcmp(env_h5_drvr, "split") &&
-                               HDstrcmp(env_h5_drvr, "multi"));
+    have_alloc_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "stdio") != 0 && HDstrcmp(env_h5_drvr, "split") != 0 &&
+                               HDstrcmp(env_h5_drvr, "multi") != 0);
     if (have_alloc_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -4711,8 +4711,8 @@ test_mf_align_alloc2(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     /* Skip test when using VFDs that have their own 'alloc' callback, which
      *  don't push mis-aligned space fragments on the file free space list
      */
-    have_alloc_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "stdio") && HDstrcmp(env_h5_drvr, "split") &&
-                               HDstrcmp(env_h5_drvr, "multi"));
+    have_alloc_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "stdio") != 0 && HDstrcmp(env_h5_drvr, "split") != 0 &&
+                               HDstrcmp(env_h5_drvr, "multi") != 0);
     if (have_alloc_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -5053,8 +5053,8 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     /* Skip test when using VFDs that have their own 'alloc' callback, which
      *  don't push mis-aligned space fragments on the file free space list
      */
-    have_alloc_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "stdio") && HDstrcmp(env_h5_drvr, "split") &&
-                               HDstrcmp(env_h5_drvr, "multi"));
+    have_alloc_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "stdio") != 0 && HDstrcmp(env_h5_drvr, "split") != 0 &&
+                               HDstrcmp(env_h5_drvr, "multi") != 0);
     if (have_alloc_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -5363,8 +5363,8 @@ test_mf_align_alloc4(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     /* Skip test when using VFDs that have their own 'alloc' callback, which
      *  don't push mis-aligned space fragments on the file free space list
      */
-    have_alloc_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "stdio") && HDstrcmp(env_h5_drvr, "split") &&
-                               HDstrcmp(env_h5_drvr, "multi"));
+    have_alloc_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "stdio") != 0 && HDstrcmp(env_h5_drvr, "split") != 0 &&
+                               HDstrcmp(env_h5_drvr, "multi") != 0);
     if (have_alloc_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -5578,8 +5578,8 @@ test_mf_align_alloc5(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     /* Skip test when using VFDs that have their own 'alloc' callback, which
      *  don't push mis-aligned space fragments on the file free space list
      */
-    have_alloc_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "stdio") && HDstrcmp(env_h5_drvr, "split") &&
-                               HDstrcmp(env_h5_drvr, "multi"));
+    have_alloc_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "stdio") != 0 && HDstrcmp(env_h5_drvr, "split") != 0 &&
+                               HDstrcmp(env_h5_drvr, "multi") != 0);
     if (have_alloc_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -5845,8 +5845,8 @@ test_mf_align_alloc6(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     /* Skip test when using VFDs that have their own 'alloc' callback, which
      *  don't push mis-aligned space fragments on the file free space list
      */
-    have_alloc_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "stdio") && HDstrcmp(env_h5_drvr, "split") &&
-                               HDstrcmp(env_h5_drvr, "multi"));
+    have_alloc_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "stdio") != 0 && HDstrcmp(env_h5_drvr, "split") != 0 &&
+                               HDstrcmp(env_h5_drvr, "multi") != 0);
     if (have_alloc_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -6856,7 +6856,7 @@ test_mf_fs_persist(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
     else
         TESTING("File's free-space is persistent with old library format")
 
-    if (HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi")) {
+    if (HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0) {
 
         /* File creation property list template */
         if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
@@ -7033,7 +7033,7 @@ test_mf_fs_gone(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
         TESTING("File's free-space is going away with old library format")
 
     /* Current VFD that does not support contigous address space */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
 
     if (contig_addr_vfd) {
 
@@ -7224,7 +7224,7 @@ test_mf_strat_thres_persist(const char *env_h5_drvr, hid_t fapl, hbool_t new_for
         TESTING("File space strategy/persisting/threshold with old library format")
 
     /* Current VFD that does not support contigous address space */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -7394,7 +7394,7 @@ test_mf_strat_thres_gone(const char *env_h5_drvr, hid_t fapl, hbool_t new_format
         TESTING("File space merge/shrink for section size < threshold with old library format")
 
     /* Current VFD that does not support contigous address space */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -7956,7 +7956,7 @@ test_page_try_shrink(const char *env_h5_drvr, hid_t fapl)
     TESTING("Paged aggregation for file space: H5MF_try_shrink()");
 
     /* Current VFD that does not support continuous address space */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
 
     if (contig_addr_vfd) {
 
@@ -8085,8 +8085,8 @@ test_page_small_try_extend(const char *env_h5_drvr, hid_t fapl)
     TESTING("Paged aggregation for file space: H5MF_try_extend() a small block");
 
     /* Current VFD that does not support continuous address space */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi") &&
-                                HDstrcmp(env_h5_drvr, "family"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
+                                HDstrcmp(env_h5_drvr, "family") != 0);
 
     if (contig_addr_vfd) {
 
@@ -8264,7 +8264,7 @@ test_page_large_try_extend(const char *env_h5_drvr, hid_t fapl)
     TESTING("Paged aggregation for file space: H5MF_try_extend() a large block");
 
     /* Current VFD that does not support continuous address space */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
 
     if (contig_addr_vfd) {
 
@@ -8428,7 +8428,7 @@ test_page_large(const char *env_h5_drvr, hid_t fapl)
     TESTING("Paged aggregation for file space: large allocations and de-allocations");
 
     /* Current VFD that does not support continuous address space */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
 
     if (contig_addr_vfd) {
 

--- a/test/mount.c
+++ b/test/mount.c
@@ -1547,7 +1547,7 @@ test_mount_after_close(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(gidABMX, objname, (size_t)NAME_BUF_SIZE) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp(objname, "/A/B/M/X"))
+    if (HDstrcmp(objname, "/A/B/M/X") != 0)
         TEST_ERROR
 
     /* Close object in mounted file */
@@ -1562,7 +1562,7 @@ test_mount_after_close(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(gidABC, objname, (size_t)NAME_BUF_SIZE) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp(objname, "/A/B/C"))
+    if (HDstrcmp(objname, "/A/B/C") != 0)
         TEST_ERROR
 
     /* Close object in mounted file */
@@ -1577,7 +1577,7 @@ test_mount_after_close(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(gidABT, objname, (size_t)NAME_BUF_SIZE) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp(objname, "/A/B/T"))
+    if (HDstrcmp(objname, "/A/B/T") != 0)
         TEST_ERROR
 
     /* Close object in original file */
@@ -1592,7 +1592,7 @@ test_mount_after_close(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(didABMXYD, objname, (size_t)NAME_BUF_SIZE) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp(objname, "/A/B/M/X/Y/D"))
+    if (HDstrcmp(objname, "/A/B/M/X/Y/D") != 0)
         TEST_ERROR
 
     /* Close object in mounted file */
@@ -1765,7 +1765,7 @@ test_mount_after_unmount(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(gidAMXX, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/A/M/X/X"))
+    if (HDstrcmp(objname, "/A/M/X/X") != 0)
         TEST_ERROR
 
     /* Open group in mounted file #2 */
@@ -1785,7 +1785,7 @@ test_mount_after_unmount(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(gidAMXMY, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/A/M/X/M/Y"))
+    if (HDstrcmp(objname, "/A/M/X/M/Y") != 0)
         TEST_ERROR
 
     /* Unmount second file */
@@ -1796,7 +1796,7 @@ test_mount_after_unmount(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(gidAMXMY, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/X/M/Y"))
+    if (HDstrcmp(objname, "/X/M/Y") != 0)
         TEST_ERROR
 
     /* Rename object in file #3 that is "disconnected" from name hiearchy */
@@ -1816,7 +1816,7 @@ test_mount_after_unmount(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(gidAMXMY, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/X/M/Z"))
+    if (HDstrcmp(objname, "/X/M/Z") != 0)
         TEST_ERROR
 
     /* Mount fourth file */
@@ -1832,7 +1832,7 @@ test_mount_after_unmount(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(gidBMZ, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(objname, "/B/M/Z"))
+    if (HDstrcmp(objname, "/B/M/Z") != 0)
         TEST_ERROR
 
     /* Unmount third file */
@@ -3080,7 +3080,7 @@ test_mult_mount(hid_t fapl)
     *name = '\0';
     if (H5Iget_name(gidAMT, name, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(name, "/A/M/T"))
+    if (HDstrcmp(name, "/A/M/T") != 0)
         TEST_ERROR
 
     /* Create object in file #3 */
@@ -3098,7 +3098,7 @@ test_mult_mount(hid_t fapl)
     *name = '\0';
     if (H5Iget_name(gidBS, name, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(name, "/B/S"))
+    if (HDstrcmp(name, "/B/S") != 0)
         TEST_ERROR
 
     /* Re-open object created in file #3 through file #1 mount path */
@@ -3279,7 +3279,7 @@ test_nested_survive(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidAM, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR
-    if (name_len == 0 || HDstrcmp(name, "/A/M"))
+    if (name_len == 0 || HDstrcmp(name, "/A/M") != 0)
         TEST_ERROR
 
     /* Unmount file #2 from file #1 */
@@ -3290,7 +3290,7 @@ test_nested_survive(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidAM, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR
-    if (name_len != 0 || HDstrcmp(name, ""))
+    if (name_len != 0 || HDstrcmp(name, "") != 0)
         TEST_ERROR
 
     /* Open object in file #3 through file #1 mount path (should fail) */
@@ -3307,7 +3307,7 @@ test_nested_survive(hid_t fapl)
     *name = '\0';
     if (H5Iget_name(gidMS, name, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(name, "/M/S"))
+    if (HDstrcmp(name, "/M/S") != 0)
         TEST_ERROR
 
     /* Close group in file #3 */
@@ -3326,7 +3326,7 @@ test_nested_survive(hid_t fapl)
     *name = '\0';
     if (H5Iget_name(gidAMS, name, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR
-    if (HDstrcmp(name, "/A/M/S"))
+    if (HDstrcmp(name, "/A/M/S") != 0)
         TEST_ERROR
 
     /* Close group in file #3 */
@@ -3475,7 +3475,7 @@ test_close_parent(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidM, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR
-    if (name_len == 0 || HDstrcmp(name, "/A/M"))
+    if (name_len == 0 || HDstrcmp(name, "/A/M") != 0)
         TEST_ERROR
 
     /* Unmount file #2 from file #1, closing file #1 */
@@ -3486,7 +3486,7 @@ test_close_parent(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidM, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR
-    if (name_len == 0 || HDstrcmp(name, "/M"))
+    if (name_len == 0 || HDstrcmp(name, "/M") != 0)
         TEST_ERROR
 
     /* Just file #2's underlying shared file should be open still */
@@ -3753,7 +3753,7 @@ test_cut_graph(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidM, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR
-    if (name_len == 0 || HDstrcmp(name, "/A/E/M"))
+    if (name_len == 0 || HDstrcmp(name, "/A/E/M") != 0)
         TEST_ERROR
 
     /* Open object in file #7 */
@@ -3764,7 +3764,7 @@ test_cut_graph(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidQ, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR
-    if (name_len == 0 || HDstrcmp(name, "/B/I/Q"))
+    if (name_len == 0 || HDstrcmp(name, "/B/I/Q") != 0)
         TEST_ERROR
 
     /* Close file #1 */
@@ -3821,7 +3821,7 @@ test_cut_graph(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidK, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR
-    if (name_len == 0 || HDstrcmp(name, "/D/K"))
+    if (name_len == 0 || HDstrcmp(name, "/D/K") != 0)
         TEST_ERROR
 
     if (H5Gclose(gidK) < 0)
@@ -3841,7 +3841,7 @@ test_cut_graph(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidO, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR
-    if (name_len == 0 || HDstrcmp(name, "/B/H/O"))
+    if (name_len == 0 || HDstrcmp(name, "/B/H/O") != 0)
         TEST_ERROR
 
     if (H5Gclose(gidO) < 0)
@@ -3851,14 +3851,14 @@ test_cut_graph(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidM, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR
-    if (name_len == 0 || HDstrcmp(name, "/E/M"))
+    if (name_len == 0 || HDstrcmp(name, "/E/M") != 0)
         TEST_ERROR
 
     /* Check the name of "Q" is still defined */
     *name = '\0';
     if ((name_len = H5Iget_name(gidQ, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR
-    if (name_len == 0 || HDstrcmp(name, "/B/I/Q"))
+    if (name_len == 0 || HDstrcmp(name, "/B/I/Q") != 0)
         TEST_ERROR
 
     /* Check that all seven underlying files are still opened */
@@ -3883,7 +3883,7 @@ test_cut_graph(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidQ, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR
-    if (name_len == 0 || HDstrcmp(name, "/I/Q"))
+    if (name_len == 0 || HDstrcmp(name, "/I/Q") != 0)
         TEST_ERROR
 
     /* Open object in file #6 from file #7 */
@@ -3894,7 +3894,7 @@ test_cut_graph(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidO, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR
-    if (name_len == 0 || HDstrcmp(name, "/H/O"))
+    if (name_len == 0 || HDstrcmp(name, "/H/O") != 0)
         TEST_ERROR
 
     if (H5Gclose(gidO) < 0)
@@ -4060,7 +4060,7 @@ test_symlink(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidL, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR
-    if (name_len == 0 || HDstrcmp(name, "/L"))
+    if (name_len == 0 || HDstrcmp(name, "/L") != 0)
         TEST_ERROR
 
     /* Close file #1 */

--- a/test/objcopy.c
+++ b/test/objcopy.c
@@ -1103,7 +1103,7 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
 
                 /* Iterate over all elements, calling memcmp() for each */
                 for (elmt = 0; elmt < nelmts; elmt++) {
-                    if (HDmemcmp(memb1, memb2, memb_size))
+                    if (HDmemcmp(memb1, memb2, memb_size) != 0)
                         TEST_ERROR
 
                     /* Update member pointers */
@@ -1325,7 +1325,7 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
         else
             TEST_ERROR
     } /* end else */
-    else if (HDmemcmp(buf1, buf2, (elmt_size * nelmts)))
+    else if (HDmemcmp(buf1, buf2, (elmt_size * nelmts)) != 0)
         TEST_ERROR
 
     /* Data should be the same. :-) */
@@ -1596,7 +1596,7 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
             if (H5Lget_name_by_idx(gid2, ".", H5_INDEX_NAME, H5_ITER_INC, idx, objname2,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR
-            if (HDstrcmp(objname, objname2))
+            if (HDstrcmp(objname, objname2) != 0)
                 TEST_ERROR
 
             /* Get link info */
@@ -1710,7 +1710,7 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
                         TEST_ERROR
 
                     /* Compare link data */
-                    if (HDmemcmp(linkval, linkval2, linfo.u.val_size))
+                    if (HDmemcmp(linkval, linkval2, linfo.u.val_size) != 0)
                         TEST_ERROR
                 } /* end else-if */
                 else {
@@ -7025,7 +7025,7 @@ compare_attribute_compound_vlstr(hid_t loc, hid_t loc2)
         FAIL_STACK_ERROR
     if (HDstrlen(rbuf.v) != HDstrlen(rbuf2.v))
         FAIL_STACK_ERROR
-    if (HDmemcmp(rbuf.v, rbuf2.v, HDstrlen(rbuf.v)))
+    if (HDmemcmp(rbuf.v, rbuf2.v, HDstrlen(rbuf.v)) != 0)
         FAIL_STACK_ERROR
 
     /* Reclaim vlen buffer */
@@ -11695,9 +11695,9 @@ test_copy_null_ref(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fap
         TEST_ERROR
 
     /* Verify that the references contain only "0" bytes */
-    if (HDmemcmp(obj_buf, zeros, sizeof(obj_buf)))
+    if (HDmemcmp(obj_buf, zeros, sizeof(obj_buf)) != 0)
         TEST_ERROR
-    if (HDmemcmp(reg_buf, zeros, sizeof(reg_buf)))
+    if (HDmemcmp(reg_buf, zeros, sizeof(reg_buf)) != 0)
         TEST_ERROR
 
     /* Close datasets */
@@ -11740,9 +11740,9 @@ test_copy_null_ref(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fap
         TEST_ERROR
 
     /* Verify that the references contain only "0" bytes */
-    if (HDmemcmp(obj_buf, zeros, sizeof(obj_buf)))
+    if (HDmemcmp(obj_buf, zeros, sizeof(obj_buf)) != 0)
         TEST_ERROR
-    if (HDmemcmp(reg_buf, zeros, sizeof(reg_buf)))
+    if (HDmemcmp(reg_buf, zeros, sizeof(reg_buf)) != 0)
         TEST_ERROR
 
     /* Close */
@@ -11902,9 +11902,9 @@ test_copy_null_ref_open(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t ds
         TEST_ERROR
 
     /* Verify that the references contain only "0" bytes */
-    if (HDmemcmp(obj_buf, zeros, sizeof(obj_buf)))
+    if (HDmemcmp(obj_buf, zeros, sizeof(obj_buf)) != 0)
         TEST_ERROR
-    if (HDmemcmp(reg_buf, zeros, sizeof(reg_buf)))
+    if (HDmemcmp(reg_buf, zeros, sizeof(reg_buf)) != 0)
         TEST_ERROR
 
     /* Create destination file */
@@ -11947,9 +11947,9 @@ test_copy_null_ref_open(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t ds
         TEST_ERROR
 
     /* Verify that the references contain only "0" bytes */
-    if (HDmemcmp(obj_buf, zeros, sizeof(obj_buf)))
+    if (HDmemcmp(obj_buf, zeros, sizeof(obj_buf)) != 0)
         TEST_ERROR
-    if (HDmemcmp(reg_buf, zeros, sizeof(reg_buf)))
+    if (HDmemcmp(reg_buf, zeros, sizeof(reg_buf)) != 0)
         TEST_ERROR
 
     /* Close */

--- a/test/objcopy_ref.c
+++ b/test/objcopy_ref.c
@@ -887,7 +887,7 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
 
                 /* Iterate over all elements, calling memcmp() for each */
                 for (elmt = 0; elmt < nelmts; elmt++) {
-                    if (HDmemcmp(memb1, memb2, memb_size))
+                    if (HDmemcmp(memb1, memb2, memb_size) != 0)
                         TEST_ERROR
 
                     /* Update member pointers */
@@ -1035,7 +1035,7 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
         else
             TEST_ERROR
     } /* end else */
-    else if (HDmemcmp(buf1, buf2, (elmt_size * nelmts)))
+    else if (HDmemcmp(buf1, buf2, (elmt_size * nelmts)) != 0)
         TEST_ERROR
 
     /* Data should be the same. :-) */
@@ -1306,7 +1306,7 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
             if (H5Lget_name_by_idx(gid2, ".", H5_INDEX_NAME, H5_ITER_INC, idx, objname2,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR
-            if (HDstrcmp(objname, objname2))
+            if (HDstrcmp(objname, objname2) != 0)
                 TEST_ERROR
 
             /* Get link info */
@@ -1420,7 +1420,7 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
                         TEST_ERROR
 
                     /* Compare link data */
-                    if (HDmemcmp(linkval, linkval2, linfo.u.val_size))
+                    if (HDmemcmp(linkval, linkval2, linfo.u.val_size) != 0)
                         TEST_ERROR
                 } /* end else-if */
                 else {

--- a/test/ohdr.c
+++ b/test/ohdr.c
@@ -907,7 +907,7 @@ test_minimized_dset_ohdr_attribute_addition(hid_t fapl_id)
     /* Read the data back and verify */
     if (H5Aread(aid, H5T_NATIVE_CHAR, out_buf) < 0)
         TEST_ERROR;
-    if (HDstrcmp(in_buf, out_buf))
+    if (HDstrcmp(in_buf, out_buf) != 0)
         TEST_ERROR;
 
     /* modify the string attribute */
@@ -922,7 +922,7 @@ test_minimized_dset_ohdr_attribute_addition(hid_t fapl_id)
     /* Read the data back and verify */
     if (H5Aread(aid, H5T_NATIVE_CHAR, out_buf) < 0)
         TEST_ERROR;
-    if (HDstrcmp(in_buf, out_buf))
+    if (HDstrcmp(in_buf, out_buf) != 0)
         TEST_ERROR;
 
     /* Close */
@@ -1753,8 +1753,8 @@ main(void)
         env_h5_drvr = "nomatch";
 
     /* Check for VFD which stores data in multiple files */
-    single_file_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi") &&
-                                HDstrcmp(env_h5_drvr, "family"));
+    single_file_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
+                                HDstrcmp(env_h5_drvr, "family") != 0);
 
     /* Reset library */
     h5_reset();

--- a/test/set_extent.c
+++ b/test/set_extent.c
@@ -121,7 +121,7 @@ main(void)
     if (env_h5_drvr == NULL)
         env_h5_drvr = "nomatch";
     /* Current VFD that does not support contigous address space */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
 
     /* Initialize random number seed */
     HDsrandom((unsigned)HDtime(NULL));

--- a/test/stab.c
+++ b/test/stab.c
@@ -134,7 +134,7 @@ test_misc(hid_t fcpl, hid_t fapl, hbool_t new_format)
         TEST_ERROR
     if (H5Oget_comment_by_name(g3, "././.", comment, sizeof comment, H5P_DEFAULT) < 0)
         TEST_ERROR
-    if (HDstrcmp(comment, "hello world")) {
+    if (HDstrcmp(comment, "hello world") != 0) {
         H5_FAILED();
         HDputs("    Read the wrong comment string from the group.");
         HDprintf("    got: \"%s\"\n    ans: \"hello world\"\n", comment);
@@ -1416,7 +1416,7 @@ main(void)
         env_h5_drvr = "nomatch";
 
     /* VFD that does not support contigous address space */
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
 
     /* Reset library */
     h5_reset();

--- a/test/swmr_generator.c
+++ b/test/swmr_generator.c
@@ -286,7 +286,7 @@ main(int argc, const char *argv[])
                     /* Chunk index type */
                     case 'i':
                         index_type = argv[u + 1];
-                        if (HDstrcmp(index_type, "ea") && HDstrcmp(index_type, "b2"))
+                        if (HDstrcmp(index_type, "ea") != 0 && HDstrcmp(index_type, "b2") != 0)
                             usage();
                         u += 2;
                         break;

--- a/test/swmr_start_write.c
+++ b/test/swmr_start_write.c
@@ -385,7 +385,7 @@ main(int argc, const char *argv[])
                     /* Chunk index type */
                     case 'i':
                         index_type = argv[u + 1];
-                        if (HDstrcmp(index_type, "ea") && HDstrcmp(index_type, "b2"))
+                        if (HDstrcmp(index_type, "ea") != 0 && HDstrcmp(index_type, "b2") != 0)
                             usage();
                         u += 2;
                         break;

--- a/test/tattr.c
+++ b/test/tattr.c
@@ -859,8 +859,8 @@ test_attr_compound_read(hid_t fapl)
     VERIFY(fields, 3, "H5Tget_nmembers");
     for (i = 0; i < fields; i++) {
         fieldname = H5Tget_member_name(type, (unsigned)i);
-        if (!(HDstrcmp(fieldname, ATTR4_FIELDNAME1) || HDstrcmp(fieldname, ATTR4_FIELDNAME2) ||
-              HDstrcmp(fieldname, ATTR4_FIELDNAME3)))
+        if (!(HDstrcmp(fieldname, ATTR4_FIELDNAME1) != 0 || HDstrcmp(fieldname, ATTR4_FIELDNAME2) != 0 ||
+              HDstrcmp(fieldname, ATTR4_FIELDNAME3) != 0))
             TestErrPrintf("invalid field name for field #%d: %s\n", i, fieldname);
         H5free_memory(fieldname);
     } /* end for */
@@ -907,7 +907,7 @@ test_attr_compound_read(hid_t fapl)
     /* Verify values read in */
     for (i = 0; i < ATTR4_DIM1; i++)
         for (j = 0; j < ATTR4_DIM2; j++)
-            if (HDmemcmp(&attr_data4[i][j], &read_data4[i][j], sizeof(struct attr4_struct))) {
+            if (HDmemcmp(&attr_data4[i][j], &read_data4[i][j], sizeof(struct attr4_struct)) != 0) {
                 HDprintf("%d: attribute data different: attr_data4[%d][%d].i=%d, read_data4[%d][%d].i=%d\n",
                          __LINE__, i, j, attr_data4[i][j].i, i, j, read_data4[i][j].i);
                 HDprintf("%d: attribute data different: attr_data4[%d][%d].d=%f, read_data4[%d][%d].d=%f\n",
@@ -920,7 +920,7 @@ test_attr_compound_read(hid_t fapl)
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
     VERIFY(name_len, HDstrlen(ATTR4_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR4_NAME))
+    if (HDstrcmp(attr_name, ATTR4_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR4_NAME);
 
     /* Close attribute datatype */
@@ -1279,7 +1279,7 @@ test_attr_mult_read(hid_t fapl)
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
     VERIFY(name_len, HDstrlen(ATTR1_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR1_NAME))
+    if (HDstrcmp(attr_name, ATTR1_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR1_NAME);
 
     /* Verify Name with too small of a buffer */
@@ -1287,7 +1287,7 @@ test_attr_mult_read(hid_t fapl)
     VERIFY(name_len, HDstrlen(ATTR1_NAME), "H5Aget_name");
     HDstrcpy(temp_name, ATTR1_NAME);            /* make a copy of the name */
     temp_name[HDstrlen(ATTR1_NAME) - 1] = '\0'; /* truncate it to match the one retrieved */
-    if (HDstrcmp(attr_name, temp_name))
+    if (HDstrcmp(attr_name, temp_name) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, temp_name);
 
     /* Close attribute */
@@ -1337,7 +1337,7 @@ test_attr_mult_read(hid_t fapl)
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
     VERIFY(name_len, HDstrlen(ATTR2_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR2_NAME))
+    if (HDstrcmp(attr_name, ATTR2_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR2_NAME);
 
     /* Verify Name with too small of a buffer */
@@ -1345,7 +1345,7 @@ test_attr_mult_read(hid_t fapl)
     VERIFY(name_len, HDstrlen(ATTR2_NAME), "H5Aget_name");
     HDstrcpy(temp_name, ATTR2_NAME);            /* make a copy of the name */
     temp_name[HDstrlen(ATTR2_NAME) - 1] = '\0'; /* truncate it to match the one retrieved */
-    if (HDstrcmp(attr_name, temp_name))
+    if (HDstrcmp(attr_name, temp_name) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, temp_name);
 
     /* Close attribute */
@@ -1399,7 +1399,7 @@ test_attr_mult_read(hid_t fapl)
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
     VERIFY(name_len, HDstrlen(ATTR3_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR3_NAME))
+    if (HDstrcmp(attr_name, ATTR3_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR3_NAME);
 
     /* Verify Name with too small of a buffer */
@@ -1407,7 +1407,7 @@ test_attr_mult_read(hid_t fapl)
     VERIFY(name_len, HDstrlen(ATTR3_NAME), "H5Aget_name");
     HDstrcpy(temp_name, ATTR3_NAME);            /* make a copy of the name */
     temp_name[HDstrlen(ATTR3_NAME) - 1] = '\0'; /* truncate it to match the one retrieved */
-    if (HDstrcmp(attr_name, temp_name))
+    if (HDstrcmp(attr_name, temp_name) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, temp_name);
 
     /* Close attribute */
@@ -1436,19 +1436,19 @@ attr_op1(hid_t H5_ATTR_UNUSED loc_id, const char *name, const H5A_info_t H5_ATTR
 
     switch (*count) {
         case 0:
-            if (HDstrcmp(name, ATTR1_NAME))
+            if (HDstrcmp(name, ATTR1_NAME) != 0)
                 TestErrPrintf("attribute name different: name=%s, should be %s\n", name, ATTR1_NAME);
             (*count)++;
             break;
 
         case 1:
-            if (HDstrcmp(name, ATTR2_NAME))
+            if (HDstrcmp(name, ATTR2_NAME) != 0)
                 TestErrPrintf("attribute name different: name=%s, should be %s\n", name, ATTR2_NAME);
             (*count)++;
             break;
 
         case 2:
-            if (HDstrcmp(name, ATTR3_NAME))
+            if (HDstrcmp(name, ATTR3_NAME) != 0)
                 TestErrPrintf("attribute name different: name=%s, should be %s\n", name, ATTR3_NAME);
             (*count)++;
             break;
@@ -1590,7 +1590,7 @@ test_attr_delete(hid_t fapl)
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
     VERIFY(name_len, HDstrlen(ATTR1_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR1_NAME))
+    if (HDstrcmp(attr_name, ATTR1_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR1_NAME);
 
     /* Close attribute */
@@ -1605,7 +1605,7 @@ test_attr_delete(hid_t fapl)
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
     VERIFY(name_len, HDstrlen(ATTR3_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR3_NAME))
+    if (HDstrcmp(attr_name, ATTR3_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR3_NAME);
 
     /* Close attribute */
@@ -1629,7 +1629,7 @@ test_attr_delete(hid_t fapl)
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
     VERIFY(name_len, HDstrlen(ATTR3_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR3_NAME))
+    if (HDstrcmp(attr_name, ATTR3_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR3_NAME);
 
     /* Close attribute */
@@ -2123,7 +2123,7 @@ test_attr_dense_verify(hid_t loc_id, unsigned max_attr)
         HDsprintf(attrname, "attr %02u", u);
         name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, check_name);
         VERIFY(name_len, HDstrlen(attrname), "H5Aget_name");
-        if (HDstrcmp(check_name, attrname))
+        if (HDstrcmp(check_name, attrname) != 0)
             TestErrPrintf("attribute name different: attrname = '%s', should be '%s'\n", check_name,
                           attrname);
 
@@ -5658,7 +5658,7 @@ attr_info_by_idx_check(hid_t obj_id, const char *attrname, hsize_t n, hbool_t us
     ret = (herr_t)H5Aget_name_by_idx(obj_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, tmpname,
                                      (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Aget_name_by_idx");
-    if (HDstrcmp(attrname, tmpname))
+    if (HDstrcmp(attrname, tmpname) != 0)
         TestErrPrintf("Line %d: attribute name size wrong!\n", __LINE__);
 
     /* Don't test "native" order if there is no creation order index, since
@@ -5684,7 +5684,7 @@ attr_info_by_idx_check(hid_t obj_id, const char *attrname, hsize_t n, hbool_t us
         ret = (herr_t)H5Aget_name_by_idx(obj_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, n, tmpname,
                                          (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
         CHECK(ret, FAIL, "H5Aget_name_by_idx");
-        if (HDstrcmp(attrname, tmpname))
+        if (HDstrcmp(attrname, tmpname) != 0)
             TestErrPrintf("Line %d: attribute name size wrong!\n", __LINE__);
     } /* end if */
 
@@ -5705,7 +5705,7 @@ attr_info_by_idx_check(hid_t obj_id, const char *attrname, hsize_t n, hbool_t us
     ret = (herr_t)H5Aget_name_by_idx(obj_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, tmpname,
                                      (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Aget_name_by_idx");
-    if (HDstrcmp(attrname, tmpname))
+    if (HDstrcmp(attrname, tmpname) != 0)
         TestErrPrintf("Line %d: attribute name size wrong!\n", __LINE__);
 
     /* Verify the information for first attribute, in increasing name order */
@@ -5725,7 +5725,7 @@ attr_info_by_idx_check(hid_t obj_id, const char *attrname, hsize_t n, hbool_t us
     ret = (herr_t)H5Aget_name_by_idx(obj_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, tmpname,
                                      (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Aget_name_by_idx");
-    if (HDstrcmp(attrname, tmpname))
+    if (HDstrcmp(attrname, tmpname) != 0)
         TestErrPrintf("Line %d: attribute name size wrong!\n", __LINE__);
 
     /* Don't test "native" order queries on link name order, since there's not
@@ -5749,7 +5749,7 @@ attr_info_by_idx_check(hid_t obj_id, const char *attrname, hsize_t n, hbool_t us
     ret = (herr_t)H5Aget_name_by_idx(obj_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, tmpname,
                                      (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Aget_name_by_idx");
-    if (HDstrcmp(attrname, tmpname))
+    if (HDstrcmp(attrname, tmpname) != 0)
         TestErrPrintf("Line %d: attribute name size wrong!\n", __LINE__);
 
     /* Retrieve current # of errors */
@@ -6782,7 +6782,7 @@ attr_iterate2_cb(hid_t loc_id, const char *attr_name, const H5A_info_t *info, vo
 
     /* Verify name of link */
     HDsprintf(attrname, "attr %02u", (unsigned)my_info.corder);
-    if (HDstrcmp(attr_name, attrname))
+    if (HDstrcmp(attr_name, attrname) != 0)
         return (H5_ITER_ERROR);
 
     /* Check if we've visited this link before */

--- a/test/tfile.c
+++ b/test/tfile.c
@@ -3834,7 +3834,7 @@ test_filespace_info(const char *env_h5_drvr)
     MESSAGE(5, ("Testing file creation public routines: H5Pget/set_file_space_strategy & "
                 "H5Pget/set_file_space_page_size\n"));
 
-    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi"));
+    contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
 
     fapl = h5_fileaccess();
     h5_fixname(FILESPACE_NAME[0], fapl, filename, sizeof filename);

--- a/test/th5s.c
+++ b/test/th5s.c
@@ -2398,7 +2398,7 @@ test_h5s_compound_scalar_read(void)
 
     ret = H5Dread(dataset, type, H5S_ALL, H5S_ALL, H5P_DEFAULT, &rdata);
     CHECK(ret, FAIL, "H5Dread");
-    if (HDmemcmp(&space4_data, &rdata, sizeof(struct space4_struct))) {
+    if (HDmemcmp(&space4_data, &rdata, sizeof(struct space4_struct)) != 0) {
         HDprintf("scalar data different: space4_data.c1=%c, read_data4.c1=%c\n", space4_data.c1, rdata.c1);
         HDprintf("scalar data different: space4_data.u=%u, read_data4.u=%u\n", space4_data.u, rdata.u);
         HDprintf("scalar data different: space4_data.f=%f, read_data4.f=%f\n", (double)space4_data.f,

--- a/test/titerate.c
+++ b/test/titerate.c
@@ -570,7 +570,7 @@ liter_cb2(hid_t loc_id, const char *name, const H5L_info2_t H5_ATTR_UNUSED *link
     H5O_info2_t      oinfo;
     herr_t           ret; /* Generic return value        */
 
-    if (HDstrcmp(name, test_info->name)) {
+    if (HDstrcmp(name, test_info->name) != 0) {
         TestErrPrintf("name = '%s', test_info = '%s'\n", name, test_info->name);
         return (H5_ITER_ERROR);
     } /* end if */

--- a/test/tmisc.c
+++ b/test/tmisc.c
@@ -2083,11 +2083,11 @@ test_misc12(void)
     CHECK(ret, FAIL, "H5Dread");
 
     for (i = 0; i < MISC12_SPACE1_DIM1; i++)
-        if (HDstrcmp(wdata[i], rdata[i]))
+        if (HDstrcmp(wdata[i], rdata[i]) != 0)
             TestErrPrintf("Error on line %d: wdata[%d]=%s, rdata[%d]=%s\n", __LINE__, i, wdata[i], i,
                           rdata[i]);
     for (; i < (MISC12_SPACE1_DIM1 + MISC12_APPEND_SIZE); i++)
-        if (HDstrcmp(wdata1[i - MISC12_SPACE1_DIM1], rdata[i]))
+        if (HDstrcmp(wdata1[i - MISC12_SPACE1_DIM1], rdata[i]) != 0)
             TestErrPrintf("Error on line %d: wdata1[%d]=%s, rdata[%d]=%s\n", __LINE__, i - MISC12_SPACE1_DIM1,
                           wdata1[i - MISC12_SPACE1_DIM1], i, rdata[i]);
 

--- a/test/tselect.c
+++ b/test/tselect.c
@@ -1515,7 +1515,7 @@ test_select_hyper_contig(hid_t dset_type, hid_t xfer_plist)
     CHECK(ret, FAIL, "H5Dread");
 
     /* Compare data read with data written out */
-    if (HDmemcmp(rbuf, wbuf, sizeof(uint16_t) * 30 * 12))
+    if (HDmemcmp(rbuf, wbuf, sizeof(uint16_t) * 30 * 12) != 0)
         TestErrPrintf("hyperslab values don't match! Line=%d\n", __LINE__);
 
     /* Close memory dataspace */
@@ -1658,7 +1658,7 @@ test_select_hyper_contig2(hid_t dset_type, hid_t xfer_plist)
     CHECK(ret, FAIL, "H5Dread");
 
     /* Compare data read with data written out */
-    if (HDmemcmp(rbuf, wbuf, sizeof(uint16_t) * 2 * SPACE8_DIM3 * SPACE8_DIM2 * SPACE8_DIM1))
+    if (HDmemcmp(rbuf, wbuf, sizeof(uint16_t) * 2 * SPACE8_DIM3 * SPACE8_DIM2 * SPACE8_DIM1) != 0)
         TestErrPrintf("Error: hyperslab values don't match!\n");
 
     /* Close memory dataspace */
@@ -3765,7 +3765,7 @@ test_select_hyper_copy(void)
     CHECK(ret, FAIL, "H5Dread");
 
     /* Compare data read with data written out */
-    if (HDmemcmp(rbuf, rbuf2, sizeof(uint16_t) * SPACE3_DIM1 * SPACE3_DIM2))
+    if (HDmemcmp(rbuf, rbuf2, sizeof(uint16_t) * SPACE3_DIM1 * SPACE3_DIM2) != 0)
         TestErrPrintf("hyperslab values don't match! Line=%d\n", __LINE__);
 
     /* Close memory dataspace */
@@ -3978,7 +3978,7 @@ test_select_point_copy(void)
     CHECK(ret, FAIL, "H5Dread");
 
     /* Compare data read with data written out */
-    if (HDmemcmp(rbuf, rbuf2, sizeof(uint16_t) * SPACE3_DIM1 * SPACE3_DIM2))
+    if (HDmemcmp(rbuf, rbuf2, sizeof(uint16_t) * SPACE3_DIM1 * SPACE3_DIM2) != 0)
         TestErrPrintf("point values don't match!\n");
 
     /* Close memory dataspace */
@@ -14220,18 +14220,18 @@ test_hyper_unlim_check(hid_t sid, hsize_t *dims, hssize_t enpoints, hssize_t enb
 
             /* Verify blocklist */
             if (nblocks == (hssize_t)1) {
-                if (HDmemcmp(blocklist, eblock1, 6 * sizeof(eblock1[0])))
+                if (HDmemcmp(blocklist, eblock1, 6 * sizeof(eblock1[0])) != 0)
                     ERROR("H5Sget_select_hyper_blocklist");
             } /* end if */
             else {
                 HDassert(nblocks == (hssize_t)2);
-                if (HDmemcmp(blocklist, eblock1, 6 * sizeof(eblock1[0]))) {
-                    if (HDmemcmp(blocklist, eblock2, 6 * sizeof(eblock2[0])))
+                if (HDmemcmp(blocklist, eblock1, 6 * sizeof(eblock1[0])) != 0) {
+                    if (HDmemcmp(blocklist, eblock2, 6 * sizeof(eblock2[0])) != 0)
                         ERROR("H5Sget_select_hyper_blocklist");
-                    if (HDmemcmp(&blocklist[6], eblock1, 6 * sizeof(eblock1[0])))
+                    if (HDmemcmp(&blocklist[6], eblock1, 6 * sizeof(eblock1[0])) != 0)
                         ERROR("H5Sget_select_hyper_blocklist");
                 } /* end if */
-                else if (HDmemcmp(&blocklist[6], eblock2, 6 * sizeof(eblock2[0])))
+                else if (HDmemcmp(&blocklist[6], eblock2, 6 * sizeof(eblock2[0])) != 0)
                     ERROR("H5Sget_select_hyper_blocklist");
             } /* end else */
         }     /* end if */

--- a/test/ttst.c
+++ b/test/ttst.c
@@ -204,14 +204,14 @@ test_tst_insert(void)
         found = H5ST_find(tree, uniq_words[u]);
         CHECK_PTR(found, "H5ST_find");
 
-        if (HDstrcmp((const char *)found->eqkid, uniq_words[u]))
+        if (HDstrcmp((const char *)found->eqkid, uniq_words[u]) != 0)
             TestErrPrintf("%d: TST node values don't match!, found->eqkid=%s, uniq_words[%u]=%s\n", __LINE__,
                           (char *)found->eqkid, (unsigned)u, uniq_words[u]);
 
         obj = H5ST_locate(tree, uniq_words[u]);
         CHECK_PTR(obj, "H5ST_locate");
 
-        if (HDstrcmp((const char *)obj, uniq_words[u]))
+        if (HDstrcmp((const char *)obj, uniq_words[u]) != 0)
             TestErrPrintf("%d: TST objects don't match!, obj=%s, uniq_words[%u]=%s\n", __LINE__, (char *)obj,
                           (unsigned)u, uniq_words[u]);
     } /* end for */
@@ -262,7 +262,7 @@ test_tst_iterate(void)
     u = 0;
     do {
         /* Check that the strings in the TST are in the correct order */
-        if (HDstrcmp((const char *)found->eqkid, sort_uniq_words[u]))
+        if (HDstrcmp((const char *)found->eqkid, sort_uniq_words[u]) != 0)
             TestErrPrintf("%d: TST node values don't match!, found->eqkid=%s, sort_uniq_words[%u]=%s\n",
                           __LINE__, (char *)found->eqkid, (unsigned)u, sort_uniq_words[u]);
 
@@ -311,7 +311,7 @@ test_tst_remove(void)
         CHECK_PTR(obj, "H5ST_remove");
 
         /* Check that the correct string was removed from TST */
-        if (HDstrcmp((const char *)obj, rand_uniq_words[u]))
+        if (HDstrcmp((const char *)obj, rand_uniq_words[u]) != 0)
             TestErrPrintf("%d: TST node values don't match!, obj=%s, rand_uniq_words[%u]=%s\n", __LINE__,
                           (char *)obj, (unsigned)u, rand_uniq_words[u]);
 
@@ -333,7 +333,7 @@ test_tst_remove(void)
         CHECK_PTR(found, "H5ST_find");
 
         /* Check that the correct object will be removed from TST */
-        if (HDstrcmp((const char *)found->eqkid, rand_uniq_words[u]))
+        if (HDstrcmp((const char *)found->eqkid, rand_uniq_words[u]) != 0)
             TestErrPrintf("%d: TST node values don't match!, found->eqkid=%s, rand_uniq_words[%u]=%s\n",
                           __LINE__, (char *)found->eqkid, (unsigned)u, rand_uniq_words[u]);
 

--- a/test/tvlstr.c
+++ b/test/tvlstr.c
@@ -773,7 +773,7 @@ read_scalar_dset(hid_t file, hid_t type, hid_t space, char *name, char *data)
     ret = H5Dclose(dset);
     CHECK(ret, FAIL, "H5Dclose");
 
-    if (HDstrcmp(data, data_read))
+    if (HDstrcmp(data, data_read) != 0)
         TestErrPrintf("Expected %s for dataset %s but read %s\n", data, name, data_read);
 
     ret = H5Treclaim(type, space, H5P_DEFAULT, &data_read);

--- a/test/tvltypes.c
+++ b/test/tvltypes.c
@@ -1370,7 +1370,7 @@ test_vltypes_compound_vlstr(void)
 
         for (t1 = (s2 *)(wdata[i].v.p), t2 = (s2 *)(rdata[i].v.p), j = 0; j < rdata[i].v.len;
              j++, t1++, t2++) {
-            if (HDstrcmp(t1->string, t2->string)) {
+            if (HDstrcmp(t1->string, t2->string) != 0) {
                 TestErrPrintf("VL data values don't match!, t1->string=%s, t2->string=%s\n", t1->string,
                               t2->string);
                 continue;
@@ -1431,7 +1431,7 @@ test_vltypes_compound_vlstr(void)
 
         for (t1 = (s2 *)(wdata2[i].v.p), t2 = (s2 *)(rdata2[i].v.p), j = 0; j < rdata2[i].v.len;
              j++, t1++, t2++) {
-            if (HDstrcmp(t1->string, t2->string)) {
+            if (HDstrcmp(t1->string, t2->string) != 0) {
                 TestErrPrintf("VL data values don't match!, t1->string=%s, t2->string=%s\n", t1->string,
                               t2->string);
                 continue;
@@ -2804,10 +2804,10 @@ test_vltypes_fill_value(void)
 
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
-                if (HDstrcmp(rbuf[i].str_id, "foobar") || HDstrcmp(rbuf[i].str_name, "") ||
-                    rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") ||
-                    HDstrcmp(rbuf[i].str_stat, "dead") || HDstrcmp(rbuf[i].str_form, "liquid") ||
-                    HDstrcmp(rbuf[i].str_unit, "meter")) {
+                if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
+                    rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
+                    HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
+                    HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
                     TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                     continue;
                 } /* end if */
@@ -2827,10 +2827,10 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if ((i % 2) == select_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, "foobar") || HDstrcmp(rbuf[i].str_name, "") ||
-                        rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") ||
-                        HDstrcmp(rbuf[i].str_stat, "dead") || HDstrcmp(rbuf[i].str_form, "liquid") ||
-                        HDstrcmp(rbuf[i].str_unit, "meter")) {
+                    if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
+                        rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
+                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
+                        HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
@@ -2861,10 +2861,10 @@ test_vltypes_fill_value(void)
 
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
-                if (HDstrcmp(rbuf[i].str_id, "foobar") || HDstrcmp(rbuf[i].str_name, "") ||
-                    rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") ||
-                    HDstrcmp(rbuf[i].str_stat, "dead") || HDstrcmp(rbuf[i].str_form, "liquid") ||
-                    HDstrcmp(rbuf[i].str_unit, "meter")) {
+                if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
+                    rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
+                    HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
+                    HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
                     TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                     continue;
                 } /* end if */
@@ -2884,10 +2884,10 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if ((i % 2) == select_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, "foobar") || HDstrcmp(rbuf[i].str_name, "") ||
-                        rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") ||
-                        HDstrcmp(rbuf[i].str_stat, "dead") || HDstrcmp(rbuf[i].str_form, "liquid") ||
-                        HDstrcmp(rbuf[i].str_unit, "meter")) {
+                    if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
+                        rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
+                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
+                        HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
@@ -3002,21 +3002,21 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if (i == single_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, wdata.str_id) || rbuf[i].str_name ||
-                        HDstrcmp(rbuf[i].str_desc, wdata.str_desc) ||
-                        HDstrcmp(rbuf[i].str_orig, wdata.str_orig) ||
-                        HDstrcmp(rbuf[i].str_stat, wdata.str_stat) ||
-                        HDstrcmp(rbuf[i].str_form, wdata.str_form) ||
-                        HDstrcmp(rbuf[i].str_unit, wdata.str_unit)) {
+                    if (HDstrcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
+                        HDstrcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
+                        HDstrcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
+                        HDstrcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
+                        HDstrcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
+                        HDstrcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
                 }     /* end if */
                 else {
-                    if (HDstrcmp(rbuf[i].str_id, "foobar") || HDstrcmp(rbuf[i].str_name, "") ||
-                        rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") ||
-                        HDstrcmp(rbuf[i].str_stat, "dead") || HDstrcmp(rbuf[i].str_form, "liquid") ||
-                        HDstrcmp(rbuf[i].str_unit, "meter")) {
+                    if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
+                        rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
+                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
+                        HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
@@ -3037,22 +3037,22 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if (i == single_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, wdata.str_id) || rbuf[i].str_name ||
-                        HDstrcmp(rbuf[i].str_desc, wdata.str_desc) ||
-                        HDstrcmp(rbuf[i].str_orig, wdata.str_orig) ||
-                        HDstrcmp(rbuf[i].str_stat, wdata.str_stat) ||
-                        HDstrcmp(rbuf[i].str_form, wdata.str_form) ||
-                        HDstrcmp(rbuf[i].str_unit, wdata.str_unit)) {
+                    if (HDstrcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
+                        HDstrcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
+                        HDstrcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
+                        HDstrcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
+                        HDstrcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
+                        HDstrcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
                 }     /* end if */
                 else {
                     if ((i % 2) == select_offset[0]) {
-                        if (HDstrcmp(rbuf[i].str_id, "foobar") || HDstrcmp(rbuf[i].str_name, "") ||
-                            rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") ||
-                            HDstrcmp(rbuf[i].str_stat, "dead") || HDstrcmp(rbuf[i].str_form, "liquid") ||
-                            HDstrcmp(rbuf[i].str_unit, "meter")) {
+                        if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
+                            rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
+                            HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
+                            HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
                             TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                             continue;
                         } /* end if */
@@ -3088,21 +3088,21 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if (i == single_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, wdata.str_id) || rbuf[i].str_name ||
-                        HDstrcmp(rbuf[i].str_desc, wdata.str_desc) ||
-                        HDstrcmp(rbuf[i].str_orig, wdata.str_orig) ||
-                        HDstrcmp(rbuf[i].str_stat, wdata.str_stat) ||
-                        HDstrcmp(rbuf[i].str_form, wdata.str_form) ||
-                        HDstrcmp(rbuf[i].str_unit, wdata.str_unit)) {
+                    if (HDstrcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
+                        HDstrcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
+                        HDstrcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
+                        HDstrcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
+                        HDstrcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
+                        HDstrcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
                 }     /* end if */
                 else {
-                    if (HDstrcmp(rbuf[i].str_id, "foobar") || HDstrcmp(rbuf[i].str_name, "") ||
-                        rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") ||
-                        HDstrcmp(rbuf[i].str_stat, "dead") || HDstrcmp(rbuf[i].str_form, "liquid") ||
-                        HDstrcmp(rbuf[i].str_unit, "meter")) {
+                    if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
+                        rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
+                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
+                        HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
@@ -3123,22 +3123,22 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if (i == single_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, wdata.str_id) || rbuf[i].str_name ||
-                        HDstrcmp(rbuf[i].str_desc, wdata.str_desc) ||
-                        HDstrcmp(rbuf[i].str_orig, wdata.str_orig) ||
-                        HDstrcmp(rbuf[i].str_stat, wdata.str_stat) ||
-                        HDstrcmp(rbuf[i].str_form, wdata.str_form) ||
-                        HDstrcmp(rbuf[i].str_unit, wdata.str_unit)) {
+                    if (HDstrcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
+                        HDstrcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
+                        HDstrcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
+                        HDstrcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
+                        HDstrcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
+                        HDstrcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
                 }     /* end if */
                 else {
                     if ((i % 2) == select_offset[0]) {
-                        if (HDstrcmp(rbuf[i].str_id, "foobar") || HDstrcmp(rbuf[i].str_name, "") ||
-                            rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") ||
-                            HDstrcmp(rbuf[i].str_stat, "dead") || HDstrcmp(rbuf[i].str_form, "liquid") ||
-                            HDstrcmp(rbuf[i].str_unit, "meter")) {
+                        if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
+                            rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
+                            HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
+                            HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
                             TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                             continue;
                         } /* end if */

--- a/test/tvltypes.c
+++ b/test/tvltypes.c
@@ -2829,7 +2829,8 @@ test_vltypes_fill_value(void)
                 if ((i % 2) == select_offset[0]) {
                     if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
                         rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
+                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
+                        HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
                         HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                         continue;
@@ -2886,7 +2887,8 @@ test_vltypes_fill_value(void)
                 if ((i % 2) == select_offset[0]) {
                     if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
                         rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
+                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
+                        HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
                         HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                         continue;
@@ -3015,7 +3017,8 @@ test_vltypes_fill_value(void)
                 else {
                     if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
                         rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
+                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
+                        HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
                         HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
@@ -3051,7 +3054,8 @@ test_vltypes_fill_value(void)
                     if ((i % 2) == select_offset[0]) {
                         if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
                             rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                            HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
+                            HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
+                            HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
                             HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
                             TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                             continue;
@@ -3101,7 +3105,8 @@ test_vltypes_fill_value(void)
                 else {
                     if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
                         rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
+                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
+                        HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
                         HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
@@ -3137,7 +3142,8 @@ test_vltypes_fill_value(void)
                     if ((i % 2) == select_offset[0]) {
                         if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
                             rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                            HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
+                            HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
+                            HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
                             HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
                             TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                             continue;

--- a/test/unlink.c
+++ b/test/unlink.c
@@ -510,7 +510,7 @@ check_new_move(hid_t fapl)
     /* Check soft links */
     if (H5Lget_val(file, "group2/soft", linkval, sizeof(linkval), H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR
-    if (HDstrcmp(linkval, "/group1/group_move"))
+    if (HDstrcmp(linkval, "/group1/group_move") != 0)
         FAIL_PUTS_ERROR("    Soft link test failed. Wrong link value")
 
     /* Cleanup */

--- a/test/vfd.c
+++ b/test/vfd.c
@@ -2304,7 +2304,7 @@ compare_splitter_config_info(hid_t fapl_id, H5FD_splitter_vfd_config_t *info)
         }
     }
     if ((HDstrlen(info->wo_path) != HDstrlen(fetched_info->wo_path)) ||
-        HDstrncmp(info->wo_path, fetched_info->wo_path, H5FD_SPLITTER_PATH_MAX)) {
+        HDstrncmp(info->wo_path, fetched_info->wo_path, H5FD_SPLITTER_PATH_MAX) != 0) {
         HDfprintf(stderr, "MISMATCH: '%s' :: '%s'\n", info->wo_path, fetched_info->wo_path);
         HEXPRINT(H5FD_SPLITTER_PATH_MAX, info->wo_path);
         HEXPRINT(H5FD_SPLITTER_PATH_MAX, fetched_info->wo_path);

--- a/test/vol.c
+++ b/test/vol.c
@@ -399,8 +399,8 @@ test_basic_file_operation(const char *env_h5_drvr)
         TEST_ERROR;
 
     /* Can't compare VFD properties for split / multi / family VFDs */
-    if ((hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi") &&
-                  HDstrcmp(env_h5_drvr, "family"))) {
+    if ((hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
+                  HDstrcmp(env_h5_drvr, "family") != 0)) {
         /* H5Fget_access_plist */
         if ((fapl_id2 = H5Fget_access_plist(fid)) < 0)
             TEST_ERROR;
@@ -421,8 +421,8 @@ test_basic_file_operation(const char *env_h5_drvr)
         TEST_ERROR;
 
     /* Can't retrieve VFD handle for split / multi / family VFDs */
-    if ((hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi") &&
-                  HDstrcmp(env_h5_drvr, "family"))) {
+    if ((hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
+                  HDstrcmp(env_h5_drvr, "family") != 0)) {
         /* H5Fget_vfd_handle */
         if (H5Fget_vfd_handle(fid, H5P_DEFAULT, &os_file_handle) < 0)
             TEST_ERROR;
@@ -461,8 +461,8 @@ test_basic_file_operation(const char *env_h5_drvr)
         TEST_ERROR;
 
     /* Can't compare VFD properties for split / multi / family VFDs */
-    if ((hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi") &&
-                  HDstrcmp(env_h5_drvr, "family"))) {
+    if ((hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
+                  HDstrcmp(env_h5_drvr, "family") != 0)) {
         /* H5Fget_access_plist */
         if ((fapl_id2 = H5Fget_access_plist(fid)) < 0)
             TEST_ERROR;
@@ -476,8 +476,8 @@ test_basic_file_operation(const char *env_h5_drvr)
         TEST_ERROR;
 
     /* Can't compare VFD properties for split / multi / family VFDs */
-    if ((hbool_t)(HDstrcmp(env_h5_drvr, "split") && HDstrcmp(env_h5_drvr, "multi") &&
-                  HDstrcmp(env_h5_drvr, "family"))) {
+    if ((hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
+                  HDstrcmp(env_h5_drvr, "family") != 0)) {
         /* H5Fget_access_plist */
         if ((fapl_id2 = H5Fget_access_plist(fid_reopen)) < 0)
             TEST_ERROR;

--- a/tools/lib/h5diff.c
+++ b/tools/lib/h5diff.c
@@ -687,7 +687,7 @@ h5diff(const char *fname1, const char *fname2, const char *objname1, const char 
     /* if any object is specified */
     if (objname1) {
         /* make the given object1 fullpath, start with "/"  */
-        if (HDstrncmp(objname1, "/", 1)) {
+        if (HDstrncmp(objname1, "/", 1) != 0) {
 #ifdef H5_HAVE_ASPRINTF
             /* Use the asprintf() routine, since it does what we're trying to do below */
             if (HDasprintf(&obj1fullname, "/%s", objname1) < 0)
@@ -706,7 +706,7 @@ h5diff(const char *fname1, const char *fname2, const char *objname1, const char 
         H5TOOLS_DEBUG("obj1fullname = %s", obj1fullname);
 
         /* make the given object2 fullpath, start with "/" */
-        if (HDstrncmp(objname2, "/", 1)) {
+        if (HDstrncmp(objname2, "/", 1) != 0) {
 #ifdef H5_HAVE_ASPRINTF
             /* Use the asprintf() routine, since it does what we're trying to do below */
             if (HDasprintf(&obj2fullname, "/%s", objname2) < 0)
@@ -1013,7 +1013,7 @@ h5diff(const char *fname1, const char *fname2, const char *objname1, const char 
 
             parallel_print("\n");
             /* if given objects is group under root */
-            if (HDstrcmp(obj1fullname, "/") || HDstrcmp(obj2fullname, "/"))
+            if (HDstrcmp(obj1fullname, "/") != 0 || HDstrcmp(obj2fullname, "/") != 0)
                 parallel_print("group1   group2\n");
             else
                 parallel_print("file1     file2\n");
@@ -1115,9 +1115,9 @@ diff_match(hid_t file1_id, const char *grp1, trav_info_t *info1, hid_t file2_id,
      * if not root, prepare object name to be pre-appended to group path to
      * make full path
      */
-    if (HDstrcmp(grp1, "/"))
+    if (HDstrcmp(grp1, "/") != 0)
         grp1_path = grp1;
-    if (HDstrcmp(grp2, "/"))
+    if (HDstrcmp(grp2, "/") != 0)
         grp2_path = grp2;
 
     /*-------------------------------------------------------------------------

--- a/tools/lib/h5tools.c
+++ b/tools/lib/h5tools.c
@@ -2221,12 +2221,12 @@ h5tools_is_obj_same(hid_t loc_id1, const char *name1, hid_t loc_id2, const char 
     H5O_info2_t oinfo1, oinfo2;
     hbool_t     ret_val = FALSE;
 
-    if (name1 && HDstrcmp(name1, "."))
+    if (name1 && HDstrcmp(name1, ".") != 0)
         H5Oget_info_by_name3(loc_id1, name1, &oinfo1, H5O_INFO_BASIC, H5P_DEFAULT);
     else
         H5Oget_info3(loc_id1, &oinfo1, H5O_INFO_BASIC);
 
-    if (name2 && HDstrcmp(name2, "."))
+    if (name2 && HDstrcmp(name2, ".") != 0)
         H5Oget_info_by_name3(loc_id2, name2, &oinfo2, H5O_INFO_BASIC, H5P_DEFAULT);
     else
         H5Oget_info3(loc_id2, &oinfo2, H5O_INFO_BASIC);

--- a/tools/lib/h5tools_ref.c
+++ b/tools/lib/h5tools_ref.c
@@ -200,7 +200,7 @@ ref_path_table_lookup(const char *thepath, H5O_token_t *token)
     if ((thepath == NULL) || (HDstrlen(thepath) == 0))
         return -1;
     /* Allow lookups on the root group, even though it doesn't have any link info */
-    if (HDstrcmp(thepath, "/")) {
+    if (HDstrcmp(thepath, "/") != 0) {
         H5L_info2_t li;
 
         /* Check for external link first, so we don't return the OID of an object in another file */

--- a/tools/lib/h5tools_str.c
+++ b/tools/lib/h5tools_str.c
@@ -142,7 +142,7 @@ h5tools_str_append(h5tools_str_t *str /*in,out*/, const char *fmt, ...)
             /* failure, such as bad format */
             return NULL;
 
-        if ((size_t)nchars >= avail || (0 == nchars && (HDstrcmp(fmt, "%s")))) {
+        if ((size_t)nchars >= avail || (0 == nchars && (HDstrcmp(fmt, "%s") != 0))) {
             /* Truncation return value as documented by C99, or zero return value with either of the
              * following conditions, each of which indicates that the proper C99 return value probably
              *  should have been positive when the format string is

--- a/tools/lib/h5trav.c
+++ b/tools/lib/h5trav.c
@@ -357,7 +357,7 @@ trav_fileinfo_add(trav_info_t *info, hid_t loc_id)
     H5O_info2_t oinfo;
     size_t      idx = info->nused - 1;
 
-    if (info->paths[idx].path && HDstrcmp(info->paths[idx].path, "."))
+    if (info->paths[idx].path && HDstrcmp(info->paths[idx].path, ".") != 0)
         H5Oget_info_by_name3(loc_id, info->paths[idx].path, &oinfo, H5O_INFO_BASIC, H5P_DEFAULT);
     else
         H5Oget_info3(loc_id, &oinfo, H5O_INFO_BASIC);

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -1529,7 +1529,7 @@ main(int argc, const char *argv[])
                 }
             }
             else {
-                if (useschema_g && HDstrcmp(xmlnsprefix, "")) {
+                if (useschema_g && HDstrcmp(xmlnsprefix, "") != 0) {
                     error_msg(
                         "Cannot set Schema URL for a qualified namespace--use -X or -U option with -D \n");
                     h5tools_setstatus(EXIT_FAILURE);

--- a/tools/src/h5import/h5import.c
+++ b/tools/src/h5import/h5import.c
@@ -1570,7 +1570,7 @@ processConfigurationFile(char *infile, struct Input *in)
 #ifdef H5DEBUGIMPORT
                             HDprintf("h5dump DATATYPE STRING STRSIZE %s found\n", temp);
 #endif
-                            if (HDstrcmp("H5T_VARIABLE;", temp)) {
+                            if (HDstrcmp("H5T_VARIABLE;", temp) != 0) {
                                 char *more = temp;
                                 ival       = (int)HDstrtol(more, &more, 10);
                                 if (getInputSize(in, ival) == -1) {
@@ -1896,7 +1896,7 @@ processConfigurationFile(char *infile, struct Input *in)
                         HDprintf("h5dump STORAGE_LAYOUT CHUNKED SIZE %d found\n", ival);
 #endif
                     }
-                    while (HDstrcmp("}", temp)) {
+                    while (HDstrcmp("}", temp) != 0) {
                         if (fscanf(strm, "%254s", temp) != 1) { /* end bracket */
                             (void)HDfprintf(stderr, "%s", err18);
                             goto error;

--- a/tools/src/h5ls/h5ls.c
+++ b/tools/src/h5ls/h5ls.c
@@ -3088,7 +3088,7 @@ main(int argc, const char *argv[])
         symlink_list.objs                        = NULL;
 
         /* Check for root group as object name */
-        if (HDstrcmp(oname, root_name)) {
+        if (HDstrcmp(oname, root_name) != 0) {
             /* Check the type of link given */
             if (H5Lget_info2(file_id, oname, &li, H5P_DEFAULT) < 0) {
                 hsize_t           curr_pos = 0; /* total data element position   */

--- a/tools/src/h5repack/h5repack_main.c
+++ b/tools/src/h5repack/h5repack_main.c
@@ -367,7 +367,7 @@ read_info(const char *filename, pack_opt_t *options)
             break;
 
         /* Info indicator must be for layout or filter */
-        if (HDstrcmp(stype, "-l") && HDstrcmp(stype, "-f")) {
+        if (HDstrcmp(stype, "-l") != 0 && HDstrcmp(stype, "-f") != 0) {
             error_msg("bad file format for %s", filename);
             h5tools_setstatus(EXIT_FAILURE);
             ret_value = EXIT_FAILURE;

--- a/tools/src/h5repack/h5repack_opttable.c
+++ b/tools/src/h5repack/h5repack_opttable.c
@@ -339,7 +339,7 @@ options_get_object(const char *path, pack_opttbl_t *table)
 
     for (i = 0; i < table->nelems; i++) {
         /* make full path (start with "/") to compare correctly  */
-        if (HDstrncmp(table->objs[i].path, "/", 1)) {
+        if (HDstrncmp(table->objs[i].path, "/", 1) != 0) {
             HDstrcpy(tbl_path, "/");
             HDstrcat(tbl_path, table->objs[i].path);
         }

--- a/tools/src/misc/h5delete.c
+++ b/tools/src/misc/h5delete.c
@@ -37,7 +37,7 @@ main(int argc, const char *argv[])
 
     switch (argc) {
         case 3:
-            if (HDstrcmp(argv[1], "-f")) {
+            if (HDstrcmp(argv[1], "-f") != 0) {
                 usage();
                 return EXIT_FAILURE;
             }


### PR DESCRIPTION
This change was generated entirely by clang-tidy itself.