### PR TITLE
DO NOT MERGE: proof of concept global symbol hiding

### DIFF
--- a/config/gnu-flags
+++ b/config/gnu-flags
@@ -130,6 +130,7 @@ if test "X-gcc" = "X-$cc_vendor"; then
         # Everybody else gets c99 as the standard.
         *)
             H5_CFLAGS="$H5_CFLAGS -std=c99"
+            H5_CFLAGS="$H5_CFLAGS -fvisibility=hidden"
             ;;
     esac
 

--- a/src/H5Cprivate.h
+++ b/src/H5Cprivate.h
@@ -2235,7 +2235,7 @@ H5_DLL herr_t H5C_flush_cache(H5F_t *f, unsigned flags);
 H5_DLL herr_t H5C_flush_tagged_entries(H5F_t *f, haddr_t tag);
 H5_DLL herr_t H5C_evict_tagged_entries(H5F_t *f, haddr_t tag, hbool_t match_global);
 H5_DLL herr_t H5C_expunge_tag_type_metadata(H5F_t *f, haddr_t tag, int type_id, unsigned flags);
-H5_DLL herr_t H5C_get_tag(const void *thing, /*OUT*/ haddr_t *tag);
+herr_t H5C_get_tag(const void *thing, /*OUT*/ haddr_t *tag);
 #if H5C_DO_TAGGING_SANITY_CHECKS
 herr_t H5C_verify_tag(int id, haddr_t tag);
 #endif

--- a/src/H5api_adpt.h
+++ b/src/H5api_adpt.h
@@ -230,24 +230,24 @@
 #endif /* HDF5_HL_F90CSTUBDLL */
 
 #else
-#define H5_DLL
-#define H5_DLLVAR extern
-#define H5TEST_DLL
-#define H5TEST_DLLVAR extern
-#define H5TOOLS_DLL
-#define H5TOOLS_DLLVAR extern
-#define H5_DLLCPP
-#define H5_DLLCPPVAR extern
-#define H5_HLDLL
-#define H5_HLDLLVAR extern
-#define H5_HLCPPDLL
-#define H5_HLCPPDLLVAR extern
-#define H5_FCDLL
-#define H5_FCDLLVAR extern
-#define H5_FCTESTDLL
-#define H5_FCTESTDLLVAR extern
-#define HDF5_HL_F90CSTUBDLL
-#define HDF5_HL_F90CSTUBDLLVAR extern
+#define H5_DLL __attribute__((visibility("default")))
+#define H5_DLLVAR extern __attribute__((visibility("default")))
+#define H5TEST_DLL __attribute__((visibility("default")))
+#define H5TEST_DLLVAR extern __attribute__((visibility("default")))
+#define H5TOOLS_DLL __attribute__((visibility("default")))
+#define H5TOOLS_DLLVAR extern __attribute__((visibility("default")))
+#define H5_DLLCPP __attribute__((visibility("default")))
+#define H5_DLLCPPVAR extern __attribute__((visibility("default")))
+#define H5_HLDLL __attribute__((visibility("default")))
+#define H5_HLDLLVAR extern __attribute__((visibility("default")))
+#define H5_HLCPPDLL __attribute__((visibility("default")))
+#define H5_HLCPPDLLVAR extern __attribute__((visibility("default")))
+#define H5_FCDLL __attribute__((visibility("default")))
+#define H5_FCDLLVAR extern __attribute__((visibility("default")))
+#define H5_FCTESTDLL __attribute__((visibility("default")))
+#define H5_FCTESTDLLVAR extern __attribute__((visibility("default")))
+#define HDF5_HL_F90CSTUBDLL __attribute__((visibility("default")))
+#define HDF5_HL_F90CSTUBDLLVAR extern __attribute__((visibility("default")))
 #endif /* H5_BUILT_AS_DYNAMIC_LIB */
 
 #endif /* H5API_ADPT_H */


### PR DESCRIPTION
This is a rough & ready demonstration of global symbol hiding using GCC—also should work with Clang. Only the library symbols deliberately marked with attributes such as H5_DLL become visible outside the library. This protects against symbol clashes between HDF5, other libraries, and application programs.