### PR TITLE
Replaces checks for fork, etc. with checks for unistd.h

### DIFF
--- a/test/accum.c
+++ b/test/accum.c
@@ -2092,7 +2092,7 @@ error:
 unsigned
 test_swmr_write_big(hbool_t newest_format)
 {
-#if defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID) && defined(H5_HAVE_UNISTD_H)
+#ifdef H5_HAVE_UNISTD_H
     hid_t    fid  = -1;   /* File ID */
     hid_t    fapl = -1;   /* File access property list */
     H5F_t *  rf   = NULL; /* File pointer */
@@ -2287,11 +2287,11 @@ error:
 
     return 1;
 
-#else
+#else /* H5_HAVE_UNISTD_H */
     SKIPPED();
     HDputs("    Test skipped due to fork, waitpid, or pid_t not defined.");
     return 0;
-#endif /* defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID) && defined(H5_HAVE_UNISTD_H) */
+#endif /* H5_HAVE_UNISTD_H */
 
 } /* end test_swmr_write_big() */
 

--- a/test/accum.c
+++ b/test/accum.c
@@ -2287,7 +2287,7 @@ error:
 
     return 1;
 
-#else /* H5_HAVE_UNISTD_H */
+#else  /* H5_HAVE_UNISTD_H */
     SKIPPED();
     HDputs("    Test skipped due to fork, waitpid, or pid_t not defined.");
     return 0;

--- a/test/dt_arith.c
+++ b/test/dt_arith.c
@@ -84,7 +84,7 @@ static int skip_overflow_tests_g = 0;
  * be allowed to continue (cf. Posix signals) so in order to recover from a
  * SIGFPE we run tests that might generate one in a child process.
  */
-#if defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID)
+#ifdef H5_HAVE_UNISTD_H
 #define HANDLE_SIGFPE
 #endif
 
@@ -556,7 +556,7 @@ some_dummy_func(float x)
 static void
 generates_sigfpe(void)
 {
-#if defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID)
+#ifdef H5_HAVE_UNISTD_H
     pid_t          pid;
     int            status;
     size_t         i, j;
@@ -592,12 +592,12 @@ generates_sigfpe(void)
         /* delete the core dump file that SIGFPE may have created */
         HDunlink("core");
     }
-#else
-    HDputs("Cannot determine if floating-point overflows generate a SIGFPE;");
-    HDputs("assuming yes.");
+#else /* H5_HAVE_UNISTD_H */
+    HDputs("Cannot determine if floating-point overflows generate a SIGFPE");
+    HDputs("due to a lack of fork(2) - assuming yes.");
     HDputs("Overflow cases will not be tested.");
     skip_overflow_tests_g = TRUE;
-#endif
+#endif /* H5_HAVE_UNISTD_H */
 }
 
 /*-------------------------------------------------------------------------

--- a/test/dt_arith.c
+++ b/test/dt_arith.c
@@ -592,7 +592,7 @@ generates_sigfpe(void)
         /* delete the core dump file that SIGFPE may have created */
         HDunlink("core");
     }
-#else /* H5_HAVE_UNISTD_H */
+#else  /* H5_HAVE_UNISTD_H */
     HDputs("Cannot determine if floating-point overflows generate a SIGFPE");
     HDputs("due to a lack of fork(2) - assuming yes.");
     HDputs("Overflow cases will not be tested.");

--- a/test/swmr.c
+++ b/test/swmr.c
@@ -2341,17 +2341,24 @@ error:
  *  (5) Parent: open a file with write access; enable SWMR writing mode
  *      Child: concurrent open of the file with write and SWMR write access (fail)
  */
-#if !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID))
+#ifndef H5_HAVE_UNISTD_H
 
 static int
-test_start_swmr_write_concur(hid_t H5_ATTR_UNUSED in_fapl, hbool_t H5_ATTR_UNUSED new_format)
+test_start_swmr_write_concur(hid_t H5_ATTR_UNUSED in_fapl, hbool_t new_format)
 {
+    if (new_format) {
+        TESTING("H5Fstart_swmr_write()--concurrent access for latest format");
+    }
+    else {
+        TESTING("H5Fstart_swmr_write()--concurrent access for non-latest-format");
+    }
+
     SKIPPED();
-    HDputs("    Test skipped due to fork or waitpid not defined.");
+    HDputs("    Test skipped due to a lack of unistd.h functionality.");
     return 0;
 } /* test_start_swmr_write_concur() */
 
-#else  /* defined(H5_HAVE_FORK && defined(H5_HAVE_WAITPID) */
+#else  /* H5_HAVE_UNISTD_H */
 
 static int
 test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
@@ -2383,7 +2390,7 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
     }
     else {
         TESTING("H5Fstart_swmr_write()--concurrent access for non-latest-format");
-    } /* end if */
+    }
 
     if ((fapl = H5Pcopy(in_fapl)) < 0)
         FAIL_STACK_ERROR
@@ -2944,7 +2951,7 @@ error:
     return -1;
 
 } /* test_start_swmr_write_concur() */
-#endif /* !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID)) */
+#endif /* H5_HAVE_UNISTD_H */
 
 /*
  * test_start_swmr_write_stress_ohdr():
@@ -4675,7 +4682,7 @@ error:
 **    This is for concurrent access.
 **
 *****************************************************************/
-#if !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID) && defined(H5_HAVE_FLOCK))
+#ifndef H5_HAVE_UNISTD_H
 
 static int
 test_file_lock_concur(hid_t H5_ATTR_UNUSED in_fapl)
@@ -4683,12 +4690,12 @@ test_file_lock_concur(hid_t H5_ATTR_UNUSED in_fapl)
     /* Output message about test being performed */
     TESTING("File open with different combinations of flags--concurrent access");
     SKIPPED();
-    HDputs("    Test skipped due to fork, waitpid, or flock not defined.");
+    HDputs("    Test skipped due to a lack of unistd.h functionality.");
     return 0;
 
 } /* end test_file_lock_concur() */
 
-#else
+#else /* H5_HAVE_UNISTD_H */
 
 static int
 test_file_lock_concur(hid_t in_fapl)
@@ -5046,7 +5053,7 @@ error:
 
 } /* end test_file_lock_concur() */
 
-#endif /* !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID) && defined(H5_HAVE_FLOCK)) */
+#endif /* H5_HAVE_UNISTD_H */
 
 /****************************************************************
 **
@@ -5056,7 +5063,7 @@ error:
 **    This is for concurrent access.
 **
 *****************************************************************/
-#if !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID))
+#ifndef H5_HAVE_UNISTD_H
 
 static int
 test_file_lock_swmr_concur(hid_t H5_ATTR_UNUSED in_fapl)
@@ -5064,12 +5071,12 @@ test_file_lock_swmr_concur(hid_t H5_ATTR_UNUSED in_fapl)
     /* Output message about test being performed */
     TESTING("File open with different combintations of flags + SWMR flags--concurrent access");
     SKIPPED();
-    HDputs("    Test skipped due to fork or waitpid not defined.");
+    HDputs("    Test skipped due to a lack of unistd.h functionality.");
     return 0;
 
 } /* end test_file_lock_swmr_concur() */
 
-#else
+#else /* H5_HAVE_UNISTD_H */
 
 static int
 test_file_lock_swmr_concur(hid_t in_fapl)
@@ -6036,7 +6043,7 @@ error:
 
 } /* end test_file_lock_swmr_concur() */
 
-#endif /* !(defined(H5_HAVE_FORK && defined(H5_HAVE_WAITPID)) */
+#endif /* H5_HAVE_UNISTD_H */
 
 /****************************************************************
 **
@@ -6048,11 +6055,19 @@ error:
 static int
 test_file_locking(hid_t in_fapl, hbool_t turn_locking_on, hbool_t env_var_override)
 {
-#if !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID))
+#ifndef H5_HAVE_UNISTD_H
+    if (turn_locking_on && env_var_override)
+        TESTING("File locking: ON w/ env var override")
+    else if (turn_locking_on && !env_var_override)
+        TESTING("File locking: ON")
+    else if (!turn_locking_on && env_var_override)
+        TESTING("File locking: OFF w/ env var override")
+    else
+        TESTING("File locking: OFF")
     SKIPPED();
-    HDputs("    Test skipped due to fork or waitpid not defined.");
+    HDputs("    Test skipped due to a lack of unistd.h functionality.");
     return 0;
-#else
+#else /* H5_HAVE_UNISTD_H */
     hid_t  fid  = -1;               /* File ID */
     hid_t  fapl = -1;               /* File access property list */
     char   filename[NAME_BUF_SIZE]; /* file name */
@@ -6218,7 +6233,7 @@ error:
 
     return -1;
 
-#endif /* !(defined(H5_HAVE_FORK && defined(H5_HAVE_WAITPID)) */
+#endif /* H5_HAVE_UNISTD_H */
 
 } /* end test_file_locking() */
 
@@ -6498,17 +6513,24 @@ error:
  *              (7) Refresh the dataset
  *              (8) Verify the dataset's dimension and data are correct
  */
-#if !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID))
+#ifndef H5_HAVE_UNISTD_H
 
 static int
-test_refresh_concur(hid_t H5_ATTR_UNUSED in_fapl, hbool_t H5_ATTR_UNUSED new_format)
+test_refresh_concur(hid_t H5_ATTR_UNUSED in_fapl, hbool_t new_format)
 {
+    if (new_format) {
+        TESTING("H5Drefresh()--concurrent access for latest format");
+    }
+    else {
+        TESTING("H5Drefresh()--concurrent access for non-latest-format");
+    }
+
     SKIPPED();
-    HDputs("    Test skipped due to fork or waitpid not defined.");
+    HDputs("    Test skipped due to a lack of unistd.h functionality.");
     return 0;
 } /* test_refresh_concur() */
 
-#else  /* defined(H5_HAVE_FORK && defined(H5_HAVE_WAITPID) */
+#else  /* H5_HAVE_UNISTD_H */
 
 static int
 test_refresh_concur(hid_t in_fapl, hbool_t new_format)
@@ -6808,7 +6830,7 @@ error:
     return -1;
 
 } /* test_refresh_concur() */
-#endif /* !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID)) */
+#endif /* H5_HAVE_UNISTD_H */
 
 /*
  * test_multiple_same():

--- a/test/twriteorder.c
+++ b/test/twriteorder.c
@@ -61,11 +61,9 @@
 #include "h5test.h"
 
 /* This test uses many POSIX things that are not available on
- * Windows. We're using a check for fork(2) here as a proxy for
- * all POSIX/Unix/Linux things until this test can be made
- * more platform-independent.
+ * Windows.
  */
-#ifdef H5_HAVE_FORK
+#ifdef H5_HAVE_UNISTD_H
 
 #define DATAFILE "twriteorder.dat"
 /* #define READERS_MAX      10 */ /* max number of readers */
@@ -468,7 +466,7 @@ done:
     return ret_value;
 }
 
-#else /* H5_HAVE_FORK */
+#else /* H5_HAVE_UNISTD_H */
 
 int
 main(void)
@@ -477,4 +475,4 @@ main(void)
     return EXIT_SUCCESS;
 } /* end main() */
 
-#endif /* H5_HAVE_FORK */
+#endif /* H5_HAVE_UNISTD_H */

--- a/test/use_append_chunk.c
+++ b/test/use_append_chunk.c
@@ -61,11 +61,9 @@
 #include "h5test.h"
 
 /* This test uses many POSIX things that are not available on
- * Windows. We're using a check for fork(2) here as a proxy for
- * all POSIX/Unix/Linux things until this test can be made
- * more platform-independent.
+ * Windows.
  */
-#ifdef H5_HAVE_FORK
+#ifdef H5_HAVE_UNISTD_H
 
 #include "use.h"
 
@@ -272,7 +270,7 @@ done:
     return (ret_value);
 }
 
-#else /* H5_HAVE_FORK */
+#else /* H5_HAVE_UNISTD_H */
 
 int
 main(void)
@@ -281,4 +279,4 @@ main(void)
     return EXIT_SUCCESS;
 } /* end main() */
 
-#endif /* H5_HAVE_FORK */
+#endif /* H5_HAVE_UNISTD_H */

--- a/test/use_append_chunk_mirror.c
+++ b/test/use_append_chunk_mirror.c
@@ -91,11 +91,9 @@
 #include "use.h"
 
 /* This test uses many POSIX things that are not available on
- * Windows. We're using a check for fork(2) here as a proxy for
- * all POSIX/Unix/Linux things until this test can be made
- * more platform-independent.
+ * Windows.
  */
-#ifdef H5_HAVE_FORK
+#ifdef H5_HAVE_UNISTD_H
 
 #ifdef H5_HAVE_MIRROR_VFD
 
@@ -391,7 +389,7 @@ main(void)
 
 #endif /* H5_HAVE_MIRROR_VFD */
 
-#else /* H5_HAVE_FORK */
+#else /* H5_HAVE_UNISTD_H */
 
 int
 main(void)
@@ -400,4 +398,4 @@ main(void)
     return EXIT_SUCCESS;
 } /* end main() */
 
-#endif /* H5_HAVE_FORK */
+#endif /* H5_HAVE_UNISTD_H */

--- a/test/use_append_mchunks.c
+++ b/test/use_append_mchunks.c
@@ -53,11 +53,9 @@
 #include "h5test.h"
 
 /* This test uses many POSIX things that are not available on
- * Windows. We're using a check for fork(2) here as a proxy for
- * all POSIX/Unix/Linux things until this test can be made
- * more platform-independent.
+ * Windows.
  */
-#ifdef H5_HAVE_FORK
+#ifdef H5_HAVE_UNISTD_H
 
 #include "use.h"
 
@@ -267,7 +265,7 @@ done:
     return (ret_value);
 } /* end main() */
 
-#else /* H5_HAVE_FORK */
+#else /* H5_HAVE_UNISTD_H */
 
 int
 main(void)
@@ -276,4 +274,4 @@ main(void)
     return EXIT_SUCCESS;
 } /* end main() */
 
-#endif /* H5_HAVE_FORK */
+#endif /* H5_HAVE_UNISTD_H */

--- a/test/use_common.c
+++ b/test/use_common.c
@@ -13,11 +13,9 @@
 #include "h5test.h"
 
 /* This test uses many POSIX things that are not available on
- * Windows. We're using a check for fork(2) here as a proxy for
- * all POSIX/Unix/Linux things until this test can be made
- * more platform-independent.
+ * Windows.
  */
-#ifdef H5_HAVE_FORK
+#ifdef H5_HAVE_UNISTD_H
 
 #include "use.h"
 
@@ -613,4 +611,4 @@ read_uc_file(hbool_t towait, options_t *opts)
         return 0;
 } /* end read_uc_file() */
 
-#endif /* H5_HAVE_FORK */
+#endif /* H5_HAVE_UNISTD_H */

--- a/test/use_disable_mdc_flushes.c
+++ b/test/use_disable_mdc_flushes.c
@@ -18,11 +18,9 @@
 #include "h5test.h"
 
 /* This test uses many POSIX things that are not available on
- * Windows. We're using a check for fork(2) here as a proxy for
- * all POSIX/Unix/Linux things until this test can be made
- * more platform-independent.
+ * Windows.
  */
-#ifdef H5_HAVE_FORK
+#ifdef H5_HAVE_UNISTD_H
 
 #define H5D_FRIEND /*suppress error about including H5Dpkg      */
 #define H5D_TESTING
@@ -539,7 +537,7 @@ done:
     return (ret_value);
 }
 
-#else /* H5_HAVE_FORK */
+#else /* H5_HAVE_UNISTD_H */
 
 int
 main(void)
@@ -548,4 +546,4 @@ main(void)
     HDexit(EXIT_SUCCESS);
 } /* end main() */
 
-#endif /* H5_HAVE_FORK */
+#endif /* H5_HAVE_UNISTD_H */


### PR DESCRIPTION
Code previously checked for individual POSIX API calls using
H5_HAVE_FORK, etc. The calls we use have been standardized for
decades and are available via unistd.h.

Some test messages that were missing when tests are skipped
due to a lack of unistd.h were also added.

The configure checks for individual POSIX API calls will be
removed in a later commit.