### PR TITLE
Update clang config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,6 +7,7 @@ AlignConsecutiveDeclarations: true
 AlignConsecutiveMacros: true
 #llvm10-11: AlignOperands:   true - Align
 #llvm11: AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: None
 AlwaysBreakAfterReturnType: AllDefinitions
 # Can enable the following section when llvm 12.x is out
 #AttributeMacros:
@@ -32,6 +33,7 @@ BreakBeforeBraces: Stroustrup
 BreakAfterJavaFieldAnnotations: true
 BreakStringLiterals: true
 ColumnLimit:     110    # Update $max_trace_macro_line_len in bin/trace also
+ForEachMacros: ['ALL_MEMBERS', 'UNIQUE_MEMBERS']
 IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        3

--- a/bin/format_source
+++ b/bin/format_source
@@ -8,7 +8,7 @@
 #
 # (Remember to update both bin/format_source and bin/format_source_patch)
 
-find . -type d \( -path ./config \) -prune \
+find . \( -type d -path ./config -prune -and -not -path ./config \) \
     -or \( \( \! \( \
         -name H5LTanalyze.c \
         -or -name H5LTparse.c \

--- a/bin/format_source_patch
+++ b/bin/format_source_patch
@@ -8,7 +8,7 @@
 #
 # (Remember to update both bin/format_source and bin/format_source_patch)
 
-find . -type d \( -path ./config \) -prune \
+find . \( -type d -path ./config -prune -and -not -path ./config \) \
     -or \( \( \! \( \
         -name H5LTanalyze.c \
         -or -name H5LTparse.c \

--- a/c++/src/H5AbstractDs.cpp
+++ b/c++/src/H5AbstractDs.cpp
@@ -38,7 +38,9 @@ namespace H5 {
 ///\brief       Default constructor
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-AbstractDs::AbstractDs() {}
+AbstractDs::AbstractDs()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    AbstractDs default constructor
@@ -331,6 +333,8 @@ AbstractDs::getVarLenType() const
 ///\brief       Noop destructor.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-AbstractDs::~AbstractDs() {}
+AbstractDs::~AbstractDs()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5ArrayType.cpp
+++ b/c++/src/H5ArrayType.cpp
@@ -34,7 +34,9 @@ namespace H5 {
 ///\brief       Default constructor: Creates a stub ArrayType
 // Programmer   Binh-Minh Ribler - May 2004
 //--------------------------------------------------------------------------
-ArrayType::ArrayType() : DataType() {}
+ArrayType::ArrayType() : DataType()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    ArrayType overloaded constructor
@@ -43,14 +45,18 @@ ArrayType::ArrayType() : DataType() {}
 ///\exception   H5::DataTypeIException
 // Programmer   Binh-Minh Ribler - May 2004
 //--------------------------------------------------------------------------
-ArrayType::ArrayType(const hid_t existing_id) : DataType(existing_id) {}
+ArrayType::ArrayType(const hid_t existing_id) : DataType(existing_id)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    ArrayType copy constructor
 ///\brief       Copy constructor: same HDF5 object as \a original
 // Programmer   Binh-Minh Ribler - May 2004
 //--------------------------------------------------------------------------
-ArrayType::ArrayType(const ArrayType &original) : DataType(original) {}
+ArrayType::ArrayType(const ArrayType &original) : DataType(original)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    ArrayType overloaded constructor
@@ -206,6 +212,8 @@ ArrayType::getArrayDims(hsize_t *dims) const
 ///\brief       Properly terminates access to this array datatype.
 // Programmer   Binh-Minh Ribler - May 2004
 //--------------------------------------------------------------------------
-ArrayType::~ArrayType() {}
+ArrayType::~ArrayType()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5AtomType.cpp
+++ b/c++/src/H5AtomType.cpp
@@ -35,7 +35,9 @@ namespace H5 {
 // Purpose      Default constructor: creates a stub atomic datatype.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-AtomType::AtomType() : DataType() {}
+AtomType::AtomType() : DataType()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    AtomType overloaded constructor [protected]
@@ -44,14 +46,18 @@ AtomType::AtomType() : DataType() {}
 // Exception    H5::DataTypeIException
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-AtomType::AtomType(const hid_t existing_id) : DataType(existing_id) {}
+AtomType::AtomType(const hid_t existing_id) : DataType(existing_id)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    AtomType copy constructor
 ///\brief       Copy constructor: same HDF5 object as \a original
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-AtomType::AtomType(const AtomType &original) : DataType(original) {}
+AtomType::AtomType(const AtomType &original) : DataType(original)
+{
+}
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 //--------------------------------------------------------------------------
@@ -290,7 +296,9 @@ AtomType::setPad(H5T_pad_t lsb, H5T_pad_t msb) const
 ///\brief       Noop destructor.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-AtomType::~AtomType() {}
+AtomType::~AtomType()
+{
+}
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 } // namespace H5

--- a/c++/src/H5Attribute.cpp
+++ b/c++/src/H5Attribute.cpp
@@ -44,7 +44,9 @@ class H5Object; // forward declaration for UserData4Aiterate
 ///\brief       Default constructor: Creates a stub attribute
 // Programmer   Binh-Minh Ribler - May, 2004
 //--------------------------------------------------------------------------
-Attribute::Attribute() : AbstractDs(), H5Location(), id(H5I_INVALID_HID) {}
+Attribute::Attribute() : AbstractDs(), H5Location(), id(H5I_INVALID_HID)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    Attribute copy constructor

--- a/c++/src/H5CommonFG.cpp
+++ b/c++/src/H5CommonFG.cpp
@@ -357,14 +357,18 @@ CommonFG::openVarLenType(const H5std_string &name) const
 ///\brief       Default constructor.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-CommonFG::CommonFG() {}
+CommonFG::CommonFG()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    CommonFG destructor
 ///\brief       Noop destructor.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-CommonFG::~CommonFG() {}
+CommonFG::~CommonFG()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    f_DataType_setId - friend

--- a/c++/src/H5CompType.cpp
+++ b/c++/src/H5CompType.cpp
@@ -37,7 +37,9 @@ namespace H5 {
 ///\brief       Default constructor: Creates a stub compound datatype
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-CompType::CompType() : DataType() {}
+CompType::CompType() : DataType()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    CompType copy constructor
@@ -45,7 +47,9 @@ CompType::CompType() : DataType() {}
 ///\param       original - IN: Original CompType instance
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-CompType::CompType(const CompType &original) : DataType(original) {}
+CompType::CompType(const CompType &original) : DataType(original)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    CompType overloaded constructor
@@ -53,7 +57,9 @@ CompType::CompType(const CompType &original) : DataType(original) {}
 ///\param       existing_id - IN: Id of an existing compound datatype
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-CompType::CompType(const hid_t existing_id) : DataType(existing_id) {}
+CompType::CompType(const hid_t existing_id) : DataType(existing_id)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    CompType overloaded constructor
@@ -65,7 +71,9 @@ CompType::CompType(const hid_t existing_id) : DataType(existing_id) {}
 //              the compound datatype.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-CompType::CompType(size_t size) : DataType(H5T_COMPOUND, size) {}
+CompType::CompType(size_t size) : DataType(H5T_COMPOUND, size)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    CompType overloaded constructor
@@ -549,6 +557,8 @@ CompType::setSize(size_t size) const
 ///\brief       Properly terminates access to this compound datatype.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-CompType::~CompType() {}
+CompType::~CompType()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5DaccProp.cpp
+++ b/c++/src/H5DaccProp.cpp
@@ -88,7 +88,9 @@ const DSetAccPropList &DSetAccPropList::DEFAULT = *getConstant();
 ///\brief       Default constructor: creates a stub dataset creation property list
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-DSetAccPropList::DSetAccPropList() : LinkAccPropList(H5P_DATASET_ACCESS) {}
+DSetAccPropList::DSetAccPropList() : LinkAccPropList(H5P_DATASET_ACCESS)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    DSetAccPropList copy constructor
@@ -96,7 +98,9 @@ DSetAccPropList::DSetAccPropList() : LinkAccPropList(H5P_DATASET_ACCESS) {}
 ///             DSetAccPropList object
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-DSetAccPropList::DSetAccPropList(const DSetAccPropList &orig) : LinkAccPropList(orig) {}
+DSetAccPropList::DSetAccPropList(const DSetAccPropList &orig) : LinkAccPropList(orig)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    DSetAccPropList overloaded constructor
@@ -104,7 +108,9 @@ DSetAccPropList::DSetAccPropList(const DSetAccPropList &orig) : LinkAccPropList(
 ///             existing dataset creation property list.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-DSetAccPropList::DSetAccPropList(const hid_t plist_id) : LinkAccPropList(plist_id) {}
+DSetAccPropList::DSetAccPropList(const hid_t plist_id) : LinkAccPropList(plist_id)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    DSetAccPropList::setChunkCache
@@ -159,6 +165,8 @@ DSetAccPropList::getChunkCache(size_t &rdcc_nslots, size_t &rdcc_nbytes, double 
 ///\brief       Noop destructor.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-DSetAccPropList::~DSetAccPropList() {}
+DSetAccPropList::~DSetAccPropList()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5DataSet.cpp
+++ b/c++/src/H5DataSet.cpp
@@ -44,7 +44,9 @@ using std::endl;
 ///\brief       Default constructor: creates a stub DataSet.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-DataSet::DataSet() : H5Object(), AbstractDs(), id(H5I_INVALID_HID) {}
+DataSet::DataSet() : H5Object(), AbstractDs(), id(H5I_INVALID_HID)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    DataSet overloaded constructor

--- a/c++/src/H5DataType.cpp
+++ b/c++/src/H5DataType.cpp
@@ -46,7 +46,9 @@ using std::endl;
 ///\brief       Default constructor: Creates a stub datatype
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-DataType::DataType() : H5Object(), id(H5I_INVALID_HID), encoded_buf(NULL), buf_size(0) {}
+DataType::DataType() : H5Object(), id(H5I_INVALID_HID), encoded_buf(NULL), buf_size(0)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    DataType overloaded constructor

--- a/c++/src/H5DcreatProp.cpp
+++ b/c++/src/H5DcreatProp.cpp
@@ -94,7 +94,9 @@ const DSetCreatPropList &DSetCreatPropList::DEFAULT = *getConstant();
 ///\brief       Default constructor: creates a stub dataset creation property list
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-DSetCreatPropList::DSetCreatPropList() : ObjCreatPropList(H5P_DATASET_CREATE) {}
+DSetCreatPropList::DSetCreatPropList() : ObjCreatPropList(H5P_DATASET_CREATE)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    DSetCreatPropList copy constructor
@@ -102,7 +104,9 @@ DSetCreatPropList::DSetCreatPropList() : ObjCreatPropList(H5P_DATASET_CREATE) {}
 ///             DSetCreatPropList object
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-DSetCreatPropList::DSetCreatPropList(const DSetCreatPropList &orig) : ObjCreatPropList(orig) {}
+DSetCreatPropList::DSetCreatPropList(const DSetCreatPropList &orig) : ObjCreatPropList(orig)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    DSetCreatPropList overloaded constructor
@@ -110,7 +114,9 @@ DSetCreatPropList::DSetCreatPropList(const DSetCreatPropList &orig) : ObjCreatPr
 ///             existing dataset creation property list.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-DSetCreatPropList::DSetCreatPropList(const hid_t plist_id) : ObjCreatPropList(plist_id) {}
+DSetCreatPropList::DSetCreatPropList(const hid_t plist_id) : ObjCreatPropList(plist_id)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    DSetCreatPropList::setChunk
@@ -780,6 +786,8 @@ DSetCreatPropList::setVirtual(const DataSpace &vspace, const H5std_string &src_f
 ///\brief       Noop destructor.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-DSetCreatPropList::~DSetCreatPropList() {}
+DSetCreatPropList::~DSetCreatPropList()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5DxferProp.cpp
+++ b/c++/src/H5DxferProp.cpp
@@ -89,7 +89,9 @@ const DSetMemXferPropList &DSetMemXferPropList::DEFAULT = *getConstant();
 ///             transfer property list object.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-DSetMemXferPropList::DSetMemXferPropList() : PropList(H5P_DATASET_XFER) {}
+DSetMemXferPropList::DSetMemXferPropList() : PropList(H5P_DATASET_XFER)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function     DSetMemXferPropList constructor
@@ -110,7 +112,9 @@ DSetMemXferPropList::DSetMemXferPropList(const char *exp) : PropList(H5P_DATASET
 ///                            list object to copy
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-DSetMemXferPropList::DSetMemXferPropList(const DSetMemXferPropList &original) : PropList(original) {}
+DSetMemXferPropList::DSetMemXferPropList(const DSetMemXferPropList &original) : PropList(original)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function     DSetMemXferPropList overloaded constructor
@@ -120,7 +124,9 @@ DSetMemXferPropList::DSetMemXferPropList(const DSetMemXferPropList &original) : 
 ///                            property list
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-DSetMemXferPropList::DSetMemXferPropList(const hid_t plist_id) : PropList(plist_id) {}
+DSetMemXferPropList::DSetMemXferPropList(const hid_t plist_id) : PropList(plist_id)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    DSetMemXferPropList::setBuffer
@@ -552,6 +558,8 @@ DSetMemXferPropList::getEDCCheck() const
 ///\brief       Noop destructor.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-DSetMemXferPropList::~DSetMemXferPropList() {}
+DSetMemXferPropList::~DSetMemXferPropList()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5EnumType.cpp
+++ b/c++/src/H5EnumType.cpp
@@ -41,7 +41,9 @@ namespace H5 {
 ///\brief       Default constructor: Creates a stub datatype
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-EnumType::EnumType() : DataType() {}
+EnumType::EnumType() : DataType()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    EnumType overloaded constructor
@@ -50,14 +52,18 @@ EnumType::EnumType() : DataType() {}
 ///\exception   H5::DataTypeIException
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-EnumType::EnumType(const hid_t existing_id) : DataType(existing_id) {}
+EnumType::EnumType(const hid_t existing_id) : DataType(existing_id)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    EnumType copy constructor
 ///\brief       Copy constructor: same HDF5 object as \a original
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-EnumType::EnumType(const EnumType &original) : DataType(original) {}
+EnumType::EnumType(const EnumType &original) : DataType(original)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    EnumType overloaded constructor
@@ -69,7 +75,9 @@ EnumType::EnumType(const EnumType &original) : DataType(original) {}
 //              the enum datatype.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-EnumType::EnumType(size_t size) : DataType(H5T_ENUM, size) {}
+EnumType::EnumType(size_t size) : DataType(H5T_ENUM, size)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    EnumType overloaded constructor
@@ -335,6 +343,8 @@ EnumType::getMemberValue(unsigned memb_no, void *value) const
 ///\brief       Properly terminates access to this enum datatype.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-EnumType::~EnumType() {}
+EnumType::~EnumType()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5Exception.cpp
+++ b/c++/src/H5Exception.cpp
@@ -25,7 +25,9 @@ const char Exception::DEFAULT_MSG[] = "No detailed information provided";
 ///\brief       Default constructor.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-Exception::Exception() {}
+Exception::Exception()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    Exception overloaded constructor
@@ -340,7 +342,9 @@ Exception::printErrorStack(FILE *stream, hid_t err_stack)
 ///\brief       Noop destructor
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-Exception::~Exception() throw() {}
+Exception::~Exception() throw()
+{
+}
 
 //--------------------------------------------------------------------------
 // Subclass:    FileIException
@@ -350,7 +354,9 @@ Exception::~Exception() throw() {}
 // Function:    FileIException default constructor
 ///\brief       Default constructor.
 //--------------------------------------------------------------------------
-FileIException::FileIException() : Exception() {}
+FileIException::FileIException() : Exception()
+{
+}
 //--------------------------------------------------------------------------
 // Function:    FileIException overloaded constructor
 ///\brief       Creates a FileIException with the name of the function,
@@ -366,7 +372,9 @@ FileIException::FileIException(const H5std_string &func, const H5std_string &mes
 // Function:    FileIException destructor
 ///\brief       Noop destructor.
 //--------------------------------------------------------------------------
-FileIException::~FileIException() throw() {}
+FileIException::~FileIException() throw()
+{
+}
 
 //--------------------------------------------------------------------------
 // Subclass:    GroupIException
@@ -376,7 +384,9 @@ FileIException::~FileIException() throw() {}
 // Function:    GroupIException default constructor
 ///\brief       Default constructor.
 //--------------------------------------------------------------------------
-GroupIException::GroupIException() : Exception() {}
+GroupIException::GroupIException() : Exception()
+{
+}
 //--------------------------------------------------------------------------
 // Function:    GroupIException overloaded constructor
 ///\brief       Creates a GroupIException with the name of the function,
@@ -392,7 +402,9 @@ GroupIException::GroupIException(const H5std_string &func, const H5std_string &m
 // Function:    GroupIException destructor
 ///\brief       Noop destructor.
 //--------------------------------------------------------------------------
-GroupIException::~GroupIException() throw() {}
+GroupIException::~GroupIException() throw()
+{
+}
 
 //--------------------------------------------------------------------------
 // Subclass:    DataSpaceIException
@@ -402,7 +414,9 @@ GroupIException::~GroupIException() throw() {}
 // Function:    DataSpaceIException default constructor
 ///\brief       Default constructor.
 //--------------------------------------------------------------------------
-DataSpaceIException::DataSpaceIException() : Exception() {}
+DataSpaceIException::DataSpaceIException() : Exception()
+{
+}
 //--------------------------------------------------------------------------
 // Function:    DataSpaceIException overloaded constructor
 ///\brief       Creates a DataSpaceIException with the name of the function,
@@ -418,7 +432,9 @@ DataSpaceIException::DataSpaceIException(const H5std_string &func, const H5std_s
 // Function:    DataSpaceIException destructor
 ///\brief       Noop destructor.
 //--------------------------------------------------------------------------
-DataSpaceIException::~DataSpaceIException() throw() {}
+DataSpaceIException::~DataSpaceIException() throw()
+{
+}
 
 //--------------------------------------------------------------------------
 // Subclass:    DataTypeIException
@@ -428,7 +444,9 @@ DataSpaceIException::~DataSpaceIException() throw() {}
 // Function:    DataTypeIException default constructor
 ///\brief       Default constructor.
 //--------------------------------------------------------------------------
-DataTypeIException::DataTypeIException() : Exception() {}
+DataTypeIException::DataTypeIException() : Exception()
+{
+}
 //--------------------------------------------------------------------------
 // Function:    DataTypeIException overloaded constructor
 ///\brief       Creates a DataTypeIException with the name of the function,
@@ -444,7 +462,9 @@ DataTypeIException::DataTypeIException(const H5std_string &func, const H5std_str
 // Function:    DataTypeIException destructor
 ///\brief       Noop destructor.
 //--------------------------------------------------------------------------
-DataTypeIException::~DataTypeIException() throw() {}
+DataTypeIException::~DataTypeIException() throw()
+{
+}
 
 //--------------------------------------------------------------------------
 // Subclass:    ObjHeaderIException
@@ -454,7 +474,9 @@ DataTypeIException::~DataTypeIException() throw() {}
 // Function:    ObjHeaderIException default constructor
 ///\brief       Default constructor.
 //--------------------------------------------------------------------------
-ObjHeaderIException::ObjHeaderIException() : Exception() {}
+ObjHeaderIException::ObjHeaderIException() : Exception()
+{
+}
 //--------------------------------------------------------------------------
 // Function:    ObjHeaderIException overloaded constructor
 ///\brief       Creates an ObjHeaderIException with the name of the function,
@@ -470,7 +492,9 @@ ObjHeaderIException::ObjHeaderIException(const H5std_string &func, const H5std_s
 // Function:    ObjHeaderIException destructor
 ///\brief       Noop destructor.
 //--------------------------------------------------------------------------
-ObjHeaderIException::~ObjHeaderIException() throw() {}
+ObjHeaderIException::~ObjHeaderIException() throw()
+{
+}
 
 //--------------------------------------------------------------------------
 // Subclass:    PropListIException
@@ -480,7 +504,9 @@ ObjHeaderIException::~ObjHeaderIException() throw() {}
 // Function:    PropListIException default constructor
 ///\brief       Default constructor.
 //--------------------------------------------------------------------------
-PropListIException::PropListIException() : Exception() {}
+PropListIException::PropListIException() : Exception()
+{
+}
 //--------------------------------------------------------------------------
 // Function:    PropListIException overloaded constructor
 ///\brief       Creates a PropListIException with the name of the function,
@@ -496,7 +522,9 @@ PropListIException::PropListIException(const H5std_string &func, const H5std_str
 // Function:    PropListIException destructor
 ///\brief       Noop destructor.
 //--------------------------------------------------------------------------
-PropListIException::~PropListIException() throw() {}
+PropListIException::~PropListIException() throw()
+{
+}
 
 //--------------------------------------------------------------------------
 // Subclass:    DataSetIException
@@ -506,7 +534,9 @@ PropListIException::~PropListIException() throw() {}
 // Function:    DataSetIException default constructor
 ///\brief       Default constructor.
 //--------------------------------------------------------------------------
-DataSetIException::DataSetIException() : Exception() {}
+DataSetIException::DataSetIException() : Exception()
+{
+}
 //--------------------------------------------------------------------------
 // Function:    DataSetIException overloaded constructor
 ///\brief       Creates a DataSetIException with the name of the function,
@@ -522,7 +552,9 @@ DataSetIException::DataSetIException(const H5std_string &func, const H5std_strin
 // Function:    DataSetIException destructor
 ///\brief       Noop destructor.
 //--------------------------------------------------------------------------
-DataSetIException::~DataSetIException() throw() {}
+DataSetIException::~DataSetIException() throw()
+{
+}
 
 //--------------------------------------------------------------------------
 // Subclass:    AttributeIException
@@ -532,7 +564,9 @@ DataSetIException::~DataSetIException() throw() {}
 // Function:    AttributeIException default constructor
 ///\brief       Default constructor.
 //--------------------------------------------------------------------------
-AttributeIException::AttributeIException() : Exception() {}
+AttributeIException::AttributeIException() : Exception()
+{
+}
 //--------------------------------------------------------------------------
 // Function:    AttributeIException overloaded constructor
 ///\brief       Creates an AttributeIException with the name of the function,
@@ -548,7 +582,9 @@ AttributeIException::AttributeIException(const H5std_string &func, const H5std_s
 // Function:    AttributeIException destructor
 ///\brief       Noop destructor.
 //--------------------------------------------------------------------------
-AttributeIException::~AttributeIException() throw() {}
+AttributeIException::~AttributeIException() throw()
+{
+}
 
 //--------------------------------------------------------------------------
 // Subclass:    ReferenceException
@@ -558,7 +594,9 @@ AttributeIException::~AttributeIException() throw() {}
 // Function:    ReferenceException default constructor
 ///\brief       Default constructor.
 //--------------------------------------------------------------------------
-ReferenceException::ReferenceException() : Exception() {}
+ReferenceException::ReferenceException() : Exception()
+{
+}
 //--------------------------------------------------------------------------
 // Function:    ReferenceException overloaded constructor
 ///\brief       Creates a ReferenceException with the name of the function,
@@ -574,7 +612,9 @@ ReferenceException::ReferenceException(const H5std_string &func, const H5std_str
 // Function:    ReferenceException destructor
 ///\brief       Noop destructor.
 //--------------------------------------------------------------------------
-ReferenceException::~ReferenceException() throw() {}
+ReferenceException::~ReferenceException() throw()
+{
+}
 
 //--------------------------------------------------------------------------
 // Subclass:    LibraryIException
@@ -584,7 +624,9 @@ ReferenceException::~ReferenceException() throw() {}
 // Function:    LibraryIException default constructor
 ///\brief       Default constructor.
 //--------------------------------------------------------------------------
-LibraryIException::LibraryIException() : Exception() {}
+LibraryIException::LibraryIException() : Exception()
+{
+}
 //--------------------------------------------------------------------------
 // Function:    LibraryIException overloaded constructor
 ///\brief       Creates a LibraryIException with the name of the function,
@@ -600,7 +642,9 @@ LibraryIException::LibraryIException(const H5std_string &func, const H5std_strin
 // Function:    LibraryIException destructor
 ///\brief       Noop destructor.
 //--------------------------------------------------------------------------
-LibraryIException::~LibraryIException() throw() {}
+LibraryIException::~LibraryIException() throw()
+{
+}
 
 //--------------------------------------------------------------------------
 // Subclass:    LocationException
@@ -610,7 +654,9 @@ LibraryIException::~LibraryIException() throw() {}
 // Function:    LocationException default constructor
 ///\brief       Default constructor.
 //--------------------------------------------------------------------------
-LocationException::LocationException() : Exception() {}
+LocationException::LocationException() : Exception()
+{
+}
 //--------------------------------------------------------------------------
 // Function:    LocationException overloaded constructor
 ///\brief       Creates a LocationException with the name of the function,
@@ -626,7 +672,9 @@ LocationException::LocationException(const H5std_string &func, const H5std_strin
 // Function:    LocationException destructor
 ///\brief       Noop destructor.
 //--------------------------------------------------------------------------
-LocationException::~LocationException() throw() {}
+LocationException::~LocationException() throw()
+{
+}
 
 //--------------------------------------------------------------------------
 // Subclass:    IdComponentException
@@ -636,7 +684,9 @@ LocationException::~LocationException() throw() {}
 // Function:    IdComponentException default constructor
 ///\brief       Default constructor.
 //--------------------------------------------------------------------------
-IdComponentException::IdComponentException() : Exception() {}
+IdComponentException::IdComponentException() : Exception()
+{
+}
 //--------------------------------------------------------------------------
 // Function:    IdComponentException overloaded constructor
 ///\brief       Creates a IdComponentException with the name of the function,
@@ -652,6 +702,8 @@ IdComponentException::IdComponentException(const H5std_string &func, const H5std
 // Function:    IdComponentException destructor
 ///\brief       Noop destructor.
 //--------------------------------------------------------------------------
-IdComponentException::~IdComponentException() throw() {}
+IdComponentException::~IdComponentException() throw()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5FaccProp.cpp
+++ b/c++/src/H5FaccProp.cpp
@@ -92,7 +92,9 @@ const FileAccPropList &FileAccPropList::DEFAULT = *getConstant();
 ///\brief       Creates a file access property list
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-FileAccPropList::FileAccPropList() : PropList(H5P_FILE_ACCESS) {}
+FileAccPropList::FileAccPropList() : PropList(H5P_FILE_ACCESS)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    FileAccPropList copy constructor
@@ -100,7 +102,9 @@ FileAccPropList::FileAccPropList() : PropList(H5P_FILE_ACCESS) {}
 ///\param       original - IN: FileAccPropList instance to copy
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-FileAccPropList::FileAccPropList(const FileAccPropList &original) : PropList(original) {}
+FileAccPropList::FileAccPropList(const FileAccPropList &original) : PropList(original)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    FileAccPropList overloaded constructor
@@ -108,7 +112,9 @@ FileAccPropList::FileAccPropList(const FileAccPropList &original) : PropList(ori
 ///             existing one.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-FileAccPropList::FileAccPropList(const hid_t plist_id) : PropList(plist_id) {}
+FileAccPropList::FileAccPropList(const hid_t plist_id) : PropList(plist_id)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    FileAccPropList::setStdio
@@ -810,6 +816,8 @@ FileAccPropList::getLibverBounds(H5F_libver_t &libver_low, H5F_libver_t &libver_
 ///\brief       Noop destructor
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-FileAccPropList::~FileAccPropList() {}
+FileAccPropList::~FileAccPropList()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5FcreatProp.cpp
+++ b/c++/src/H5FcreatProp.cpp
@@ -84,7 +84,9 @@ const FileCreatPropList &FileCreatPropList::DEFAULT = *getConstant();
 ///\brief       Default constructor: Creates a file create property list
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-FileCreatPropList::FileCreatPropList() : PropList(H5P_FILE_CREATE) {}
+FileCreatPropList::FileCreatPropList() : PropList(H5P_FILE_CREATE)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    FileCreatPropList copy constructor
@@ -93,7 +95,9 @@ FileCreatPropList::FileCreatPropList() : PropList(H5P_FILE_CREATE) {}
 ///\param       original - IN: FileCreatPropList instance to copy
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-FileCreatPropList::FileCreatPropList(const FileCreatPropList &original) : PropList(original) {}
+FileCreatPropList::FileCreatPropList(const FileCreatPropList &original) : PropList(original)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    FileCreatPropList overloaded constructor
@@ -102,7 +106,9 @@ FileCreatPropList::FileCreatPropList(const FileCreatPropList &original) : PropLi
 ///\param       plist_id - IN: FileCreatPropList id to use
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-FileCreatPropList::FileCreatPropList(const hid_t plist_id) : PropList(plist_id) {}
+FileCreatPropList::FileCreatPropList(const hid_t plist_id) : PropList(plist_id)
+{
+}
 
 #ifndef H5_NO_DEPRECATED_SYMBOLS
 //--------------------------------------------------------------------------
@@ -376,6 +382,8 @@ FileCreatPropList::getFileSpacePagesize() const
 ///\brief       Noop destructor.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-FileCreatPropList::~FileCreatPropList() {}
+FileCreatPropList::~FileCreatPropList()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5File.cpp
+++ b/c++/src/H5File.cpp
@@ -45,7 +45,9 @@ using std::endl;
 ///\brief       Default constructor: creates a stub H5File object.
 // December 2000
 //--------------------------------------------------------------------------
-H5File::H5File() : Group(), id(H5I_INVALID_HID) {}
+H5File::H5File() : Group(), id(H5I_INVALID_HID)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    H5File overloaded constructor

--- a/c++/src/H5FloatType.cpp
+++ b/c++/src/H5FloatType.cpp
@@ -40,7 +40,9 @@ namespace H5 {
 ///\brief       Default constructor: Creates a stub floating-point datatype
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-FloatType::FloatType() {}
+FloatType::FloatType()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    FloatType overloaded constructor
@@ -63,14 +65,18 @@ FloatType::FloatType(const PredType &pred_type) : AtomType()
 ///\exception   H5::DataTypeIException
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-FloatType::FloatType(const hid_t existing_id) : AtomType(existing_id) {}
+FloatType::FloatType(const hid_t existing_id) : AtomType(existing_id)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    FloatType copy constructor
 ///\brief       Copy constructor: same HDF5 object as \a original
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-FloatType::FloatType(const FloatType &original) : AtomType(original) {}
+FloatType::FloatType(const FloatType &original) : AtomType(original)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    FloatType overloaded constructor
@@ -342,6 +348,8 @@ FloatType::setInpad(H5T_pad_t inpad) const
 ///\brief       Noop destructor.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-FloatType::~FloatType() {}
+FloatType::~FloatType()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5Group.cpp
+++ b/c++/src/H5Group.cpp
@@ -46,7 +46,9 @@ using std::endl;
 ///\brief       Default constructor: creates a stub Group.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-Group::Group() : H5Object(), CommonFG(), id(H5I_INVALID_HID) {}
+Group::Group() : H5Object(), CommonFG(), id(H5I_INVALID_HID)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    Group copy constructor

--- a/c++/src/H5IdComponent.cpp
+++ b/c++/src/H5IdComponent.cpp
@@ -327,7 +327,9 @@ IdComponent::setId(const hid_t new_id)
 ///\brief       Noop destructor.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-IdComponent::~IdComponent() {}
+IdComponent::~IdComponent()
+{
+}
 
 //
 // Implementation of protected functions for HDF5 Reference Interface

--- a/c++/src/H5IntType.cpp
+++ b/c++/src/H5IntType.cpp
@@ -40,14 +40,18 @@ namespace H5 {
 ///\brief       Default constructor: Creates a stub integer datatype
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-IntType::IntType() {}
+IntType::IntType()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    IntType copy constructor
 ///\brief       Copy constructor: same HDF5 object as \a original
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-IntType::IntType(const IntType &original) : AtomType(original) {}
+IntType::IntType(const IntType &original) : AtomType(original)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    IntType overloaded constructor
@@ -70,7 +74,9 @@ IntType::IntType(const PredType &pred_type) : AtomType()
 ///\exception   H5::DataTypeIException
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-IntType::IntType(const hid_t existing_id) : AtomType(existing_id) {}
+IntType::IntType(const hid_t existing_id) : AtomType(existing_id)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    IntType overloaded constructor
@@ -192,6 +198,8 @@ IntType::setSign(H5T_sign_t sign) const
 ///\brief       Noop destructor.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-IntType::~IntType() {}
+IntType::~IntType()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5LaccProp.cpp
+++ b/c++/src/H5LaccProp.cpp
@@ -86,7 +86,9 @@ const LinkAccPropList &LinkAccPropList::DEFAULT = *getConstant();
 ///\brief       Creates a file access property list
 // Programmer   Binh-Minh Ribler - December, 2016
 //--------------------------------------------------------------------------
-LinkAccPropList::LinkAccPropList() : PropList(H5P_LINK_ACCESS) {}
+LinkAccPropList::LinkAccPropList() : PropList(H5P_LINK_ACCESS)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    LinkAccPropList copy constructor
@@ -94,7 +96,9 @@ LinkAccPropList::LinkAccPropList() : PropList(H5P_LINK_ACCESS) {}
 ///\param       original - IN: LinkAccPropList instance to copy
 // Programmer   Binh-Minh Ribler - December, 2016
 //--------------------------------------------------------------------------
-LinkAccPropList::LinkAccPropList(const LinkAccPropList &original) : PropList(original) {}
+LinkAccPropList::LinkAccPropList(const LinkAccPropList &original) : PropList(original)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    LinkAccPropList overloaded constructor
@@ -102,7 +106,9 @@ LinkAccPropList::LinkAccPropList(const LinkAccPropList &original) : PropList(ori
 ///             existing one.
 // Programmer   Binh-Minh Ribler - December, 2016
 //--------------------------------------------------------------------------
-LinkAccPropList::LinkAccPropList(const hid_t plist_id) : PropList(plist_id) {}
+LinkAccPropList::LinkAccPropList(const hid_t plist_id) : PropList(plist_id)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    LinkAccPropList::setNumLinks
@@ -148,6 +154,8 @@ LinkAccPropList::getNumLinks() const
 ///\brief       Noop destructor
 // Programmer   Binh-Minh Ribler - December, 2016
 //--------------------------------------------------------------------------
-LinkAccPropList::~LinkAccPropList() {}
+LinkAccPropList::~LinkAccPropList()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5LcreatProp.cpp
+++ b/c++/src/H5LcreatProp.cpp
@@ -86,7 +86,9 @@ const LinkCreatPropList &LinkCreatPropList::DEFAULT = *getConstant();
 ///\brief       Creates a file access property list
 // December, 2016
 //--------------------------------------------------------------------------
-LinkCreatPropList::LinkCreatPropList() : PropList(H5P_LINK_CREATE) {}
+LinkCreatPropList::LinkCreatPropList() : PropList(H5P_LINK_CREATE)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    LinkCreatPropList copy constructor
@@ -94,7 +96,9 @@ LinkCreatPropList::LinkCreatPropList() : PropList(H5P_LINK_CREATE) {}
 ///\param       original - IN: LinkCreatPropList instance to copy
 // December, 2016
 //--------------------------------------------------------------------------
-LinkCreatPropList::LinkCreatPropList(const LinkCreatPropList &original) : PropList(original) {}
+LinkCreatPropList::LinkCreatPropList(const LinkCreatPropList &original) : PropList(original)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    LinkCreatPropList overloaded constructor
@@ -102,7 +106,9 @@ LinkCreatPropList::LinkCreatPropList(const LinkCreatPropList &original) : PropLi
 ///             existing one.
 // December, 2016
 //--------------------------------------------------------------------------
-LinkCreatPropList::LinkCreatPropList(const hid_t plist_id) : PropList(plist_id) {}
+LinkCreatPropList::LinkCreatPropList(const hid_t plist_id) : PropList(plist_id)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    LinkCreatPropList::setCreateIntermediateGroup
@@ -185,6 +191,8 @@ LinkCreatPropList::getCharEncoding() const
 ///\brief       Noop destructor
 // December, 2016
 //--------------------------------------------------------------------------
-LinkCreatPropList::~LinkCreatPropList() {}
+LinkCreatPropList::~LinkCreatPropList()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5Library.cpp
+++ b/c++/src/H5Library.cpp
@@ -281,14 +281,18 @@ H5Library::setFreeListLimits(int reg_global_lim, int reg_list_lim, int arr_globa
 ///\brief       Default constructor: Creates a stub H5Library object
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-H5Library::H5Library() {}
+H5Library::H5Library()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    H5Library destructor
 ///\brief       Noop destructor
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-H5Library::~H5Library() {}
+H5Library::~H5Library()
+{
+}
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 } // namespace H5

--- a/c++/src/H5Location.cpp
+++ b/c++/src/H5Location.cpp
@@ -45,7 +45,9 @@ namespace H5 {
 // Function:    H5Location default constructor (protected)
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-H5Location::H5Location() : IdComponent() {}
+H5Location::H5Location() : IdComponent()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    H5Location overloaded constructor (protected)
@@ -2432,6 +2434,8 @@ f_DataSpace_setId(DataSpace *dspace, hid_t new_id)
 ///\brief       Noop destructor.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-H5Location::~H5Location() {}
+H5Location::~H5Location()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5Object.cpp
+++ b/c++/src/H5Object.cpp
@@ -72,7 +72,9 @@ userVisitOpWrpr(H5_ATTR_UNUSED hid_t obj_id, const char *attr_name, const H5O_in
 // Function:    H5Object default constructor (protected)
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-H5Object::H5Object() : H5Location() {}
+H5Object::H5Object() : H5Location()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    f_Attribute_setId - friend
@@ -556,7 +558,9 @@ H5Object::getObjName(H5std_string &obj_name, size_t len) const
 ///\brief       Noop destructor.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-H5Object::~H5Object() {}
+H5Object::~H5Object()
+{
+}
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 } // namespace H5

--- a/c++/src/H5OcreatProp.cpp
+++ b/c++/src/H5OcreatProp.cpp
@@ -86,7 +86,9 @@ const ObjCreatPropList &ObjCreatPropList::DEFAULT = *getConstant();
 ///\brief       Creates a file access property list
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-ObjCreatPropList::ObjCreatPropList() : PropList(H5P_OBJECT_CREATE) {}
+ObjCreatPropList::ObjCreatPropList() : PropList(H5P_OBJECT_CREATE)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    ObjCreatPropList copy constructor
@@ -94,7 +96,9 @@ ObjCreatPropList::ObjCreatPropList() : PropList(H5P_OBJECT_CREATE) {}
 ///\param       original - IN: ObjCreatPropList instance to copy
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-ObjCreatPropList::ObjCreatPropList(const ObjCreatPropList &original) : PropList(original) {}
+ObjCreatPropList::ObjCreatPropList(const ObjCreatPropList &original) : PropList(original)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    ObjCreatPropList overloaded constructor
@@ -102,7 +106,9 @@ ObjCreatPropList::ObjCreatPropList(const ObjCreatPropList &original) : PropList(
 ///             existing one.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-ObjCreatPropList::ObjCreatPropList(const hid_t plist_id) : PropList(plist_id) {}
+ObjCreatPropList::ObjCreatPropList(const hid_t plist_id) : PropList(plist_id)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    ObjCreatPropList::setAttrPhaseChange
@@ -209,6 +215,8 @@ ObjCreatPropList::getAttrCrtOrder() const
 ///\brief       Noop destructor
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-ObjCreatPropList::~ObjCreatPropList() {}
+ObjCreatPropList::~ObjCreatPropList()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5PredType.cpp
+++ b/c++/src/H5PredType.cpp
@@ -42,14 +42,19 @@ namespace H5 {
 //              the provided HDF5 predefined datatype.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-PredType::PredType(const hid_t predtype_id) : AtomType(predtype_id) { id = H5Tcopy(predtype_id); }
+PredType::PredType(const hid_t predtype_id) : AtomType(predtype_id)
+{
+    id = H5Tcopy(predtype_id);
+}
 
 //--------------------------------------------------------------------------
 // Function:    PredType default constructor
 ///\brief       Default constructor: Creates a stub predefined datatype
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-PredType::PredType() : AtomType() {}
+PredType::PredType() : AtomType()
+{
+}
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 //--------------------------------------------------------------------------
@@ -58,7 +63,9 @@ PredType::PredType() : AtomType() {}
 ///\param       original - IN: PredType instance to copy
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-PredType::PredType(const PredType &original) : AtomType(original) {}
+PredType::PredType(const PredType &original) : AtomType(original)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    PredType::operator=
@@ -109,7 +116,9 @@ PredType::committed()
 ///\brief       Noop destructor.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-PredType::~PredType() {}
+PredType::~PredType()
+{
+}
 
 /*****************************************************************************
         The following section is regarding the global constants PredType,

--- a/c++/src/H5PropList.cpp
+++ b/c++/src/H5PropList.cpp
@@ -87,7 +87,9 @@ const PropList &PropList::DEFAULT = *getConstant();
 ///\brief       Default constructor: creates a stub property list object.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-PropList::PropList() : IdComponent(), id(H5P_DEFAULT) {}
+PropList::PropList() : IdComponent(), id(H5P_DEFAULT)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    PropList copy constructor

--- a/c++/src/H5StrType.cpp
+++ b/c++/src/H5StrType.cpp
@@ -41,7 +41,9 @@ namespace H5 {
 ///\brief       Default constructor: Creates a stub string datatype
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-StrType::StrType() : AtomType() {}
+StrType::StrType() : AtomType()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    StrType overloaded constructor
@@ -118,14 +120,18 @@ StrType::StrType(H5_ATTR_UNUSED const int dummy, const size_t &size) : AtomType(
 ///\exception   H5::DataTypeIException
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-StrType::StrType(const hid_t existing_id) : AtomType(existing_id) {}
+StrType::StrType(const hid_t existing_id) : AtomType(existing_id)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    StrType copy constructor
 ///\brief       Copy constructor: same HDF5 object as \a original
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-StrType::StrType(const StrType &original) : AtomType(original) {}
+StrType::StrType(const StrType &original) : AtomType(original)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    StrType overloaded constructor
@@ -302,6 +308,8 @@ StrType::setStrpad(H5T_str_t strpad) const
 ///\brief       Properly terminates access to this string datatype.
 // Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
-StrType::~StrType() {}
+StrType::~StrType()
+{
+}
 
 } // namespace H5

--- a/c++/src/H5VarLenType.cpp
+++ b/c++/src/H5VarLenType.cpp
@@ -33,7 +33,9 @@ namespace H5 {
 // Function:    VarLenType default constructor
 ///\brief       Default constructor: Creates a stub variable-length datatype.
 //--------------------------------------------------------------------------
-VarLenType::VarLenType() : DataType() {}
+VarLenType::VarLenType() : DataType()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    VarLenType overloaded constructor
@@ -42,14 +44,18 @@ VarLenType::VarLenType() : DataType() {}
 ///\exception   H5::DataTypeIException
 // Programmer   Binh-Minh Ribler - May, 2004
 //--------------------------------------------------------------------------
-VarLenType::VarLenType(const hid_t existing_id) : DataType(existing_id) {}
+VarLenType::VarLenType(const hid_t existing_id) : DataType(existing_id)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    VarLenType copy constructor
 ///\brief       Copy constructor: same HDF5 object as \a original
 // Programmer   Binh-Minh Ribler - May, 2004
 //--------------------------------------------------------------------------
-VarLenType::VarLenType(const VarLenType &original) : DataType(original) {}
+VarLenType::VarLenType(const VarLenType &original) : DataType(original)
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    VarLenType overloaded constructor
@@ -153,6 +159,8 @@ VarLenType::decode() const
 ///\brief       Properly terminates access to this datatype.
 // Programmer   Binh-Minh Ribler - May, 2004
 //--------------------------------------------------------------------------
-VarLenType::~VarLenType() {}
+VarLenType::~VarLenType()
+{
+}
 
 } // namespace H5

--- a/c++/test/h5cpputil.cpp
+++ b/c++/test/h5cpputil.cpp
@@ -200,7 +200,9 @@ verify_val(const char *x, const char *value, const char *where, int line, const 
 //--------------------------------------------------------------------------
 // Function:    InvalidActionException default constructor
 //--------------------------------------------------------------------------
-InvalidActionException::InvalidActionException() : Exception() {}
+InvalidActionException::InvalidActionException() : Exception()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    InvalidActionException overloaded constructor
@@ -220,12 +222,16 @@ InvalidActionException::InvalidActionException(const H5std_string &func, const H
 //--------------------------------------------------------------------------
 // Function:    InvalidActionException destructor
 //--------------------------------------------------------------------------
-InvalidActionException::~InvalidActionException() throw() {}
+InvalidActionException::~InvalidActionException() throw()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    TestFailedException default constructor
 //--------------------------------------------------------------------------
-TestFailedException::TestFailedException() : Exception() {}
+TestFailedException::TestFailedException() : Exception()
+{
+}
 
 //--------------------------------------------------------------------------
 // Function:    TestFailedException overloaded constructor
@@ -245,4 +251,6 @@ TestFailedException::TestFailedException(const H5std_string &func, const H5std_s
 //--------------------------------------------------------------------------
 // Function:    TestFailedException destructor
 //--------------------------------------------------------------------------
-TestFailedException::~TestFailedException() throw() {}
+TestFailedException::~TestFailedException() throw()
+{
+}

--- a/hl/c++/src/H5PacketTable.cpp
+++ b/hl/c++/src/H5PacketTable.cpp
@@ -32,15 +32,24 @@
  * Opens an existing packet table, which can contain either fixed-length or
  * variable-length packets.
  */
-PacketTable::PacketTable(hid_t fileID, const char *name) { table_id = H5PTopen(fileID, name); }
+PacketTable::PacketTable(hid_t fileID, const char *name)
+{
+    table_id = H5PTopen(fileID, name);
+}
 
 /* "Open" Constructor - will be deprecated because of char* name */
-PacketTable::PacketTable(hid_t fileID, char *name) { table_id = H5PTopen(fileID, name); }
+PacketTable::PacketTable(hid_t fileID, char *name)
+{
+    table_id = H5PTopen(fileID, name);
+}
 
 /* Destructor
  * Cleans up the packet table
  */
-PacketTable::~PacketTable() { H5PTclose(table_id); }
+PacketTable::~PacketTable()
+{
+    H5PTclose(table_id);
+}
 
 /* IsValid
  * Returns true if this packet table is valid, false otherwise.
@@ -206,10 +215,14 @@ FL_PacketTable::FL_PacketTable(hid_t fileID, char *name, hid_t dtypeID, hsize_t 
  * Opens an existing fixed-length packet table.
  * Fails if the packet table specified is variable-length.
  */
-FL_PacketTable::FL_PacketTable(hid_t fileID, const char *name) : PacketTable(fileID, name) {}
+FL_PacketTable::FL_PacketTable(hid_t fileID, const char *name) : PacketTable(fileID, name)
+{
+}
 
 /* "Open" Constructor - will be deprecated because of char* name */
-FL_PacketTable::FL_PacketTable(hid_t fileID, char *name) : PacketTable(fileID, name) {}
+FL_PacketTable::FL_PacketTable(hid_t fileID, char *name) : PacketTable(fileID, name)
+{
+}
 
 /* AppendPacket
  * Adds a single packet to the packet table.  Takes a pointer

--- a/hl/c++/src/H5PacketTable.h
+++ b/hl/c++/src/H5PacketTable.h
@@ -33,7 +33,10 @@ class H5_HLCPPDLL PacketTable {
     /* Null constructor
      * Sets table_id to "invalid"
      */
-    PacketTable() { table_id = H5I_BADID; }
+    PacketTable()
+    {
+        table_id = H5I_BADID;
+    }
 
     /* "Open" Constructor
      * Opens an existing packet table, which can contain either fixed-length or
@@ -163,7 +166,9 @@ class H5_HLCPPDLL FL_PacketTable : virtual public PacketTable {
     /* Destructor
      * Cleans up the packet table
      */
-    virtual ~FL_PacketTable() {}
+    virtual ~FL_PacketTable()
+    {
+    }
 
     /* AppendPacket
      * Adds a single packet to the packet table.  Takes a pointer

--- a/hl/c++/test/ptableTest.cpp
+++ b/hl/c++/test/ptableTest.cpp
@@ -191,7 +191,10 @@ TestCompoundDatatype()
 
 error:
 
-    H5E_BEGIN_TRY { H5Tclose(dtypeID); }
+    H5E_BEGIN_TRY
+    {
+        H5Tclose(dtypeID);
+    }
     H5E_END_TRY;
 
     H5_FAILED();

--- a/hl/src/H5DS.c
+++ b/hl/src/H5DS.c
@@ -2215,7 +2215,10 @@ H5DS_get_REFLIST_type(void)
 
     return ntid_t;
 out:
-    H5E_BEGIN_TRY { H5Tclose(ntid_t); }
+    H5E_BEGIN_TRY
+    {
+        H5Tclose(ntid_t);
+    }
     H5E_END_TRY;
     return FAIL;
 }

--- a/hl/src/H5LD.c
+++ b/hl/src/H5LD.c
@@ -303,7 +303,10 @@ H5LD_get_dset_dims(hid_t did, hsize_t *cur_dims)
     ret_value = SUCCEED;
 
 done:
-    H5E_BEGIN_TRY { H5Sclose(sid); }
+    H5E_BEGIN_TRY
+    {
+        H5Sclose(sid);
+    }
     H5E_END_TRY;
 
     return (ret_value);

--- a/hl/src/H5LT.c
+++ b/hl/src/H5LT.c
@@ -907,7 +907,10 @@ H5LTopen_file_image(void *buf_ptr, size_t buf_size, unsigned flags)
     return file_id;
 
 out:
-    H5E_BEGIN_TRY { H5Pclose(fapl); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(fapl);
+    }
     H5E_END_TRY;
     return -1;
 } /* end H5LTopen_file_image() */

--- a/hl/test/test_ds.c
+++ b/hl/test/test_ds.c
@@ -3740,7 +3740,10 @@ match_dim_scale(hid_t did, unsigned dim, hid_t dsid, void *visitor_data)
     return ret;
 
 out:
-    H5E_BEGIN_TRY { H5Sclose(sid); }
+    H5E_BEGIN_TRY
+    {
+        H5Sclose(sid);
+    }
     H5E_END_TRY;
     return FAIL;
 }

--- a/hl/test/test_file_image.c
+++ b/hl/test/test_file_image.c
@@ -335,7 +335,10 @@ test_file_image(size_t open_images, size_t nflags, const unsigned *flags)
             VERIFY(status1 < 0, "H5Dwrite() should have failed");
 
             /* extend dimensions of dataset */
-            H5E_BEGIN_TRY { status1 = H5Dset_extent(dset_id[i], dims4); }
+            H5E_BEGIN_TRY
+            {
+                status1 = H5Dset_extent(dset_id[i], dims4);
+            }
             H5E_END_TRY;
 
             VERIFY(status1 < 0, "H5Dset_extent() should have failed");

--- a/hl/test/test_image.c
+++ b/hl/test/test_image.c
@@ -301,7 +301,10 @@ out:
         HDfree(buf1_out);
     if (buf2_out)
         HDfree(buf2_out);
-    H5E_BEGIN_TRY { H5Fclose(fid); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(fid);
+    }
     H5E_END_TRY;
     H5_FAILED();
     return FAIL;
@@ -488,7 +491,10 @@ out:
     if (image_data)
         HDfree(image_data);
 
-    H5E_BEGIN_TRY { H5Fclose(fid); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(fid);
+    }
     H5E_END_TRY;
 
     H5_FAILED();
@@ -720,7 +726,10 @@ out:
     if (image_data)
         HDfree(image_data);
 
-    H5E_BEGIN_TRY { H5Fclose(fid); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(fid);
+    }
     H5E_END_TRY;
     if (f)
         HDfclose(f);

--- a/hl/test/test_ld.c
+++ b/hl/test/test_ld.c
@@ -252,7 +252,10 @@ test_LD_dims_params(const char *file)
     /*
      * 1. Verify failure with negative dataset id
      */
-    H5E_BEGIN_TRY { ret = H5LDget_dset_dims(invalid_id, one_cur_dims); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5LDget_dset_dims(invalid_id, one_cur_dims);
+    }
     H5E_END_TRY;
     VERIFY_EQUAL(ret, FAIL)
 
@@ -261,7 +264,10 @@ test_LD_dims_params(const char *file)
      */
     if ((did = H5Dopen2(fid, DSET_ALLOC_EARLY, H5P_DEFAULT)) < 0)
         FAIL_STACK_ERROR
-    H5E_BEGIN_TRY { ret = H5LDget_dset_dims(did, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5LDget_dset_dims(did, NULL);
+    }
     H5E_END_TRY;
     VERIFY_EQUAL(ret, FAIL)
     if (H5Dclose(did) < 0)
@@ -536,7 +542,10 @@ test_LD_size(const char *file)
     /*
      * Verify failure with an invalid dataset id
      */
-    H5E_BEGIN_TRY { dsize = H5LDget_dset_type_size(invalid_id, NULL); }
+    H5E_BEGIN_TRY
+    {
+        dsize = H5LDget_dset_type_size(invalid_id, NULL);
+    }
     H5E_END_TRY;
     VERIFY_EQUAL(dsize, 0)
 
@@ -916,7 +925,10 @@ test_LD_elmts_invalid(const char *file)
      */
 
     /* Verify failure from case #1: an invalid dataset id */
-    H5E_BEGIN_TRY { ret = H5LDget_dset_elmts(invalid_id, prev_dims, cur_dims, NULL, tbuf); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5LDget_dset_elmts(invalid_id, prev_dims, cur_dims, NULL, tbuf);
+    }
     H5E_END_TRY;
     VERIFY_EQUAL(ret, FAIL)
 

--- a/hl/tools/gif2h5/gifread.c
+++ b/hl/tools/gif2h5/gifread.c
@@ -38,7 +38,10 @@ GetWord(GIFBYTE *MemGif)
 }
 
 GIFBYTE
-GetByte(const GIFBYTE *MemGif) { return *MemGif; }
+GetByte(const GIFBYTE *MemGif)
+{
+    return *MemGif;
+}
 
 /*
  *  Read a GIF image GIFBYTE Header.

--- a/java/src/jni/h5util.c
+++ b/java/src/jni/h5util.c
@@ -1474,7 +1474,10 @@ h5str_dump_region_blocks(JNIEnv *env, h5str_t *str, hid_t region_space, hid_t re
     /*
      * This function fails if the region does not have blocks.
      */
-    H5E_BEGIN_TRY { nblocks = H5Sget_select_hyper_nblocks(region_space); }
+    H5E_BEGIN_TRY
+    {
+        nblocks = H5Sget_select_hyper_nblocks(region_space);
+    }
     H5E_END_TRY;
 
     if (nblocks <= 0) {
@@ -1647,7 +1650,10 @@ h5str_dump_region_points(JNIEnv *env, h5str_t *str, hid_t region_space, hid_t re
     /*
      * This function fails if the region does not have points.
      */
-    H5E_BEGIN_TRY { npoints = H5Sget_select_elem_npoints(region_space); }
+    H5E_BEGIN_TRY
+    {
+        npoints = H5Sget_select_elem_npoints(region_space);
+    }
     H5E_END_TRY;
 
     if (npoints <= 0) {

--- a/src/H5FDmulti.c
+++ b/src/H5FDmulti.c
@@ -281,8 +281,7 @@ H5Pset_fapl_split(hid_t fapl, const char *meta_ext, hid_t meta_plist_id, const c
     H5Eclear2(H5E_DEFAULT);
 
     /* Initialize */
-    ALL_MEMBERS(mt)
-    {
+    ALL_MEMBERS (mt) {
         /* Treat global heap as raw data, not metadata */
         memb_map[mt]  = ((mt == H5FD_MEM_DRAW || mt == H5FD_MEM_GHEAP) ? H5FD_MEM_DRAW : H5FD_MEM_SUPER);
         memb_fapl[mt] = -1;
@@ -588,15 +587,16 @@ H5FD_multi_sb_size(H5FD_t *_file)
     H5Eclear2(H5E_DEFAULT);
 
     /* How many unique files? */
-    UNIQUE_MEMBERS(file->fa.memb_map, mt) { nseen++; }
+    UNIQUE_MEMBERS (file->fa.memb_map, mt) {
+        nseen++;
+    }
     END_MEMBERS;
 
     /* Addresses and EOA markers */
     nbytes += nseen * 2 * 8;
 
     /* Name templates */
-    UNIQUE_MEMBERS(file->fa.memb_map, mt)
-    {
+    UNIQUE_MEMBERS (file->fa.memb_map, mt) {
         size_t n = strlen(file->fa.memb_name[mt]) + 1;
         nbytes += (n + 7) & ~((size_t)0x0007);
     }
@@ -663,8 +663,7 @@ H5FD_multi_sb_encode(H5FD_t *_file, char *name /*out*/, unsigned char *buf /*out
     nseen = 0;
     p     = buf + 8;
     assert(sizeof(haddr_t) <= 8);
-    UNIQUE_MEMBERS(file->fa.memb_map, mt)
-    {
+    UNIQUE_MEMBERS (file->fa.memb_map, mt) {
         memcpy(p, &(file->fa.memb_addr[mt]), sizeof(haddr_t));
         p += sizeof(haddr_t);
         memb_eoa = H5FDget_eoa(file->memb[mt], mt);
@@ -678,8 +677,7 @@ H5FD_multi_sb_encode(H5FD_t *_file, char *name /*out*/, unsigned char *buf /*out
 
     /* Encode all name templates */
     p = buf + 8 + nseen * 2 * 8;
-    UNIQUE_MEMBERS(file->fa.memb_map, mt)
-    {
+    UNIQUE_MEMBERS (file->fa.memb_map, mt) {
         size_t n = strlen(file->fa.memb_name[mt]) + 1;
         strncpy((char *)p, file->fa.memb_name[mt], n);
         p += n;
@@ -735,8 +733,7 @@ H5FD_multi_sb_decode(H5FD_t *_file, const char *name, const unsigned char *buf)
         H5Epush_ret(func, H5E_ERR_CLS, H5E_FILE, H5E_BADVALUE, "invalid multi superblock", -1);
 
     /* Set default values */
-    ALL_MEMBERS(mt)
-    {
+    ALL_MEMBERS (mt) {
         memb_addr[mt] = HADDR_UNDEF;
         memb_eoa[mt]  = HADDR_UNDEF;
         memb_name[mt] = NULL;
@@ -754,7 +751,9 @@ H5FD_multi_sb_decode(H5FD_t *_file, const char *name, const unsigned char *buf)
             map_changed = TRUE;
     }
 
-    UNIQUE_MEMBERS(map, mt) { nseen++; }
+    UNIQUE_MEMBERS (map, mt) {
+        nseen++;
+    }
     END_MEMBERS;
     buf += 8;
 
@@ -766,16 +765,14 @@ H5FD_multi_sb_decode(H5FD_t *_file, const char *name, const unsigned char *buf)
         H5Epush_ret(func, H5E_ERR_CLS, H5E_DATATYPE, H5E_CANTCONVERT, "can't convert superblock info", -1);
     ap = (haddr_t *)((void *)x); /* Extra (void *) cast to quiet "cast to create alignment" warning -
                                     2019/07/05, QAK */
-    UNIQUE_MEMBERS(map, mt)
-    {
+    UNIQUE_MEMBERS (map, mt) {
         memb_addr[_unmapped] = *ap++;
         memb_eoa[_unmapped]  = *ap++;
     }
     END_MEMBERS;
 
     /* Decode name templates */
-    UNIQUE_MEMBERS(map, mt)
-    {
+    UNIQUE_MEMBERS (map, mt) {
         size_t n             = strlen((const char *)buf) + 1;
         memb_name[_unmapped] = (const char *)buf;
         buf += (n + 7) & ~((unsigned)0x0007);
@@ -790,15 +787,18 @@ H5FD_multi_sb_decode(H5FD_t *_file, const char *name, const unsigned char *buf)
      */
     if (map_changed) {
         /* Commit map */
-        ALL_MEMBERS(mt) { file->fa.memb_map[mt] = map[mt]; }
+        ALL_MEMBERS (mt) {
+            file->fa.memb_map[mt] = map[mt];
+        }
         END_MEMBERS;
 
         /* Close files which are unused now */
         memset(in_use, 0, sizeof in_use);
-        UNIQUE_MEMBERS(map, mt) { in_use[mt] = TRUE; }
+        UNIQUE_MEMBERS (map, mt) {
+            in_use[mt] = TRUE;
+        }
         END_MEMBERS;
-        ALL_MEMBERS(mt)
-        {
+        ALL_MEMBERS (mt) {
             if (!in_use[mt] && file->memb[mt]) {
                 (void)H5FDclose(file->memb[mt]);
                 file->memb[mt] = NULL;
@@ -809,8 +809,7 @@ H5FD_multi_sb_decode(H5FD_t *_file, const char *name, const unsigned char *buf)
     }
 
     /* Commit member starting addresses and name templates */
-    ALL_MEMBERS(mt)
-    {
+    ALL_MEMBERS (mt) {
         file->fa.memb_addr[mt] = memb_addr[mt];
         if (memb_name[mt]) {
             if (file->fa.memb_name[mt])
@@ -827,8 +826,7 @@ H5FD_multi_sb_decode(H5FD_t *_file, const char *name, const unsigned char *buf)
         H5Epush_ret(func, H5E_ERR_CLS, H5E_INTERNAL, H5E_BADVALUE, "open_members() failed", -1);
 
     /* Set the EOA marker for all open files */
-    UNIQUE_MEMBERS(file->fa.memb_map, mt)
-    {
+    UNIQUE_MEMBERS (file->fa.memb_map, mt) {
         if (file->memb[mt])
             if (H5FDset_eoa(file->memb[mt], mt, memb_eoa[mt]) < 0)
                 H5Epush_ret(func, H5E_ERR_CLS, H5E_INTERNAL, H5E_CANTSET, "set_eoa() failed", -1);
@@ -898,8 +896,7 @@ H5FD_multi_fapl_copy(const void *_old_fa)
     H5Eclear2(H5E_DEFAULT);
 
     memcpy(new_fa, old_fa, sizeof(H5FD_multi_fapl_t));
-    ALL_MEMBERS(mt)
-    {
+    ALL_MEMBERS (mt) {
         if (old_fa->memb_fapl[mt] >= 0) {
             if (H5Iinc_ref(old_fa->memb_fapl[mt]) < 0) {
                 nerrors++;
@@ -918,8 +915,7 @@ H5FD_multi_fapl_copy(const void *_old_fa)
     END_MEMBERS;
 
     if (nerrors) {
-        ALL_MEMBERS(mt)
-        {
+        ALL_MEMBERS (mt) {
             if (new_fa->memb_fapl[mt] >= 0)
                 (void)H5Idec_ref(new_fa->memb_fapl[mt]);
             if (new_fa->memb_name[mt])
@@ -955,8 +951,7 @@ H5FD_multi_fapl_free(void *_fa)
     /* Clear the error stack */
     H5Eclear2(H5E_DEFAULT);
 
-    ALL_MEMBERS(mt)
-    {
+    ALL_MEMBERS (mt) {
         if (fa->memb_fapl[mt] >= 0)
             if (H5Idec_ref(fa->memb_fapl[mt]) < 0)
                 H5Epush_ret(func, H5E_ERR_CLS, H5E_FILE, H5E_CANTCLOSEOBJ, "can't close property list", -1);
@@ -1018,8 +1013,7 @@ H5FD_multi_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
     }
     fa = (const H5FD_multi_fapl_t *)H5Pget_driver_info(fapl_id);
     assert(fa);
-    ALL_MEMBERS(mt)
-    {
+    ALL_MEMBERS (mt) {
         file->fa.memb_map[mt]  = fa->memb_map[mt];
         file->fa.memb_addr[mt] = fa->memb_addr[mt];
         if (fa->memb_fapl[mt] >= 0)
@@ -1055,8 +1049,7 @@ H5FD_multi_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
 error:
     /* Cleanup and fail */
     if (file) {
-        ALL_MEMBERS(mt)
-        {
+        ALL_MEMBERS (mt) {
             if (file->memb[mt])
                 (void)H5FDclose(file->memb[mt]);
             if (file->fa.memb_fapl[mt] >= 0)
@@ -1099,8 +1092,7 @@ H5FD_multi_close(H5FD_t *_file)
     H5Eclear2(H5E_DEFAULT);
 
     /* Close as many members as possible */
-    ALL_MEMBERS(mt)
-    {
+    ALL_MEMBERS (mt) {
         if (file->memb[mt]) {
             if (H5FDclose(file->memb[mt]) < 0) {
                 nerrors++;
@@ -1115,8 +1107,7 @@ H5FD_multi_close(H5FD_t *_file)
         H5Epush_ret(func, H5E_ERR_CLS, H5E_INTERNAL, H5E_BADVALUE, "error closing member files", -1);
 
     /* Clean up other stuff */
-    ALL_MEMBERS(mt)
-    {
+    ALL_MEMBERS (mt) {
         if (file->fa.memb_fapl[mt] >= 0)
             (void)H5Idec_ref(file->fa.memb_fapl[mt]);
         if (file->fa.memb_name[mt])
@@ -1158,8 +1149,7 @@ H5FD_multi_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
     /* Clear the error stack */
     H5Eclear2(H5E_DEFAULT);
 
-    ALL_MEMBERS(mt)
-    {
+    ALL_MEMBERS (mt) {
         out_mt = mt;
         if (f1->memb[mt] && f2->memb[mt])
             break;
@@ -1268,13 +1258,15 @@ H5FD_multi_get_eoa(const H5FD_t *_file, H5FD_mem_t type)
      * the query is for TYPE == H5FD_MEM_DEFAULT.
      */
     if (H5FD_MEM_DEFAULT == type) {
-        UNIQUE_MEMBERS(file->fa.memb_map, mt)
-        {
+        UNIQUE_MEMBERS (file->fa.memb_map, mt) {
             haddr_t memb_eoa;
 
             if (file->memb[mt]) {
                 /* Retrieve EOA */
-                H5E_BEGIN_TRY { memb_eoa = H5FDget_eoa(file->memb[mt], mt); }
+                H5E_BEGIN_TRY
+                {
+                    memb_eoa = H5FDget_eoa(file->memb[mt], mt);
+                }
                 H5E_END_TRY;
 
                 if (HADDR_UNDEF == memb_eoa)
@@ -1307,7 +1299,10 @@ H5FD_multi_get_eoa(const H5FD_t *_file, H5FD_mem_t type)
             mmt = type;
 
         if (file->memb[mmt]) {
-            H5E_BEGIN_TRY { eoa = H5FDget_eoa(file->memb[mmt], mmt); }
+            H5E_BEGIN_TRY
+            {
+                eoa = H5FDget_eoa(file->memb[mmt], mmt);
+            }
             H5E_END_TRY;
 
             if (HADDR_UNDEF == eoa)
@@ -1385,7 +1380,10 @@ H5FD_multi_set_eoa(H5FD_t *_file, H5FD_mem_t type, haddr_t eoa)
     assert(eoa >= file->fa.memb_addr[mmt]);
     assert(eoa < file->memb_next[mmt]);
 
-    H5E_BEGIN_TRY { status = H5FDset_eoa(file->memb[mmt], mmt, (eoa - file->fa.memb_addr[mmt])); }
+    H5E_BEGIN_TRY
+    {
+        status = H5FDset_eoa(file->memb[mmt], mmt, (eoa - file->fa.memb_addr[mmt]));
+    }
     H5E_END_TRY;
     if (status < 0)
         H5Epush_ret(func, H5E_ERR_CLS, H5E_FILE, H5E_BADVALUE, "member H5FDset_eoa failed", -1);
@@ -1421,13 +1419,15 @@ H5FD_multi_get_eof(const H5FD_t *_file, H5FD_mem_t type)
     H5Eclear2(H5E_DEFAULT);
 
     if (H5FD_MEM_DEFAULT == type) {
-        UNIQUE_MEMBERS(file->fa.memb_map, mt)
-        {
+        UNIQUE_MEMBERS (file->fa.memb_map, mt) {
             haddr_t tmp_eof;
 
             if (file->memb[mt]) {
                 /* Retrieve EOF */
-                H5E_BEGIN_TRY { tmp_eof = H5FDget_eof(file->memb[mt], type); }
+                H5E_BEGIN_TRY
+                {
+                    tmp_eof = H5FDget_eof(file->memb[mt], type);
+                }
                 H5E_END_TRY;
 
                 if (HADDR_UNDEF == tmp_eof)
@@ -1460,7 +1460,10 @@ H5FD_multi_get_eof(const H5FD_t *_file, H5FD_mem_t type)
 
         if (file->memb[mmt]) {
             /* Retrieve EOF */
-            H5E_BEGIN_TRY { eof = H5FDget_eof(file->memb[mmt], mmt); }
+            H5E_BEGIN_TRY
+            {
+                eof = H5FDget_eof(file->memb[mmt], mmt);
+            }
             H5E_END_TRY;
 
             if (HADDR_UNDEF == eof)
@@ -1544,8 +1547,7 @@ H5FD_multi_alloc(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, hsize_t size)
 
     /* XXX: NEED to work on this again */
     if (file->pub.paged_aggr) {
-        ALL_MEMBERS(mt)
-        {
+        ALL_MEMBERS (mt) {
             if (file->memb[mt])
                 file->memb[mt]->paged_aggr = file->pub.paged_aggr;
         }
@@ -1840,8 +1842,7 @@ H5FD_multi_lock(H5FD_t *_file, hbool_t rw)
     H5Eclear2(H5E_DEFAULT);
 
     /* Lock all member files */
-    ALL_MEMBERS(mt)
-    {
+    ALL_MEMBERS (mt) {
         out_mt = mt;
         if (file->memb[mt]) {
             H5E_BEGIN_TRY
@@ -1900,8 +1901,7 @@ H5FD_multi_unlock(H5FD_t *_file)
     /* Clear the error stack */
     H5Eclear2(H5E_DEFAULT);
 
-    ALL_MEMBERS(mt)
-    {
+    ALL_MEMBERS (mt) {
         if (file->memb[mt])
             if (H5FDunlock(file->memb[mt]) < 0)
                 nerrors++;
@@ -1935,11 +1935,12 @@ compute_next(H5FD_multi_t *file)
     /* Clear the error stack */
     H5Eclear2(H5E_DEFAULT);
 
-    ALL_MEMBERS(mt) { file->memb_next[mt] = HADDR_UNDEF; }
+    ALL_MEMBERS (mt) {
+        file->memb_next[mt] = HADDR_UNDEF;
+    }
     END_MEMBERS;
 
-    UNIQUE_MEMBERS(file->fa.memb_map, mt1)
-    {
+    UNIQUE_MEMBERS (file->fa.memb_map, mt1) {
         UNIQUE_MEMBERS2(file->fa.memb_map, mt2)
         {
             if (file->fa.memb_addr[mt1] < file->fa.memb_addr[mt2] &&
@@ -1988,8 +1989,7 @@ open_members(H5FD_multi_t *file)
     /* Clear the error stack */
     H5Eclear2(H5E_DEFAULT);
 
-    UNIQUE_MEMBERS(file->fa.memb_map, mt)
-    {
+    UNIQUE_MEMBERS (file->fa.memb_map, mt) {
         if (file->memb[mt])
             continue; /*already open*/
         assert(file->fa.memb_name[mt]);
@@ -1999,7 +1999,10 @@ open_members(H5FD_multi_t *file)
         sprintf(tmp, file->fa.memb_name[mt], file->name);
         tmp[sizeof(tmp) - 1] = '\0';
 
-        H5E_BEGIN_TRY { file->memb[mt] = H5FDopen(tmp, file->flags, file->fa.memb_fapl[mt], HADDR_UNDEF); }
+        H5E_BEGIN_TRY
+        {
+            file->memb[mt] = H5FDopen(tmp, file->flags, file->fa.memb_fapl[mt], HADDR_UNDEF);
+        }
         H5E_END_TRY;
         if (!file->memb[mt]) {
             if (!file->fa.relax || (file->flags & H5F_ACC_RDWR))

--- a/src/H5FScache.c
+++ b/src/H5FScache.c
@@ -1005,10 +1005,10 @@ H5FS__cache_sinfo_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED l
     if (fspace->serial_sect_count > 0) {
         hsize_t old_tot_sect_count; /* Total section count from header */
         hsize_t H5_ATTR_NDEBUG_UNUSED
-            old_serial_sect_count;                          /* Total serializable section count from header */
-        hsize_t H5_ATTR_NDEBUG_UNUSED old_ghost_sect_count; /* Total ghost section count from header */
-        hsize_t H5_ATTR_NDEBUG_UNUSED old_tot_space;        /* Total space managed from header */
-        unsigned                      sect_cnt_size;        /* The size of the section size counts */
+                                      old_serial_sect_count; /* Total serializable section count from header */
+        hsize_t H5_ATTR_NDEBUG_UNUSED old_ghost_sect_count;  /* Total ghost section count from header */
+        hsize_t H5_ATTR_NDEBUG_UNUSED old_tot_space;         /* Total space managed from header */
+        unsigned                      sect_cnt_size;         /* The size of the section size counts */
 
         /* Compute the size of the section counts */
         sect_cnt_size = H5VM_limit_enc_size((uint64_t)fspace->serial_sect_count);

--- a/src/H5FScache.c
+++ b/src/H5FScache.c
@@ -1005,10 +1005,10 @@ H5FS__cache_sinfo_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED l
     if (fspace->serial_sect_count > 0) {
         hsize_t old_tot_sect_count; /* Total section count from header */
         hsize_t H5_ATTR_NDEBUG_UNUSED
-                                      old_serial_sect_count; /* Total serializable section count from header */
-        hsize_t H5_ATTR_NDEBUG_UNUSED old_ghost_sect_count;  /* Total ghost section count from header */
-        hsize_t H5_ATTR_NDEBUG_UNUSED old_tot_space;         /* Total space managed from header */
-        unsigned                      sect_cnt_size;         /* The size of the section size counts */
+            old_serial_sect_count;                          /* Total serializable section count from header */
+        hsize_t H5_ATTR_NDEBUG_UNUSED old_ghost_sect_count; /* Total ghost section count from header */
+        hsize_t H5_ATTR_NDEBUG_UNUSED old_tot_space;        /* Total space managed from header */
+        unsigned                      sect_cnt_size;        /* The size of the section size counts */
 
         /* Compute the size of the section counts */
         sect_cnt_size = H5VM_limit_enc_size((uint64_t)fspace->serial_sect_count);

--- a/src/H5Fsuper.c
+++ b/src/H5Fsuper.c
@@ -377,7 +377,10 @@ H5F__super_read(H5F_t *f, H5P_genplist_t *fa_plist, hbool_t initial_read)
 
             /* Try detecting file's siganture */
             /* (Don't leave before Bcast, to avoid hang on error) */
-            H5E_BEGIN_TRY { status = H5FD_locate_signature(file, &super_addr); }
+            H5E_BEGIN_TRY
+            {
+                status = H5FD_locate_signature(file, &super_addr);
+            }
             H5E_END_TRY;
 
             /* Set superblock address to undefined on error */

--- a/src/H5Gdeprec.c
+++ b/src/H5Gdeprec.c
@@ -1087,7 +1087,10 @@ H5G__get_objinfo(const H5G_loc_t *loc, const char *name, hbool_t follow_link, H5
 
         /* Get information about link to the object. If this fails, e.g.
          * because the object is ".", just treat the object as a hard link. */
-        H5E_BEGIN_TRY { ret = H5L_get_info(loc, name, &linfo); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5L_get_info(loc, name, &linfo);
+        }
         H5E_END_TRY;
 
         if (ret >= 0 && linfo.type != H5L_TYPE_HARD) {

--- a/src/H5Iint.c
+++ b/src/H5Iint.c
@@ -461,7 +461,10 @@ H5I__destroy_type(H5I_type_t type)
         HGOTO_ERROR(H5E_ID, H5E_BADGROUP, FAIL, "invalid type")
 
     /* Close/clear/destroy all IDs for this type */
-    H5E_BEGIN_TRY { H5I_clear_type(type, TRUE, FALSE); }
+    H5E_BEGIN_TRY
+    {
+        H5I_clear_type(type, TRUE, FALSE);
+    }
     H5E_END_TRY /* don't care about errors */
 
         /* Check if we should release the ID class */

--- a/src/H5MM.c
+++ b/src/H5MM.c
@@ -53,7 +53,7 @@
 struct H5MM_block_t; /* Forward declaration for typedef */
 typedef struct H5MM_block_t {
     unsigned char
-                         sig[H5MM_SIG_SIZE]; /* Signature for the block, to indicate it was allocated with H5MM* interface */
+        sig[H5MM_SIG_SIZE]; /* Signature for the block, to indicate it was allocated with H5MM* interface */
     struct H5MM_block_t *next; /* Pointer to next block in the list of allocated blocks */
     struct H5MM_block_t *prev; /* Pointer to previous block in the list of allocated blocks */
     union {

--- a/src/H5MM.c
+++ b/src/H5MM.c
@@ -53,7 +53,7 @@
 struct H5MM_block_t; /* Forward declaration for typedef */
 typedef struct H5MM_block_t {
     unsigned char
-        sig[H5MM_SIG_SIZE]; /* Signature for the block, to indicate it was allocated with H5MM* interface */
+                         sig[H5MM_SIG_SIZE]; /* Signature for the block, to indicate it was allocated with H5MM* interface */
     struct H5MM_block_t *next; /* Pointer to next block in the list of allocated blocks */
     struct H5MM_block_t *prev; /* Pointer to previous block in the list of allocated blocks */
     union {

--- a/src/H5Pdcpl.c
+++ b/src/H5Pdcpl.c
@@ -96,19 +96,31 @@
 #ifdef H5_HAVE_C99_DESIGNATED_INITIALIZER
 #define H5D_DEF_STORAGE_COMPACT                                                                              \
     {                                                                                                        \
-        H5D_COMPACT, { .compact = H5D_DEF_STORAGE_COMPACT_INIT }                                             \
+        H5D_COMPACT,                                                                                         \
+        {                                                                                                    \
+            .compact = H5D_DEF_STORAGE_COMPACT_INIT                                                          \
+        }                                                                                                    \
     }
 #define H5D_DEF_STORAGE_CONTIG                                                                               \
     {                                                                                                        \
-        H5D_CONTIGUOUS, { .contig = H5D_DEF_STORAGE_CONTIG_INIT }                                            \
+        H5D_CONTIGUOUS,                                                                                      \
+        {                                                                                                    \
+            .contig = H5D_DEF_STORAGE_CONTIG_INIT                                                            \
+        }                                                                                                    \
     }
 #define H5D_DEF_STORAGE_CHUNK                                                                                \
     {                                                                                                        \
-        H5D_CHUNKED, { .chunk = H5D_DEF_STORAGE_CHUNK_INIT }                                                 \
+        H5D_CHUNKED,                                                                                         \
+        {                                                                                                    \
+            .chunk = H5D_DEF_STORAGE_CHUNK_INIT                                                              \
+        }                                                                                                    \
     }
 #define H5D_DEF_STORAGE_VIRTUAL                                                                              \
     {                                                                                                        \
-        H5D_VIRTUAL, { .virt = H5D_DEF_STORAGE_VIRTUAL_INIT }                                                \
+        H5D_VIRTUAL,                                                                                         \
+        {                                                                                                    \
+            .virt = H5D_DEF_STORAGE_VIRTUAL_INIT                                                             \
+        }                                                                                                    \
     }
 #define H5D_DEF_LAYOUT_COMPACT                                                                               \
     {                                                                                                        \

--- a/src/H5Ppkg.h
+++ b/src/H5Ppkg.h
@@ -87,7 +87,7 @@ struct H5P_genclass_t {
     H5P_plist_type_t       type;   /* Type of property */
     size_t                 nprops; /* Number of properties in class */
     unsigned
-             plists; /* Number of property lists that have been created since the last modification to the class */
+        plists; /* Number of property lists that have been created since the last modification to the class */
     unsigned classes; /* Number of classes that have been derived since the last modification to the class */
     unsigned ref_count; /* Number of outstanding ID's open on this class object */
     hbool_t  deleted;  /* Whether this class has been deleted and is waiting for dependent classes & proplists

--- a/src/H5Ppkg.h
+++ b/src/H5Ppkg.h
@@ -87,7 +87,7 @@ struct H5P_genclass_t {
     H5P_plist_type_t       type;   /* Type of property */
     size_t                 nprops; /* Number of properties in class */
     unsigned
-        plists; /* Number of property lists that have been created since the last modification to the class */
+             plists; /* Number of property lists that have been created since the last modification to the class */
     unsigned classes; /* Number of classes that have been derived since the last modification to the class */
     unsigned ref_count; /* Number of outstanding ID's open on this class object */
     hbool_t  deleted;  /* Whether this class has been deleted and is waiting for dependent classes & proplists

--- a/src/H5Spkg.h
+++ b/src/H5Spkg.h
@@ -286,7 +286,7 @@ typedef struct {
     H5S_sel_release_func_t  release;  /* Method to release current selection */
     H5S_sel_is_valid_func_t is_valid; /* Method to determine if current selection is valid for dataspace */
     H5S_sel_serial_size_func_t
-        serial_size; /* Method to determine number of bytes required to store current selection */
+                             serial_size; /* Method to determine number of bytes required to store current selection */
     H5S_sel_serialize_func_t serialize;     /* Method to store current selection in "serialized" form (a byte
                                                sequence suitable for storing on disk) */
     H5S_sel_deserialize_func_t deserialize; /* Method to store create selection from "serialized" form (a byte
@@ -294,7 +294,7 @@ typedef struct {
     H5S_sel_bounds_func_t
         bounds; /* Method to determine to smallest n-D bounding box containing the current selection */
     H5S_sel_offset_func_t
-        offset; /* Method to determine linear offset of initial element in selection within dataspace */
+                             offset; /* Method to determine linear offset of initial element in selection within dataspace */
     H5S_sel_unlim_dim_func_t unlim_dim; /* Method to get unlimited dimension of selection (or -1 for none) */
     H5S_sel_num_elem_non_unlim_func_t num_elem_non_unlim; /* Method to get the number of elements in a slice
                                                              through the unlimited dimension */
@@ -304,9 +304,9 @@ typedef struct {
     H5S_sel_shape_same_func_t
         shape_same; /* Method to determine if two dataspaces' selections are the same shape */
     H5S_sel_intersect_block_func_t
-        intersect_block;               /* Method to determine if a dataspaces' selection intersects a block */
-    H5S_sel_adjust_u_func_t  adjust_u; /* Method to adjust a selection by an offset */
-    H5S_sel_adjust_s_func_t  adjust_s; /* Method to adjust a selection by an offset (signed) */
+                             intersect_block; /* Method to determine if a dataspaces' selection intersects a block */
+    H5S_sel_adjust_u_func_t  adjust_u;        /* Method to adjust a selection by an offset */
+    H5S_sel_adjust_s_func_t  adjust_s;        /* Method to adjust a selection by an offset (signed) */
     H5S_sel_project_scalar   project_scalar; /* Method to construct scalar dataspace projection */
     H5S_sel_project_simple   project_simple; /* Method to construct simple dataspace projection */
     H5S_sel_iter_init_func_t iter_init;      /* Method to initialize iterator for current selection */
@@ -370,7 +370,7 @@ typedef struct H5S_sel_iter_class_t {
     H5S_sel_iter_next_block_func_t
         iter_next_block; /* Method to move selection iterator to the next block in the selection */
     H5S_sel_iter_get_seq_list_func_t
-        iter_get_seq_list; /* Method to retrieve a list of offset/length sequences for selection iterator */
+                                iter_get_seq_list; /* Method to retrieve a list of offset/length sequences for selection iterator */
     H5S_sel_iter_release_func_t iter_release; /* Method to release iterator for current selection */
 } H5S_sel_iter_class_t;
 

--- a/src/H5Spkg.h
+++ b/src/H5Spkg.h
@@ -286,7 +286,7 @@ typedef struct {
     H5S_sel_release_func_t  release;  /* Method to release current selection */
     H5S_sel_is_valid_func_t is_valid; /* Method to determine if current selection is valid for dataspace */
     H5S_sel_serial_size_func_t
-                             serial_size; /* Method to determine number of bytes required to store current selection */
+        serial_size; /* Method to determine number of bytes required to store current selection */
     H5S_sel_serialize_func_t serialize;     /* Method to store current selection in "serialized" form (a byte
                                                sequence suitable for storing on disk) */
     H5S_sel_deserialize_func_t deserialize; /* Method to store create selection from "serialized" form (a byte
@@ -294,7 +294,7 @@ typedef struct {
     H5S_sel_bounds_func_t
         bounds; /* Method to determine to smallest n-D bounding box containing the current selection */
     H5S_sel_offset_func_t
-                             offset; /* Method to determine linear offset of initial element in selection within dataspace */
+        offset; /* Method to determine linear offset of initial element in selection within dataspace */
     H5S_sel_unlim_dim_func_t unlim_dim; /* Method to get unlimited dimension of selection (or -1 for none) */
     H5S_sel_num_elem_non_unlim_func_t num_elem_non_unlim; /* Method to get the number of elements in a slice
                                                              through the unlimited dimension */
@@ -304,9 +304,9 @@ typedef struct {
     H5S_sel_shape_same_func_t
         shape_same; /* Method to determine if two dataspaces' selections are the same shape */
     H5S_sel_intersect_block_func_t
-                             intersect_block; /* Method to determine if a dataspaces' selection intersects a block */
-    H5S_sel_adjust_u_func_t  adjust_u;        /* Method to adjust a selection by an offset */
-    H5S_sel_adjust_s_func_t  adjust_s;        /* Method to adjust a selection by an offset (signed) */
+        intersect_block;               /* Method to determine if a dataspaces' selection intersects a block */
+    H5S_sel_adjust_u_func_t  adjust_u; /* Method to adjust a selection by an offset */
+    H5S_sel_adjust_s_func_t  adjust_s; /* Method to adjust a selection by an offset (signed) */
     H5S_sel_project_scalar   project_scalar; /* Method to construct scalar dataspace projection */
     H5S_sel_project_simple   project_simple; /* Method to construct simple dataspace projection */
     H5S_sel_iter_init_func_t iter_init;      /* Method to initialize iterator for current selection */
@@ -370,7 +370,7 @@ typedef struct H5S_sel_iter_class_t {
     H5S_sel_iter_next_block_func_t
         iter_next_block; /* Method to move selection iterator to the next block in the selection */
     H5S_sel_iter_get_seq_list_func_t
-                                iter_get_seq_list; /* Method to retrieve a list of offset/length sequences for selection iterator */
+        iter_get_seq_list; /* Method to retrieve a list of offset/length sequences for selection iterator */
     H5S_sel_iter_release_func_t iter_release; /* Method to release iterator for current selection */
 } H5S_sel_iter_class_t;
 

--- a/src/H5Tpkg.h
+++ b/src/H5Tpkg.h
@@ -339,7 +339,7 @@ typedef struct H5T_shared_t {
     size_t      size;     /*total size of an instance of this type     */
     unsigned    version;  /* Version of object header message to encode this object with */
     hbool_t
-        force_conv; /* Set if this type always needs to be converted and H5T__conv_noop cannot be called */
+                   force_conv; /* Set if this type always needs to be converted and H5T__conv_noop cannot be called */
     struct H5T_t * parent;        /*parent type for derived datatypes	     */
     H5VL_object_t *owned_vol_obj; /* Vol object owned by this type (free on close) */
     union {

--- a/src/H5Tpkg.h
+++ b/src/H5Tpkg.h
@@ -339,7 +339,7 @@ typedef struct H5T_shared_t {
     size_t      size;     /*total size of an instance of this type     */
     unsigned    version;  /* Version of object header message to encode this object with */
     hbool_t
-                   force_conv; /* Set if this type always needs to be converted and H5T__conv_noop cannot be called */
+        force_conv; /* Set if this type always needs to be converted and H5T__conv_noop cannot be called */
     struct H5T_t * parent;        /*parent type for derived datatypes	     */
     H5VL_object_t *owned_vol_obj; /* Vol object owned by this type (free on close) */
     union {

--- a/src/H5Zscaleoffset.c
+++ b/src/H5Zscaleoffset.c
@@ -1229,7 +1229,7 @@ H5Z__filter_scaleoffset(unsigned flags, size_t cd_nelmts, const unsigned cd_valu
          */
         minval_size = sizeof(unsigned long long) <= ((unsigned char *)*buf)[4] ? sizeof(unsigned long long)
                                                                                : ((unsigned char *)*buf)[4];
-        minval      = 0;
+        minval = 0;
         for (i = 0; i < minval_size; i++) {
             minval_mask = ((unsigned char *)*buf)[5 + i];
             minval_mask <<= i * 8;

--- a/src/H5Zscaleoffset.c
+++ b/src/H5Zscaleoffset.c
@@ -1229,7 +1229,7 @@ H5Z__filter_scaleoffset(unsigned flags, size_t cd_nelmts, const unsigned cd_valu
          */
         minval_size = sizeof(unsigned long long) <= ((unsigned char *)*buf)[4] ? sizeof(unsigned long long)
                                                                                : ((unsigned char *)*buf)[4];
-        minval = 0;
+        minval      = 0;
         for (i = 0; i < minval_size; i++) {
             minval_mask = ((unsigned char *)*buf)[5 + i];
             minval_mask <<= i * 8;

--- a/test/btree2.c
+++ b/test/btree2.c
@@ -676,7 +676,10 @@ test_insert_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Attempt to index record in B-tree with no records */
     idx = 0;
-    H5E_BEGIN_TRY { ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)0, find_cb, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)0, find_cb, NULL);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -731,7 +734,10 @@ test_insert_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Attempt to index non-existant record in B-tree with 1 record */
     idx = 0;
-    H5E_BEGIN_TRY { ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)1, find_cb, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)1, find_cb, NULL);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -793,7 +799,10 @@ test_insert_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Attempt to index non-existant record in B-tree with several records */
     idx = 0;
-    H5E_BEGIN_TRY { ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)4, find_cb, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)4, find_cb, NULL);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -3120,12 +3129,18 @@ HDfprintf(stderr,"curr_time=%lu\n",(unsigned long)curr_time);
     } /* end for */
 
     /* Attempt to index non-existant record in level-4 B-tree, in increasing & decreasing order */
-    H5E_BEGIN_TRY { ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)(INSERT_MANY * 3), find_cb, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)(INSERT_MANY * 3), find_cb, NULL);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
         TEST_ERROR
-    H5E_BEGIN_TRY { ret = H5B2_index(bt2, H5_ITER_DEC, (hsize_t)(INSERT_MANY * 3), find_cb, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_index(bt2, H5_ITER_DEC, (hsize_t)(INSERT_MANY * 3), find_cb, NULL);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -3156,7 +3171,10 @@ HDfprintf(stderr,"curr_time=%lu\n",(unsigned long)curr_time);
         TEST_ERROR
 
     record = INSERT_MANY / 2;
-    H5E_BEGIN_TRY { ret = H5B2_insert(bt2, &record); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_insert(bt2, &record);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -3288,7 +3306,10 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
         TEST_ERROR
 
     /* Attempt to index non-existant record in B-tree with 1 record */
-    H5E_BEGIN_TRY { ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)1, index_rec_cb, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)1, index_rec_cb, NULL);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -3362,7 +3383,10 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
         TEST_ERROR
 
     /* Attempt to index non-existant record in B-tree with 1 record */
-    H5E_BEGIN_TRY { ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)1, index_rec_cb, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)1, index_rec_cb, NULL);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -3436,7 +3460,10 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
         TEST_ERROR
 
     /* Attempt to index non-existant record in B-tree with several records */
-    H5E_BEGIN_TRY { ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)4, index_rec_cb, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)4, index_rec_cb, NULL);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -3527,7 +3554,10 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
         TEST_ERROR
 
     /* Attempt to index non-existant record in B-tree with several records */
-    H5E_BEGIN_TRY { ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)4, index_rec_cb, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)4, index_rec_cb, NULL);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -5187,12 +5217,18 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
     } /* end for */
 
     /* Attempt to index non-existant record in level-4 B-tree, in increasing & decreasing order */
-    H5E_BEGIN_TRY { ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)(INSERT_MANY_REC * 3), find_rec_cb, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_index(bt2, H5_ITER_INC, (hsize_t)(INSERT_MANY_REC * 3), find_rec_cb, NULL);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
         TEST_ERROR
-    H5E_BEGIN_TRY { ret = H5B2_index(bt2, H5_ITER_DEC, (hsize_t)(INSERT_MANY_REC * 3), find_rec_cb, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_index(bt2, H5_ITER_DEC, (hsize_t)(INSERT_MANY_REC * 3), find_rec_cb, NULL);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -5330,7 +5366,10 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Attempt to remove a record from a B-tree with no records */
     record = 0;
-    H5E_BEGIN_TRY { ret = H5B2_remove(bt2, &record, NULL, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_remove(bt2, &record, NULL, NULL);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -5367,7 +5406,10 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Attempt to remove a non-existant record from a B-tree with 1 record */
     record = 0;
-    H5E_BEGIN_TRY { ret = H5B2_remove(bt2, &record, NULL, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_remove(bt2, &record, NULL, NULL);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -5448,7 +5490,10 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
         TEST_ERROR
 
     record = 0;
-    H5E_BEGIN_TRY { ret = H5B2_remove(bt2, &record, NULL, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_remove(bt2, &record, NULL, NULL);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -5650,7 +5695,10 @@ test_remove_level1_noredistrib(hid_t fapl, const H5B2_create_t *cparam, const bt
 
     /* Attempt to remove a non-existant record from a B-tree with 1 record */
     record = (INSERT_SPLIT_ROOT_NREC * 2) + 1;
-    H5E_BEGIN_TRY { ret = H5B2_remove(bt2, &record, NULL, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_remove(bt2, &record, NULL, NULL);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -9229,7 +9277,10 @@ test_find_neighbor(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param
 
     /* Attempt to find record B-tree less than a value */
     search = 0;
-    H5E_BEGIN_TRY { ret = H5B2_neighbor(bt2, H5B2_COMPARE_LESS, &search, neighbor_cb, &record); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_neighbor(bt2, H5B2_COMPARE_LESS, &search, neighbor_cb, &record);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -9306,7 +9357,10 @@ test_find_neighbor(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param
 
     /* Attempt to find record B-tree less than a value */
     search = (FIND_NEIGHBOR * 2) + 1;
-    H5E_BEGIN_TRY { ret = H5B2_neighbor(bt2, H5B2_COMPARE_GREATER, &search, neighbor_cb, &record); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_neighbor(bt2, H5B2_COMPARE_GREATER, &search, neighbor_cb, &record);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -9721,7 +9775,10 @@ test_modify(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_t *tpa
     /* Attempt to modify a non-existant record */
     record = 3;
     modify = 4;
-    H5E_BEGIN_TRY { ret = H5B2_modify(bt2, &record, modify_cb, &modify); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_modify(bt2, &record, modify_cb, &modify);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -9769,7 +9826,10 @@ test_modify(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_t *tpa
     /* Attempt to find original record */
     record = 4330;
     found  = HSIZET_MAX;
-    H5E_BEGIN_TRY { ret = H5B2_modify(bt2, &record, modify_cb, &modify); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_modify(bt2, &record, modify_cb, &modify);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -9817,7 +9877,10 @@ test_modify(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_t *tpa
     /* Attempt to find original record */
     record = 5350;
     found  = 5350;
-    H5E_BEGIN_TRY { ret = H5B2_modify(bt2, &record, modify_cb, &modify); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_modify(bt2, &record, modify_cb, &modify);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -9865,7 +9928,10 @@ test_modify(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_t *tpa
     /* Attempt to find original record */
     record = 9445;
     found  = 9445;
-    H5E_BEGIN_TRY { ret = H5B2_modify(bt2, &record, modify_cb, &modify); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5B2_modify(bt2, &record, modify_cb, &modify);
+    }
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
@@ -10185,7 +10251,10 @@ main(void)
 error:
     HDputs("*** TESTS FAILED ***");
 
-    H5E_BEGIN_TRY { H5Pclose(fapl); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(fapl);
+    }
     H5E_END_TRY;
 
     if (api_ctx_pushed)

--- a/test/cache_api.c
+++ b/test/cache_api.c
@@ -1699,7 +1699,10 @@ check_fapl_mdc_api_errs(void)
     scratch.version = H5C__CURR_AUTO_SIZE_CTL_VER;
     if (pass) {
 
-        H5E_BEGIN_TRY { result = H5Pget_mdc_config((hid_t)-1, &scratch); }
+        H5E_BEGIN_TRY
+        {
+            result = H5Pget_mdc_config((hid_t)-1, &scratch);
+        }
         H5E_END_TRY;
 
         if (result >= 0) {
@@ -1734,7 +1737,10 @@ check_fapl_mdc_api_errs(void)
 
     if (pass) {
 
-        H5E_BEGIN_TRY { result = H5Pget_mdc_config(fapl_id, NULL); }
+        H5E_BEGIN_TRY
+        {
+            result = H5Pget_mdc_config(fapl_id, NULL);
+        }
         H5E_END_TRY;
 
         if (result >= 0) {
@@ -1749,7 +1755,10 @@ check_fapl_mdc_api_errs(void)
     scratch.version = -1; /* a convenient, invalid value */
     if (pass) {
 
-        H5E_BEGIN_TRY { result = H5Pget_mdc_config(fapl_id, &scratch); }
+        H5E_BEGIN_TRY
+        {
+            result = H5Pget_mdc_config(fapl_id, &scratch);
+        }
         H5E_END_TRY;
 
         if (result >= 0) {
@@ -1765,7 +1774,10 @@ check_fapl_mdc_api_errs(void)
     scratch.version = H5C__CURR_AUTO_SIZE_CTL_VER;
     if (pass) {
 
-        H5E_BEGIN_TRY { result = H5Pset_mdc_config((hid_t)-1, &default_config); }
+        H5E_BEGIN_TRY
+        {
+            result = H5Pset_mdc_config((hid_t)-1, &default_config);
+        }
         H5E_END_TRY;
 
         if (result >= 0) {
@@ -1777,7 +1789,10 @@ check_fapl_mdc_api_errs(void)
 
     if (pass) {
 
-        H5E_BEGIN_TRY { result = H5Pset_mdc_config(fapl_id, NULL); }
+        H5E_BEGIN_TRY
+        {
+            result = H5Pset_mdc_config(fapl_id, NULL);
+        }
         H5E_END_TRY;
 
         if (result >= 0) {
@@ -1789,7 +1804,10 @@ check_fapl_mdc_api_errs(void)
 
     i = 0;
     while ((pass) && (i < NUM_INVALID_CONFIGS)) {
-        H5E_BEGIN_TRY { result = H5Pset_mdc_config(fapl_id, &(invalid_configs[i])); }
+        H5E_BEGIN_TRY
+        {
+            result = H5Pset_mdc_config(fapl_id, &(invalid_configs[i]));
+        }
         H5E_END_TRY;
 
         if (result >= 0) {
@@ -1914,7 +1932,10 @@ check_file_mdc_api_errs(unsigned paged, hid_t fcpl_id)
             HDfprintf(stdout, "%s: testing H5Fget_mdc_config() 1.\n", FUNC);
         }
 
-        H5E_BEGIN_TRY { result = H5Fget_mdc_config((hid_t)-1, &scratch); }
+        H5E_BEGIN_TRY
+        {
+            result = H5Fget_mdc_config((hid_t)-1, &scratch);
+        }
         H5E_END_TRY;
 
         if (result >= 0) {
@@ -1931,7 +1952,10 @@ check_file_mdc_api_errs(unsigned paged, hid_t fcpl_id)
             HDfprintf(stdout, "%s: testing H5Fget_mdc_config() 2.\n", FUNC);
         }
 
-        H5E_BEGIN_TRY { result = H5Fget_mdc_config(file_id, NULL); }
+        H5E_BEGIN_TRY
+        {
+            result = H5Fget_mdc_config(file_id, NULL);
+        }
         H5E_END_TRY;
 
         if (result >= 0) {
@@ -1949,7 +1973,10 @@ check_file_mdc_api_errs(unsigned paged, hid_t fcpl_id)
             HDfprintf(stdout, "%s: testing H5Fget_mdc_config() 3.\n", FUNC);
         }
 
-        H5E_BEGIN_TRY { result = H5Fget_mdc_config(file_id, &scratch); }
+        H5E_BEGIN_TRY
+        {
+            result = H5Fget_mdc_config(file_id, &scratch);
+        }
         H5E_END_TRY;
 
         if (result >= 0) {
@@ -1969,7 +1996,10 @@ check_file_mdc_api_errs(unsigned paged, hid_t fcpl_id)
             HDfprintf(stdout, "%s: testing H5Fset_mdc_config() 1.\n", FUNC);
         }
 
-        H5E_BEGIN_TRY { result = H5Fset_mdc_config((hid_t)-1, &default_config); }
+        H5E_BEGIN_TRY
+        {
+            result = H5Fset_mdc_config((hid_t)-1, &default_config);
+        }
         H5E_END_TRY;
 
         if (result >= 0) {
@@ -1986,7 +2016,10 @@ check_file_mdc_api_errs(unsigned paged, hid_t fcpl_id)
             HDfprintf(stdout, "%s: testing H5Fset_mdc_config() 2.\n", FUNC);
         }
 
-        H5E_BEGIN_TRY { result = H5Fset_mdc_config(file_id, NULL); }
+        H5E_BEGIN_TRY
+        {
+            result = H5Fset_mdc_config(file_id, NULL);
+        }
         H5E_END_TRY;
 
         if (result >= 0) {
@@ -2003,7 +2036,10 @@ check_file_mdc_api_errs(unsigned paged, hid_t fcpl_id)
             HDfprintf(stdout, "%s: testing H5Fset_mdc_config() with invalid config %d.\n", FUNC, i);
         }
 
-        H5E_BEGIN_TRY { result = H5Fset_mdc_config(file_id, &(invalid_configs[i])); }
+        H5E_BEGIN_TRY
+        {
+            result = H5Fset_mdc_config(file_id, &(invalid_configs[i]));
+        }
         H5E_END_TRY;
 
         if (result >= 0) {
@@ -2028,7 +2064,10 @@ check_file_mdc_api_errs(unsigned paged, hid_t fcpl_id)
             HDfprintf(stdout, "%s: testing H5Fget_mdc_hit_rate() 1.\n", FUNC);
         }
 
-        H5E_BEGIN_TRY { result = H5Fget_mdc_hit_rate((hid_t)-1, &hit_rate); }
+        H5E_BEGIN_TRY
+        {
+            result = H5Fget_mdc_hit_rate((hid_t)-1, &hit_rate);
+        }
         H5E_END_TRY;
 
         if (result >= 0) {
@@ -2045,7 +2084,10 @@ check_file_mdc_api_errs(unsigned paged, hid_t fcpl_id)
             HDfprintf(stdout, "%s: testing H5Fget_mdc_hit_rate() 2.\n", FUNC);
         }
 
-        H5E_BEGIN_TRY { result = H5Fget_mdc_hit_rate(file_id, NULL); }
+        H5E_BEGIN_TRY
+        {
+            result = H5Fget_mdc_hit_rate(file_id, NULL);
+        }
         H5E_END_TRY;
 
         if (result >= 0) {
@@ -2063,7 +2105,10 @@ check_file_mdc_api_errs(unsigned paged, hid_t fcpl_id)
             HDfprintf(stdout, "%s: testing H5Freset_mdc_hit_rate_stats().\n", FUNC);
         }
 
-        H5E_BEGIN_TRY { result = H5Freset_mdc_hit_rate_stats((hid_t)-1); }
+        H5E_BEGIN_TRY
+        {
+            result = H5Freset_mdc_hit_rate_stats((hid_t)-1);
+        }
         H5E_END_TRY;
 
         if (result >= 0) {

--- a/test/cache_common.h
+++ b/test/cache_common.h
@@ -393,7 +393,7 @@ typedef struct test_entry_t {
     unsigned flush_dep_npar;                         /* Number of flush dependency parents */
     unsigned flush_dep_nchd;                         /* Number of flush dependency children */
     unsigned
-             flush_dep_ndirty_chd; /* Number of dirty flush dependency children (including granchildren, etc.) */
+        flush_dep_ndirty_chd; /* Number of dirty flush dependency children (including granchildren, etc.) */
     hbool_t  pinned_from_client; /* entry was pinned by client call */
     hbool_t  pinned_from_cache;  /* entry was pinned by cache internally */
     unsigned flush_order;        /* Order that entry was flushed in */

--- a/test/cache_common.h
+++ b/test/cache_common.h
@@ -393,7 +393,7 @@ typedef struct test_entry_t {
     unsigned flush_dep_npar;                         /* Number of flush dependency parents */
     unsigned flush_dep_nchd;                         /* Number of flush dependency children */
     unsigned
-        flush_dep_ndirty_chd; /* Number of dirty flush dependency children (including granchildren, etc.) */
+             flush_dep_ndirty_chd; /* Number of dirty flush dependency children (including granchildren, etc.) */
     hbool_t  pinned_from_client; /* entry was pinned by client call */
     hbool_t  pinned_from_cache;  /* entry was pinned by cache internally */
     unsigned flush_order;        /* Order that entry was flushed in */

--- a/test/cache_image.c
+++ b/test/cache_image.c
@@ -940,7 +940,10 @@ attempt_swmr_open_hdf5_file(const hbool_t create_file, const hbool_t set_mdci_fa
         }
         else {
 
-            H5E_BEGIN_TRY { file_id = H5Fopen(hdf_file_name, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl_id); }
+            H5E_BEGIN_TRY
+            {
+                file_id = H5Fopen(hdf_file_name, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl_id);
+            }
             H5E_END_TRY;
         }
 

--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -1725,7 +1725,10 @@ test_failed_attempts(const char *filename, hid_t fapl)
         TEST_ERROR
 
     /* Attempt to get the number of chunks on contiguous dataset, should fail */
-    H5E_BEGIN_TRY { ret = H5Dget_num_chunks(dset, dspace, &nchunks); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dget_num_chunks(dset, dspace, &nchunks);
+    }
     H5E_END_TRY;
     if (ret != FAIL)
         FAIL_PUTS_ERROR("    Attempt a chunk query function on a contiguous dataset.")
@@ -1745,7 +1748,10 @@ test_failed_attempts(const char *filename, hid_t fapl)
      * dataset, should fail */
     offset[0] = 0;
     offset[1] = 0;
-    H5E_BEGIN_TRY { ret = H5Dget_chunk_info_by_coord(dset, offset, &read_flt_msk, &addr, &size); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dget_chunk_info_by_coord(dset, offset, &read_flt_msk, &addr, &size);
+    }
     H5E_END_TRY;
     if (ret != FAIL)
         FAIL_PUTS_ERROR("    Attempt a chunk query function on a contiguous dataset.")

--- a/test/cork.c
+++ b/test/cork.c
@@ -1469,19 +1469,28 @@ verify_multiple_cork(hbool_t swmr)
         TEST_ERROR
 
     /* Should fail to cork the attribute: aidg2; not an object */
-    H5E_BEGIN_TRY { ret = H5Odisable_mdc_flushes(aidg2); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Odisable_mdc_flushes(aidg2);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
 
     /* Should fail to uncork the attribute: aidd1; not an object */
-    H5E_BEGIN_TRY { ret = H5Odisable_mdc_flushes(aidd1); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Odisable_mdc_flushes(aidd1);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
 
     /* Should fail to check cork status of the attribute: aidt2; not an object */
-    H5E_BEGIN_TRY { ret = H5Oare_mdc_flushes_disabled(aidt2, &corked); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Oare_mdc_flushes_disabled(aidt2, &corked);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -1511,7 +1520,10 @@ verify_multiple_cork(hbool_t swmr)
         TEST_ERROR
 
     /* Should fail to uncork the file: fid2; not an object */
-    H5E_BEGIN_TRY { ret = H5Oenable_mdc_flushes(fid2); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Oenable_mdc_flushes(fid2);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -1646,7 +1658,10 @@ test_objs_cork(hbool_t swmr, hbool_t new_format)
         TEST_ERROR
 
     /* Should fail to cork the datatype: not an object */
-    H5E_BEGIN_TRY { ret = H5Odisable_mdc_flushes(tid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Odisable_mdc_flushes(tid);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -1682,7 +1697,10 @@ test_objs_cork(hbool_t swmr, hbool_t new_format)
         TEST_ERROR
 
     /* Should fail to uncork the dataspace: not an object */
-    H5E_BEGIN_TRY { ret = H5Oenable_mdc_flushes(sid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Oenable_mdc_flushes(sid);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -1696,7 +1714,10 @@ test_objs_cork(hbool_t swmr, hbool_t new_format)
         TEST_ERROR
 
     /* Should fail to check cork status of the attribute: not an object */
-    H5E_BEGIN_TRY { ret = H5Oare_mdc_flushes_disabled(aid, &corked); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Oare_mdc_flushes_disabled(aid, &corked);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -1736,7 +1757,10 @@ test_objs_cork(hbool_t swmr, hbool_t new_format)
         TEST_ERROR
 
     /* Should fail to cork the group again */
-    H5E_BEGIN_TRY { ret = H5Odisable_mdc_flushes(gid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Odisable_mdc_flushes(gid);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -1758,7 +1782,10 @@ test_objs_cork(hbool_t swmr, hbool_t new_format)
         TEST_ERROR
 
     /* Should fail to un-cork the named datatype that is not corked yet */
-    H5E_BEGIN_TRY { ret = H5Oenable_mdc_flushes(tid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Oenable_mdc_flushes(tid);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR

--- a/test/cross_read.c
+++ b/test/cross_read.c
@@ -121,7 +121,10 @@ check_data_i(const char *dsetname, hid_t fid)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Dclose(did); }
+    H5E_BEGIN_TRY
+    {
+        H5Dclose(did);
+    }
     H5E_END_TRY;
     return 1;
 } /* end check_data_i() */
@@ -192,7 +195,10 @@ check_data_f(const char *dsetname, hid_t fid)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Dclose(did); }
+    H5E_BEGIN_TRY
+    {
+        H5Dclose(did);
+    }
     H5E_END_TRY;
     return 1;
 } /* end check_data_f() */
@@ -321,7 +327,10 @@ check_file(char *filename)
     return nerrors;
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(fid); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(fid);
+    }
     H5E_END_TRY;
     return nerrors;
 } /* end check_file() */

--- a/test/dangle.c
+++ b/test/dangle.c
@@ -176,7 +176,10 @@ test_dangle_group(H5F_close_degree_t degree)
         TEST_ERROR;
 
     /* Try creating duplicate group */
-    H5E_BEGIN_TRY { gid = H5Gcreate2(fid, GROUPNAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gcreate2(fid, GROUPNAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (gid >= 0)
         TEST_ERROR

--- a/test/direct_chunk.c
+++ b/test/direct_chunk.c
@@ -2026,7 +2026,10 @@ test_read_unallocated_chunk(hid_t file)
             offset[1] = j * CHUNK_NY;
 
             /* Read a non-existant chunk using the direct read function. */
-            H5E_BEGIN_TRY { status = H5Dread_chunk(dataset, dxpl, offset, &filter_mask, &direct_buf); }
+            H5E_BEGIN_TRY
+            {
+                status = H5Dread_chunk(dataset, dxpl, offset, &filter_mask, &direct_buf);
+            }
             H5E_END_TRY;
 
             /* Check that the chunk read call does not succeed. */
@@ -2035,7 +2038,10 @@ test_read_unallocated_chunk(hid_t file)
 
             /* Query the size of the non-existant chunk */
             direct_chunk_nbytes = ULONG_MAX;
-            H5E_BEGIN_TRY { status = H5Dget_chunk_storage_size(dataset, offset, &direct_chunk_nbytes); }
+            H5E_BEGIN_TRY
+            {
+                status = H5Dget_chunk_storage_size(dataset, offset, &direct_chunk_nbytes);
+            }
             H5E_END_TRY;
 
             /* Check that the chunk storage size call does not succeed. */

--- a/test/dsets.c
+++ b/test/dsets.c
@@ -434,7 +434,10 @@ test_create(hid_t file)
      * cannot be created with this function.  Temporarily turn off error
      * reporting.
      */
-    H5E_BEGIN_TRY { dataset = H5Dopen2(file, "does_not_exist", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        dataset = H5Dopen2(file, "does_not_exist", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (dataset >= 0) {
         H5_FAILED();
@@ -929,7 +932,10 @@ test_compact_io(hid_t fapl)
         for (high = H5F_LIBVER_EARLIEST; high < H5F_LIBVER_NBOUNDS; high++) {
 
             /* Set version bounds */
-            H5E_BEGIN_TRY { ret = H5Pset_libver_bounds(new_fapl, low, high); }
+            H5E_BEGIN_TRY
+            {
+                ret = H5Pset_libver_bounds(new_fapl, low, high);
+            }
             H5E_END_TRY;
 
             if (ret < 0) /* Invalid low/high combinations */
@@ -1450,7 +1456,10 @@ test_conv_buffer(hid_t fid)
     if (H5Pset_buffer(xfer_list, size, NULL, NULL) < 0)
         goto error;
 
-    H5E_BEGIN_TRY { status = H5Dread(dataset, ctype2, H5S_ALL, H5S_ALL, xfer_list, cfrR); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Dread(dataset, ctype2, H5S_ALL, H5S_ALL, xfer_list, cfrR);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -1981,7 +1990,10 @@ test_filter_internal(hid_t fid, const char *name, hid_t dcpl, int if_fletcher32,
     if (corrupted) {
         /* Default behavior is failure when data is corrupted. */
         /* (Use the "write" DXPL in order to make certain corruption is seen) */
-        H5E_BEGIN_TRY { status = H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, write_dxpl, check_data); }
+        H5E_BEGIN_TRY
+        {
+            status = H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, write_dxpl, check_data);
+        }
         H5E_END_TRY;
         if (status >= 0)
             TEST_ERROR;
@@ -1996,7 +2008,10 @@ test_filter_internal(hid_t fid, const char *name, hid_t dcpl, int if_fletcher32,
         if (H5Pset_filter_callback(write_dxpl, filter_cb_fail, NULL) < 0)
             TEST_ERROR;
         /* (Use the "write" DXPL in order to make certain corruption is seen) */
-        H5E_BEGIN_TRY { status = H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, write_dxpl, check_data); }
+        H5E_BEGIN_TRY
+        {
+            status = H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, write_dxpl, check_data);
+        }
         H5E_END_TRY;
         if (status >= 0)
             TEST_ERROR;
@@ -2042,7 +2057,10 @@ test_filter_internal(hid_t fid, const char *name, hid_t dcpl, int if_fletcher32,
     if (corrupted) {
         /* Default behavior is failure when data is corrupted. */
         /* (Use the "write" DXPL in order to make certain corruption is seen) */
-        H5E_BEGIN_TRY { status = H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, write_dxpl, check_data); }
+        H5E_BEGIN_TRY
+        {
+            status = H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, write_dxpl, check_data);
+        }
         H5E_END_TRY;
         if (status >= 0)
             TEST_ERROR;
@@ -2057,7 +2075,10 @@ test_filter_internal(hid_t fid, const char *name, hid_t dcpl, int if_fletcher32,
         if (H5Pset_filter_callback(write_dxpl, filter_cb_fail, NULL) < 0)
             TEST_ERROR;
         /* (Use the "write" DXPL in order to make certain corruption is seen) */
-        H5E_BEGIN_TRY { status = H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, write_dxpl, check_data); }
+        H5E_BEGIN_TRY
+        {
+            status = H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, write_dxpl, check_data);
+        }
         H5E_END_TRY;
         if (status >= 0)
             TEST_ERROR;
@@ -2100,7 +2121,10 @@ test_filter_internal(hid_t fid, const char *name, hid_t dcpl, int if_fletcher32,
     if (corrupted) {
         /* Default behavior is failure when data is corrupted. */
         /* (Use the "write" DXPL in order to make certain corruption is seen) */
-        H5E_BEGIN_TRY { status = H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, write_dxpl, check_data); }
+        H5E_BEGIN_TRY
+        {
+            status = H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, write_dxpl, check_data);
+        }
         H5E_END_TRY;
         if (status >= 0)
             TEST_ERROR;
@@ -2116,7 +2140,10 @@ test_filter_internal(hid_t fid, const char *name, hid_t dcpl, int if_fletcher32,
             TEST_ERROR;
 
         /* (Use the "write" DXPL in order to make certain corruption is seen) */
-        H5E_BEGIN_TRY { status = H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, write_dxpl, check_data); }
+        H5E_BEGIN_TRY
+        {
+            status = H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, write_dxpl, check_data);
+        }
         H5E_END_TRY;
         if (status >= 0)
             TEST_ERROR;
@@ -2161,7 +2188,10 @@ test_filter_internal(hid_t fid, const char *name, hid_t dcpl, int if_fletcher32,
     if (corrupted) {
         /* Default behavior is failure when data is corrupted. */
         /* (Use the "write" DXPL in order to make certain corruption is seen) */
-        H5E_BEGIN_TRY { status = H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, write_dxpl, check_data); }
+        H5E_BEGIN_TRY
+        {
+            status = H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, write_dxpl, check_data);
+        }
         H5E_END_TRY;
         if (status >= 0)
             TEST_ERROR;
@@ -2176,7 +2206,10 @@ test_filter_internal(hid_t fid, const char *name, hid_t dcpl, int if_fletcher32,
         if (H5Pset_filter_callback(write_dxpl, filter_cb_fail, NULL) < 0)
             TEST_ERROR;
         /* (Use the "write" DXPL in order to make certain corruption is seen) */
-        H5E_BEGIN_TRY { status = H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, write_dxpl, check_data); }
+        H5E_BEGIN_TRY
+        {
+            status = H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, write_dxpl, check_data);
+        }
         H5E_END_TRY;
         if (status >= 0)
             TEST_ERROR;
@@ -2317,7 +2350,10 @@ test_filter_noencoder(const char *dset_name)
      * allocation.
      */
     dims = 20; /* Dataset is originally of size 10 */
-    H5E_BEGIN_TRY { err = H5Dset_extent(dset_id, &dims); }
+    H5E_BEGIN_TRY
+    {
+        err = H5Dset_extent(dset_id, &dims);
+    }
     H5E_END_TRY
 
     if (err >= 0)
@@ -2326,7 +2362,10 @@ test_filter_noencoder(const char *dset_name)
     /* Attempt to write to the dataset.  This should fail because
      * the filter does not have an encoder.
      */
-    H5E_BEGIN_TRY { err = H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, test_ints); }
+    H5E_BEGIN_TRY
+    {
+        err = H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, test_ints);
+    }
     H5E_END_TRY
 
     if (err >= 0)
@@ -2419,7 +2458,10 @@ test_get_filter_info(void)
 
     /* Verify that get_filter_info throws an error when given a bad filter */
     /* (Depends on 1.6 compatibility flag) */
-    H5E_BEGIN_TRY { err = H5Zget_filter_info(-1, &flags); }
+    H5E_BEGIN_TRY
+    {
+        err = H5Zget_filter_info(-1, &flags);
+    }
     H5E_END_TRY;
     if (err >= 0)
         TEST_ERROR
@@ -2966,7 +3008,10 @@ test_missing_filter(hid_t file)
     } /* end if */
 
     /* Read data (should fail, since deflate filter is missing) */
-    H5E_BEGIN_TRY { ret = H5Dread(dsid, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, check_data); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dread(dsid, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, check_data);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         H5_FAILED();
@@ -6287,7 +6332,10 @@ test_can_apply_szip(hid_t
 
         /* Set (invalid at property set time) szip parameters */
         szip_pixels_per_block = 3;
-        H5E_BEGIN_TRY { ret = H5Pset_szip(dcpl, szip_options_mask, szip_pixels_per_block); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Pset_szip(dcpl, szip_options_mask, szip_pixels_per_block);
+        }
         H5E_END_TRY;
         if (ret >= 0) {
             H5_FAILED();
@@ -6297,7 +6345,10 @@ test_can_apply_szip(hid_t
 
         /* Set (invalid at property set time) szip parameters */
         szip_pixels_per_block = 512;
-        H5E_BEGIN_TRY { ret = H5Pset_szip(dcpl, szip_options_mask, szip_pixels_per_block); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Pset_szip(dcpl, szip_options_mask, szip_pixels_per_block);
+        }
         H5E_END_TRY;
         if (ret >= 0) {
             H5_FAILED();
@@ -7052,7 +7103,10 @@ test_filter_delete(hid_t file)
     } /* end if */
 
     /* try to delete the deflate filter again */
-    H5E_BEGIN_TRY { ret = H5Premove_filter(dcpl1, H5Z_FILTER_DEFLATE); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Premove_filter(dcpl1, H5Z_FILTER_DEFLATE);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         H5_FAILED();
@@ -7337,7 +7391,10 @@ test_zero_dims(hid_t file)
     } /* end if */
 
     /* Try creating chunked dataset with zero-sized chunk dimensions */
-    H5E_BEGIN_TRY { ret = H5Pset_chunk(dcpl, 1, &dzero); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_chunk(dcpl, 1, &dzero);
+    }
     H5E_END_TRY;
     if (ret > 0)
         FAIL_PUTS_ERROR("set zero-sized chunk dimensions")
@@ -7415,7 +7472,10 @@ test_zero_dims(hid_t file)
     } /* end if */
 
     /* Try creating chunked dataset with zero-sized chunk dimensions */
-    H5E_BEGIN_TRY { ret = H5Pset_chunk(dcpl2, 2, dzero2); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_chunk(dcpl2, 2, dzero2);
+    }
     H5E_END_TRY;
     if (ret > 0)
         FAIL_PUTS_ERROR("set zero-sized chunk dimensions")
@@ -8384,7 +8444,10 @@ test_deprec(hid_t file)
      * dataset can only be created once.  Temporarily turn off error
      * reporting.
      */
-    H5E_BEGIN_TRY { dataset = H5Dcreate1(file, DSET_DEFAULT_NAME, H5T_NATIVE_DOUBLE, space, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        dataset = H5Dcreate1(file, DSET_DEFAULT_NAME, H5T_NATIVE_DOUBLE, space, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (dataset >= 0) {
         H5_FAILED();
@@ -8406,7 +8469,10 @@ test_deprec(hid_t file)
      * cannot be created with this function.  Temporarily turn off error
      * reporting.
      */
-    H5E_BEGIN_TRY { dataset = H5Dopen1(file, "does_not_exist"); }
+    H5E_BEGIN_TRY
+    {
+        dataset = H5Dopen1(file, "does_not_exist");
+    }
     H5E_END_TRY;
     if (dataset >= 0) {
         H5_FAILED();
@@ -8581,7 +8647,10 @@ test_huge_chunks(hid_t fapl)
 
     /* Try to set too large of a chunk for 1-D dataset (# of elements) */
     chunk_dim = TOO_HUGE_CHUNK_DIM;
-    H5E_BEGIN_TRY { ret = H5Pset_chunk(dcpl, 1, &chunk_dim); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_chunk(dcpl, 1, &chunk_dim);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         FAIL_PUTS_ERROR("    Set chunk size with too large of chunk dimensions.")
@@ -8590,7 +8659,10 @@ test_huge_chunks(hid_t fapl)
     chunk_dim2[0] = TOO_HUGE_CHUNK_DIM2_0;
     chunk_dim2[1] = TOO_HUGE_CHUNK_DIM2_1;
     chunk_dim2[2] = TOO_HUGE_CHUNK_DIM2_2;
-    H5E_BEGIN_TRY { ret = H5Pset_chunk(dcpl, 3, chunk_dim2); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_chunk(dcpl, 3, chunk_dim2);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         FAIL_PUTS_ERROR("    Set chunk size with too large of chunk dimensions.")
@@ -11824,7 +11896,10 @@ test_zero_dim_dset(hid_t fapl)
         for (high = H5F_LIBVER_EARLIEST; high < H5F_LIBVER_NBOUNDS; high++) {
 
             /* Set version bounds before opening the file */
-            H5E_BEGIN_TRY { ret = H5Pset_libver_bounds(fapl, low, high); }
+            H5E_BEGIN_TRY
+            {
+                ret = H5Pset_libver_bounds(fapl, low, high);
+            }
             H5E_END_TRY;
 
             if (ret < 0) /* Invalid low/high combinations */
@@ -13078,7 +13153,10 @@ test_power2up(hid_t fapl)
     ext_dims[1] = dims[1] + 5;
 
     /* Extend to (2^63)+ */
-    H5E_BEGIN_TRY { status = H5Dset_extent(did, ext_dims); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Dset_extent(did, ext_dims);
+    }
     H5E_END_TRY;
     if (status >= 0)
         TEST_ERROR
@@ -13414,7 +13492,10 @@ test_scatter(void)
     return SUCCEED;
 
 error:
-    H5E_BEGIN_TRY { H5Sclose(sid); }
+    H5E_BEGIN_TRY
+    {
+        H5Sclose(sid);
+    }
     H5E_END_TRY;
     return FAIL;
 } /* end test_scatter() */
@@ -13778,7 +13859,10 @@ test_gather(void)
     return SUCCEED;
 
 error:
-    H5E_BEGIN_TRY { H5Sclose(sid); }
+    H5E_BEGIN_TRY
+    {
+        H5Sclose(sid);
+    }
     H5E_END_TRY;
     return FAIL;
 } /* end test_gather() */
@@ -13882,14 +13966,20 @@ test_scatter_error(void)
      */
     scatter_info.src_buf = src_buf;
     scatter_info.size    = 6;
-    H5E_BEGIN_TRY { ret = H5Dscatter(NULL, NULL, H5T_NATIVE_INT, sid, dst_buf); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dscatter(NULL, NULL, H5T_NATIVE_INT, sid, dst_buf);
+    }
     H5E_END_TRY
     if (ret >= 0)
         TEST_ERROR
 
     scatter_info.src_buf = src_buf;
     scatter_info.size    = 6;
-    H5E_BEGIN_TRY { ret = H5Dscatter((H5D_scatter_func_t)scatter_cb, &scatter_info, sid, sid, dst_buf); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dscatter((H5D_scatter_func_t)scatter_cb, &scatter_info, sid, sid, dst_buf);
+    }
     H5E_END_TRY
     if (ret >= 0)
         TEST_ERROR
@@ -14002,7 +14092,10 @@ test_scatter_error(void)
     return SUCCEED;
 
 error:
-    H5E_BEGIN_TRY { H5Sclose(sid); }
+    H5E_BEGIN_TRY
+    {
+        H5Sclose(sid);
+    }
     H5E_END_TRY;
     return FAIL;
 } /* end test_scatter_error() */
@@ -14104,14 +14197,20 @@ test_gather_error(void)
 
     gather_info.expect_dst_buf = expect_dst_buf;
     gather_info.last_call      = FALSE;
-    H5E_BEGIN_TRY { ret = H5Dgather(sid, src_buf, H5T_NATIVE_INT, 0, dst_buf, gather_cb, &gather_info); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dgather(sid, src_buf, H5T_NATIVE_INT, 0, dst_buf, gather_cb, &gather_info);
+    }
     H5E_END_TRY
     if (ret >= 0)
         TEST_ERROR
 
     gather_info.expect_dst_buf = expect_dst_buf;
     gather_info.last_call      = FALSE;
-    H5E_BEGIN_TRY { ret = H5Dgather(sid, src_buf, H5T_NATIVE_INT, 1, dst_buf, gather_cb, &gather_info); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dgather(sid, src_buf, H5T_NATIVE_INT, 1, dst_buf, gather_cb, &gather_info);
+    }
     H5E_END_TRY
     if (ret >= 0)
         TEST_ERROR
@@ -14159,7 +14258,10 @@ test_gather_error(void)
     return SUCCEED;
 
 error:
-    H5E_BEGIN_TRY { H5Sclose(sid); }
+    H5E_BEGIN_TRY
+    {
+        H5Sclose(sid);
+    }
     H5E_END_TRY;
     return FAIL;
 } /* end test_gather_error() */
@@ -14520,7 +14622,10 @@ test_compact_open_close_dirty(hid_t fapl)
 
     /* Verify the repeated open/close of the dataset will not fail */
     for (i = 0; i < 20; i++) {
-        H5E_BEGIN_TRY { did = H5Dopen2(fid, DSET_COMPACT_MAX_NAME, H5P_DEFAULT); }
+        H5E_BEGIN_TRY
+        {
+            did = H5Dopen2(fid, DSET_COMPACT_MAX_NAME, H5P_DEFAULT);
+        }
         H5E_END_TRY;
         if (did < 0)
             TEST_ERROR
@@ -14648,7 +14753,10 @@ test_versionbounds(void)
         for (high = H5F_LIBVER_EARLIEST; high < H5F_LIBVER_NBOUNDS; high++) {
 
             /* Set version bounds, skip for invalid low/high combination */
-            H5E_BEGIN_TRY { ret = H5Pset_libver_bounds(fapl, low, high); }
+            H5E_BEGIN_TRY
+            {
+                ret = H5Pset_libver_bounds(fapl, low, high);
+            }
             H5E_END_TRY;
 
             if (ret < 0) /* Invalid low/high combinations */
@@ -14803,7 +14911,10 @@ test_object_header_minimization_dcpl(void)
 
     /* error cases
      */
-    H5E_BEGIN_TRY { ret = H5Pget_dset_no_attrs_hint(-1, &minimize); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pget_dset_no_attrs_hint(-1, &minimize);
+    }
     H5E_END_TRY;
     if (ret == SUCCEED)
         TEST_ERROR /* Invalid DCPL ID should fail */

--- a/test/dt_arith.c
+++ b/test/dt_arith.c
@@ -864,7 +864,10 @@ test_particular_fp_integer(void)
 
 error:
     HDfflush(stdout);
-    H5E_BEGIN_TRY { H5Pclose(dxpl_id); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(dxpl_id);
+    }
     H5E_END_TRY;
     if (buf1)
         HDfree(buf1);

--- a/test/dtransform.c
+++ b/test/dtransform.c
@@ -938,7 +938,10 @@ test_set(void)
 error:
     if (ptrgetTest)
         HDfree(ptrgetTest);
-    H5E_BEGIN_TRY { H5Pclose(dxpl_id); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(dxpl_id);
+    }
     H5E_END_TRY
 
     return -1;

--- a/test/dtypes.c
+++ b/test/dtypes.c
@@ -312,7 +312,10 @@ test_copy(void)
         goto error;
 
     /* We should not be able to close a built-in byte */
-    H5E_BEGIN_TRY { status = H5Tclose(H5T_NATIVE_SCHAR); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tclose(H5T_NATIVE_SCHAR);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -598,7 +601,10 @@ test_compound_1(void)
         goto error;
 
     /* Attempt to add the new compound datatype as a field within itself */
-    H5E_BEGIN_TRY { ret = H5Tinsert(complex_id, "compound", (size_t)0, complex_id); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tinsert(complex_id, "compound", (size_t)0, complex_id);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         FAIL_PUTS_ERROR("Inserted compound datatype into itself?");
@@ -612,56 +618,83 @@ test_compound_1(void)
 
     /* Test some functions that aren't supposed to work for compound type */
     /* Tries to shrink the size and trail the last member */
-    H5E_BEGIN_TRY { ret = H5Tset_size(complex_id, sizeof(double)); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tset_size(complex_id, sizeof(double));
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
     } /* end if */
 
-    H5E_BEGIN_TRY { size = H5Tget_precision(complex_id); }
+    H5E_BEGIN_TRY
+    {
+        size = H5Tget_precision(complex_id);
+    }
     H5E_END_TRY;
     if (size > 0) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
     } /* end if */
 
     size = 128;
-    H5E_BEGIN_TRY { ret = H5Tset_precision(complex_id, size); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tset_precision(complex_id, size);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
     } /* end if */
 
-    H5E_BEGIN_TRY { ret = H5Tget_pad(complex_id, &lsb, &msb); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tget_pad(complex_id, &lsb, &msb);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
     } /* end if */
 
-    H5E_BEGIN_TRY { size = H5Tget_ebias(complex_id); }
+    H5E_BEGIN_TRY
+    {
+        size = H5Tget_ebias(complex_id);
+    }
     H5E_END_TRY;
     if (size > 0) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
     } /* end if */
 
-    H5E_BEGIN_TRY { lsb = H5Tget_inpad(complex_id); }
+    H5E_BEGIN_TRY
+    {
+        lsb = H5Tget_inpad(complex_id);
+    }
     H5E_END_TRY;
     if (lsb >= 0) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
     } /* end if */
 
-    H5E_BEGIN_TRY { cset = H5Tget_cset(complex_id); }
+    H5E_BEGIN_TRY
+    {
+        cset = H5Tget_cset(complex_id);
+    }
     H5E_END_TRY;
     if (cset > -1) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
     } /* end if */
 
-    H5E_BEGIN_TRY { strpad = H5Tget_strpad(complex_id); }
+    H5E_BEGIN_TRY
+    {
+        strpad = H5Tget_strpad(complex_id);
+    }
     H5E_END_TRY;
     if (strpad > -1) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
     } /* end if */
 
-    H5E_BEGIN_TRY { offset = H5Tget_offset(complex_id); }
+    H5E_BEGIN_TRY
+    {
+        offset = H5Tget_offset(complex_id);
+    }
     H5E_END_TRY;
     if (offset >= 0) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
@@ -673,19 +706,28 @@ test_compound_1(void)
     if (order != H5T_ORDER_LE && order != H5T_ORDER_BE)
         FAIL_PUTS_ERROR("Wrong order for this type.");
 
-    H5E_BEGIN_TRY { sign = H5Tget_sign(complex_id); }
+    H5E_BEGIN_TRY
+    {
+        sign = H5Tget_sign(complex_id);
+    }
     H5E_END_TRY;
     if (sign > -1) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
     } /* end if */
 
-    H5E_BEGIN_TRY { tag = H5Tget_tag(complex_id); }
+    H5E_BEGIN_TRY
+    {
+        tag = H5Tget_tag(complex_id);
+    }
     H5E_END_TRY;
     if (tag) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
     } /* end if */
 
-    H5E_BEGIN_TRY { super = H5Tget_super(complex_id); }
+    H5E_BEGIN_TRY
+    {
+        super = H5Tget_super(complex_id);
+    }
     H5E_END_TRY;
     if (super >= 0) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
@@ -1347,7 +1389,10 @@ test_compound_7(void)
     } /* end if */
 
     /* Should not be able to insert field past end of compound datatype */
-    H5E_BEGIN_TRY { ret = H5Tinsert(tid2, "d", HOFFSET(struct s2, d), H5T_NATIVE_DOUBLE); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tinsert(tid2, "d", HOFFSET(struct s2, d), H5T_NATIVE_DOUBLE);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         H5_FAILED();
@@ -1356,7 +1401,10 @@ test_compound_7(void)
     } /* end if */
 
     /* Should not be able to shrink size of compound datatype */
-    H5E_BEGIN_TRY { ret = H5Tset_size(tid2, sizeof(struct s1) / 2); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tset_size(tid2, sizeof(struct s1) / 2);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         H5_FAILED();
@@ -1590,7 +1638,10 @@ test_compound_8(void)
     } /* end if */
 
     /* If the type is not packed, packing a locked type shouldn't work */
-    H5E_BEGIN_TRY { ret = H5Tpack(tid3); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tpack(tid3);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         H5_FAILED();
@@ -2498,7 +2549,10 @@ test_compound_12(void)
 
     /* Tries to cut last member.  Supposed to fail. */
     size--;
-    H5E_BEGIN_TRY { ret = H5Tset_size(complex_id, size); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tset_size(complex_id, size);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         H5_FAILED();
@@ -3594,7 +3648,10 @@ test_compound_18(void)
     HDassert(sid > 0);
 
     /* Create a dataset with the bad compound datatype */
-    H5E_BEGIN_TRY { did = H5Dcreate2(file, "dataset", tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        did = H5Dcreate2(file, "dataset", tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (did > 0) {
         H5Dclose(did);
@@ -3606,7 +3663,10 @@ test_compound_18(void)
     HDassert(gid > 0);
 
     /* Create an attribute with the bad compound datatype */
-    H5E_BEGIN_TRY { aid = H5Acreate2(gid, "attr", tid, sid, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        aid = H5Acreate2(gid, "attr", tid, sid, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (aid > 0) {
         H5Aclose(aid);
@@ -3614,7 +3674,10 @@ test_compound_18(void)
     } /* end if */
 
     /* Commit the datatype */
-    H5E_BEGIN_TRY { ret = H5Tcommit2(file, "cmpnd", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tcommit2(file, "cmpnd", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         FAIL_PUTS_ERROR("committed named datatype with bad compound datatype")
@@ -3636,7 +3699,10 @@ test_compound_18(void)
         FAIL_STACK_ERROR
 
     /* Try to open the datatype */
-    H5E_BEGIN_TRY { tid = H5Topen2(file, "cmpnd", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tid = H5Topen2(file, "cmpnd", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (tid > 0) {
         H5Tclose(tid);
@@ -3644,7 +3710,10 @@ test_compound_18(void)
     } /* end if */
 
     /* Try to open the dataset */
-    H5E_BEGIN_TRY { did = H5Dopen2(file, "dataset", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        did = H5Dopen2(file, "dataset", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (did > 0) {
         H5Dclose(did);
@@ -3656,7 +3725,10 @@ test_compound_18(void)
         TEST_ERROR
 
     /* Try to open the dataset */
-    H5E_BEGIN_TRY { aid = H5Aopen(gid, "attr", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        aid = H5Aopen(gid, "attr", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (aid > 0) {
         H5Aclose(aid);
@@ -3958,14 +4030,20 @@ test_transient(hid_t fapl)
         goto error;
 
     /* Predefined types cannot be modified or closed */
-    H5E_BEGIN_TRY { status = H5Tset_precision(H5T_NATIVE_INT, (size_t)256); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tset_precision(H5T_NATIVE_INT, (size_t)256);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
         HDputs("    Predefined types should not be modifiable!");
         goto error;
     }
-    H5E_BEGIN_TRY { status = H5Tclose(H5T_NATIVE_INT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tclose(H5T_NATIVE_INT);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -3980,7 +4058,10 @@ test_transient(hid_t fapl)
         goto error;
 
     /* It should not be possible to create an attribute for a transient type */
-    H5E_BEGIN_TRY { ret_id = H5Acreate2(type, "attr1", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        ret_id = H5Acreate2(type, "attr1", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (ret_id >= 0) {
         H5_FAILED();
@@ -3999,7 +4080,10 @@ test_transient(hid_t fapl)
     /* The type returned from a dataset should not be modifiable */
     if ((t2 = H5Dget_type(dset)) < 0)
         goto error;
-    H5E_BEGIN_TRY { status = H5Tset_precision(t2, (size_t)256); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tset_precision(t2, (size_t)256);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -4019,7 +4103,10 @@ test_transient(hid_t fapl)
         goto error;
     if ((t2 = H5Dget_type(dset)) < 0)
         goto error;
-    H5E_BEGIN_TRY { status = H5Tset_precision(t2, (size_t)256); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tset_precision(t2, (size_t)256);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -4127,7 +4214,10 @@ test_named(hid_t fapl)
     }
 
     /* We should not be able to modify a type after it has been committed. */
-    H5E_BEGIN_TRY { status = H5Tset_precision(type, (size_t)256); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tset_precision(type, (size_t)256);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -4325,7 +4415,10 @@ test_named(hid_t fapl)
     /* Verify that H5Tcommit_anon returns an error */
     if ((type = H5Tcopy(H5T_NATIVE_INT)) < 0)
         goto error;
-    H5E_BEGIN_TRY { status = H5Tcommit_anon(file, type, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tcommit_anon(file, type, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -4935,37 +5028,55 @@ test_conv_str_3(void)
     if (H5Tget_order(type) < 0)
         FAIL_STACK_ERROR
 
-    H5E_BEGIN_TRY { ret = H5Tset_precision(type, nelmts); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tset_precision(type, nelmts);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
     } /* end if */
 
-    H5E_BEGIN_TRY { size = H5Tget_ebias(type); }
+    H5E_BEGIN_TRY
+    {
+        size = H5Tget_ebias(type);
+    }
     H5E_END_TRY;
     if (size > 0) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
     } /* end if */
 
-    H5E_BEGIN_TRY { inpad = H5Tget_inpad(type); }
+    H5E_BEGIN_TRY
+    {
+        inpad = H5Tget_inpad(type);
+    }
     H5E_END_TRY;
     if (inpad > -1) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
     } /* end if */
 
-    H5E_BEGIN_TRY { sign = H5Tget_sign(type); }
+    H5E_BEGIN_TRY
+    {
+        sign = H5Tget_sign(type);
+    }
     H5E_END_TRY;
     if (sign > -1) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
     } /* end if */
 
-    H5E_BEGIN_TRY { tag = H5Tget_tag(type); }
+    H5E_BEGIN_TRY
+    {
+        tag = H5Tget_tag(type);
+    }
     H5E_END_TRY;
     if (tag) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
     } /* end if */
 
-    H5E_BEGIN_TRY { super = H5Tget_super(type); }
+    H5E_BEGIN_TRY
+    {
+        super = H5Tget_super(type);
+    }
     H5E_END_TRY;
     if (super >= 0) {
         FAIL_PUTS_ERROR("Operation not allowed for this type.");
@@ -5298,7 +5409,10 @@ test_bitfield_funcs(void)
     if ((ntype = H5Tget_native_type(type, H5T_DIR_ASCEND)) < 0)
         goto error;
 
-    H5E_BEGIN_TRY { size = H5Tget_ebias(type); }
+    H5E_BEGIN_TRY
+    {
+        size = H5Tget_ebias(type);
+    }
     H5E_END_TRY;
     if (size > 0) {
         H5_FAILED();
@@ -5306,7 +5420,10 @@ test_bitfield_funcs(void)
         goto error;
     } /* end if */
 
-    H5E_BEGIN_TRY { inpad = H5Tget_inpad(type); }
+    H5E_BEGIN_TRY
+    {
+        inpad = H5Tget_inpad(type);
+    }
     H5E_END_TRY;
     if (inpad > -1) {
         H5_FAILED();
@@ -5314,7 +5431,10 @@ test_bitfield_funcs(void)
         goto error;
     } /* end if */
 
-    H5E_BEGIN_TRY { cset = H5Tget_cset(type); }
+    H5E_BEGIN_TRY
+    {
+        cset = H5Tget_cset(type);
+    }
     H5E_END_TRY;
     if (cset > -1) {
         H5_FAILED();
@@ -5322,7 +5442,10 @@ test_bitfield_funcs(void)
         goto error;
     } /* end if */
 
-    H5E_BEGIN_TRY { strpad = H5Tget_strpad(type); }
+    H5E_BEGIN_TRY
+    {
+        strpad = H5Tget_strpad(type);
+    }
     H5E_END_TRY;
     if (strpad > -1) {
         H5_FAILED();
@@ -5330,7 +5453,10 @@ test_bitfield_funcs(void)
         goto error;
     } /* end if */
 
-    H5E_BEGIN_TRY { ret = H5Tset_sign(type, H5T_SGN_2); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tset_sign(type, H5T_SGN_2);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         H5_FAILED();
@@ -5338,7 +5464,10 @@ test_bitfield_funcs(void)
         goto error;
     } /* end if */
 
-    H5E_BEGIN_TRY { tag = H5Tget_tag(type); }
+    H5E_BEGIN_TRY
+    {
+        tag = H5Tget_tag(type);
+    }
     H5E_END_TRY;
     if (tag) {
         H5_FAILED();
@@ -5346,7 +5475,10 @@ test_bitfield_funcs(void)
         goto error;
     } /* end if */
 
-    H5E_BEGIN_TRY { super = H5Tget_super(type); }
+    H5E_BEGIN_TRY
+    {
+        super = H5Tget_super(type);
+    }
     H5E_END_TRY;
     if (super >= 0) {
         H5_FAILED();
@@ -5471,7 +5603,10 @@ opaque_check(int tag_it)
     }
 
     /* Make sure that we can't convert between the types yet */
-    H5E_BEGIN_TRY { status = H5Tconvert(st, dt, (size_t)OPAQUE_NELMTS, buf, NULL, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tconvert(st, dt, (size_t)OPAQUE_NELMTS, buf, NULL, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -5540,7 +5675,10 @@ opaque_long(void)
     long_tag[16384] = '\0';
 
     /* Set opaque type's tag */
-    H5E_BEGIN_TRY { ret = H5Tset_tag(dt, long_tag); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tset_tag(dt, long_tag);
+    }
     H5E_END_TRY;
     if (ret != FAIL)
         TEST_ERROR
@@ -5596,63 +5734,90 @@ opaque_funcs(void)
     if ((size = H5Tget_size(type)) == 0)
         goto error;
 
-    H5E_BEGIN_TRY { ret = H5Tset_precision(type, (size_t)32); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tset_precision(type, (size_t)32);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         HDprintf("Operation not allowed for this type.\n");
         TEST_ERROR
     } /* end if */
 
-    H5E_BEGIN_TRY { ret = H5Tset_pad(type, H5T_PAD_ZERO, H5T_PAD_ONE); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tset_pad(type, H5T_PAD_ZERO, H5T_PAD_ONE);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         HDprintf("Operation not allowed for this type.\n");
         TEST_ERROR
     } /* end if */
 
-    H5E_BEGIN_TRY { size = H5Tget_ebias(type); }
+    H5E_BEGIN_TRY
+    {
+        size = H5Tget_ebias(type);
+    }
     H5E_END_TRY;
     if (size > 0) {
         HDprintf("Operation not allowed for this type.\n");
         TEST_ERROR
     } /* end if */
 
-    H5E_BEGIN_TRY { inpad = H5Tget_inpad(type); }
+    H5E_BEGIN_TRY
+    {
+        inpad = H5Tget_inpad(type);
+    }
     H5E_END_TRY;
     if (inpad > -1) {
         HDprintf("Operation not allowed for this type.\n");
         TEST_ERROR
     } /* end if */
 
-    H5E_BEGIN_TRY { cset = H5Tget_cset(type); }
+    H5E_BEGIN_TRY
+    {
+        cset = H5Tget_cset(type);
+    }
     H5E_END_TRY;
     if (cset > -1) {
         HDprintf("Operation not allowed for this type.\n");
         TEST_ERROR
     } /* end if */
 
-    H5E_BEGIN_TRY { strpad = H5Tget_strpad(type); }
+    H5E_BEGIN_TRY
+    {
+        strpad = H5Tget_strpad(type);
+    }
     H5E_END_TRY;
     if (strpad > -1) {
         HDprintf("Operation not allowed for this type.\n");
         TEST_ERROR
     } /* end if */
 
-    H5E_BEGIN_TRY { ret = H5Tset_offset(type, (size_t)16); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tset_offset(type, (size_t)16);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         HDprintf("Operation not allowed for this type.\n");
         TEST_ERROR
     } /* end if */
 
-    H5E_BEGIN_TRY { sign = H5Tget_sign(type); }
+    H5E_BEGIN_TRY
+    {
+        sign = H5Tget_sign(type);
+    }
     H5E_END_TRY;
     if (sign > -1) {
         HDprintf("Operation not allowed for this type.\n");
         TEST_ERROR
     } /* end if */
 
-    H5E_BEGIN_TRY { super = H5Tget_super(type); }
+    H5E_BEGIN_TRY
+    {
+        super = H5Tget_super(type);
+    }
     H5E_END_TRY;
     if (super >= 0) {
         HDprintf("Operation not allowed for this type.\n");
@@ -5810,7 +5975,10 @@ test_encode(void)
         cmpd_buf = (unsigned char *)HDcalloc((size_t)1, cmpd_buf_size);
 
     /* Try decoding bogus buffer */
-    H5E_BEGIN_TRY { ret_id = H5Tdecode(cmpd_buf); }
+    H5E_BEGIN_TRY
+    {
+        ret_id = H5Tdecode(cmpd_buf);
+    }
     H5E_END_TRY;
     if (ret_id != FAIL) {
         H5_FAILED();
@@ -6159,7 +6327,10 @@ test_encode(void)
     } /* end if */
 
     /* Make sure the decoded datatypes are already closed. */
-    H5E_BEGIN_TRY { ret = H5Tclose(decoded_tid1); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tclose(decoded_tid1);
+    }
     H5E_END_TRY;
     if (ret != FAIL) {
         H5_FAILED();
@@ -6167,7 +6338,10 @@ test_encode(void)
         goto error;
     }
 
-    H5E_BEGIN_TRY { ret = H5Tclose(decoded_tid2); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tclose(decoded_tid2);
+    }
     H5E_END_TRY;
     if (ret != FAIL) {
         H5_FAILED();
@@ -6175,7 +6349,10 @@ test_encode(void)
         goto error;
     }
 
-    H5E_BEGIN_TRY { ret = H5Tclose(decoded_tid3); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tclose(decoded_tid3);
+    }
     H5E_END_TRY;
     if (ret != FAIL) {
         H5_FAILED();
@@ -6610,7 +6787,10 @@ test_int_float_except(void)
 
 #if H5_SIZEOF_INT == 4 && H5_SIZEOF_FLOAT == 4
 error:
-    H5E_BEGIN_TRY { H5Pclose(dxpl); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(dxpl);
+    }
     H5E_END_TRY;
     return 1;
 #endif /* H5_SIZEOF_INT==4 && H5_SIZEOF_FLOAT==4 */
@@ -7788,7 +7968,10 @@ test_deprec(hid_t fapl)
         FAIL_STACK_ERROR
 
     /* Predefined types cannot be committed */
-    H5E_BEGIN_TRY { status = H5Tcommit1(file, "test_named_1 (should not exist)", H5T_NATIVE_INT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tcommit1(file, "test_named_1 (should not exist)", H5T_NATIVE_INT);
+    }
     H5E_END_TRY;
     if (status >= 0)
         FAIL_PUTS_ERROR("    Predefined types should not be committable!")
@@ -7804,13 +7987,19 @@ test_deprec(hid_t fapl)
         FAIL_PUTS_ERROR("    H5Tcommitted() returned false!")
 
     /* We should not be able to modify a type after it has been committed. */
-    H5E_BEGIN_TRY { status = H5Tset_precision(type, (size_t)256); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tset_precision(type, (size_t)256);
+    }
     H5E_END_TRY;
     if (status >= 0)
         FAIL_PUTS_ERROR("    Committed type is not constant!")
 
     /* We should not be able to re-commit a committed type */
-    H5E_BEGIN_TRY { status = H5Tcommit1(file, "test_named_2 (should not exist)", type); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tcommit1(file, "test_named_2 (should not exist)", type);
+    }
     H5E_END_TRY;
     if (status >= 0)
         FAIL_PUTS_ERROR("    Committed types should not be recommitted!")
@@ -7840,7 +8029,10 @@ test_deprec(hid_t fapl)
     /* Verify that H5Tcommit2 returns an error */
     if ((type = H5Tcopy(H5T_NATIVE_INT)) < 0)
         goto error;
-    H5E_BEGIN_TRY { status = H5Tcommit1(file, "test_named_3 (should not exist)", type); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tcommit1(file, "test_named_3 (should not exist)", type);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -7927,7 +8119,10 @@ test_utf_ascii_conv(void)
         FAIL_STACK_ERROR
 
     /* Test conversion in memory */
-    H5E_BEGIN_TRY { status = H5Tconvert(utf8_vtid, ascii_vtid, 1, &utf8_w, NULL, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tconvert(utf8_vtid, ascii_vtid, 1, &utf8_w, NULL, H5P_DEFAULT);
+    }
     H5E_END_TRY
     if (status >= 0)
         FAIL_STACK_ERROR
@@ -7950,7 +8145,10 @@ test_utf_ascii_conv(void)
         FAIL_STACK_ERROR
 
     /* Read the UTF8 string, as ASCII, supposed to fail */
-    H5E_BEGIN_TRY { status = H5Dread(did, ascii_vtid, H5S_ALL, H5S_ALL, H5P_DEFAULT, &ascii_r); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Dread(did, ascii_vtid, H5S_ALL, H5S_ALL, H5P_DEFAULT, &ascii_r);
+    }
     H5E_END_TRY
     if (status >= 0)
         FAIL_STACK_ERROR
@@ -7963,7 +8161,10 @@ test_utf_ascii_conv(void)
      * Test VL string conversion from ASCII to UTF8
      ************************************************/
     /* Test conversion in memory */
-    H5E_BEGIN_TRY { status = H5Tconvert(ascii_vtid, utf8_vtid, 1, &ascii_w, NULL, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tconvert(ascii_vtid, utf8_vtid, 1, &ascii_w, NULL, H5P_DEFAULT);
+    }
     H5E_END_TRY
     if (status >= 0)
         FAIL_STACK_ERROR
@@ -7977,7 +8178,10 @@ test_utf_ascii_conv(void)
         FAIL_STACK_ERROR
 
     /* Read the ASCII string, as UTF8, supposed to fail */
-    H5E_BEGIN_TRY { status = H5Dread(did, utf8_vtid, H5S_ALL, H5S_ALL, H5P_DEFAULT, &utf8_r); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Dread(did, utf8_vtid, H5S_ALL, H5S_ALL, H5P_DEFAULT, &utf8_r);
+    }
     H5E_END_TRY
     if (status >= 0)
         FAIL_STACK_ERROR
@@ -8020,7 +8224,10 @@ test_utf_ascii_conv(void)
         FAIL_STACK_ERROR
 
     /* Test conversion in memory */
-    H5E_BEGIN_TRY { status = H5Tconvert(utf8_tid, ascii_tid, 1, utf8_2, NULL, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tconvert(utf8_tid, ascii_tid, 1, utf8_2, NULL, H5P_DEFAULT);
+    }
     H5E_END_TRY
     if (status >= 0)
         FAIL_STACK_ERROR
@@ -8034,7 +8241,10 @@ test_utf_ascii_conv(void)
         FAIL_STACK_ERROR
 
     /* Read the UTF8 string as ASCII, supposed to fail */
-    H5E_BEGIN_TRY { status = H5Dread(did, ascii_tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, &ascii2); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Dread(did, ascii_tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, &ascii2);
+    }
     H5E_END_TRY
     if (status >= 0)
         FAIL_STACK_ERROR
@@ -8047,7 +8257,10 @@ test_utf_ascii_conv(void)
      * Test fixed-length string conversion from ASCII to UTF8
      **********************************************************/
     /* Test conversion in memory */
-    H5E_BEGIN_TRY { status = H5Tconvert(ascii_tid, utf8_tid, 1, ascii2, NULL, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tconvert(ascii_tid, utf8_tid, 1, ascii2, NULL, H5P_DEFAULT);
+    }
     H5E_END_TRY
     if (status >= 0)
         FAIL_STACK_ERROR
@@ -8061,7 +8274,10 @@ test_utf_ascii_conv(void)
         FAIL_STACK_ERROR
 
     /* Read the UTF8 string as ASCII, supposed to fail */
-    H5E_BEGIN_TRY { status = H5Dread(did, utf8_tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, &utf8_2); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Dread(did, utf8_tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, &utf8_2);
+    }
     H5E_END_TRY
     if (status >= 0)
         FAIL_STACK_ERROR
@@ -8441,7 +8657,10 @@ test_versionbounds(void)
         for (high = 0; high < versions_count; high++) {
 
             /* Set version bounds */
-            H5E_BEGIN_TRY { ret = H5Pset_libver_bounds(fapl, versions[low], versions[high]); }
+            H5E_BEGIN_TRY
+            {
+                ret = H5Pset_libver_bounds(fapl, versions[low], versions[high]);
+            }
             H5E_END_TRY;
 
             if (ret < 0) /* Invalid low/high combinations */

--- a/test/earray.c
+++ b/test/earray.c
@@ -623,7 +623,10 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
         /* Set invalid element size */
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
         test_cparam.raw_elmt_size = 0;
-        H5E_BEGIN_TRY { ea = H5EA_create(f, &test_cparam, NULL); }
+        H5E_BEGIN_TRY
+        {
+            ea = H5EA_create(f, &test_cparam, NULL);
+        }
         H5E_END_TRY;
         if (ea) {
             /* Close opened extensible array */
@@ -637,7 +640,10 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
         /* Set invalid max. # of elements bits */
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
         test_cparam.max_nelmts_bits = 0;
-        H5E_BEGIN_TRY { ea = H5EA_create(f, &test_cparam, NULL); }
+        H5E_BEGIN_TRY
+        {
+            ea = H5EA_create(f, &test_cparam, NULL);
+        }
         H5E_END_TRY;
         if (ea) {
             /* Close opened extensible array */
@@ -650,7 +656,10 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
 
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
         test_cparam.max_nelmts_bits = 65;
-        H5E_BEGIN_TRY { ea = H5EA_create(f, &test_cparam, NULL); }
+        H5E_BEGIN_TRY
+        {
+            ea = H5EA_create(f, &test_cparam, NULL);
+        }
         H5E_END_TRY;
         if (ea) {
             /* Close opened extensible array */
@@ -664,7 +673,10 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
         /* Set invalid min. # of data block pointers in super blocks */
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
         test_cparam.sup_blk_min_data_ptrs = 0;
-        H5E_BEGIN_TRY { ea = H5EA_create(f, &test_cparam, NULL); }
+        H5E_BEGIN_TRY
+        {
+            ea = H5EA_create(f, &test_cparam, NULL);
+        }
         H5E_END_TRY;
         if (ea) {
             /* Close opened extensible array */
@@ -676,7 +688,10 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
         } /* end if */
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
         test_cparam.sup_blk_min_data_ptrs = 1;
-        H5E_BEGIN_TRY { ea = H5EA_create(f, &test_cparam, NULL); }
+        H5E_BEGIN_TRY
+        {
+            ea = H5EA_create(f, &test_cparam, NULL);
+        }
         H5E_END_TRY;
         if (ea) {
             /* Close opened extensible array */
@@ -688,7 +703,10 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
         } /* end if */
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
         test_cparam.sup_blk_min_data_ptrs = 6;
-        H5E_BEGIN_TRY { ea = H5EA_create(f, &test_cparam, NULL); }
+        H5E_BEGIN_TRY
+        {
+            ea = H5EA_create(f, &test_cparam, NULL);
+        }
         H5E_END_TRY;
         if (ea) {
             /* Close opened extensible array */
@@ -702,7 +720,10 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
         /* Set invalid min. # of elements per data block */
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
         test_cparam.data_blk_min_elmts = 0;
-        H5E_BEGIN_TRY { ea = H5EA_create(f, &test_cparam, NULL); }
+        H5E_BEGIN_TRY
+        {
+            ea = H5EA_create(f, &test_cparam, NULL);
+        }
         H5E_END_TRY;
         if (ea) {
             /* Close opened extensible array */
@@ -718,7 +739,10 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
             HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
             test_cparam.max_dblk_page_nelmts_bits =
                 (uint8_t)(H5VM_log2_gen((uint64_t)test_cparam.idx_blk_elmts) - 1);
-            H5E_BEGIN_TRY { ea = H5EA_create(f, &test_cparam, NULL); }
+            H5E_BEGIN_TRY
+            {
+                ea = H5EA_create(f, &test_cparam, NULL);
+            }
             H5E_END_TRY;
             if (ea) {
                 /* Close opened extensible array */
@@ -732,7 +756,10 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
         test_cparam.max_dblk_page_nelmts_bits = 4; /* corresponds to 16 elements in data block page, which is
                                                       less than the 64 elements for the default settings */
-        H5E_BEGIN_TRY { ea = H5EA_create(f, &test_cparam, NULL); }
+        H5E_BEGIN_TRY
+        {
+            ea = H5EA_create(f, &test_cparam, NULL);
+        }
         H5E_END_TRY;
         if (ea) {
             /* Close opened extensible array */
@@ -744,7 +771,10 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
         } /* end if */
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
         test_cparam.max_dblk_page_nelmts_bits = (uint8_t)(test_cparam.max_nelmts_bits + 1);
-        H5E_BEGIN_TRY { ea = H5EA_create(f, &test_cparam, NULL); }
+        H5E_BEGIN_TRY
+        {
+            ea = H5EA_create(f, &test_cparam, NULL);
+        }
         H5E_END_TRY;
         if (ea) {
             /* Close opened extensible array */
@@ -1178,7 +1208,10 @@ test_delete_open(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tparam)
     ea2 = NULL;
 
     /* Try re-opening the array again (should fail, as array will be deleted) */
-    H5E_BEGIN_TRY { ea2 = H5EA_open(f, ea_addr, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ea2 = H5EA_open(f, ea_addr, NULL);
+    }
     H5E_END_TRY;
     if (ea2) {
         /* Close opened array */
@@ -1198,7 +1231,10 @@ test_delete_open(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tparam)
         TEST_ERROR
 
     /* Try re-opening the array again (should fail, as array is now deleted) */
-    H5E_BEGIN_TRY { ea = H5EA_open(f, ea_addr, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ea = H5EA_open(f, ea_addr, NULL);
+    }
     H5E_END_TRY;
     if (ea) {
         /* Close opened array */
@@ -2568,7 +2604,10 @@ main(void)
 error:
     HDputs("*** TESTS FAILED ***");
 
-    H5E_BEGIN_TRY { H5Pclose(fapl); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(fapl);
+    }
     H5E_END_TRY;
 
     if (api_ctx_pushed)

--- a/test/efc.c
+++ b/test/efc.c
@@ -2724,7 +2724,10 @@ main(void)
 error:
     HDputs("*** TESTS FAILED ***");
 
-    H5E_BEGIN_TRY { H5Pclose(fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(fapl_id);
+    }
     H5E_END_TRY
 
     if (api_ctx_pushed)

--- a/test/enc_dec_plist.c
+++ b/test/enc_dec_plist.c
@@ -39,7 +39,10 @@ test_encode_decode(hid_t orig_pl, H5F_libver_t low, H5F_libver_t high, hbool_t s
     if (H5Pset_libver_bounds(fapl, low, high) < 0)
         TEST_ERROR
 
-    H5E_BEGIN_TRY { ret = H5Pencode2(orig_pl, NULL, &temp_size, fapl); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pencode2(orig_pl, NULL, &temp_size, fapl);
+    }
     H5E_END_TRY;
 
     if (support_virtual && high < H5F_LIBVER_V110)

--- a/test/enum.c
+++ b/test/enum.c
@@ -602,7 +602,10 @@ test_value_dsnt_exist(void)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Tclose(datatype_id); }
+    H5E_BEGIN_TRY
+    {
+        H5Tclose(datatype_id);
+    }
     H5E_END_TRY;
     return 1;
 }
@@ -661,7 +664,10 @@ test_funcs(void)
     if (H5Tget_super(type) < 0)
         FAIL_STACK_ERROR
 
-    H5E_BEGIN_TRY { ret = H5Tset_pad(type, H5T_PAD_ZERO, H5T_PAD_ONE); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tset_pad(type, H5T_PAD_ZERO, H5T_PAD_ONE);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         H5_FAILED();
@@ -669,7 +675,10 @@ test_funcs(void)
         goto error;
     } /* end if */
 
-    H5E_BEGIN_TRY { size = H5Tget_ebias(type); }
+    H5E_BEGIN_TRY
+    {
+        size = H5Tget_ebias(type);
+    }
     H5E_END_TRY;
     if (size > 0) {
         H5_FAILED();
@@ -677,7 +686,10 @@ test_funcs(void)
         goto error;
     } /* end if */
 
-    H5E_BEGIN_TRY { inpad = H5Tget_inpad(type); }
+    H5E_BEGIN_TRY
+    {
+        inpad = H5Tget_inpad(type);
+    }
     H5E_END_TRY;
     if (inpad > -1) {
         H5_FAILED();
@@ -685,7 +697,10 @@ test_funcs(void)
         goto error;
     } /* end if */
 
-    H5E_BEGIN_TRY { cset = H5Tget_cset(type); }
+    H5E_BEGIN_TRY
+    {
+        cset = H5Tget_cset(type);
+    }
     H5E_END_TRY;
     if (cset > -1) {
         H5_FAILED();
@@ -694,7 +709,10 @@ test_funcs(void)
     } /* end if */
 
     size = 16;
-    H5E_BEGIN_TRY { ret = H5Tset_offset(type, (size_t)size); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tset_offset(type, (size_t)size);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         H5_FAILED();
@@ -702,7 +720,10 @@ test_funcs(void)
         goto error;
     } /* end if */
 
-    H5E_BEGIN_TRY { ret = H5Tset_order(type, H5T_ORDER_BE); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tset_order(type, H5T_ORDER_BE);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         H5_FAILED();
@@ -717,7 +738,10 @@ test_funcs(void)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Tclose(type); }
+    H5E_BEGIN_TRY
+    {
+        H5Tclose(type);
+    }
     H5E_END_TRY;
     return 1;
 }

--- a/test/error_test.c
+++ b/test/error_test.c
@@ -558,7 +558,10 @@ test_copy(void)
     /* Try to close error stack copy.  Should fail because
      * the current H5Eset_current_stack closes the stack to be set.
      */
-    H5E_BEGIN_TRY { ret = H5Eclose_stack(estack_id); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Eclose_stack(estack_id);
+    }
     H5E_END_TRY
     if (ret >= 0)
         TEST_ERROR
@@ -624,15 +627,24 @@ test_append(void)
         TEST_ERROR
 
     /* Try to append bad error stack IDs */
-    H5E_BEGIN_TRY { ret = H5Eappend_stack(H5E_DEFAULT, H5E_DEFAULT, FALSE); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Eappend_stack(H5E_DEFAULT, H5E_DEFAULT, FALSE);
+    }
     H5E_END_TRY
     if (ret >= 0)
         TEST_ERROR
-    H5E_BEGIN_TRY { ret = H5Eappend_stack(estack_id1, H5E_DEFAULT, FALSE); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Eappend_stack(estack_id1, H5E_DEFAULT, FALSE);
+    }
     H5E_END_TRY
     if (ret >= 0)
         TEST_ERROR
-    H5E_BEGIN_TRY { ret = H5Eappend_stack(H5E_DEFAULT, estack_id2, FALSE); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Eappend_stack(H5E_DEFAULT, estack_id2, FALSE);
+    }
     H5E_END_TRY
     if (ret >= 0)
         TEST_ERROR
@@ -658,7 +670,10 @@ test_append(void)
     /* Try to close error stack #2.  Should fail because H5Eappend_stack
      * should have already closed it.
      */
-    H5E_BEGIN_TRY { ret = H5Eclose_stack(estack_id2); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Eclose_stack(estack_id2);
+    }
     H5E_END_TRY
     if (ret >= 0)
         TEST_ERROR

--- a/test/event_set.c
+++ b/test/event_set.c
@@ -85,7 +85,10 @@ test_es_create(void)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5ESclose(es_id); }
+    H5E_BEGIN_TRY
+    {
+        H5ESclose(es_id);
+    }
     H5E_END_TRY;
     return 1;
 }

--- a/test/evict_on_close.c
+++ b/test/evict_on_close.c
@@ -778,7 +778,10 @@ check_dset_scheme(hid_t fid, const char *dset_name)
     return SUCCEED;
 
 error:
-    H5E_BEGIN_TRY { H5Dclose(did); }
+    H5E_BEGIN_TRY
+    {
+        H5Dclose(did);
+    }
     H5E_END_TRY;
 
     H5_FAILED();
@@ -841,13 +844,19 @@ check_evict_on_close_api(void)
         TEST_ERROR;
 
     /* ensure using an incorrect access plist fails */
-    H5E_BEGIN_TRY { status = H5Pset_evict_on_close(dapl_id, evict_on_close); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Pset_evict_on_close(dapl_id, evict_on_close);
+    }
     H5E_END_TRY;
     if (status >= 0)
         FAIL_PUTS_ERROR("H5Pset_evict_on_close() accepted invalid access plist.");
 
     /* ensure an invalid plist fails */
-    H5E_BEGIN_TRY { status = H5Pget_evict_on_close(H5I_INVALID_HID, &evict_on_close); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Pget_evict_on_close(H5I_INVALID_HID, &evict_on_close);
+    }
     H5E_END_TRY;
     if (status >= 0)
         FAIL_PUTS_ERROR("H5Pget_evict_on_close() accepted invalid hid_t.");
@@ -994,7 +1003,10 @@ check_evict_on_close_parallel_fail(void)
 
     /* Set the evict on close property (should fail)*/
     evict_on_close = TRUE;
-    H5E_BEGIN_TRY { status = H5Pset_evict_on_close(fapl_id, evict_on_close); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Pset_evict_on_close(fapl_id, evict_on_close);
+    }
     H5E_END_TRY;
     if (status >= 0)
         FAIL_PUTS_ERROR("H5Pset_evict_on_close() did not fail in parallel HDF5.");

--- a/test/external.c
+++ b/test/external.c
@@ -134,7 +134,10 @@ test_non_extendible(hid_t file)
         FAIL_STACK_ERROR
 
     /* Test dataset address.  Should be undefined. */
-    H5E_BEGIN_TRY { dset_addr = H5Dget_offset(dset); }
+    H5E_BEGIN_TRY
+    {
+        dset_addr = H5Dget_offset(dset);
+    }
     H5E_END_TRY;
     if (dset_addr != HADDR_UNDEF)
         FAIL_STACK_ERROR
@@ -220,7 +223,10 @@ test_too_small(hid_t file)
     if ((space = H5Screate_simple(1, cur_size, max_size)) < 0)
         FAIL_STACK_ERROR
 
-    H5E_BEGIN_TRY { dset = H5Dcreate2(file, "dset2", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        dset = H5Dcreate2(file, "dset2", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (dset >= 0)
         FAIL_PUTS_ERROR("    Small external file succeeded instead of failing.");
@@ -332,7 +338,10 @@ test_large_enough_current_not_eventual(hid_t file)
     if ((space = H5Screate_simple(1, cur_size, max_size)) < 0)
         FAIL_STACK_ERROR
 
-    H5E_BEGIN_TRY { dset = H5Dcreate2(file, "dset4", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        dset = H5Dcreate2(file, "dset4", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (dset >= 0)
         FAIL_PUTS_ERROR("    Small external file succeeded instead of failing.");
@@ -547,7 +556,10 @@ test_multiple_files(hid_t file)
         FAIL_STACK_ERROR;
     }
 
-    H5E_BEGIN_TRY { dset = H5Dcreate2(file, "dset7", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        dset = H5Dcreate2(file, "dset7", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (dset >= 0)
         FAIL_PUTS_ERROR("    Small external files succeeded instead of failing.");
@@ -599,7 +611,10 @@ test_add_to_unlimited(void)
     if (H5Pset_external(dcpl, "ext1.data", (off_t)0, H5F_UNLIMITED) < 0)
         FAIL_STACK_ERROR
 
-    H5E_BEGIN_TRY { status = H5Pset_external(dcpl, "ext2.data", (off_t)0, (hsize_t)100); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Pset_external(dcpl, "ext2.data", (off_t)0, (hsize_t)100);
+    }
     H5E_END_TRY;
     if (status >= 0)
         FAIL_PUTS_ERROR("    H5Pset_external() succeeded when it should have failed.");
@@ -615,7 +630,10 @@ test_add_to_unlimited(void)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Pclose(dcpl); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(dcpl);
+    }
     H5E_END_TRY;
     return 1;
 } /* end test_add_to_unlimited() */
@@ -647,7 +665,10 @@ test_overflow(void)
     if (H5Pset_external(dcpl, "ext1.data", (off_t)0, H5F_UNLIMITED - 1) < 0)
         FAIL_STACK_ERROR
 
-    H5E_BEGIN_TRY { status = H5Pset_external(dcpl, "ext2.data", (off_t)0, (hsize_t)100); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Pset_external(dcpl, "ext2.data", (off_t)0, (hsize_t)100);
+    }
     H5E_END_TRY;
     if (status >= 0)
         FAIL_PUTS_ERROR("    H5Pset_external() succeeded when it should have failed.");
@@ -659,7 +680,10 @@ test_overflow(void)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Pclose(dcpl); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(dcpl);
+    }
     H5E_END_TRY;
     return 1;
 } /* end test_overflow() */
@@ -1187,7 +1211,10 @@ test_path_relative_cwd(hid_t fapl)
     /* Reopen dataset with different efile_prefix property */
     if (H5Pset_efile_prefix(dapl, "//") < 0)
         FAIL_STACK_ERROR
-    H5E_BEGIN_TRY { dset3 = H5Dopen2(file, "dset1", dapl); }
+    H5E_BEGIN_TRY
+    {
+        dset3 = H5Dopen2(file, "dset1", dapl);
+    }
     H5E_END_TRY;
     if (dset3 >= 0)
         FAIL_PUTS_ERROR("reopening the dataset with a different efile_prefix succeded");
@@ -1221,7 +1248,10 @@ test_path_relative_cwd(hid_t fapl)
     /* Reopen dataset with different efile_prefix property */
     if (H5Pset_efile_prefix(dapl, NULL) < 0)
         FAIL_STACK_ERROR
-    H5E_BEGIN_TRY { dset3 = H5Dopen2(file, "dset1", dapl); }
+    H5E_BEGIN_TRY
+    {
+        dset3 = H5Dopen2(file, "dset1", dapl);
+    }
     H5E_END_TRY;
     if (dset3 >= 0)
         FAIL_PUTS_ERROR("reopening the dataset with a different efile_prefix succeded");

--- a/test/farray.c
+++ b/test/farray.c
@@ -440,7 +440,10 @@ test_create(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t H5_ATTR_UNUSE
         /* Set invalid element size */
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
         test_cparam.raw_elmt_size = 0;
-        H5E_BEGIN_TRY { fa = H5FA_create(f, &test_cparam, NULL); }
+        H5E_BEGIN_TRY
+        {
+            fa = H5FA_create(f, &test_cparam, NULL);
+        }
         H5E_END_TRY;
         if (fa) {
             /* Close opened fixed array */
@@ -454,7 +457,10 @@ test_create(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t H5_ATTR_UNUSE
         /* Set invalid max. # of elements bits */
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
         test_cparam.max_dblk_page_nelmts_bits = 0;
-        H5E_BEGIN_TRY { fa = H5FA_create(f, &test_cparam, NULL); }
+        H5E_BEGIN_TRY
+        {
+            fa = H5FA_create(f, &test_cparam, NULL);
+        }
         H5E_END_TRY;
         if (fa) {
             /* Close opened fixed array */
@@ -468,7 +474,10 @@ test_create(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t H5_ATTR_UNUSE
         /* Set invalid max. # of elements */
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
         test_cparam.nelmts = 0;
-        H5E_BEGIN_TRY { fa = H5FA_create(f, &test_cparam, NULL); }
+        H5E_BEGIN_TRY
+        {
+            fa = H5FA_create(f, &test_cparam, NULL);
+        }
         H5E_END_TRY;
         if (fa) {
             /* Close opened fixed array */
@@ -885,7 +894,10 @@ test_delete_open(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t *tparam)
     fa2 = NULL;
 
     /* Try re-opening the array again (should fail, as array will be deleted) */
-    H5E_BEGIN_TRY { fa2 = H5FA_open(f, fa_addr, NULL); }
+    H5E_BEGIN_TRY
+    {
+        fa2 = H5FA_open(f, fa_addr, NULL);
+    }
     H5E_END_TRY;
     if (fa2) {
         /* Close opened array */
@@ -905,7 +917,10 @@ test_delete_open(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t *tparam)
         TEST_ERROR
 
     /* Try re-opening the array again (should fail, as array is now deleted) */
-    H5E_BEGIN_TRY { fa = H5FA_open(f, fa_addr, NULL); }
+    H5E_BEGIN_TRY
+    {
+        fa = H5FA_open(f, fa_addr, NULL);
+    }
     H5E_END_TRY;
     if (fa) {
         /* Close opened array */
@@ -1783,7 +1798,10 @@ main(void)
 error:
     HDputs("*** TESTS FAILED ***");
 
-    H5E_BEGIN_TRY { H5Pclose(fapl); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(fapl);
+    }
     H5E_END_TRY;
 
     if (api_ctx_pushed)

--- a/test/fheap.c
+++ b/test/fheap.c
@@ -9580,7 +9580,7 @@ test_man_fill_2nd_direct_less_one_wrap_start_block_add_skipped(hid_t fapl, H5HF_
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -9726,8 +9726,8 @@ test_man_fill_direct_skip_2nd_indirect_skip_2nd_block_add_skipped(hid_t fapl, H5
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
-    unsigned           row;      /* Current row in indirect block */
+                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+    unsigned           row;                     /* Current row in indirect block */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -9889,7 +9889,7 @@ test_man_fill_direct_skip_indirect_two_rows_add_skipped(hid_t fapl, H5HF_create_
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     unsigned           max_dblock_rows; /* Max. # of rows (of direct blocks) in the root indirect block */
     h5_stat_size_t     empty_size;      /* Size of a file with an empty heap */
     size_t             obj_size;        /* Size of object */
@@ -10045,7 +10045,7 @@ test_man_fill_direct_skip_indirect_two_rows_skip_indirect_row_add_skipped(hid_t 
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     unsigned           max_dblock_rows; /* Max. # of rows (of direct blocks) in the root indirect block */
     h5_stat_size_t     empty_size;      /* Size of a file with an empty heap */
     size_t             obj_size;        /* Size of object */
@@ -10502,7 +10502,7 @@ test_man_fill_2nd_direct_fill_direct_skip_3rd_indirect_start_block_add_skipped(h
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -10655,7 +10655,7 @@ test_man_fill_2nd_direct_fill_direct_skip2_3rd_indirect_start_block_add_skipped(
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -10812,7 +10812,7 @@ test_man_fill_3rd_direct_less_one_fill_direct_wrap_start_block_add_skipped(hid_t
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -10976,7 +10976,7 @@ test_man_fill_1st_row_3rd_direct_fill_2nd_direct_less_one_wrap_start_block_add_s
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size;                    /* Size of a file with an empty heap */
     size_t             obj_size;                      /* Size of object */
     size_t             fill_size;                     /* Size of objects for "bulk" filled blocks */
@@ -11144,7 +11144,7 @@ test_man_fill_3rd_direct_fill_direct_skip_start_block_add_skipped(hid_t fapl, H5
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -11307,7 +11307,7 @@ test_man_fill_3rd_direct_fill_2nd_direct_fill_direct_skip_3rd_indirect_start_blo
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -11490,7 +11490,7 @@ test_man_fill_3rd_direct_fill_2nd_direct_fill_direct_skip_3rd_indirect_two_rows_
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -11710,7 +11710,7 @@ test_man_fill_3rd_direct_fill_2nd_direct_fill_direct_skip_3rd_indirect_wrap_star
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -11910,7 +11910,7 @@ test_man_fill_4th_direct_less_one_fill_2nd_direct_fill_direct_skip_3rd_indirect_
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -12441,7 +12441,7 @@ test_man_frag_2nd_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */

--- a/test/fheap.c
+++ b/test/fheap.c
@@ -2360,7 +2360,10 @@ test_delete_open(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
     fh2 = NULL;
 
     /* Try re-opening the heap again (should fail, as heap will be deleted) */
-    H5E_BEGIN_TRY { fh2 = H5HF_open(f, fh_addr); }
+    H5E_BEGIN_TRY
+    {
+        fh2 = H5HF_open(f, fh_addr);
+    }
     H5E_END_TRY;
     if (fh2) {
         /* Close opened heap */
@@ -2397,7 +2400,10 @@ test_delete_open(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
     } /* end if */
 
     /* Try re-opening the heap again (should fail, as heap is now deleted) */
-    H5E_BEGIN_TRY { fh = H5HF_open(f, fh_addr); }
+    H5E_BEGIN_TRY
+    {
+        fh = H5HF_open(f, fh_addr);
+    }
     H5E_END_TRY;
     if (fh) {
         /* Close opened heap */
@@ -2584,7 +2590,10 @@ test_id_limits(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
     tmp_cparam.id_len = 3;
 
     /* Create absolute heap */
-    H5E_BEGIN_TRY { fh = H5HF_create(f, &tmp_cparam); }
+    H5E_BEGIN_TRY
+    {
+        fh = H5HF_create(f, &tmp_cparam);
+    }
     H5E_END_TRY;
     if (NULL != fh)
         FAIL_STACK_ERROR
@@ -2745,7 +2754,10 @@ test_id_limits(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
     tmp_cparam.id_len = H5HF_MAX_ID_LEN + 1;
 
     /* Create absolute heap */
-    H5E_BEGIN_TRY { fh = H5HF_create(f, &tmp_cparam); }
+    H5E_BEGIN_TRY
+    {
+        fh = H5HF_create(f, &tmp_cparam);
+    }
     H5E_END_TRY;
     if (NULL != fh)
         FAIL_STACK_ERROR
@@ -3232,7 +3244,10 @@ test_man_insert_weird(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpa
     TESTING("inserting 'weird' sized objects into absolute heap");
 
     /* Attempt to insert 0-sized object into heap */
-    H5E_BEGIN_TRY { ret = H5HF_insert(fh, (size_t)0, shared_wobj_g, heap_id); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5HF_insert(fh, (size_t)0, shared_wobj_g, heap_id);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -6459,7 +6474,10 @@ HDfprintf(stderr, "Random # seed was: %lu\n", seed);
         heap_id[u] = (unsigned char)(HDrandom() + 1);
 
     /* Try removing bogus heap ID from empty heap */
-    H5E_BEGIN_TRY { ret = H5HF_remove(fh, heap_id); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5HF_remove(fh, heap_id);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         FAIL_STACK_ERROR
@@ -6485,14 +6503,20 @@ HDfprintf(stderr, "Random # seed was: %lu\n", seed);
     } /* end while */
 
     /* Try removing bogus heap ID from heap w/objects */
-    H5E_BEGIN_TRY { ret = H5HF_remove(fh, heap_id); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5HF_remove(fh, heap_id);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
     H5Eclear2(H5E_DEFAULT);
 
     /* Try reading bogus heap ID from heap w/objects */
-    H5E_BEGIN_TRY { ret = H5HF_read(fh, heap_id, shared_robj_g); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5HF_read(fh, heap_id, shared_robj_g);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -9556,7 +9580,7 @@ test_man_fill_2nd_direct_less_one_wrap_start_block_add_skipped(hid_t fapl, H5HF_
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -9702,8 +9726,8 @@ test_man_fill_direct_skip_2nd_indirect_skip_2nd_block_add_skipped(hid_t fapl, H5
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
-    unsigned           row;                     /* Current row in indirect block */
+        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+    unsigned           row;      /* Current row in indirect block */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -9865,7 +9889,7 @@ test_man_fill_direct_skip_indirect_two_rows_add_skipped(hid_t fapl, H5HF_create_
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     unsigned           max_dblock_rows; /* Max. # of rows (of direct blocks) in the root indirect block */
     h5_stat_size_t     empty_size;      /* Size of a file with an empty heap */
     size_t             obj_size;        /* Size of object */
@@ -10021,7 +10045,7 @@ test_man_fill_direct_skip_indirect_two_rows_skip_indirect_row_add_skipped(hid_t 
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     unsigned           max_dblock_rows; /* Max. # of rows (of direct blocks) in the root indirect block */
     h5_stat_size_t     empty_size;      /* Size of a file with an empty heap */
     size_t             obj_size;        /* Size of object */
@@ -10478,7 +10502,7 @@ test_man_fill_2nd_direct_fill_direct_skip_3rd_indirect_start_block_add_skipped(h
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -10631,7 +10655,7 @@ test_man_fill_2nd_direct_fill_direct_skip2_3rd_indirect_start_block_add_skipped(
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -10788,7 +10812,7 @@ test_man_fill_3rd_direct_less_one_fill_direct_wrap_start_block_add_skipped(hid_t
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -10952,7 +10976,7 @@ test_man_fill_1st_row_3rd_direct_fill_2nd_direct_less_one_wrap_start_block_add_s
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size;                    /* Size of a file with an empty heap */
     size_t             obj_size;                      /* Size of object */
     size_t             fill_size;                     /* Size of objects for "bulk" filled blocks */
@@ -11120,7 +11144,7 @@ test_man_fill_3rd_direct_fill_direct_skip_start_block_add_skipped(hid_t fapl, H5
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -11283,7 +11307,7 @@ test_man_fill_3rd_direct_fill_2nd_direct_fill_direct_skip_3rd_indirect_start_blo
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -11466,7 +11490,7 @@ test_man_fill_3rd_direct_fill_2nd_direct_fill_direct_skip_3rd_indirect_two_rows_
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -11686,7 +11710,7 @@ test_man_fill_3rd_direct_fill_2nd_direct_fill_direct_skip_3rd_indirect_wrap_star
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -11886,7 +11910,7 @@ test_man_fill_4th_direct_less_one_fill_2nd_direct_fill_direct_skip_3rd_indirect_
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -12417,7 +12441,7 @@ test_man_frag_2nd_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *
     haddr_t          fh_addr;                      /* Address of fractal heap */
     fheap_heap_ids_t keep_ids;                     /* Structure to retain heap IDs */
     unsigned
-                       num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
+        num_first_indirect_rows; /* Number of rows (of direct blocks) in each of the first indirect blocks */
     h5_stat_size_t     empty_size; /* Size of a file with an empty heap */
     size_t             obj_size;   /* Size of object */
     size_t             fill_size;  /* Size of objects for "bulk" filled blocks */
@@ -15954,7 +15978,10 @@ test_write(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
         FAIL_STACK_ERROR
 
     /* Verify that writing to 'huge' objects works for un-filtered heaps */
-    H5E_BEGIN_TRY { ret = H5HF_write(fh, huge_heap_id, &id_changed, shared_wobj_g); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5HF_write(fh, huge_heap_id, &id_changed, shared_wobj_g);
+    }
     H5E_END_TRY;
     HDassert(!id_changed);
     if (tparam->comp == FHEAP_TEST_COMPRESS) {
@@ -15967,7 +15994,10 @@ test_write(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
     } /* end else */
 
     /* Verify that writing to 'tiny' objects return failure (for now) */
-    H5E_BEGIN_TRY { ret = H5HF_write(fh, tiny_heap_id, &id_changed, shared_wobj_g); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5HF_write(fh, tiny_heap_id, &id_changed, shared_wobj_g);
+    }
     H5E_END_TRY;
     HDassert(!id_changed);
     if (ret >= 0)

--- a/test/file_image.c
+++ b/test/file_image.c
@@ -1064,21 +1064,30 @@ test_get_file_image_error_rejection(void)
     VERIFY(image_ptr != NULL, "HDmalloc(1) failed.");
 
     /* load the image of the file into the buffer */
-    H5E_BEGIN_TRY { bytes_read = H5Fget_file_image(file_id, image_ptr, (size_t)(image_size - 1)); }
+    H5E_BEGIN_TRY
+    {
+        bytes_read = H5Fget_file_image(file_id, image_ptr, (size_t)(image_size - 1));
+    }
     H5E_END_TRY;
     VERIFY(bytes_read < 0, "H5Fget_file_image(2 -- test 1) succeeded.");
 
     /* Call H5Fget_file_image() with good buffer and buffer size,
      * but non-existant file_id.  Should fail.
      */
-    H5E_BEGIN_TRY { bytes_read = H5Fget_file_image((hid_t)0, image_ptr, (size_t)(image_size)); }
+    H5E_BEGIN_TRY
+    {
+        bytes_read = H5Fget_file_image((hid_t)0, image_ptr, (size_t)(image_size));
+    }
     H5E_END_TRY;
     VERIFY(bytes_read < 0, "H5Fget_file_image(3 -- test 1) succeeded.");
 
     /* Call H5Fget_file_image() with good buffer and buffer size,
      * but a file_id of the wrong type.  Should fail.
      */
-    H5E_BEGIN_TRY { bytes_read = H5Fget_file_image(dset_id, image_ptr, (size_t)(image_size)); }
+    H5E_BEGIN_TRY
+    {
+        bytes_read = H5Fget_file_image(dset_id, image_ptr, (size_t)(image_size));
+    }
     H5E_END_TRY;
     VERIFY(bytes_read < 0, "H5Fget_file_image(4 -- test 1) succeeded.");
 
@@ -1179,7 +1188,10 @@ test_get_file_image_error_rejection(void)
     VERIFY(err >= 0, "H5Fflush failed");
 
     /* attempt to get the size of the file -- should fail */
-    H5E_BEGIN_TRY { image_size = H5Fget_file_image(file_id, NULL, (size_t)0); }
+    H5E_BEGIN_TRY
+    {
+        image_size = H5Fget_file_image(file_id, NULL, (size_t)0);
+    }
     H5E_END_TRY;
     VERIFY(image_size == -1, "H5Fget_file_image(5) succeeded.");
 
@@ -1238,7 +1250,10 @@ test_get_file_image_error_rejection(void)
     VERIFY(err >= 0, "H5Fflush failed");
 
     /* attempt to get the size of the file -- should fail */
-    H5E_BEGIN_TRY { image_size = H5Fget_file_image(file_id, NULL, (size_t)0); }
+    H5E_BEGIN_TRY
+    {
+        image_size = H5Fget_file_image(file_id, NULL, (size_t)0);
+    }
     H5E_END_TRY;
     VERIFY(image_size == -1, "H5Fget_file_image(6) succeeded.");
 
@@ -1295,7 +1310,10 @@ test_get_file_image_error_rejection(void)
     VERIFY(err >= 0, "H5Fflush failed");
 
     /* attempt to get the size of the file -- should fail */
-    H5E_BEGIN_TRY { image_size = H5Fget_file_image(file_id, NULL, (size_t)0); }
+    H5E_BEGIN_TRY
+    {
+        image_size = H5Fget_file_image(file_id, NULL, (size_t)0);
+    }
     H5E_END_TRY;
     VERIFY(image_size == -1, "H5Fget_file_image(7) succeeded.");
 

--- a/test/fillval.c
+++ b/test/fillval.c
@@ -86,7 +86,10 @@ create_compound_type(void)
     return ret_value;
 
 error:
-    H5E_BEGIN_TRY { H5Tclose(ret_value); }
+    H5E_BEGIN_TRY
+    {
+        H5Tclose(ret_value);
+    }
     H5E_END_TRY;
     return -1;
 }
@@ -197,7 +200,10 @@ test_getset(void)
      * Reading the fill value from a dataset creation property list that has
      * no fill value should result in a failure.
      */
-    H5E_BEGIN_TRY { H5Pget_fill_value(dcpl, H5T_NATIVE_INT, &fill_i); }
+    H5E_BEGIN_TRY
+    {
+        H5Pget_fill_value(dcpl, H5T_NATIVE_INT, &fill_i);
+    }
     H5E_END_TRY;
     if (fill_i != 0) {
         H5_FAILED();
@@ -380,7 +386,9 @@ test_getset_vl(hid_t fapl)
     return 0;
 
 error:
-    H5E_BEGIN_TRY {}
+    H5E_BEGIN_TRY
+    {
+    }
     H5E_END_TRY;
     return 1;
 } /* end test_getset_vl() */

--- a/test/filter_fail.c
+++ b/test/filter_fail.c
@@ -167,7 +167,10 @@ test_filter_write(char *file_name, hid_t my_fapl, hbool_t cache_enabled)
     }
     else {
         /* Data writing should fail */
-        H5E_BEGIN_TRY { ret = H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, sid, H5P_DEFAULT, points); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, sid, H5P_DEFAULT, points);
+        }
         H5E_END_TRY;
         if (ret >= 0) {
             H5_FAILED();
@@ -185,7 +188,10 @@ test_filter_write(char *file_name, hid_t my_fapl, hbool_t cache_enabled)
     /* Close dataset.  If the chunk cache is enabled, the flushing of chunks should fail
      * during H5Dclose.  If it is diabled, H5Dwrite should fail but H5Dclose should succeed. */
     if (cache_enabled) {
-        H5E_BEGIN_TRY { ret = H5Dclose(dataset); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Dclose(dataset);
+        }
         H5E_END_TRY;
         if (ret >= 0) {
             H5_FAILED();

--- a/test/filter_plugin.c
+++ b/test/filter_plugin.c
@@ -566,7 +566,10 @@ test_dataset_write_with_filters(hid_t fid)
 
 error:
     /* Clean up objects used for this test */
-    H5E_BEGIN_TRY { H5Pclose(dcpl_id); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(dcpl_id);
+    }
     H5E_END_TRY
 
     return FAIL;
@@ -703,7 +706,10 @@ test_dataset_read_with_filters(hid_t fid)
 
 error:
     /* Clean up objects used for this test */
-    H5E_BEGIN_TRY { H5Dclose(did); }
+    H5E_BEGIN_TRY
+    {
+        H5Dclose(did);
+    }
     H5E_END_TRY
 
     return FAIL;
@@ -728,7 +734,10 @@ ensure_data_read_fails(hid_t did)
         TEST_ERROR;
 
     /* Read the dataset back (should fail) */
-    H5E_BEGIN_TRY { ret = H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, *check); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, *check);
+    }
     H5E_END_TRY
     if (ret >= 0)
         TEST_ERROR;
@@ -998,7 +1007,10 @@ test_path_api_calls(void)
     TESTING("    remove (index 0 in empty table)");
 
     /* Try to remove index zero in an empty list (SHOULD FAIL) */
-    H5E_BEGIN_TRY { ret = H5PLremove(0); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5PLremove(0);
+    }
     H5E_END_TRY
     if (ret >= 0)
         TEST_ERROR;
@@ -1029,7 +1041,10 @@ test_path_api_calls(void)
     TESTING("    remove (index too high)");
 
     /* Try to remove a path where the index is beyond the table capacity (SHOULD FAIL) */
-    H5E_BEGIN_TRY { ret = H5PLremove(n_starting_paths); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5PLremove(n_starting_paths);
+    }
     H5E_END_TRY
 
     if (ret >= 0)
@@ -1087,7 +1102,10 @@ test_path_api_calls(void)
     TESTING("    get (index too high)");
 
     /* Get path at the last + 1 index (SHOULD FAIL) */
-    H5E_BEGIN_TRY { path_len = H5PLget(n_starting_paths, NULL, 0); }
+    H5E_BEGIN_TRY
+    {
+        path_len = H5PLget(n_starting_paths, NULL, 0);
+    }
     H5E_END_TRY
     if (path_len > 0)
         TEST_ERROR;

--- a/test/flush1.c
+++ b/test/flush1.c
@@ -327,7 +327,10 @@ main(void)
     HD_exit(EXIT_SUCCESS);
 
 error:
-    H5E_BEGIN_TRY { H5Pclose(fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(fapl_id);
+    }
     H5E_END_TRY;
 
     HDexit(EXIT_FAILURE);

--- a/test/freespace.c
+++ b/test/freespace.c
@@ -2916,7 +2916,10 @@ main(void)
 
 error:
     HDputs("*** TESTS FAILED ***");
-    H5E_BEGIN_TRY { H5Pclose(fapl); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(fapl);
+    }
     H5E_END_TRY;
 
     if (api_ctx_pushed)

--- a/test/getname.c
+++ b/test/getname.c
@@ -3794,7 +3794,10 @@ main(void)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file_id); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file_id);
+    }
     H5E_END_TRY;
 
     HDputs("***** GET NAME TESTS FAILED *****");

--- a/test/gheap.c
+++ b/test/gheap.c
@@ -149,7 +149,10 @@ test_1(hid_t fapl)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     if (obj)
         HDfree(obj);
@@ -246,7 +249,10 @@ test_2(hid_t fapl)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     if (obj)
         HDfree(obj);
@@ -333,7 +339,10 @@ test_3(hid_t fapl)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     if (obj)
         HDfree(obj);
@@ -426,7 +435,10 @@ test_4(hid_t fapl)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     if (obj)
         HDfree(obj);
@@ -542,7 +554,10 @@ test_ooo_indices(hid_t fapl)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     if (obj)
         HDfree(obj);
@@ -597,7 +612,10 @@ main(void)
     HDexit(EXIT_SUCCESS);
 
 error:
-    H5E_BEGIN_TRY { H5Pclose(fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(fapl_id);
+    }
     H5E_END_TRY;
 
     if (api_ctx_pushed)

--- a/test/h5test.c
+++ b/test/h5test.c
@@ -1725,7 +1725,10 @@ h5_verify_cached_stabs(const char *base_name[], hid_t fapl)
         if (h5_fixname(base_name[i], fapl, filename, sizeof(filename)) == NULL)
             continue;
 
-        H5E_BEGIN_TRY { file = H5Fopen(filename, H5F_ACC_RDONLY, fapl); }
+        H5E_BEGIN_TRY
+        {
+            file = H5Fopen(filename, H5F_ACC_RDONLY, fapl);
+        }
         H5E_END_TRY
         if (file < 0) {
             i++;
@@ -1746,7 +1749,10 @@ h5_verify_cached_stabs(const char *base_name[], hid_t fapl)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
 
     return -1;

--- a/test/hdfs.c
+++ b/test/hdfs.c
@@ -588,7 +588,10 @@ error:
      ***********/
 
     if (fapl_id < 0) {
-        H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+        H5E_BEGIN_TRY
+        {
+            (void)H5Pclose(fapl_id);
+        }
         H5E_END_TRY;
     }
     return 1;
@@ -671,7 +674,10 @@ test_hdfs_fapl(void)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        (void)H5Pclose(fapl_id);
+    }
     H5E_END_TRY;
 
     return 1;
@@ -856,7 +862,10 @@ test_vfd_open(void)
         HDfprintf(stderr, "testing: %s\n", T.message);
 #endif /* HDFS_TEST_DEBUG */
 
-        H5E_BEGIN_TRY { fd = H5FDopen(T.url, T.flags, fapl_id, T.maxaddr); }
+        H5E_BEGIN_TRY
+        {
+            fd = H5FDopen(T.url, T.flags, fapl_id, T.maxaddr);
+        }
         H5E_END_TRY;
         if (NULL != fd) {
             if (TRUE == T.might_use_other_driver && H5FD_HDFS != fd->driver_id) {
@@ -1037,7 +1046,10 @@ error:
         (void)H5FDclose(fd_shakespeare);
     }
     if (fapl_id >= 0) {
-        H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+        H5E_BEGIN_TRY
+        {
+            (void)H5Pclose(fapl_id);
+        }
         H5E_END_TRY;
     }
 
@@ -1134,7 +1146,10 @@ error:
         (void)H5FDclose(file_shakespeare);
     }
     if (fapl_id >= 0) {
-        H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+        H5E_BEGIN_TRY
+        {
+            (void)H5Pclose(fapl_id);
+        }
         H5E_END_TRY;
     }
 
@@ -1338,7 +1353,10 @@ error:
         (void)H5FDclose(file_raven);
     }
     if (fapl_id >= 0) {
-        H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+        H5E_BEGIN_TRY
+        {
+            (void)H5Pclose(fapl_id);
+        }
         H5E_END_TRY;
     }
 
@@ -1450,7 +1468,10 @@ error:
      ***********/
 
     if (fapl_id >= 0) {
-        H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+        H5E_BEGIN_TRY
+        {
+            (void)H5Pclose(fapl_id);
+        }
         H5E_END_TRY;
     }
     if (file != NULL) {
@@ -1593,7 +1614,10 @@ error:
 #endif /* HDFS_TEST_DEBUG */
 
     if (fapl_id >= 0) {
-        H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+        H5E_BEGIN_TRY
+        {
+            (void)H5Pclose(fapl_id);
+        }
         H5E_END_TRY;
     }
     if (file > 0) {

--- a/test/lheap.c
+++ b/test/lheap.c
@@ -212,7 +212,10 @@ main(void)
 
 error:
     HDputs("*** TESTS FAILED ***");
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
 
     if (api_ctx_pushed)

--- a/test/links.c
+++ b/test/links.c
@@ -9898,8 +9898,8 @@ external_set_elink_cb(hid_t fapl, hbool_t new_format)
                          base_driver == H5FD_MPIO || base_driver == H5FD_CORE)
                             ? H5P_DEFAULT
                             : fapl;
-    op_data.fam_size  = ELINK_CB_FAM_SIZE;
-    op_data.code      = 0;
+    op_data.fam_size = ELINK_CB_FAM_SIZE;
+    op_data.code     = 0;
 
     /* Create family fapl */
     if ((fam_fapl = H5Pcopy(fapl)) < 0)

--- a/test/links.c
+++ b/test/links.c
@@ -664,14 +664,20 @@ cklinks(hid_t fapl, hbool_t new_format)
         FAIL_STACK_ERROR
     if (H5Lexists(file, "/grp1/hard", H5P_DEFAULT) != TRUE)
         FAIL_STACK_ERROR
-    H5E_BEGIN_TRY { status = H5Lexists(file, "no_grp1/hard", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Lexists(file, "no_grp1/hard", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
         HDputs("    H5Lexists() should have failed for a path with missing components.");
         TEST_ERROR
     } /* end if */
-    H5E_BEGIN_TRY { status = H5Lexists(file, "/no_grp1/hard", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Lexists(file, "/no_grp1/hard", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -1074,7 +1080,10 @@ toomany(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through too deep soft link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "soft17", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "soft17", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (gid >= 0) {
         H5_FAILED();
@@ -1419,7 +1428,10 @@ test_move(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Verify that the group is no longer in the original location */
-    H5E_BEGIN_TRY { moved_grp = H5Gopen2(grp_1, "group_move", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        moved_grp = H5Gopen2(grp_1, "group_move", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (moved_grp >= 0) {
         H5_FAILED();
@@ -2169,14 +2181,20 @@ cklinks_deprec(hid_t fapl, hbool_t new_format)
         FAIL_STACK_ERROR
     if (H5Lexists(file, "/grp1/hard", H5P_DEFAULT) != TRUE)
         FAIL_STACK_ERROR
-    H5E_BEGIN_TRY { status = H5Lexists(file, "no_grp1/hard", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Lexists(file, "no_grp1/hard", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
         HDputs("    H5Lexists() should have failed for a path with missing components.");
         TEST_ERROR
     } /* end if */
-    H5E_BEGIN_TRY { status = H5Lexists(file, "/no_grp1/hard", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Lexists(file, "/no_grp1/hard", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -2924,7 +2942,10 @@ external_link_root_deprec(hid_t fapl, hbool_t new_format)
     if ((fid = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
         TEST_ERROR
 
-    H5E_BEGIN_TRY { gid = H5Gcreate2(fid, "ext_link/readonly_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gcreate2(fid, "ext_link/readonly_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY
     if (gid >= 0)
         TEST_ERROR
@@ -4231,7 +4252,10 @@ lapl_nlinks_deprec(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Try opening through what is now too many soft links */
-    H5E_BEGIN_TRY { gid = H5Oopen(fid, "soft5", plist); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Oopen(fid, "soft5", plist);
+    }
     H5E_END_TRY;
     if (gid >= 0) {
         H5_FAILED();
@@ -6397,7 +6421,10 @@ link_iterate_check_deprec(hid_t group_id, H5_index_t idx_type, H5_iter_order_t o
 
     /* Check for iteration routine indicating failure */
     skip = 0;
-    H5E_BEGIN_TRY { ret = H5Literate1(group_id, idx_type, order, &skip, link_iterate_fail_deprec_cb, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Literate1(group_id, idx_type, order, &skip, link_iterate_fail_deprec_cb, NULL);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -6895,7 +6922,10 @@ link_iterate_old_check_deprec(hid_t group_id, H5_iter_order_t order, unsigned ma
     if (ret >= 0)
         TEST_ERROR
 
-    H5E_BEGIN_TRY { ret = H5Giterate((hid_t)(-1), ".", &gskip, group_iterate_old_deprec_cb, iter_info); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Giterate((hid_t)(-1), ".", &gskip, group_iterate_old_deprec_cb, iter_info);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -7230,7 +7260,10 @@ external_link_root(hid_t fapl, hbool_t new_format)
     if ((fid = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
         TEST_ERROR
 
-    H5E_BEGIN_TRY { gid = H5Gcreate2(fid, "ext_link/readonly_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gcreate2(fid, "ext_link/readonly_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY
     if (gid >= 0)
         TEST_ERROR
@@ -8024,7 +8057,10 @@ external_link_toomany(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "link1", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "link1", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (gid >= 0) {
         H5_FAILED();
@@ -8131,7 +8167,10 @@ external_link_dangling(hid_t fapl, hbool_t new_format)
         TEST_ERROR;
 
     /* Open object through dangling file external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "no_file", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "no_file", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (gid >= 0) {
         H5_FAILED();
@@ -8140,7 +8179,10 @@ external_link_dangling(hid_t fapl, hbool_t new_format)
     }
 
     /* Open object through dangling object external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "no_object", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "no_object", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (gid >= 0) {
         H5_FAILED();
@@ -8248,7 +8290,10 @@ external_link_prefix(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", gapl_id); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", gapl_id);
+    }
     H5E_END_TRY;
 
     /* should be able to find the target file from pathnames set via H5Pset_elink_prefix() */
@@ -8342,7 +8387,10 @@ external_link_abs_mainpath(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     /* should be able to find the target file from absolute path set for main file */
@@ -8427,7 +8475,10 @@ external_link_rel_mainpath(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     /* should be able to find the target file from the main file's relative pathname */
@@ -8517,7 +8568,10 @@ external_link_cwd(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     /* should be able to find the target file from the current working directory */
@@ -8612,7 +8666,10 @@ external_link_abstar(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     /* should be able to find the target file with abolute path */
@@ -8707,7 +8764,10 @@ external_link_abstar_cur(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     /* should be able to find the target file from main file's current working directory */
@@ -8879,7 +8939,10 @@ external_link_chdir(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     if (HDchdir("..") < 0)
@@ -9511,7 +9574,10 @@ external_set_elink_acc_flags(const char *env_h5_drvr, hid_t fapl, hbool_t new_fo
         TEST_ERROR
 
     /* Attempt to create a group through the external link using gapl (should fail) */
-    H5E_BEGIN_TRY { group = H5Gcreate2(file1, "/ext_link/group", H5P_DEFAULT, H5P_DEFAULT, gapl); }
+    H5E_BEGIN_TRY
+    {
+        group = H5Gcreate2(file1, "/ext_link/group", H5P_DEFAULT, H5P_DEFAULT, gapl);
+    }
     H5E_END_TRY;
     if (group != FAIL)
         TEST_ERROR
@@ -9559,25 +9625,40 @@ external_set_elink_acc_flags(const char *env_h5_drvr, hid_t fapl, hbool_t new_fo
         TEST_ERROR
 
     /* Attempt to set invalid flags on gapl */
-    H5E_BEGIN_TRY { ret = H5Pset_elink_acc_flags(gapl, H5F_ACC_TRUNC); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_elink_acc_flags(gapl, H5F_ACC_TRUNC);
+    }
     H5E_END_TRY;
     if (ret != FAIL)
         TEST_ERROR
-    H5E_BEGIN_TRY { ret = H5Pset_elink_acc_flags(gapl, H5F_ACC_EXCL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_elink_acc_flags(gapl, H5F_ACC_EXCL);
+    }
     H5E_END_TRY;
     if (ret != FAIL)
         TEST_ERROR
-    H5E_BEGIN_TRY { ret = H5Pset_elink_acc_flags(gapl, H5F_ACC_CREAT); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_elink_acc_flags(gapl, H5F_ACC_CREAT);
+    }
     H5E_END_TRY;
     if (ret != FAIL)
         TEST_ERROR
     /* SWMR reader with write access */
-    H5E_BEGIN_TRY { ret = H5Pset_elink_acc_flags(gapl, H5F_ACC_RDWR | H5F_ACC_SWMR_READ); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_elink_acc_flags(gapl, H5F_ACC_RDWR | H5F_ACC_SWMR_READ);
+    }
     H5E_END_TRY;
     if (ret != FAIL)
         TEST_ERROR
     /* SWMR writer with read-only access */
-    H5E_BEGIN_TRY { ret = H5Pset_elink_acc_flags(gapl, H5F_ACC_RDONLY | H5F_ACC_SWMR_WRITE); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_elink_acc_flags(gapl, H5F_ACC_RDONLY | H5F_ACC_SWMR_WRITE);
+    }
     H5E_END_TRY;
     if (ret != FAIL)
         TEST_ERROR
@@ -9690,19 +9771,31 @@ external_set_elink_acc_flags(const char *env_h5_drvr, hid_t fapl, hbool_t new_fo
     } /* end if */
 
     /* Verify that H5Fcreate and H5Fopen reject H5F_ACC_DEFAULT */
-    H5E_BEGIN_TRY { file1 = H5Fcreate(filename1, H5F_ACC_DEFAULT, H5P_DEFAULT, fapl); }
+    H5E_BEGIN_TRY
+    {
+        file1 = H5Fcreate(filename1, H5F_ACC_DEFAULT, H5P_DEFAULT, fapl);
+    }
     H5E_END_TRY;
     if (file1 != FAIL)
         TEST_ERROR
-    H5E_BEGIN_TRY { file1 = H5Fcreate(filename1, H5F_ACC_TRUNC | H5F_ACC_DEFAULT, H5P_DEFAULT, fapl); }
+    H5E_BEGIN_TRY
+    {
+        file1 = H5Fcreate(filename1, H5F_ACC_TRUNC | H5F_ACC_DEFAULT, H5P_DEFAULT, fapl);
+    }
     H5E_END_TRY;
     if (file1 != FAIL)
         TEST_ERROR
-    H5E_BEGIN_TRY { file1 = H5Fopen(filename1, H5F_ACC_DEFAULT, fapl); }
+    H5E_BEGIN_TRY
+    {
+        file1 = H5Fopen(filename1, H5F_ACC_DEFAULT, fapl);
+    }
     H5E_END_TRY;
     if (file1 != FAIL)
         TEST_ERROR
-    H5E_BEGIN_TRY { file1 = H5Fopen(filename1, H5F_ACC_RDWR | H5F_ACC_DEFAULT, fapl); }
+    H5E_BEGIN_TRY
+    {
+        file1 = H5Fopen(filename1, H5F_ACC_RDWR | H5F_ACC_DEFAULT, fapl);
+    }
     H5E_END_TRY;
     if (file1 != FAIL)
         TEST_ERROR
@@ -9805,8 +9898,8 @@ external_set_elink_cb(hid_t fapl, hbool_t new_format)
                          base_driver == H5FD_MPIO || base_driver == H5FD_CORE)
                             ? H5P_DEFAULT
                             : fapl;
-    op_data.fam_size = ELINK_CB_FAM_SIZE;
-    op_data.code     = 0;
+    op_data.fam_size  = ELINK_CB_FAM_SIZE;
+    op_data.code      = 0;
 
     /* Create family fapl */
     if ((fam_fapl = H5Pcopy(fapl)) < 0)
@@ -9883,7 +9976,10 @@ external_set_elink_cb(hid_t fapl, hbool_t new_format)
     op_data.code = 1;
 
     /* Attempt to reopen group2 (should fail) */
-    H5E_BEGIN_TRY { group = H5Gopen2(file1, "/group1/ext_link/group2", gapl); }
+    H5E_BEGIN_TRY
+    {
+        group = H5Gopen2(file1, "/group1/ext_link/group2", gapl);
+    }
     H5E_END_TRY;
     if (group != FAIL)
         TEST_ERROR
@@ -9892,7 +9988,10 @@ external_set_elink_cb(hid_t fapl, hbool_t new_format)
     op_data.code = 2;
 
     /* Attempt to reopen group2 (should fail) */
-    H5E_BEGIN_TRY { group = H5Gopen2(file1, "/group1/ext_link/group2", gapl); }
+    H5E_BEGIN_TRY
+    {
+        group = H5Gopen2(file1, "/group1/ext_link/group2", gapl);
+    }
     H5E_END_TRY;
     if (group != FAIL)
         TEST_ERROR
@@ -9977,7 +10076,10 @@ external_reset_register(void)
     return SUCCEED;
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return FAIL;
 } /* end external_reset_register() */
@@ -10046,7 +10148,10 @@ external_link_win1(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     /* should be able to find the target file via main file's CWD*/
@@ -10140,7 +10245,10 @@ external_link_win2(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     /* should be able to find the target file directly */
@@ -10231,7 +10339,10 @@ external_link_win3(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     /* should be able to find the target file directly */
@@ -10319,7 +10430,10 @@ external_link_win4(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     /* should be able to find the target file via main file's absolute drive/relative path */
@@ -10417,7 +10531,10 @@ external_link_win5(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     /* should be able to find the target file via main file's rel drive/abs path */
@@ -10512,7 +10629,10 @@ external_link_win6(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     /* should be able to find the target file via target file's rel path in current drive */
@@ -10604,7 +10724,10 @@ external_link_win7(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     /* should be able to find the target file via main file's local host/main drive*/
@@ -10701,7 +10824,10 @@ external_link_win8(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     /* should be able to find the target file directly */
@@ -10793,7 +10919,10 @@ external_link_win9(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     /* should be able to find the target file via main file's local host/main drive*/
@@ -10865,7 +10994,10 @@ external_link_recursive(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through dangling file external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "recursive", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "recursive", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (gid >= 0) {
         H5_FAILED();
@@ -12706,7 +12838,10 @@ external_dont_fail_to_source(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Attempt to open the object the link points to.  This should fail */
-    H5E_BEGIN_TRY { oid = H5Oopen(fid, "link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        oid = H5Oopen(fid, "link", H5P_DEFAULT);
+    }
     H5E_END_TRY
     if (oid >= 0)
         FAIL_PUTS_ERROR("Succeeded in opening target of invalid external link")
@@ -15103,7 +15238,10 @@ lapl_nlinks(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Try opening through what is now too many soft links */
-    H5E_BEGIN_TRY { gid = H5Oopen(fid, "soft5", plist); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Oopen(fid, "soft5", plist);
+    }
     H5E_END_TRY;
     if (gid >= 0) {
         H5_FAILED();
@@ -15426,7 +15564,10 @@ check_all_closed(hid_t fapl, hbool_t new_format, int stopat)
     return SUCCEED;
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(fid); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(fid);
+    }
     H5E_END_TRY;
     return FAIL;
 } /* end check_all_closed() */
@@ -15552,7 +15693,10 @@ build_visit_file(hid_t fapl)
     return (fid);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(fid); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(fid);
+    }
     H5E_END_TRY;
     return FAIL;
 } /* end build_visit_file() */
@@ -16027,7 +16171,10 @@ obj_visit_stop(hid_t fapl, hbool_t new_format)
     return SUCCEED;
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(fid); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(fid);
+    }
     H5E_END_TRY;
     return FAIL;
 } /* end obj_visit_stop() */
@@ -16537,7 +16684,10 @@ obj_exists(hid_t fapl, hbool_t new_format)
 
     /* Hard links */
     /* Verify that H5Oexists_by_name() fails for non-existent link in root group */
-    H5E_BEGIN_TRY { status = H5Oexists_by_name(fid, "foo", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Oexists_by_name(fid, "foo", H5P_DEFAULT);
+    }
     H5E_END_TRY
     if (status >= 0)
         TEST_ERROR
@@ -16553,7 +16703,10 @@ obj_exists(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Verify that H5Oexists_by_name() fails for non-existent link in non-root group */
-    H5E_BEGIN_TRY { status = H5Oexists_by_name(fid, "group/foo", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Oexists_by_name(fid, "group/foo", H5P_DEFAULT);
+    }
     H5E_END_TRY
     if (status >= 0)
         TEST_ERROR
@@ -16867,7 +17020,10 @@ corder_create_empty(hid_t fapl)
         TEST_ERROR
 
     /* Setting invalid combination of a group order creation order indexing on should fail */
-    H5E_BEGIN_TRY { ret = H5Pset_link_creation_order(gcpl_id, H5P_CRT_ORDER_INDEXED); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_link_creation_order(gcpl_id, H5P_CRT_ORDER_INDEXED);
+    }
     H5E_END_TRY;
     if (ret > 0) {
         H5_FAILED();
@@ -19339,7 +19495,10 @@ link_iterate_check(hid_t group_id, H5_index_t idx_type, H5_iter_order_t order, u
 
     /* Check for iteration routine indicating failure */
     skip = 0;
-    H5E_BEGIN_TRY { ret = H5Literate2(group_id, idx_type, order, &skip, link_iterate_fail_cb, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Literate2(group_id, idx_type, order, &skip, link_iterate_fail_cb, NULL);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -19502,7 +19661,10 @@ link_iterate(hid_t fapl)
 
                 /* Check for out of bound iteration on compact group */
                 skip = (hsize_t)u;
-                H5E_BEGIN_TRY { ret = H5Literate2(group_id, idx_type, order, &skip, link_iterate_cb, NULL); }
+                H5E_BEGIN_TRY
+                {
+                    ret = H5Literate2(group_id, idx_type, order, &skip, link_iterate_cb, NULL);
+                }
                 H5E_END_TRY;
                 if (ret >= 0)
                     TEST_ERROR
@@ -19532,7 +19694,10 @@ link_iterate(hid_t fapl)
 
                 /* Check for out of bound iteration on dense group */
                 skip = (hsize_t)u;
-                H5E_BEGIN_TRY { ret = H5Literate2(group_id, idx_type, order, &skip, link_iterate_cb, NULL); }
+                H5E_BEGIN_TRY
+                {
+                    ret = H5Literate2(group_id, idx_type, order, &skip, link_iterate_cb, NULL);
+                }
                 H5E_END_TRY;
                 if (ret >= 0)
                     TEST_ERROR
@@ -19827,20 +19992,29 @@ link_iterate_old_check(hid_t group_id, H5_iter_order_t order, unsigned max_links
 
     /* Check for iteration routine indicating failure */
     skip = 0;
-    H5E_BEGIN_TRY { ret = H5Literate2(group_id, H5_INDEX_NAME, order, &skip, link_iterate_fail_cb, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Literate2(group_id, H5_INDEX_NAME, order, &skip, link_iterate_fail_cb, NULL);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
 
     /* Check for iteration w/bad location ID */
     skip = 0;
-    H5E_BEGIN_TRY { ret = H5Literate2((hid_t)(-1), H5_INDEX_NAME, order, &skip, link_iterate_fail_cb, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Literate2((hid_t)(-1), H5_INDEX_NAME, order, &skip, link_iterate_fail_cb, NULL);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
 
 #ifndef H5_NO_DEPRECATED_SYMBOLS
-    H5E_BEGIN_TRY { ret = H5Giterate((hid_t)(-1), ".", &gskip, group_iterate_old_cb, iter_info); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Giterate((hid_t)(-1), ".", &gskip, group_iterate_old_cb, iter_info);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -19930,7 +20104,10 @@ link_iterate_old(hid_t fapl)
 
         /* Check for out of bound iteration on old-style group */
         skip = (hsize_t)u;
-        H5E_BEGIN_TRY { ret = H5Literate2(group_id, H5_INDEX_NAME, order, &skip, link_iterate_old_cb, NULL); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Literate2(group_id, H5_INDEX_NAME, order, &skip, link_iterate_old_cb, NULL);
+        }
         H5E_END_TRY;
         if (ret >= 0)
             TEST_ERROR
@@ -20535,7 +20712,10 @@ open_by_idx_old(hid_t fapl)
             TEST_ERROR
 
         /* Try to open on object in an empty group */
-        H5E_BEGIN_TRY { ret = H5Oopen_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, H5P_DEFAULT); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Oopen_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, H5P_DEFAULT);
+        }
         H5E_END_TRY;
         if (ret >= 0)
             TEST_ERROR
@@ -20571,7 +20751,10 @@ open_by_idx_old(hid_t fapl)
             TEST_ERROR
 
         /* Check for out of bound open by index */
-        H5E_BEGIN_TRY { ret = H5Oopen_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)u, H5P_DEFAULT); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Oopen_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)u, H5P_DEFAULT);
+        }
         H5E_END_TRY;
         if (ret >= 0)
             TEST_ERROR

--- a/test/links_env.c
+++ b/test/links_env.c
@@ -106,7 +106,10 @@ external_link_env(hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Open object through external link */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     /* Should be able to find the target file from pathnames set via HDF5_EXT_PREFIX */

--- a/test/mf.c
+++ b/test/mf.c
@@ -937,17 +937,26 @@ test_mf_tmp(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
             TEST_ERROR
 
         /* Reading & writing with a temporary address value should fail */
-        H5E_BEGIN_TRY { status = H5F_block_read(f, H5FD_MEM_SUPER, tmp_addr, sizeof(buf), &buf); }
+        H5E_BEGIN_TRY
+        {
+            status = H5F_block_read(f, H5FD_MEM_SUPER, tmp_addr, sizeof(buf), &buf);
+        }
         H5E_END_TRY;
         if (status >= 0)
             TEST_ERROR
-        H5E_BEGIN_TRY { status = H5F_block_write(f, H5FD_MEM_SUPER, tmp_addr, sizeof(buf), &buf); }
+        H5E_BEGIN_TRY
+        {
+            status = H5F_block_write(f, H5FD_MEM_SUPER, tmp_addr, sizeof(buf), &buf);
+        }
         H5E_END_TRY;
         if (status >= 0)
             TEST_ERROR
 
         /* Freeing a temporary address value should fail */
-        H5E_BEGIN_TRY { status = H5MF_xfree(f, H5FD_MEM_SUPER, tmp_addr, (hsize_t)TBLOCK_SIZE30); }
+        H5E_BEGIN_TRY
+        {
+            status = H5MF_xfree(f, H5FD_MEM_SUPER, tmp_addr, (hsize_t)TBLOCK_SIZE30);
+        }
         H5E_END_TRY;
         if (status >= 0)
             TEST_ERROR
@@ -985,13 +994,19 @@ test_mf_tmp(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
             TEST_ERROR
 
         /* Test that pushing temporary space allocation into normal space fails */
-        H5E_BEGIN_TRY { check_addr = H5MF_alloc_tmp(f, (hsize_t)(maxaddr / 3)); }
+        H5E_BEGIN_TRY
+        {
+            check_addr = H5MF_alloc_tmp(f, (hsize_t)(maxaddr / 3));
+        }
         H5E_END_TRY;
         if (H5F_addr_defined(check_addr))
             TEST_ERROR
 
         /* Test that pushing normal space allocation into temporary space fails */
-        H5E_BEGIN_TRY { check_addr = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)(maxaddr / 3)); }
+        H5E_BEGIN_TRY
+        {
+            check_addr = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)(maxaddr / 3));
+        }
         H5E_END_TRY;
         if (H5F_addr_defined(check_addr))
             TEST_ERROR
@@ -1022,7 +1037,10 @@ test_mf_tmp(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_tmp() */
@@ -2132,7 +2150,10 @@ test_mf_fs_absorb(const char *env_h5_drvr, hid_t fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_fs_absorb() */
@@ -2417,7 +2438,10 @@ test_mf_aggr_alloc2(const char *env_h5_drvr, hid_t fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_aggr_alloc2() */
@@ -2580,7 +2604,10 @@ test_mf_aggr_alloc3(const char *env_h5_drvr, hid_t fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_aggr_alloc3() */
@@ -2745,7 +2772,10 @@ test_mf_aggr_alloc4(const char *env_h5_drvr, hid_t fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_aggr_alloc4() */
@@ -2868,7 +2898,10 @@ test_mf_aggr_alloc5(const char *env_h5_drvr, hid_t fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_aggr_alloc5() */
@@ -3028,7 +3061,10 @@ test_mf_aggr_alloc6(const char *env_h5_drvr, hid_t fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_aggr_alloc6() */
@@ -3217,7 +3253,10 @@ test_mf_aggr_alloc7(const char *env_h5_drvr, hid_t fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_aggr_alloc7() */
@@ -3513,7 +3552,10 @@ test_mf_aggr_extend(const char *env_h5_drvr, hid_t fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_aggr_extend() */
@@ -3750,7 +3792,10 @@ test_mf_aggr_absorb(const char *env_h5_drvr, hid_t fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_aggr_absorb() */
@@ -4038,7 +4083,10 @@ test_mf_align_eoa(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_align_eoa() */
@@ -4329,7 +4377,10 @@ test_mf_align_fs(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_align_fs() */
@@ -4601,7 +4652,10 @@ test_mf_align_alloc1(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_align_alloc1() */
@@ -4891,7 +4945,10 @@ test_mf_align_alloc2(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_align_alloc2() */
@@ -5273,7 +5330,10 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_align_alloc3() */
@@ -5485,7 +5545,10 @@ test_mf_align_alloc4(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_align_alloc4() */
@@ -5711,7 +5774,10 @@ test_mf_align_alloc5(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_align_alloc5() */
@@ -6022,7 +6088,10 @@ test_mf_align_alloc6(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return 1;
 } /* test_mf_align_alloc6() */
@@ -6191,7 +6260,10 @@ test_mf_bug1(const char *env_h5_drvr, hid_t fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_mf_bug1() */
@@ -7638,7 +7710,10 @@ test_dichotomy(hid_t fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return (1);
 } /* test_dichotomy() */
@@ -8546,7 +8621,10 @@ test_page_large(const char *env_h5_drvr, hid_t fapl)
     return (0);
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(fid); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(fid);
+    }
     H5E_END_TRY;
     return (1);
 

--- a/test/mount.c
+++ b/test/mount.c
@@ -96,7 +96,10 @@ setup(hid_t fapl)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
     return -1;
 } /* end setup() */
@@ -197,7 +200,10 @@ test_illegal(hid_t fapl)
         FAIL_STACK_ERROR
 
     /* Try mounting a file on itself */
-    H5E_BEGIN_TRY { status = H5Fmount(file1, "/mnt1", file1, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Fmount(file1, "/mnt1", file1, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -214,7 +220,10 @@ test_illegal(hid_t fapl)
         FAIL_STACK_ERROR
     if (H5Fmount(mnt, ".", file2, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR
-    H5E_BEGIN_TRY { status = H5Fmount(mnt, ".", file3, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Fmount(mnt, ".", file3, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -236,7 +245,10 @@ test_illegal(hid_t fapl)
         FAIL_STACK_ERROR
     if (H5Fmount(mnt, ".", file3, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR
-    H5E_BEGIN_TRY { status = H5Fmount(mnt, ".", file3b, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Fmount(mnt, ".", file3b, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -251,7 +263,10 @@ test_illegal(hid_t fapl)
     /* Try to create a "weak" cycle */
     if (H5Fmount(file1, "/mnt1", file2, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR
-    H5E_BEGIN_TRY { status = H5Fmount(file2, "/mnt1/file2", file1b, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Fmount(file2, "/mnt1/file2", file1b, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -353,7 +368,10 @@ test_samefile(hid_t fapl)
         FAIL_STACK_ERROR
     if (!grp_info.mounted)
         FAIL_PUTS_ERROR("    Group should have 'mounted' flag set.")
-    H5E_BEGIN_TRY { status = H5Fmount(mnt1b, ".", file3, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Fmount(mnt1b, ".", file3, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (status >= 0)
         FAIL_PUTS_ERROR("    Mounting different files at one mount point should have failed.")
@@ -389,7 +407,10 @@ test_samefile(hid_t fapl)
         FAIL_STACK_ERROR
     if (!grp_info.mounted)
         FAIL_PUTS_ERROR("    Group should have 'mounted' flag set.")
-    H5E_BEGIN_TRY { status = H5Fmount(mnt1b, ".", file2, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Fmount(mnt1b, ".", file2, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (status >= 0)
         FAIL_PUTS_ERROR("    Mounting same files at one mount point should have failed.")
@@ -470,7 +491,10 @@ test_hide(hid_t fapl)
         FAIL_STACK_ERROR
 
     /* Original names under file1:/mnt1 should not be accessible */
-    H5E_BEGIN_TRY { grp = H5Gopen2(file1, "/mnt1/file1", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        grp = H5Gopen2(file1, "/mnt1/file1", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (grp >= 0) {
         H5_FAILED();
@@ -958,7 +982,10 @@ test_unlink(hid_t fapl)
         FAIL_STACK_ERROR
     if (H5Oget_info_by_name3(root, "file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR
-    H5E_BEGIN_TRY { status = H5Oget_info_by_name3(mnt, "file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Oget_info_by_name3(mnt, "file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -976,7 +1003,10 @@ test_unlink(hid_t fapl)
      */
     if (H5Oget_info_by_name3(root, "file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR
-    H5E_BEGIN_TRY { status = H5Oget_info_by_name3(mnt, "file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Oget_info_by_name3(mnt, "file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -999,14 +1029,20 @@ test_unlink(hid_t fapl)
      * the mount point because the name doesn't exist anymore.  We must
      * supply the mount point directly.
      */
-    H5E_BEGIN_TRY { status = H5Funmount(file1, "/mnt_unlink"); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Funmount(file1, "/mnt_unlink");
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
         HDprintf("    %d: Unmount by name should not have been allowed!\n", __LINE__);
         TEST_ERROR
     } /* end if */
-    H5E_BEGIN_TRY { status = H5Funmount(file2, "/"); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Funmount(file2, "/");
+    }
     H5E_END_TRY;
     if (status >= 0) {
         H5_FAILED();
@@ -2412,7 +2448,10 @@ test_fcdegree_same(hid_t fapl)
         TEST_ERROR
 
     /* Try mounting file with different file close degree (should fail) */
-    H5E_BEGIN_TRY { ret = H5Fmount(gidA, ".", fid2, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fmount(gidA, ".", fid2, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -2565,7 +2604,10 @@ test_fcdegree_semi(hid_t fapl)
         TEST_ERROR
 
     /* Try closing file #2 (should fail, since there are still objects open) */
-    H5E_BEGIN_TRY { ret = H5Fclose(fid2); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fclose(fid2);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -2575,7 +2617,10 @@ test_fcdegree_semi(hid_t fapl)
         TEST_ERROR
 
     /* Try closing file #2 (should still fail, since there are still objects open in child file) */
-    H5E_BEGIN_TRY { ret = H5Fclose(fid2); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fclose(fid2);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -2713,11 +2758,17 @@ test_fcdegree_strong(hid_t fapl)
         TEST_ERROR
 
     /* Check that objects are closed */
-    H5E_BEGIN_TRY { ret = H5Oget_info3(gidA, &oinfo, H5O_INFO_BASIC); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Oget_info3(gidA, &oinfo, H5O_INFO_BASIC);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
-    H5E_BEGIN_TRY { ret = H5Oget_info3(gidAM, &oinfo, H5O_INFO_BASIC); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Oget_info3(gidAM, &oinfo, H5O_INFO_BASIC);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -2851,11 +2902,17 @@ test_acc_perm(hid_t fapl)
         TEST_ERROR
 
     /* Attempt to create objects in read only file (should fail) */
-    H5E_BEGIN_TRY { bad_id = H5Gcreate2(gidAM, "Z", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        bad_id = H5Gcreate2(gidAM, "Z", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (bad_id >= 0)
         TEST_ERROR
-    H5E_BEGIN_TRY { bad_id = H5Gcreate2(fid1, "/A/L", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        bad_id = H5Gcreate2(fid1, "/A/L", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (bad_id >= 0)
         TEST_ERROR
@@ -2895,7 +2952,10 @@ test_acc_perm(hid_t fapl)
         TEST_ERROR
 
     /* Attempt to create objects in read only file again (should fail) */
-    H5E_BEGIN_TRY { bad_id = H5Gcreate2(fid1, "/A/L", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        bad_id = H5Gcreate2(fid1, "/A/L", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (bad_id >= 0)
         TEST_ERROR
@@ -3294,7 +3354,10 @@ test_nested_survive(hid_t fapl)
         TEST_ERROR
 
     /* Open object in file #3 through file #1 mount path (should fail) */
-    H5E_BEGIN_TRY { gidAMS = H5Gopen2(fid1, "A/M/S", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gidAMS = H5Gopen2(fid1, "A/M/S", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (gidAMS >= 0)
         TEST_ERROR
@@ -3808,7 +3871,10 @@ test_cut_graph(hid_t fapl)
         TEST_ERROR
 
     /* Attempt to open an object in file #4, from file #1 */
-    H5E_BEGIN_TRY { gidK = H5Gopen2(gidQ, "/A/D/K", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gidK = H5Gopen2(gidQ, "/A/D/K", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (gidK >= 0)
         TEST_ERROR
@@ -3828,7 +3894,10 @@ test_cut_graph(hid_t fapl)
         TEST_ERROR
 
     /* Attempt to open an object in file #6, from file #5 */
-    H5E_BEGIN_TRY { gidO = H5Gopen2(gidM, "/B/H/O", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gidO = H5Gopen2(gidM, "/B/H/O", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (gidO >= 0)
         TEST_ERROR
@@ -4039,7 +4108,10 @@ test_symlink(hid_t fapl)
         TEST_ERROR
 
     /* Attempt to open an object in file #3 (should fail) */
-    H5E_BEGIN_TRY { gidL = H5Gopen2(fid1, "L", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gidL = H5Gopen2(fid1, "L", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (gidL >= 0)
         TEST_ERROR

--- a/test/objcopy.c
+++ b/test/objcopy.c
@@ -1728,7 +1728,9 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
     return TRUE;
 
 error:
-    H5E_BEGIN_TRY {}
+    H5E_BEGIN_TRY
+    {
+    }
     H5E_END_TRY;
     return FALSE;
 } /* end compare_groups() */
@@ -2539,7 +2541,10 @@ test_copy_dataset_versionbounds(hid_t fcpl_src, hid_t fapl_src)
         for (high = H5F_LIBVER_EARLIEST; high < H5F_LIBVER_NBOUNDS; high++) {
 
             /* Set version bounds */
-            H5E_BEGIN_TRY { ret = H5Pset_libver_bounds(fapl_dst, low, high); }
+            H5E_BEGIN_TRY
+            {
+                ret = H5Pset_libver_bounds(fapl_dst, low, high);
+            }
             H5E_END_TRY;
 
             if (ret < 0) /* Invalid low/high combinations */

--- a/test/objcopy_ref.c
+++ b/test/objcopy_ref.c
@@ -1438,7 +1438,9 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
     return TRUE;
 
 error:
-    H5E_BEGIN_TRY {}
+    H5E_BEGIN_TRY
+    {
+    }
     H5E_END_TRY;
     return FALSE;
 } /* end compare_groups() */

--- a/test/ohdr.c
+++ b/test/ohdr.c
@@ -296,7 +296,10 @@ test_ohdr_cache(char *filename, hid_t fapl)
     return SUCCEED;
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
 
     return FAIL;
@@ -549,7 +552,10 @@ test_unknown(unsigned bogus_id, char *filename, hid_t fapl)
     TESTING("object in r/o file with unknown header message & 'fail if unknown always' flag set");
 
     /* Attempt to open the dataset with the unknown header message, and "fail if unknown always" flag */
-    H5E_BEGIN_TRY { did = H5Dopen2(loc_bogus, "Dataset3", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        did = H5Dopen2(loc_bogus, "Dataset3", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (did >= 0) {
         H5Dclose(did);
@@ -713,7 +719,10 @@ test_unknown(unsigned bogus_id, char *filename, hid_t fapl)
 
     /* Attempt to open the dataset with the unknown header message, and "fail if unknown and open for write"
      * flag */
-    H5E_BEGIN_TRY { did = H5Dopen2(loc_bogus, "Dataset2", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        did = H5Dopen2(loc_bogus, "Dataset2", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (did >= 0) {
         H5Dclose(did);
@@ -725,7 +734,10 @@ test_unknown(unsigned bogus_id, char *filename, hid_t fapl)
     TESTING("object in r/w file with unknown header message & 'fail if unknown always' flag set");
 
     /* Attempt to open the dataset with the unknown header message, and "fail if unknown always" flag */
-    H5E_BEGIN_TRY { did = H5Dopen2(loc_bogus, "Dataset3", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        did = H5Dopen2(loc_bogus, "Dataset3", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (did >= 0) {
         H5Dclose(did);
@@ -1774,7 +1786,10 @@ main(void)
             char        msg[80];     /* Message for file format version */
 
             /* Set version bounds before opening the file */
-            H5E_BEGIN_TRY { ret = H5Pset_libver_bounds(fapl, low, high); }
+            H5E_BEGIN_TRY
+            {
+                ret = H5Pset_libver_bounds(fapl, low, high);
+            }
             H5E_END_TRY;
 
             if (ret < 0) /* Invalid low/high combinations */
@@ -1967,7 +1982,10 @@ main(void)
             if (ro != time_new)
                 TEST_ERROR
             time_new = 33333333;
-            H5E_BEGIN_TRY { ret = H5O_msg_write(&oh_loc, H5O_MTIME_NEW_ID, 0, 0, &time_new); }
+            H5E_BEGIN_TRY
+            {
+                ret = H5O_msg_write(&oh_loc, H5O_MTIME_NEW_ID, 0, 0, &time_new);
+            }
             H5E_END_TRY;
             if (ret >= 0)
                 TEST_ERROR
@@ -2050,7 +2068,10 @@ main(void)
 
 error:
     HDputs("*** TESTS FAILED ***");
-    H5E_BEGIN_TRY { H5Fclose(file); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file);
+    }
     H5E_END_TRY;
 
     if (api_ctx_pushed)

--- a/test/page_buffer.c
+++ b/test/page_buffer.c
@@ -408,7 +408,10 @@ test_args(hid_t orig_fapl, const char *env_h5_drvr)
     if (H5Pset_page_buffer_size(fapl, 512, 0, 0) < 0)
         TEST_ERROR;
 
-    H5E_BEGIN_TRY { file_id = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl); }
+    H5E_BEGIN_TRY
+    {
+        file_id = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl);
+    }
     H5E_END_TRY;
 
     if (file_id >= 0)
@@ -426,7 +429,10 @@ test_args(hid_t orig_fapl, const char *env_h5_drvr)
     if (H5Pset_page_buffer_size(fapl, 511, 0, 0) < 0)
         TEST_ERROR;
 
-    H5E_BEGIN_TRY { file_id = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl); }
+    H5E_BEGIN_TRY
+    {
+        file_id = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl);
+    }
     H5E_END_TRY;
 
     if (file_id >= 0)
@@ -435,7 +441,10 @@ test_args(hid_t orig_fapl, const char *env_h5_drvr)
     /* Test setting a page buffer with sum of min meta and raw
      * data percentage > 100 - should fail
      */
-    H5E_BEGIN_TRY { ret = H5Pset_page_buffer_size(fapl, 512, 50, 51); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_page_buffer_size(fapl, 512, 50, 51);
+    }
     H5E_END_TRY;
 
     if (ret >= 0)
@@ -2054,7 +2063,10 @@ verify_page_buffering_disabled(hid_t orig_fapl, const char *env_h5_drvr)
         FAIL_STACK_ERROR;
 
     /* try to create  the file -- should fail */
-    H5E_BEGIN_TRY { file_id = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl); }
+    H5E_BEGIN_TRY
+    {
+        file_id = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl);
+    }
     H5E_END_TRY;
 
     if (file_id >= 0)
@@ -2083,7 +2095,10 @@ verify_page_buffering_disabled(hid_t orig_fapl, const char *env_h5_drvr)
     /* try to open the file using the fapl prepared above which enables
      * page buffering.  Should fail.
      */
-    H5E_BEGIN_TRY { file_id = H5Fopen(filename, H5F_ACC_RDWR, fapl); }
+    H5E_BEGIN_TRY
+    {
+        file_id = H5Fopen(filename, H5F_ACC_RDWR, fapl);
+    }
     H5E_END_TRY;
 
     if (file_id >= 0)
@@ -2195,7 +2210,10 @@ main(void)
 error:
     HDprintf("***** %d Page Buffering TEST%s FAILED! *****\n", nerrors, nerrors > 1 ? "S" : "");
 
-    H5E_BEGIN_TRY { H5Pclose(fapl); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(fapl);
+    }
     H5E_END_TRY;
 
     if (api_ctx_pushed)

--- a/test/reserved.c
+++ b/test/reserved.c
@@ -65,7 +65,10 @@ rsrv_heap(void)
      * should throw an error.
      */
     for (i = 0; i < 200; i++) {
-        H5E_BEGIN_TRY { dataspace_id = H5Screate_simple(1, dims, dims); }
+        H5E_BEGIN_TRY
+        {
+            dataspace_id = H5Screate_simple(1, dims, dims);
+        }
         H5E_END_TRY
 
         HDsprintf(dset_name, "Dset %d", i);
@@ -80,7 +83,10 @@ rsrv_heap(void)
         if (dataset_id < 0)
             break;
 
-        H5E_BEGIN_TRY { H5Dwrite(dataset_id, H5T_NATIVE_INT, dataspace_id, dataspace_id, H5P_DEFAULT, &i); }
+        H5E_BEGIN_TRY
+        {
+            H5Dwrite(dataset_id, H5T_NATIVE_INT, dataspace_id, dataspace_id, H5P_DEFAULT, &i);
+        }
         H5E_END_TRY
 
         if (H5Dclose(dataset_id) < 0)

--- a/test/ros3.c
+++ b/test/ros3.c
@@ -625,7 +625,10 @@ error:
      ***********/
 
     if (fapl_id < 0) {
-        H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+        H5E_BEGIN_TRY
+        {
+            (void)H5Pclose(fapl_id);
+        }
         H5E_END_TRY;
     }
     return 1;
@@ -699,7 +702,10 @@ test_ros3_fapl(void)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        (void)H5Pclose(fapl_id);
+    }
     H5E_END_TRY;
 
     return 1;
@@ -867,7 +873,10 @@ test_vfd_open(void)
         else if (T.which_fapl == FAPL_ROS3_ANON)
             _fapl_id = fapl_id;
 
-        H5E_BEGIN_TRY { fd = H5FDopen(T.url, T.flags, _fapl_id, T.maxaddr); }
+        H5E_BEGIN_TRY
+        {
+            fd = H5FDopen(T.url, T.flags, _fapl_id, T.maxaddr);
+        }
         H5E_END_TRY;
         if (NULL != fd)
             JSVERIFY(1, 0, T.message); /* wrapper to print message and fail */
@@ -908,11 +917,17 @@ error:
         (void)H5FDclose(fd);
     }
     if (fapl_id >= 0) {
-        H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+        H5E_BEGIN_TRY
+        {
+            (void)H5Pclose(fapl_id);
+        }
         H5E_END_TRY;
     }
     if (fapl_file_access >= 0) {
-        H5E_BEGIN_TRY { (void)H5Pclose(fapl_file_access); }
+        H5E_BEGIN_TRY
+        {
+            (void)H5Pclose(fapl_file_access);
+        }
         H5E_END_TRY;
     }
     if (curl_ready == TRUE) {
@@ -1043,7 +1058,10 @@ error:
     if (TRUE == curl_ready)
         curl_global_cleanup();
     if (fapl_id >= 0) {
-        H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+        H5E_BEGIN_TRY
+        {
+            (void)H5Pclose(fapl_id);
+        }
         H5E_END_TRY;
     }
 
@@ -1138,7 +1156,10 @@ error:
         (void)H5FDclose(file_shakespeare);
     }
     if (fapl_id >= 0) {
-        H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+        H5E_BEGIN_TRY
+        {
+            (void)H5Pclose(fapl_id);
+        }
         H5E_END_TRY;
     }
 
@@ -1338,7 +1359,10 @@ error:
     if (file_raven)
         (void)H5FDclose(file_raven);
     if (fapl_id >= 0) {
-        H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+        H5E_BEGIN_TRY
+        {
+            (void)H5Pclose(fapl_id);
+        }
         H5E_END_TRY;
     }
 
@@ -1448,7 +1472,10 @@ error:
      ***********/
 
     if (fapl_id >= 0) {
-        H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+        H5E_BEGIN_TRY
+        {
+            (void)H5Pclose(fapl_id);
+        }
         H5E_END_TRY;
     }
     if (file) {
@@ -1579,7 +1606,10 @@ error:
     if (TRUE == curl_ready)
         curl_global_cleanup();
     if (fapl_id >= 0) {
-        H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+        H5E_BEGIN_TRY
+        {
+            (void)H5Pclose(fapl_id);
+        }
         H5E_END_TRY;
     }
 
@@ -1685,7 +1715,10 @@ error:
     HDfflush(stdout);
 
     if (fapl_id >= 0) {
-        H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+        H5E_BEGIN_TRY
+        {
+            (void)H5Pclose(fapl_id);
+        }
         H5E_END_TRY;
     }
     if (file > 0)

--- a/test/set_extent.c
+++ b/test/set_extent.c
@@ -388,7 +388,10 @@ do_ranks(hid_t fapl, hbool_t new_format)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Pclose(dcpl); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(dcpl);
+    }
     H5E_END_TRY
 
     return -1;
@@ -414,7 +417,10 @@ do_layouts(hid_t fapl)
             new_fapl = H5Pcopy(fapl);
 
             /* Set version bounds */
-            H5E_BEGIN_TRY { ret = H5Pset_libver_bounds(new_fapl, low, high); }
+            H5E_BEGIN_TRY
+            {
+                ret = H5Pset_libver_bounds(new_fapl, low, high);
+            }
             H5E_END_TRY;
 
             if (ret < 0) /* Invalid low/high combinations */
@@ -440,7 +446,10 @@ do_layouts(hid_t fapl)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Pclose(new_fapl); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(new_fapl);
+    }
     H5E_END_TRY;
     return -1;
 }
@@ -2075,7 +2084,10 @@ test_layouts(H5D_layout_t layout, hid_t fapl)
      *-------------------------------------------------------------------------
      */
 
-    H5E_BEGIN_TRY { ret = H5Dset_extent(did, dims_e); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dset_extent(did, dims_e);
+    }
     H5E_END_TRY;
 
     if (ret >= 0)
@@ -2121,7 +2133,10 @@ test_layouts(H5D_layout_t layout, hid_t fapl)
      *-------------------------------------------------------------------------
      */
 
-    H5E_BEGIN_TRY { ret = H5Dset_extent(did, dims_s); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dset_extent(did, dims_s);
+    }
     H5E_END_TRY;
 
     if (ret >= 0)

--- a/test/stab.c
+++ b/test/stab.c
@@ -148,12 +148,18 @@ test_misc(hid_t fcpl, hid_t fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Check that creating groups with no-op names isn't allowed */
-    H5E_BEGIN_TRY { g1 = H5Gcreate2(fid, "/", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        g1 = H5Gcreate2(fid, "/", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY
     if (g1 >= 0)
         TEST_ERROR
 
-    H5E_BEGIN_TRY { g1 = H5Gcreate2(fid, "./././", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        g1 = H5Gcreate2(fid, "./././", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY
     if (g1 >= 0)
         TEST_ERROR
@@ -1358,7 +1364,10 @@ corrupt_stab_msg(void)
         TEST_ERROR
 
     /* Verify that an error is thrown when we try to access the dataset */
-    H5E_BEGIN_TRY { did = H5Dopen2(fid, CORRUPT_STAB_DSET, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        did = H5Dopen2(fid, CORRUPT_STAB_DSET, H5P_DEFAULT);
+    }
     H5E_END_TRY
     if (did >= 0)
         TEST_ERROR

--- a/test/swmr.c
+++ b/test/swmr.c
@@ -163,7 +163,10 @@ test_metadata_read_attempts(hid_t in_fapl)
         TEST_ERROR
 
     /* Set the # of read attempts to 0--should fail */
-    H5E_BEGIN_TRY { ret = H5Pset_metadata_read_attempts(fapl, 0); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_metadata_read_attempts(fapl, 0);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -1649,7 +1652,10 @@ test_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
     /* Should fail to enable SWMR for non-latest-format */
     /* Should succeed in enabling SWMR for latest format */
-    H5E_BEGIN_TRY { ret = H5Fstart_swmr_write(fid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid);
+    }
     H5E_END_TRY;
     if (new_format) {
         if (ret < 0)
@@ -1974,7 +1980,10 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
     fid = H5Fcreate(filename, H5F_ACC_TRUNC | H5F_ACC_SWMR_WRITE, H5P_DEFAULT, fapl);
 
     /* Should fail to enable SWMR writing when the file is already in SWMR writing mode */
-    H5E_BEGIN_TRY { ret = H5Fstart_swmr_write(fid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -1997,7 +2006,10 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
             FAIL_STACK_ERROR;
 
         /* Should fail to enable SWMR writing when there is an opened named datatype */
-        H5E_BEGIN_TRY { ret = H5Fstart_swmr_write(fid); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Fstart_swmr_write(fid);
+        }
         H5E_END_TRY;
         if (ret >= 0)
             TEST_ERROR
@@ -2021,7 +2033,10 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
             TEST_ERROR
 
         /* Should fail to enable SWMR writing because the file's superblock version is not at least 3 */
-        H5E_BEGIN_TRY { ret = H5Fstart_swmr_write(fid); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Fstart_swmr_write(fid);
+        }
         H5E_END_TRY;
         if (ret >= 0)
             TEST_ERROR
@@ -2047,7 +2062,10 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
         FAIL_STACK_ERROR;
 
     /* Should fail to enable SWMR writing when the file is already in SWMR writing mode */
-    H5E_BEGIN_TRY { ret = H5Fstart_swmr_write(fid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -2063,7 +2081,10 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
         FAIL_STACK_ERROR;
 
     /* Should fail to enable SWMR writing when the file is opened with read only access */
-    H5E_BEGIN_TRY { ret = H5Fstart_swmr_write(fid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -2079,7 +2100,10 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
         FAIL_STACK_ERROR;
 
     /* Should fail to enable SWMR writing when the file is opened with SWMR read access only */
-    H5E_BEGIN_TRY { ret = H5Fstart_swmr_write(fid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -2109,7 +2133,10 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
         FAIL_STACK_ERROR;
 
     /* Should fail to enable SWMR writing when there are opened named datatype and attribute */
-    H5E_BEGIN_TRY { ret = H5Fstart_swmr_write(fid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -2119,7 +2146,10 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
         FAIL_STACK_ERROR;
 
     /* Still fail to enable SWMR writing when the attribute is still opened */
-    H5E_BEGIN_TRY { ret = H5Fstart_swmr_write(fid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -2164,7 +2194,10 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Should fail for a second call to enable SWMR writing mode */
-    H5E_BEGIN_TRY { ret = H5Fstart_swmr_write(fid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -2188,7 +2221,10 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
         FAIL_STACK_ERROR;
 
     /* Should fail to enable SWMR writing mode for fid2 */
-    H5E_BEGIN_TRY { ret = H5Fstart_swmr_write(fid2); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid2);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -2214,7 +2250,10 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
         TEST_ERROR
 
     /* Should fail to enable SWMR writing for fid2 */
-    H5E_BEGIN_TRY { ret = H5Fstart_swmr_write(fid2); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid2);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -2241,7 +2280,10 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
         /* Should fail to open the file with SWMR write + latest format due to superblock version not at least
          * 3 */
-        H5E_BEGIN_TRY { bad_fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, new_fapl); }
+        H5E_BEGIN_TRY
+        {
+            bad_fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, new_fapl);
+        }
         H5E_END_TRY;
         if (bad_fid >= 0)
             TEST_ERROR
@@ -2250,7 +2292,10 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
         /* Should fail to open the file with SWMR write + non-latest-format due to superblock version not at
          * least 3 */
-        H5E_BEGIN_TRY { bad_fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl); }
+        H5E_BEGIN_TRY
+        {
+            bad_fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl);
+        }
         H5E_END_TRY;
         if (bad_fid >= 0)
             TEST_ERROR
@@ -2262,7 +2307,10 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
             FAIL_STACK_ERROR;
 
         /* Should fail to enable SWMR writing due to superblock version not at least 3 */
-        H5E_BEGIN_TRY { ret = H5Fstart_swmr_write(fid); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Fstart_swmr_write(fid);
+        }
         H5E_END_TRY;
         if (ret >= 0)
             TEST_ERROR
@@ -2277,7 +2325,10 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
             FAIL_STACK_ERROR;
 
         /* Should fail to enable SWMR writing because the file's superblock version is not at least 3 */
-        H5E_BEGIN_TRY { ret = H5Fstart_swmr_write(fid); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Fstart_swmr_write(fid);
+        }
         H5E_END_TRY;
         if (ret >= 0)
             TEST_ERROR
@@ -2732,7 +2783,10 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
         }
 
         /* Should fail in opening the test file */
-        H5E_BEGIN_TRY { fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl); }
+        H5E_BEGIN_TRY
+        {
+            fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl);
+        }
         H5E_END_TRY;
         if (fid >= 0)
             HDexit(EXIT_FAILURE);
@@ -2805,7 +2859,10 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
         }
 
         /* Should fail in opening the test file */
-        H5E_BEGIN_TRY { fid = H5Fopen(filename, H5F_ACC_RDWR, fapl); }
+        H5E_BEGIN_TRY
+        {
+            fid = H5Fopen(filename, H5F_ACC_RDWR, fapl);
+        }
         H5E_END_TRY;
         if (fid >= 0)
             HDexit(EXIT_FAILURE);
@@ -2882,7 +2939,10 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
         }
 
         /* Should fail in opening the test file */
-        H5E_BEGIN_TRY { fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl); }
+        H5E_BEGIN_TRY
+        {
+            fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl);
+        }
         H5E_END_TRY;
         if (fid >= 0)
             HDexit(EXIT_FAILURE);
@@ -3170,7 +3230,10 @@ test_object_flush_cb(hid_t in_fapl)
      *  To verify the failure condition in setting object flush property
      */
     /* Should fail if the callback function is not defined but user data is defined */
-    H5E_BEGIN_TRY { ret = H5Pset_object_flush_cb(fapl, NULL, &flush_ct); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_object_flush_cb(fapl, NULL, &flush_ct);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -3471,19 +3534,28 @@ test_append_flush_generic(void)
         FAIL_STACK_ERROR
 
     /* Invalid dataset rank: zero value */
-    H5E_BEGIN_TRY { ret = H5Pset_append_flush(dapl, 0, NULL, NULL, &count); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_append_flush(dapl, 0, NULL, NULL, &count);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
 
     /* Invalid dataset rank: > H5S_MAX_RANK */
-    H5E_BEGIN_TRY { ret = H5Pset_append_flush(dapl, H5S_MAX_RANK + 1, NULL, NULL, &count); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_append_flush(dapl, H5S_MAX_RANK + 1, NULL, NULL, &count);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
 
     /* No boundary specified */
-    H5E_BEGIN_TRY { ret = H5Pset_append_flush(dapl, 2, NULL, NULL, &count); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_append_flush(dapl, 2, NULL, NULL, &count);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -3493,7 +3565,10 @@ test_append_flush_generic(void)
     boundary[1] = 1;
 
     /* Undefined callback function but defined user data */
-    H5E_BEGIN_TRY { ret = H5Pset_append_flush(dapl, 2, boundary, NULL, &count); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_append_flush(dapl, 2, boundary, NULL, &count);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -3501,7 +3576,10 @@ test_append_flush_generic(void)
     /* Invalid boundary size: negative value */
     boundary[0] = (hsize_t)-1;
     boundary[1] = 1;
-    H5E_BEGIN_TRY { ret = H5Pset_append_flush(dapl, 2, boundary, append_cb, &count); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_append_flush(dapl, 2, boundary, append_cb, &count);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -3509,7 +3587,10 @@ test_append_flush_generic(void)
     /* Invalid boundary size: H5S_UNLIMITED */
     boundary[0] = 1;
     boundary[1] = H5S_UNLIMITED;
-    H5E_BEGIN_TRY { ret = H5Pset_append_flush(dapl, 2, boundary, append_cb, &count); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_append_flush(dapl, 2, boundary, append_cb, &count);
+    }
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR
@@ -3552,7 +3633,10 @@ test_append_flush_generic(void)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Pclose(dapl); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(dapl);
+    }
     H5E_END_TRY;
 
     return -1;
@@ -3670,7 +3754,10 @@ test_append_flush_dataset_chunked(hid_t in_fapl)
         FAIL_STACK_ERROR
 
     /* Should fail to Create the dataset */
-    H5E_BEGIN_TRY { did2 = H5Dcreate2(fid, "dataset2", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, dapl); }
+    H5E_BEGIN_TRY
+    {
+        did2 = H5Dcreate2(fid, "dataset2", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, dapl);
+    }
     H5E_END_TRY;
     if (did2 >= 0)
         TEST_ERROR
@@ -3681,7 +3768,10 @@ test_append_flush_dataset_chunked(hid_t in_fapl)
         FAIL_STACK_ERROR
 
     /* Should fail to create the dataset */
-    H5E_BEGIN_TRY { did2 = H5Dcreate2(fid, "dataset2", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, dapl); }
+    H5E_BEGIN_TRY
+    {
+        did2 = H5Dcreate2(fid, "dataset2", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, dapl);
+    }
     H5E_END_TRY;
     if (did2 >= 0)
         TEST_ERROR
@@ -3693,7 +3783,10 @@ test_append_flush_dataset_chunked(hid_t in_fapl)
         FAIL_STACK_ERROR;
 
     /* Should fail to open the dataset */
-    H5E_BEGIN_TRY { did2 = H5Dopen2(fid, "dataset2", dapl); }
+    H5E_BEGIN_TRY
+    {
+        did2 = H5Dopen2(fid, "dataset2", dapl);
+    }
     H5E_END_TRY;
     if (did2 >= 0)
         TEST_ERROR
@@ -4332,7 +4425,10 @@ test_file_lock_same(hid_t in_fapl)
         TEST_ERROR
 
     /* Open file with RDWR should fail */
-    H5E_BEGIN_TRY { fid2 = H5Fopen(filename, H5F_ACC_RDWR, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid2 = H5Fopen(filename, H5F_ACC_RDWR, fapl);
+    }
     H5E_END_TRY;
     if (fid2 >= 0)
         TEST_ERROR
@@ -4436,7 +4532,10 @@ test_file_lock_swmr_same(hid_t in_fapl)
     /*
      * Case a: RDWR|SWRM_READ : should fail
      */
-    H5E_BEGIN_TRY { fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_READ, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_READ, fapl);
+    }
     H5E_END_TRY;
     if (fid >= 0)
         TEST_ERROR
@@ -4444,7 +4543,10 @@ test_file_lock_swmr_same(hid_t in_fapl)
     /*
      * Case b: RDWR|SWMM_WRTE|SWMR_READ : should fail
      */
-    H5E_BEGIN_TRY { fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE | H5F_ACC_SWMR_READ, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE | H5F_ACC_SWMR_READ, fapl);
+    }
     H5E_END_TRY;
     if (fid >= 0)
         TEST_ERROR
@@ -4452,7 +4554,10 @@ test_file_lock_swmr_same(hid_t in_fapl)
     /*
      * Case c: RDONLY|SWMM_WRITE : should fail
      */
-    H5E_BEGIN_TRY { fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_WRITE, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_WRITE, fapl);
+    }
     H5E_END_TRY;
     if (fid >= 0)
         TEST_ERROR
@@ -4460,7 +4565,10 @@ test_file_lock_swmr_same(hid_t in_fapl)
     /*
      * Case d: RDONLY|SWMM_WRITE|SWMR_READ : should fail
      */
-    H5E_BEGIN_TRY { fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_WRITE | H5F_ACC_SWMR_READ, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_WRITE | H5F_ACC_SWMR_READ, fapl);
+    }
     H5E_END_TRY;
     if (fid >= 0)
         TEST_ERROR
@@ -4475,7 +4583,10 @@ test_file_lock_swmr_same(hid_t in_fapl)
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
         FAIL_STACK_ERROR
 
-    H5E_BEGIN_TRY { fid2 = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid2 = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl);
+    }
     H5E_END_TRY;
     if (fid2 >= 0)
         TEST_ERROR
@@ -4568,7 +4679,10 @@ test_file_lock_swmr_same(hid_t in_fapl)
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
         FAIL_STACK_ERROR
 
-    H5E_BEGIN_TRY { fid2 = H5Fopen(filename, H5F_ACC_RDWR, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        fid2 = H5Fopen(filename, H5F_ACC_RDWR, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (fid2 >= 0)
         TEST_ERROR
@@ -4583,7 +4697,10 @@ test_file_lock_swmr_same(hid_t in_fapl)
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
         FAIL_STACK_ERROR
 
-    H5E_BEGIN_TRY { fid2 = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid2 = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl);
+    }
     H5E_END_TRY;
     if (fid2 >= 0)
         TEST_ERROR
@@ -4630,7 +4747,10 @@ test_file_lock_swmr_same(hid_t in_fapl)
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
         FAIL_STACK_ERROR
 
-    H5E_BEGIN_TRY { fid2 = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid2 = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl);
+    }
     H5E_END_TRY;
     if (fid2 >= 0)
         TEST_ERROR
@@ -4645,7 +4765,10 @@ test_file_lock_swmr_same(hid_t in_fapl)
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
         FAIL_STACK_ERROR
 
-    H5E_BEGIN_TRY { fid2 = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid2 = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl);
+    }
     H5E_END_TRY;
     if (fid2 >= 0)
         TEST_ERROR
@@ -4756,7 +4879,10 @@ test_file_lock_concur(hid_t in_fapl)
         }
 
         /* Open the test file */
-        H5E_BEGIN_TRY { child_fid = H5Fopen(filename, H5F_ACC_RDWR, fapl); }
+        H5E_BEGIN_TRY
+        {
+            child_fid = H5Fopen(filename, H5F_ACC_RDWR, fapl);
+        }
         H5E_END_TRY;
 
         /* Should fail */
@@ -4830,7 +4956,10 @@ test_file_lock_concur(hid_t in_fapl)
         }
 
         /* Opens the test file */
-        H5E_BEGIN_TRY { child_fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl); }
+        H5E_BEGIN_TRY
+        {
+            child_fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl);
+        }
         H5E_END_TRY;
 
         /* Should fail */
@@ -4905,7 +5034,10 @@ test_file_lock_concur(hid_t in_fapl)
         }
 
         /* Opens the test file */
-        H5E_BEGIN_TRY { child_fid = H5Fopen(filename, H5F_ACC_RDWR, fapl); }
+        H5E_BEGIN_TRY
+        {
+            child_fid = H5Fopen(filename, H5F_ACC_RDWR, fapl);
+        }
         H5E_END_TRY;
 
         /* Should fail */
@@ -4980,7 +5112,10 @@ test_file_lock_concur(hid_t in_fapl)
         }
 
         /* Opens the test file */
-        H5E_BEGIN_TRY { child_fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl); }
+        H5E_BEGIN_TRY
+        {
+            child_fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl);
+        }
         H5E_END_TRY;
 
         /* Should succeed */
@@ -5141,7 +5276,10 @@ test_file_lock_swmr_concur(hid_t in_fapl)
         }
 
         /* Open the test file */
-        H5E_BEGIN_TRY { child_fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl); }
+        H5E_BEGIN_TRY
+        {
+            child_fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl);
+        }
         H5E_END_TRY;
 
         /* Should fail */
@@ -5216,7 +5354,10 @@ test_file_lock_swmr_concur(hid_t in_fapl)
         }
 
         /* Open the test file */
-        H5E_BEGIN_TRY { child_fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl); }
+        H5E_BEGIN_TRY
+        {
+            child_fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl);
+        }
         H5E_END_TRY;
 
         /* Should fail */
@@ -5291,7 +5432,10 @@ test_file_lock_swmr_concur(hid_t in_fapl)
         }
 
         /* Open the test file */
-        H5E_BEGIN_TRY { child_fid = H5Fopen(filename, H5F_ACC_RDWR, H5P_DEFAULT); }
+        H5E_BEGIN_TRY
+        {
+            child_fid = H5Fopen(filename, H5F_ACC_RDWR, H5P_DEFAULT);
+        }
         H5E_END_TRY;
 
         /* Should fail */
@@ -5365,7 +5509,10 @@ test_file_lock_swmr_concur(hid_t in_fapl)
         }
 
         /* Open the test file */
-        H5E_BEGIN_TRY { child_fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl); }
+        H5E_BEGIN_TRY
+        {
+            child_fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl);
+        }
         H5E_END_TRY;
 
         /* Should fail */
@@ -5439,7 +5586,10 @@ test_file_lock_swmr_concur(hid_t in_fapl)
         }
 
         /* Open the test file */
-        H5E_BEGIN_TRY { child_fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl); }
+        H5E_BEGIN_TRY
+        {
+            child_fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl);
+        }
         H5E_END_TRY;
 
         /* Should succeed */
@@ -5516,7 +5666,10 @@ test_file_lock_swmr_concur(hid_t in_fapl)
         }
 
         /* Open the test file */
-        H5E_BEGIN_TRY { child_fid = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT); }
+        H5E_BEGIN_TRY
+        {
+            child_fid = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT);
+        }
         H5E_END_TRY;
 
         /* Should fail */
@@ -5591,7 +5744,10 @@ test_file_lock_swmr_concur(hid_t in_fapl)
         }
 
         /* Open the test file */
-        H5E_BEGIN_TRY { child_fid = H5Fopen(filename, H5F_ACC_RDWR, fapl); }
+        H5E_BEGIN_TRY
+        {
+            child_fid = H5Fopen(filename, H5F_ACC_RDWR, fapl);
+        }
         H5E_END_TRY;
 
         /* Should fail */
@@ -5666,7 +5822,10 @@ test_file_lock_swmr_concur(hid_t in_fapl)
         }
 
         /* Open the test file */
-        H5E_BEGIN_TRY { child_fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl); }
+        H5E_BEGIN_TRY
+        {
+            child_fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl);
+        }
         H5E_END_TRY;
 
         /* Should fail */
@@ -5741,7 +5900,10 @@ test_file_lock_swmr_concur(hid_t in_fapl)
         }
 
         /* Open the test file */
-        H5E_BEGIN_TRY { child_fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl); }
+        H5E_BEGIN_TRY
+        {
+            child_fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl);
+        }
         H5E_END_TRY;
 
         /* Should succeed */
@@ -5897,7 +6059,10 @@ test_file_lock_swmr_concur(hid_t in_fapl)
         }
 
         /* Open the test file */
-        H5E_BEGIN_TRY { child_fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl); }
+        H5E_BEGIN_TRY
+        {
+            child_fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl);
+        }
         H5E_END_TRY;
 
         /* Should fail */
@@ -5972,7 +6137,10 @@ test_file_lock_swmr_concur(hid_t in_fapl)
         }
 
         /* Open the test file */
-        H5E_BEGIN_TRY { child_fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl); }
+        H5E_BEGIN_TRY
+        {
+            child_fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl);
+        }
         H5E_END_TRY;
 
         /* Should succeed */
@@ -6279,7 +6447,10 @@ test_different_lock_flags(hid_t in_fapl)
         TEST_ERROR
 
     /* Open the test file with different flags (should FAIL) */
-    H5E_BEGIN_TRY { fid3 = H5Fopen(filename, H5F_ACC_RDWR, fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        fid3 = H5Fopen(filename, H5F_ACC_RDWR, fapl_id);
+    }
     H5E_END_TRY;
     if (H5I_INVALID_HID != fid3)
         FAIL_PUTS_ERROR("Should not have been able to open a file with different locking flags")
@@ -6347,7 +6518,10 @@ test_swmr_vfd_flag(void)
 
     fid = -1;
     h5_fixname(FILENAME[0], bad_fapl, filename, sizeof(filename));
-    H5E_BEGIN_TRY { fid = H5Fcreate(filename, H5F_ACC_TRUNC | H5F_ACC_SWMR_WRITE, H5P_DEFAULT, bad_fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid = H5Fcreate(filename, H5F_ACC_TRUNC | H5F_ACC_SWMR_WRITE, H5P_DEFAULT, bad_fapl);
+    }
     H5E_END_TRY;
     if (fid >= 0)
         TEST_ERROR;

--- a/test/tarray.c
+++ b/test/tarray.c
@@ -235,11 +235,17 @@ test_array_funcs(void)
     ret = H5Tset_offset(type, (size_t)16);
     CHECK(ret, FAIL, "H5Tset_offset");
 
-    H5E_BEGIN_TRY { cset = H5Tget_cset(type); }
+    H5E_BEGIN_TRY
+    {
+        cset = H5Tget_cset(type);
+    }
     H5E_END_TRY;
     VERIFY(cset, FAIL, "H5Tget_cset");
 
-    H5E_BEGIN_TRY { strpad = H5Tget_strpad(type); }
+    H5E_BEGIN_TRY
+    {
+        strpad = H5Tget_strpad(type);
+    }
     H5E_END_TRY;
     VERIFY(strpad, FAIL, "H5Tget_strpad");
 

--- a/test/tattr.c
+++ b/test/tattr.c
@@ -6010,7 +6010,10 @@ test_attr_info_null_info_pointer(hid_t fcpl, hid_t fapl)
     attr = H5Acreate2(fid, GET_INFO_NULL_POINTER_ATTR_NAME, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
-    H5E_BEGIN_TRY { err_ret = H5Aget_info(attr, NULL); }
+    H5E_BEGIN_TRY
+    {
+        err_ret = H5Aget_info(attr, NULL);
+    }
     H5E_END_TRY;
 
     CHECK(err_ret, SUCCEED, "H5Aget_info");
@@ -6071,22 +6074,34 @@ test_attr_rename_invalid_name(hid_t fcpl, hid_t fapl)
     attr = H5Acreate2(fid, INVALID_RENAME_TEST_ATTR_NAME, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
-    H5E_BEGIN_TRY { err_ret = H5Arename(fid, NULL, INVALID_RENAME_TEST_NEW_ATTR_NAME); }
+    H5E_BEGIN_TRY
+    {
+        err_ret = H5Arename(fid, NULL, INVALID_RENAME_TEST_NEW_ATTR_NAME);
+    }
     H5E_END_TRY;
 
     CHECK(err_ret, SUCCEED, "H5Arename");
 
-    H5E_BEGIN_TRY { err_ret = H5Arename(fid, "", INVALID_RENAME_TEST_NEW_ATTR_NAME); }
+    H5E_BEGIN_TRY
+    {
+        err_ret = H5Arename(fid, "", INVALID_RENAME_TEST_NEW_ATTR_NAME);
+    }
     H5E_END_TRY;
 
     CHECK(err_ret, SUCCEED, "H5Arename");
 
-    H5E_BEGIN_TRY { err_ret = H5Arename(fid, INVALID_RENAME_TEST_ATTR_NAME, NULL); }
+    H5E_BEGIN_TRY
+    {
+        err_ret = H5Arename(fid, INVALID_RENAME_TEST_ATTR_NAME, NULL);
+    }
     H5E_END_TRY;
 
     CHECK(err_ret, SUCCEED, "H5Arename");
 
-    H5E_BEGIN_TRY { err_ret = H5Arename(fid, INVALID_RENAME_TEST_ATTR_NAME, ""); }
+    H5E_BEGIN_TRY
+    {
+        err_ret = H5Arename(fid, INVALID_RENAME_TEST_ATTR_NAME, "");
+    }
     H5E_END_TRY;
 
     CHECK(err_ret, SUCCEED, "H5Arename");
@@ -6107,12 +6122,18 @@ test_attr_rename_invalid_name(hid_t fcpl, hid_t fapl)
 
     CHECK(err_ret, SUCCEED, "H5Arename_by_name");
 
-    H5E_BEGIN_TRY { err_ret = H5Arename_by_name(fid, ".", INVALID_RENAME_TEST_ATTR_NAME, NULL, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        err_ret = H5Arename_by_name(fid, ".", INVALID_RENAME_TEST_ATTR_NAME, NULL, H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     CHECK(err_ret, SUCCEED, "H5Arename_by_name");
 
-    H5E_BEGIN_TRY { err_ret = H5Arename_by_name(fid, ".", INVALID_RENAME_TEST_ATTR_NAME, "", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        err_ret = H5Arename_by_name(fid, ".", INVALID_RENAME_TEST_ATTR_NAME, "", H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     CHECK(err_ret, SUCCEED, "H5Arename_by_name");
@@ -6159,7 +6180,10 @@ test_attr_get_name_invalid_buf(hid_t fcpl, hid_t fapl)
         H5Acreate2(fid, GET_NAME_INVALID_BUF_TEST_ATTR_NAME, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
-    H5E_BEGIN_TRY { err_ret = H5Aget_name(attr, 1, NULL); }
+    H5E_BEGIN_TRY
+    {
+        err_ret = H5Aget_name(attr, 1, NULL);
+    }
     H5E_END_TRY;
 
     VERIFY(err_ret, FAIL, "H5Aget_name");

--- a/test/tfile.c
+++ b/test/tfile.c
@@ -309,25 +309,46 @@ test_file_create(void)
     CHECK(tmpl1, FAIL, "H5Pcreate");
 
     /* Try setting some bad userblock sizes */
-    H5E_BEGIN_TRY { ret = H5Pset_userblock(tmpl1, BAD_USERBLOCK_SIZE1); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_userblock(tmpl1, BAD_USERBLOCK_SIZE1);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Pset_userblock");
-    H5E_BEGIN_TRY { ret = H5Pset_userblock(tmpl1, BAD_USERBLOCK_SIZE2); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_userblock(tmpl1, BAD_USERBLOCK_SIZE2);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Pset_userblock");
-    H5E_BEGIN_TRY { ret = H5Pset_userblock(tmpl1, BAD_USERBLOCK_SIZE3); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_userblock(tmpl1, BAD_USERBLOCK_SIZE3);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Pset_userblock");
-    H5E_BEGIN_TRY { ret = H5Pset_userblock(tmpl1, BAD_USERBLOCK_SIZE4); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_userblock(tmpl1, BAD_USERBLOCK_SIZE4);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Pset_userblock");
-    H5E_BEGIN_TRY { ret = H5Pset_userblock(tmpl1, BAD_USERBLOCK_SIZE5); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_userblock(tmpl1, BAD_USERBLOCK_SIZE5);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Pset_userblock");
-    H5E_BEGIN_TRY { ret = H5Pset_userblock(tmpl1, BAD_USERBLOCK_SIZE6); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_userblock(tmpl1, BAD_USERBLOCK_SIZE6);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Pset_userblock");
-    H5E_BEGIN_TRY { ret = H5Pset_userblock(tmpl1, BAD_USERBLOCK_SIZE7); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_userblock(tmpl1, BAD_USERBLOCK_SIZE7);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Pset_userblock");
 
@@ -1282,7 +1303,10 @@ test_get_file_id(void)
     plist = H5Pcreate(H5P_FILE_ACCESS);
     CHECK(plist, FAIL, "H5Pcreate");
 
-    H5E_BEGIN_TRY { fid2 = H5Iget_file_id(plist); }
+    H5E_BEGIN_TRY
+    {
+        fid2 = H5Iget_file_id(plist);
+    }
     H5E_END_TRY;
     VERIFY(fid2, FAIL, "H5Iget_file_id");
 
@@ -1543,7 +1567,10 @@ test_file_perm2(void)
     CHECK(filero, FAIL, "H5Fopen");
 
     /* Create a group with the read-only file handle (should fail) */
-    H5E_BEGIN_TRY { group = H5Gcreate2(filero, "MY_GROUP", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        group = H5Gcreate2(filero, "MY_GROUP", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(group, FAIL, "H5Gcreate2");
 
@@ -1556,7 +1583,10 @@ test_file_perm2(void)
     VERIFY(dset, FAIL, "H5Dcreate2");
 
     /* Create an attribute with the read-only file handle (should fail) */
-    H5E_BEGIN_TRY { attr = H5Acreate2(filero, "MY_ATTR", H5T_NATIVE_INT, dspace, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        attr = H5Acreate2(filero, "MY_ATTR", H5T_NATIVE_INT, dspace, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(attr, FAIL, "H5Acreate2");
 
@@ -1564,7 +1594,10 @@ test_file_perm2(void)
     CHECK(type, FAIL, "H5Tcopy");
 
     /* Commit a datatype with the read-only file handle (should fail) */
-    H5E_BEGIN_TRY { ret = H5Tcommit2(filero, "MY_DTYPE", type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tcommit2(filero, "MY_DTYPE", type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Tcommit2");
 
@@ -1882,7 +1915,10 @@ test_file_delete(hid_t fapl_id)
     VERIFY(is_hdf5, TRUE, "H5Fis_accessible");
 
     /* Attempt to delete the file - should fail */
-    H5E_BEGIN_TRY { ret = H5Fdelete(filename, fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fdelete(filename, fapl_id);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Fdelete");
 
@@ -1914,12 +1950,18 @@ test_file_delete(hid_t fapl_id)
      * may not have been created since we created it with
      * open(2) and not the library.
      */
-    H5E_BEGIN_TRY { is_hdf5 = H5Fis_accessible(filename, fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        is_hdf5 = H5Fis_accessible(filename, fapl_id);
+    }
     H5E_END_TRY;
     CHECK(is_hdf5, TRUE, "H5Fis_accessible");
 
     /* Try to delete it (should fail) */
-    H5E_BEGIN_TRY { ret = H5Fdelete(filename, fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fdelete(filename, fapl_id);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Fdelete");
 
@@ -1962,22 +2004,34 @@ test_file_open_dot(void)
     CHECK(sid, FAIL, "H5Screate");
 
     /* Create a dataset with no name using the file ID */
-    H5E_BEGIN_TRY { did = H5Dcreate2(fid, ".", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        did = H5Dcreate2(fid, ".", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(did, FAIL, "H5Dcreate2");
 
     /* Create a dataset with no name using the group ID */
-    H5E_BEGIN_TRY { did = H5Dcreate2(gid, ".", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        did = H5Dcreate2(gid, ".", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(did, FAIL, "H5Dcreate2");
 
     /* Open a dataset with no name using the file ID */
-    H5E_BEGIN_TRY { did = H5Dopen2(fid, ".", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        did = H5Dopen2(fid, ".", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(did, FAIL, "H5Dopen2");
 
     /* Open a dataset with no name using the group ID */
-    H5E_BEGIN_TRY { did = H5Dopen2(gid, ".", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        did = H5Dopen2(gid, ".", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(did, FAIL, "H5Dopen2");
 
@@ -1986,32 +2040,50 @@ test_file_open_dot(void)
     CHECK(tid, FAIL, "H5Tcopy");
 
     /* Create a named datatype with no name using the file ID */
-    H5E_BEGIN_TRY { ret = H5Tcommit2(fid, ".", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tcommit2(fid, ".", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Tcommit2");
 
     /* Create a named datatype with no name using the group ID */
-    H5E_BEGIN_TRY { ret = H5Tcommit2(gid, ".", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tcommit2(gid, ".", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Tcommit2");
 
     /* Open a named datatype with no name using the file ID */
-    H5E_BEGIN_TRY { tid2 = H5Topen2(fid, ".", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tid2 = H5Topen2(fid, ".", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tid2, FAIL, "H5Topen2");
 
     /* Open a named datatype with no name using the group ID */
-    H5E_BEGIN_TRY { tid2 = H5Topen2(gid, ".", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tid2 = H5Topen2(gid, ".", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tid2, FAIL, "H5Topen2");
 
     /* Create a group with no name using the file ID */
-    H5E_BEGIN_TRY { gid2 = H5Gcreate2(fid, ".", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid2 = H5Gcreate2(fid, ".", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(gid2, FAIL, "H5Gcreate2");
 
     /* Create a group with no name using the group ID */
-    H5E_BEGIN_TRY { gid2 = H5Gcreate2(gid, ".", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid2 = H5Gcreate2(gid, ".", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(gid2, FAIL, "H5Gcreate2");
 
@@ -2191,7 +2263,10 @@ test_file_getname(void)
 
     /* Try get file name from data space.  Supposed to fail because
      * it's illegal operation. */
-    H5E_BEGIN_TRY { name_len = H5Fget_name(space_id, name, (size_t)TESTA_NAME_BUF_SIZE); }
+    H5E_BEGIN_TRY
+    {
+        name_len = H5Fget_name(space_id, name, (size_t)TESTA_NAME_BUF_SIZE);
+    }
     H5E_END_TRY;
     VERIFY(name_len, FAIL, "H5Fget_name");
 
@@ -3312,7 +3387,10 @@ test_userblock_alignment(void)
     CHECK(ret, FAIL, "H5Pset_alignment");
 
     /* Create a file with FAPL & FCPL */
-    H5E_BEGIN_TRY { fid = H5Fcreate(FILE1, H5F_ACC_TRUNC, fcpl, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid = H5Fcreate(FILE1, H5F_ACC_TRUNC, fcpl, fapl);
+    }
     H5E_END_TRY;
     VERIFY(fid, FAIL, "H5Fcreate");
 
@@ -3342,7 +3420,10 @@ test_userblock_alignment(void)
     CHECK(ret, FAIL, "H5Pset_alignment");
 
     /* Create a file with FAPL & FCPL */
-    H5E_BEGIN_TRY { fid = H5Fcreate(FILE1, H5F_ACC_TRUNC, fcpl, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid = H5Fcreate(FILE1, H5F_ACC_TRUNC, fcpl, fapl);
+    }
     H5E_END_TRY;
     VERIFY(fid, FAIL, "H5Fcreate");
 
@@ -3515,7 +3596,10 @@ test_userblock_alignment_paged(void)
     CHECK(ret, FAIL, "H5Pset_alignment");
 
     /* Create a file with FAPL & FCPL */
-    H5E_BEGIN_TRY { fid = H5Fcreate(FILE1, H5F_ACC_TRUNC, fcpl, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid = H5Fcreate(FILE1, H5F_ACC_TRUNC, fcpl, fapl);
+    }
     H5E_END_TRY;
     VERIFY(fid, FAIL, "H5Fcreate");
 
@@ -3590,7 +3674,10 @@ test_userblock_alignment_paged(void)
     CHECK(ret, FAIL, "H5Pset_alignment");
 
     /* Create a file with FAPL & FCPL */
-    H5E_BEGIN_TRY { fid = H5Fcreate(FILE1, H5F_ACC_TRUNC, fcpl, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid = H5Fcreate(FILE1, H5F_ACC_TRUNC, fcpl, fapl);
+    }
     H5E_END_TRY;
     VERIFY(fid, FAIL, "H5Fcreate");
 
@@ -3627,7 +3714,10 @@ test_userblock_alignment_paged(void)
     CHECK(ret, FAIL, "H5Pset_alignment");
 
     /* Create a file with FAPL & FCPL */
-    H5E_BEGIN_TRY { fid = H5Fcreate(FILE1, H5F_ACC_TRUNC, fcpl, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid = H5Fcreate(FILE1, H5F_ACC_TRUNC, fcpl, fapl);
+    }
     H5E_END_TRY;
     VERIFY(fid, FAIL, "H5Fcreate");
 
@@ -3702,7 +3792,10 @@ test_userblock_alignment_paged(void)
     CHECK(ret, FAIL, "H5Pset_alignment");
 
     /* Create a file with FAPL & FCPL */
-    H5E_BEGIN_TRY { fid = H5Fcreate(FILE1, H5F_ACC_TRUNC, fcpl, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid = H5Fcreate(FILE1, H5F_ACC_TRUNC, fcpl, fapl);
+    }
     H5E_END_TRY;
     VERIFY(fid, FAIL, "H5Fcreate");
 
@@ -3892,17 +3985,26 @@ test_filespace_info(const char *env_h5_drvr)
     CHECK(fcpl, FAIL, "H5Pcreate");
 
     /* Setting to 0: should fail */
-    H5E_BEGIN_TRY { ret = H5Pset_file_space_page_size(fcpl, 0); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_file_space_page_size(fcpl, 0);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Pset_file_space_page_size");
 
     /* Setting to 511: should fail */
-    H5E_BEGIN_TRY { ret = H5Pset_file_space_page_size(fcpl, 511); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_file_space_page_size(fcpl, 511);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Pset_file_space_page_size");
 
     /* Setting to 1GB+1: should fail */
-    H5E_BEGIN_TRY { ret = H5Pset_file_space_page_size(fcpl, FSP_SIZE1G + 1); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_file_space_page_size(fcpl, FSP_SIZE1G + 1);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Pset_file_space_page_size");
 
@@ -5302,13 +5404,19 @@ test_libver_bounds_open(void)
 
     /* Attempt to open latest file with (earliest, v18), should fail */
     ret = H5Pset_libver_bounds(fapl, H5F_LIBVER_EARLIEST, H5F_LIBVER_V18);
-    H5E_BEGIN_TRY { file = H5Fopen(VERBFNAME, H5F_ACC_RDONLY, fapl); }
+    H5E_BEGIN_TRY
+    {
+        file = H5Fopen(VERBFNAME, H5F_ACC_RDONLY, fapl);
+    }
     H5E_END_TRY;
     VERIFY(file, FAIL, "Attempted to open latest file with earliest version");
 
     /* Attempt to open latest file with (v18, v18), should fail */
     ret = H5Pset_libver_bounds(fapl, H5F_LIBVER_V18, H5F_LIBVER_V18);
-    H5E_BEGIN_TRY { file = H5Fopen(VERBFNAME, H5F_ACC_RDONLY, fapl); }
+    H5E_BEGIN_TRY
+    {
+        file = H5Fopen(VERBFNAME, H5F_ACC_RDONLY, fapl);
+    }
     H5E_END_TRY;
     VERIFY(file, FAIL, "Attempted to open latest file with v18 bounds");
 
@@ -5689,7 +5797,10 @@ test_libver_bounds_super_create(hid_t fapl, hid_t fcpl, htri_t is_swmr, htri_t n
     herr_t       ret;                   /* The return value */
 
     /* Try to create the file */
-    H5E_BEGIN_TRY { fid = H5Fcreate(FILE8, H5F_ACC_TRUNC | (is_swmr ? H5F_ACC_SWMR_WRITE : 0), fcpl, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid = H5Fcreate(FILE8, H5F_ACC_TRUNC | (is_swmr ? H5F_ACC_SWMR_WRITE : 0), fcpl, fapl);
+    }
     H5E_END_TRY;
 
     /* Get the internal file pointer if the create succeeds */
@@ -5853,7 +5964,10 @@ test_libver_bounds_super_open(hid_t fapl, hid_t fcpl, htri_t is_swmr, htri_t non
     herr_t       ret;                        /* Return value */
 
     /* Create the file with the input fcpl and fapl */
-    H5E_BEGIN_TRY { fid = H5Fcreate(FILE8, H5F_ACC_TRUNC, fcpl, fapl); }
+    H5E_BEGIN_TRY
+    {
+        fid = H5Fcreate(FILE8, H5F_ACC_TRUNC, fcpl, fapl);
+    }
     H5E_END_TRY;
 
     /* Retrieve the low/high bounds */
@@ -5884,7 +5998,10 @@ test_libver_bounds_super_open(hid_t fapl, hid_t fcpl, htri_t is_swmr, htri_t non
         /* Loop through all the combinations of low/high bounds in new_fapl */
         for (low = H5F_LIBVER_EARLIEST; low < H5F_LIBVER_NBOUNDS; low++) {
             for (high = H5F_LIBVER_EARLIEST; high < H5F_LIBVER_NBOUNDS; high++) {
-                H5E_BEGIN_TRY { ret = H5Pset_libver_bounds(new_fapl, low, high); }
+                H5E_BEGIN_TRY
+                {
+                    ret = H5Pset_libver_bounds(new_fapl, low, high);
+                }
                 H5E_END_TRY;
 
                 /* Invalid combinations */
@@ -6064,14 +6181,20 @@ test_libver_bounds_obj(hid_t fapl)
        object header version, then delete the group and close the file.*/
     for (low = H5F_LIBVER_EARLIEST; low < H5F_LIBVER_NBOUNDS; low++) {
         for (high = H5F_LIBVER_EARLIEST; high < H5F_LIBVER_NBOUNDS; high++) {
-            H5E_BEGIN_TRY { ret = H5Pset_libver_bounds(new_fapl, low, high); }
+            H5E_BEGIN_TRY
+            {
+                ret = H5Pset_libver_bounds(new_fapl, low, high);
+            }
             H5E_END_TRY;
 
             if (ret < 0) /* Invalid combinations */
                 continue;
 
             /* Open the file */
-            H5E_BEGIN_TRY { fid = H5Fopen(FILE8, H5F_ACC_RDWR, new_fapl); }
+            H5E_BEGIN_TRY
+            {
+                fid = H5Fopen(FILE8, H5F_ACC_RDWR, new_fapl);
+            }
             H5E_END_TRY;
 
             if (fid >= 0) { /* The file open succeeds */
@@ -6224,7 +6347,10 @@ test_libver_bounds_dataset(hid_t fapl)
     CHECK(ret, FAIL, "H5Pset_chunk_opts");
 
     /* Create the chunked dataset */
-    H5E_BEGIN_TRY { did = H5Dcreate2(fid, DSETB, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        did = H5Dcreate2(fid, DSETB, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     if (did >= 0) {
@@ -6273,14 +6399,20 @@ test_libver_bounds_dataset(hid_t fapl)
     /* Verify the dataset's layout, fill value and filter pipleline message versions */
     for (low = H5F_LIBVER_EARLIEST; low < H5F_LIBVER_NBOUNDS; low++) {
         for (high = H5F_LIBVER_EARLIEST; high < H5F_LIBVER_NBOUNDS; high++) {
-            H5E_BEGIN_TRY { ret = H5Pset_libver_bounds(new_fapl, low, high); }
+            H5E_BEGIN_TRY
+            {
+                ret = H5Pset_libver_bounds(new_fapl, low, high);
+            }
             H5E_END_TRY;
 
             if (ret < 0) /* Invalid low/high combinations */
                 continue;
 
             /* Open the file */
-            H5E_BEGIN_TRY { fid = H5Fopen(FILE8, H5F_ACC_RDWR, new_fapl); }
+            H5E_BEGIN_TRY
+            {
+                fid = H5Fopen(FILE8, H5F_ACC_RDWR, new_fapl);
+            }
             H5E_END_TRY;
 
             if (fid >= 0) { /* The file open succeeds */
@@ -6491,14 +6623,20 @@ test_libver_bounds_dataspace(hid_t fapl)
             hid_t  tmp_sid, tmp_sid_compact, tmp_sid_contig;         /* Dataspace IDs */
             H5S_t *tmp_space, *tmp_space_compact, *tmp_space_contig; /* Internal dataspace pointers */
 
-            H5E_BEGIN_TRY { ret = H5Pset_libver_bounds(new_fapl, low, high); }
+            H5E_BEGIN_TRY
+            {
+                ret = H5Pset_libver_bounds(new_fapl, low, high);
+            }
             H5E_END_TRY;
 
             if (ret < 0) /* Invalid low/high combinations */
                 continue;
 
             /* Open the file */
-            H5E_BEGIN_TRY { fid = H5Fopen(FILE8, H5F_ACC_RDWR, new_fapl); }
+            H5E_BEGIN_TRY
+            {
+                fid = H5Fopen(FILE8, H5F_ACC_RDWR, new_fapl);
+            }
             H5E_END_TRY;
 
             if (fid >= 0) { /* The file open succeeds */
@@ -6815,14 +6953,20 @@ test_libver_bounds_datatype_check(hid_t fapl, hid_t tid)
     /* Also verify the committed atatype message version */
     for (low = H5F_LIBVER_EARLIEST; low < H5F_LIBVER_NBOUNDS; low++) {
         for (high = H5F_LIBVER_EARLIEST; high < H5F_LIBVER_NBOUNDS; high++) {
-            H5E_BEGIN_TRY { ret = H5Pset_libver_bounds(new_fapl, low, high); }
+            H5E_BEGIN_TRY
+            {
+                ret = H5Pset_libver_bounds(new_fapl, low, high);
+            }
             H5E_END_TRY;
 
             if (ret < 0) /* Invalid low/high combinations */
                 continue;
 
             /* Open the file */
-            H5E_BEGIN_TRY { fid = H5Fopen(FILE8, H5F_ACC_RDWR, new_fapl); }
+            H5E_BEGIN_TRY
+            {
+                fid = H5Fopen(FILE8, H5F_ACC_RDWR, new_fapl);
+            }
             H5E_END_TRY;
 
             if (fid >= 0) { /* The file open succeeds */
@@ -7135,14 +7279,20 @@ test_libver_bounds_attributes(hid_t fapl)
     /* Verify the attribute version */
     for (low = H5F_LIBVER_EARLIEST; low < H5F_LIBVER_NBOUNDS; low++) {
         for (high = H5F_LIBVER_EARLIEST; high < H5F_LIBVER_NBOUNDS; high++) {
-            H5E_BEGIN_TRY { ret = H5Pset_libver_bounds(new_fapl, low, high); }
+            H5E_BEGIN_TRY
+            {
+                ret = H5Pset_libver_bounds(new_fapl, low, high);
+            }
             H5E_END_TRY;
 
             if (ret < 0) /* Invalid low/high combinations */
                 continue;
 
             /* Open the file */
-            H5E_BEGIN_TRY { fid = H5Fopen(FILE8, H5F_ACC_RDWR, new_fapl); }
+            H5E_BEGIN_TRY
+            {
+                fid = H5Fopen(FILE8, H5F_ACC_RDWR, new_fapl);
+            }
             H5E_END_TRY;
 
             if (fid >= 0) { /* The file open succeeds */
@@ -7296,7 +7446,10 @@ test_libver_macros2(void)
     ret = H5Gunlink(file, "Group");
     CHECK(ret, FAIL, "H5Gunlink");
 
-    H5E_BEGIN_TRY { grp = H5Gopen(file, "Group"); }
+    H5E_BEGIN_TRY
+    {
+        grp = H5Gopen(file, "Group");
+    }
     H5E_END_TRY;
     VERIFY(grp, FAIL, "H5Gopen");
 #endif
@@ -7532,17 +7685,26 @@ test_min_dset_ohdr(void)
      */
 
     /* trying to set with invalid file ID */
-    H5E_BEGIN_TRY { ret = H5Fset_dset_no_attrs_hint(-1, TRUE); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fset_dset_no_attrs_hint(-1, TRUE);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Fset_dset_no_attrs_hint");
 
     /* trying to get with invalid file ID */
-    H5E_BEGIN_TRY { ret = H5Fget_dset_no_attrs_hint(-1, &minimize); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fget_dset_no_attrs_hint(-1, &minimize);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Fget_dset_no_attrs_hint");
 
     /* trying to get with invalid pointer */
-    H5E_BEGIN_TRY { ret = H5Fget_dset_no_attrs_hint(file_id, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fget_dset_no_attrs_hint(file_id, NULL);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Fget_dset_no_attrs_hint");
 

--- a/test/th5o.c
+++ b/test/th5o.c
@@ -347,21 +347,30 @@ test_h5o_open_by_addr(void)
     /* Try giving some bogus values to H5O_open_by_addr. */
     /* Try to open an object with a bad address */
     grp_addr += 20;
-    H5E_BEGIN_TRY { grp = H5Oopen_by_addr(fid, grp_addr); }
+    H5E_BEGIN_TRY
+    {
+        grp = H5Oopen_by_addr(fid, grp_addr);
+    }
     H5E_END_TRY
     VERIFY(grp, FAIL, "H5Oopen_by_addr");
 
     /* For instance, an objectno smaller than the end of the file's superblock should
      * trigger an error */
     grp_addr = 10;
-    H5E_BEGIN_TRY { grp = H5Oopen_by_addr(fid, grp_addr); }
+    H5E_BEGIN_TRY
+    {
+        grp = H5Oopen_by_addr(fid, grp_addr);
+    }
     H5E_END_TRY
     VERIFY(grp, FAIL, "H5Oopen_by_addr");
 
     /* Likewise, an objectno larger than the size of the file should fail */
     grp_addr = 0;
     grp_addr = 1000000000;
-    H5E_BEGIN_TRY { grp = H5Oopen_by_addr(fid, grp_addr); }
+    H5E_BEGIN_TRY
+    {
+        grp = H5Oopen_by_addr(fid, grp_addr);
+    }
     H5E_END_TRY
     VERIFY(grp, FAIL, "H5Oopen_by_addr");
 
@@ -369,7 +378,10 @@ test_h5o_open_by_addr(void)
     CHECK(ret, FAIL, "H5Fclose");
 
     /* Also, trying to open an object without a valid location should fail */
-    H5E_BEGIN_TRY { dtype = H5Oopen_by_addr(fid, dtype_addr); }
+    H5E_BEGIN_TRY
+    {
+        dtype = H5Oopen_by_addr(fid, dtype_addr);
+    }
     H5E_END_TRY
     VERIFY(dtype, FAIL, "H5Oopen_by_addr");
 } /* test_h5o_open_by_addr() */
@@ -473,7 +485,10 @@ test_h5o_open_by_token(void)
 
     /* Try giving some bogus values to H5O_open_by_token */
     /* Try opening an object using H5O_TOKEN_UNDEF (should fail) */
-    H5E_BEGIN_TRY { dtype = H5Oopen_by_token(fid, H5O_TOKEN_UNDEF); }
+    H5E_BEGIN_TRY
+    {
+        dtype = H5Oopen_by_token(fid, H5O_TOKEN_UNDEF);
+    }
     H5E_END_TRY
     VERIFY(dtype, FAIL, "H5Oopen_by_token");
 
@@ -481,7 +496,10 @@ test_h5o_open_by_token(void)
     CHECK(ret, FAIL, "H5Fclose");
 
     /* Also, trying to open an object without a valid location (should fail) */
-    H5E_BEGIN_TRY { dtype = H5Oopen_by_token(fid, li.u.token); }
+    H5E_BEGIN_TRY
+    {
+        dtype = H5Oopen_by_token(fid, li.u.token);
+    }
     H5E_END_TRY
     VERIFY(dtype, FAIL, "H5Oopen_by_token");
 
@@ -929,7 +947,10 @@ test_h5o_link(void)
         for (high = H5F_LIBVER_EARLIEST; high < H5F_LIBVER_NBOUNDS; high++) {
 
             /* Set version bounds */
-            H5E_BEGIN_TRY { ret = H5Pset_libver_bounds(fapl_id, low, high); }
+            H5E_BEGIN_TRY
+            {
+                ret = H5Pset_libver_bounds(fapl_id, low, high);
+            }
             H5E_END_TRY;
 
             if (ret < 0) /* Invalid low/high combinations */
@@ -1114,7 +1135,10 @@ test_h5o_comment(void)
     CHECK(ret, FAIL, "H5Oset_comment");
 
     /* Putting a comment on the dataspace.  It's supposed to fail. */
-    H5E_BEGIN_TRY { ret = H5Oset_comment(dspace, "dataspace comment"); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Oset_comment(dspace, "dataspace comment");
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Oset_comment");
 
@@ -1283,7 +1307,10 @@ test_h5o_comment_by_name(void)
     CHECK(ret, FAIL, "H5Oset_comment_by_name");
 
     /* Putting a comment on the dataspace.  It's supposed to fail. */
-    H5E_BEGIN_TRY { ret = H5Oset_comment_by_name(dspace, ".", "dataspace comment", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Oset_comment_by_name(dspace, ".", "dataspace comment", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Oset_comment");
 
@@ -1565,21 +1592,30 @@ test_h5o_open_by_addr_deprec(void)
     /* Try giving some bogus values to H5O_open_by_addr. */
     /* Try to open an object with a bad address */
     grp_addr += 20;
-    H5E_BEGIN_TRY { grp = H5Oopen_by_addr(fid, grp_addr); }
+    H5E_BEGIN_TRY
+    {
+        grp = H5Oopen_by_addr(fid, grp_addr);
+    }
     H5E_END_TRY
     VERIFY(grp, FAIL, "H5Oopen_by_addr");
 
     /* For instance, an objectno smaller than the end of the file's superblock should
      * trigger an error */
     grp_addr = 10;
-    H5E_BEGIN_TRY { grp = H5Oopen_by_addr(fid, grp_addr); }
+    H5E_BEGIN_TRY
+    {
+        grp = H5Oopen_by_addr(fid, grp_addr);
+    }
     H5E_END_TRY
     VERIFY(grp, FAIL, "H5Oopen_by_addr");
 
     /* Likewise, an objectno larger than the size of the file should fail */
     grp_addr = 0;
     grp_addr = 1000000000;
-    H5E_BEGIN_TRY { grp = H5Oopen_by_addr(fid, grp_addr); }
+    H5E_BEGIN_TRY
+    {
+        grp = H5Oopen_by_addr(fid, grp_addr);
+    }
     H5E_END_TRY
     VERIFY(grp, FAIL, "H5Oopen_by_addr");
 
@@ -1587,7 +1623,10 @@ test_h5o_open_by_addr_deprec(void)
     CHECK(ret, FAIL, "H5Fclose");
 
     /* Also, trying to open an object without a valid location should fail */
-    H5E_BEGIN_TRY { dtype = H5Oopen_by_addr(fid, dtype_addr); }
+    H5E_BEGIN_TRY
+    {
+        dtype = H5Oopen_by_addr(fid, dtype_addr);
+    }
     H5E_END_TRY
     VERIFY(dtype, FAIL, "H5Oopen_by_addr");
 } /* test_h5o_open_by_addr_deprec() */

--- a/test/th5s.c
+++ b/test/th5s.c
@@ -180,7 +180,10 @@ test_h5s_basic(void)
      * Check to be sure we can't create a simple dataspace that has too many
      * dimensions.
      */
-    H5E_BEGIN_TRY { sid1 = H5Screate_simple(H5S_MAX_RANK + 1, dims3, NULL); }
+    H5E_BEGIN_TRY
+    {
+        sid1 = H5Screate_simple(H5S_MAX_RANK + 1, dims3, NULL);
+    }
     H5E_END_TRY;
     VERIFY(sid1, FAIL, "H5Screate_simple");
 
@@ -247,43 +250,70 @@ test_h5s_basic(void)
     CHECK(dset1, FAIL, "H5Dcreate2");
 
     /* Try some writes with the bad dataspace (sid1) */
-    H5E_BEGIN_TRY { ret = H5Dwrite(dset1, H5T_NATIVE_INT, sid1, H5S_ALL, H5P_DEFAULT, &n); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dwrite(dset1, H5T_NATIVE_INT, sid1, H5S_ALL, H5P_DEFAULT, &n);
+    }
     H5E_END_TRY
     VERIFY(ret, FAIL, "H5Dwrite");
 
-    H5E_BEGIN_TRY { ret = H5Dwrite(dset1, H5T_NATIVE_INT, H5S_ALL, sid1, H5P_DEFAULT, &n); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dwrite(dset1, H5T_NATIVE_INT, H5S_ALL, sid1, H5P_DEFAULT, &n);
+    }
     H5E_END_TRY
     VERIFY(ret, FAIL, "H5Dwrite");
 
-    H5E_BEGIN_TRY { ret = H5Dwrite(dset1, H5T_NATIVE_INT, sid1, sid1, H5P_DEFAULT, &n); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dwrite(dset1, H5T_NATIVE_INT, sid1, sid1, H5P_DEFAULT, &n);
+    }
     H5E_END_TRY
     VERIFY(ret, FAIL, "H5Dwrite");
 
     /* Try to iterate using the bad dataspace */
-    H5E_BEGIN_TRY { ret = H5Diterate(&n, H5T_NATIVE_INT, sid1, NULL, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Diterate(&n, H5T_NATIVE_INT, sid1, NULL, NULL);
+    }
     H5E_END_TRY
     VERIFY(ret, FAIL, "H5Diterate");
 
     /* Try to fill using the bad dataspace */
-    H5E_BEGIN_TRY { ret = H5Dfill(NULL, H5T_NATIVE_INT, &n, H5T_NATIVE_INT, sid1); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dfill(NULL, H5T_NATIVE_INT, &n, H5T_NATIVE_INT, sid1);
+    }
     H5E_END_TRY
     VERIFY(ret, FAIL, "H5Dfill");
 
     /* Now use the bad dataspace as the space for an attribute */
-    H5E_BEGIN_TRY { aid1 = H5Acreate2(dset1, BASICATTR, H5T_NATIVE_INT, sid1, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        aid1 = H5Acreate2(dset1, BASICATTR, H5T_NATIVE_INT, sid1, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY
     VERIFY(aid1, FAIL, "H5Acreate2");
 
     /* Make sure that dataspace reads using the bad dataspace fail */
-    H5E_BEGIN_TRY { ret = H5Dread(dset1, H5T_NATIVE_INT, sid1, H5S_ALL, H5P_DEFAULT, &n); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dread(dset1, H5T_NATIVE_INT, sid1, H5S_ALL, H5P_DEFAULT, &n);
+    }
     H5E_END_TRY
     VERIFY(ret, FAIL, "H5Dread");
 
-    H5E_BEGIN_TRY { ret = H5Dread(dset1, H5T_NATIVE_INT, H5S_ALL, sid1, H5P_DEFAULT, &n); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dread(dset1, H5T_NATIVE_INT, H5S_ALL, sid1, H5P_DEFAULT, &n);
+    }
     H5E_END_TRY
     VERIFY(ret, FAIL, "H5Dread");
 
-    H5E_BEGIN_TRY { ret = H5Dread(dset1, H5T_NATIVE_INT, sid1, sid1, H5P_DEFAULT, &n); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dread(dset1, H5T_NATIVE_INT, sid1, sid1, H5P_DEFAULT, &n);
+    }
     H5E_END_TRY
     VERIFY(ret, FAIL, "H5Dread");
 
@@ -700,7 +730,10 @@ test_h5s_zero_dim(void)
         ret = H5Sselect_hyperslab(sid1, H5S_SELECT_SET, start, NULL, count, NULL);
         CHECK(ret, FAIL, "H5Sselect_hyperslab");
 
-        H5E_BEGIN_TRY { ret = H5Dwrite(dset1, H5T_NATIVE_INT, H5S_ALL, sid1, H5P_DEFAULT, wdata); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Dwrite(dset1, H5T_NATIVE_INT, H5S_ALL, sid1, H5P_DEFAULT, wdata);
+        }
         H5E_END_TRY;
         VERIFY(ret, FAIL, "H5Dwrite");
 
@@ -716,7 +749,10 @@ test_h5s_zero_dim(void)
         ret         = H5Sselect_elements(sid1, H5S_SELECT_SET, (size_t)1, (const hsize_t *)coord);
         CHECK(ret, FAIL, "H5Sselect_elements");
 
-        H5E_BEGIN_TRY { ret = H5Dwrite(dset1, H5T_NATIVE_INT, H5S_ALL, sid1, H5P_DEFAULT, &val); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Dwrite(dset1, H5T_NATIVE_INT, H5S_ALL, sid1, H5P_DEFAULT, &val);
+        }
         H5E_END_TRY;
         VERIFY(ret, FAIL, "H5Dwrite");
 
@@ -813,7 +849,10 @@ test_h5s_zero_dim(void)
         /* Now extend the first dimension size of the dataset to SPACE1_DIM1*3 past the maximal size.
          * It is supposed to fail. */
         extend_dims[0] = SPACE1_DIM1 * 3;
-        H5E_BEGIN_TRY { ret = H5Dset_extent(dset1, extend_dims); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Dset_extent(dset1, extend_dims);
+        }
         H5E_END_TRY;
         VERIFY(ret, FAIL, "H5Dset_extent");
 
@@ -1211,7 +1250,10 @@ test_h5s_encode(H5F_libver_t low, H5F_libver_t high)
     }
 
     /* Try decoding bogus buffer */
-    H5E_BEGIN_TRY { ret_id = H5Sdecode(sbuf); }
+    H5E_BEGIN_TRY
+    {
+        ret_id = H5Sdecode(sbuf);
+    }
     H5E_END_TRY;
     VERIFY(ret_id, FAIL, "H5Sdecode");
 
@@ -1400,7 +1442,10 @@ test_h5s_encode1(void)
     }
 
     /* Try decoding bogus buffer */
-    H5E_BEGIN_TRY { ret_id = H5Sdecode(sbuf); }
+    H5E_BEGIN_TRY
+    {
+        ret_id = H5Sdecode(sbuf);
+    }
     H5E_END_TRY;
     VERIFY(ret_id, FAIL, "H5Sdecode");
 
@@ -1563,7 +1608,10 @@ test_h5s_check_encoding(hid_t in_fapl, hid_t in_sid, uint32_t expected_version, 
     herr_t  ret;               /* Return value */
 
     /* Get buffer size for encoding with the format setting in in_fapl */
-    H5E_BEGIN_TRY { ret = H5Sencode2(in_sid, NULL, &buf_size, in_fapl); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Sencode2(in_sid, NULL, &buf_size, in_fapl);
+    }
     H5E_END_TRY
 
     if (expected_to_fail) {
@@ -2158,7 +2206,10 @@ test_h5s_scalar_write(void)
     CHECK(fid1, FAIL, "H5Fcreate");
 
     /* Verify a non-zero rank fails with a NULL dimension. */
-    H5E_BEGIN_TRY { sid1 = H5Screate_simple(SPACE1_RANK, NULL, NULL); }
+    H5E_BEGIN_TRY
+    {
+        sid1 = H5Screate_simple(SPACE1_RANK, NULL, NULL);
+    }
     H5E_END_TRY
     VERIFY(sid1, FAIL, "H5Screate_simple");
 

--- a/test/tid.c
+++ b/test/tid.c
@@ -856,7 +856,10 @@ test_remove_clear_type(void)
 
 error:
     /* Cleanup. For simplicity, just destroy the types and ignore errors. */
-    H5E_BEGIN_TRY { H5Idestroy_type(obj_type); }
+    H5E_BEGIN_TRY
+    {
+        H5Idestroy_type(obj_type);
+    }
     H5E_END_TRY
 
     HDfree(obj_list.objects);
@@ -995,19 +998,28 @@ test_future_ids(void)
 
     /* Test basic error conditions */
     fake_future_obj = 0;
-    H5E_BEGIN_TRY { future_id = H5Iregister_future(obj_type, &fake_future_obj, NULL, NULL); }
+    H5E_BEGIN_TRY
+    {
+        future_id = H5Iregister_future(obj_type, &fake_future_obj, NULL, NULL);
+    }
     H5E_END_TRY
     VERIFY(future_id, H5I_INVALID_HID, "H5Iregister_future");
     if (H5I_INVALID_HID != future_id)
         goto error;
 
-    H5E_BEGIN_TRY { future_id = H5Iregister_future(obj_type, &fake_future_obj, realize_future_cb, NULL); }
+    H5E_BEGIN_TRY
+    {
+        future_id = H5Iregister_future(obj_type, &fake_future_obj, realize_future_cb, NULL);
+    }
     H5E_END_TRY
     VERIFY(future_id, H5I_INVALID_HID, "H5Iregister_future");
     if (H5I_INVALID_HID != future_id)
         goto error;
 
-    H5E_BEGIN_TRY { future_id = H5Iregister_future(obj_type, &fake_future_obj, NULL, discard_future_cb); }
+    H5E_BEGIN_TRY
+    {
+        future_id = H5Iregister_future(obj_type, &fake_future_obj, NULL, discard_future_cb);
+    }
     H5E_END_TRY
     VERIFY(future_id, H5I_INVALID_HID, "H5Iregister_future");
     if (H5I_INVALID_HID != future_id)
@@ -1349,7 +1361,10 @@ test_future_ids(void)
 
 error:
     /* Cleanup. For simplicity, just destroy the types and ignore errors. */
-    H5E_BEGIN_TRY { H5Idestroy_type(obj_type); }
+    H5E_BEGIN_TRY
+    {
+        H5Idestroy_type(obj_type);
+    }
     H5E_END_TRY
 
     return -1;

--- a/test/titerate.c
+++ b/test/titerate.c
@@ -271,19 +271,28 @@ test_iter_group(hid_t fapl, hbool_t new_format)
     /* Test invalid indices for starting iteration */
     info.command = RET_ZERO;
     idx          = (hsize_t)-1;
-    H5E_BEGIN_TRY { ret = H5Literate2(file, H5_INDEX_NAME, H5_ITER_INC, &idx, liter_cb, &info); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Literate2(file, H5_INDEX_NAME, H5_ITER_INC, &idx, liter_cb, &info);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Literate2");
 
     /* Test skipping exactly as many entries as in the group */
     idx = NDATASETS + 2;
-    H5E_BEGIN_TRY { ret = H5Literate2(file, H5_INDEX_NAME, H5_ITER_INC, &idx, liter_cb, &info); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Literate2(file, H5_INDEX_NAME, H5_ITER_INC, &idx, liter_cb, &info);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Literate2");
 
     /* Test skipping more entries than are in the group */
     idx = NDATASETS + 3;
-    H5E_BEGIN_TRY { ret = H5Literate2(file, H5_INDEX_NAME, H5_ITER_INC, &idx, liter_cb, &info); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Literate2(file, H5_INDEX_NAME, H5_ITER_INC, &idx, liter_cb, &info);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Literate2");
 
@@ -461,13 +470,19 @@ test_iter_attr(hid_t fapl, hbool_t new_format)
 
     /* Test skipping exactly as many attributes as there are */
     idx = NATTR;
-    H5E_BEGIN_TRY { ret = H5Aiterate2(dataset, H5_INDEX_NAME, H5_ITER_INC, &idx, aiter_cb, &info); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Aiterate2(dataset, H5_INDEX_NAME, H5_ITER_INC, &idx, aiter_cb, &info);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Aiterate2");
 
     /* Test skipping more attributes than there are */
     idx = NATTR + 1;
-    H5E_BEGIN_TRY { ret = H5Aiterate2(dataset, H5_INDEX_NAME, H5_ITER_INC, &idx, aiter_cb, &info); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Aiterate2(dataset, H5_INDEX_NAME, H5_ITER_INC, &idx, aiter_cb, &info);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Aiterate2");
 

--- a/test/tmisc.c
+++ b/test/tmisc.c
@@ -1894,7 +1894,10 @@ test_misc11(void)
     CHECK(ret, FAIL, "H5Pset_sizes");
 
     /* This should fail as (32770*2) will exceed ^16 - 2 bytes for storing btree entries */
-    H5E_BEGIN_TRY { ret = H5Pset_sym_k(fcpl, 32770, 0); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_sym_k(fcpl, 32770, 0);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Pset_sym_k");
 
@@ -1902,7 +1905,10 @@ test_misc11(void)
     CHECK(ret, FAIL, "H5Pset_sym_k");
 
     /* This should fail as (32770*2) will exceed ^16 - 2 bytes for storing btree entries */
-    H5E_BEGIN_TRY { ret = H5Pset_istore_k(fcpl, 32770); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_istore_k(fcpl, 32770);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Pset_istore_k");
 
@@ -3160,7 +3166,10 @@ test_misc19(void)
     VERIFY(rc, 0, "H5Idec_ref");
 
     /* Try closing the file again (should fail) */
-    H5E_BEGIN_TRY { ret = H5Fclose(fid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fclose(fid);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Fclose");
 
@@ -3191,7 +3200,10 @@ test_misc19(void)
     VERIFY(rc, 0, "H5Idec_ref");
 
     /* Try closing the property list again (should fail) */
-    H5E_BEGIN_TRY { ret = H5Pclose(plid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pclose(plid);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Pclose");
 
@@ -3222,7 +3234,10 @@ test_misc19(void)
     VERIFY(rc, 0, "H5Idec_ref");
 
     /* Try closing the property class again (should fail) */
-    H5E_BEGIN_TRY { ret = H5Pclose_class(pcid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pclose_class(pcid);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Pclose_class");
 
@@ -3253,7 +3268,10 @@ test_misc19(void)
     VERIFY(rc, 0, "H5Idec_ref");
 
     /* Try closing the datatype again (should fail) */
-    H5E_BEGIN_TRY { ret = H5Tclose(tid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Tclose(tid);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Tclose");
 
@@ -3284,7 +3302,10 @@ test_misc19(void)
     VERIFY(rc, 0, "H5Idec_ref");
 
     /* Try closing the dataspace again (should fail) */
-    H5E_BEGIN_TRY { ret = H5Sclose(sid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Sclose(sid);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Sclose");
 
@@ -3323,7 +3344,10 @@ test_misc19(void)
     VERIFY(rc, 0, "H5Idec_ref");
 
     /* Try closing the dataset again (should fail) */
-    H5E_BEGIN_TRY { ret = H5Dclose(did); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dclose(did);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Dclose");
 
@@ -3374,7 +3398,10 @@ test_misc19(void)
     VERIFY(rc, 0, "H5Idec_ref");
 
     /* Try closing the attribute again (should fail) */
-    H5E_BEGIN_TRY { ret = H5Aclose(aid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Aclose(aid);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Aclose");
 
@@ -3421,7 +3448,10 @@ test_misc19(void)
     VERIFY(rc, 0, "H5Idec_ref");
 
     /* Try closing the group again (should fail) */
-    H5E_BEGIN_TRY { ret = H5Gclose(gid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Gclose(gid);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Gclose");
 
@@ -3456,7 +3486,10 @@ test_misc19(void)
     VERIFY(rc, 0, "H5Idec_ref");
 
     /* Try closing the error class again (should fail) */
-    H5E_BEGIN_TRY { ret = H5Eunregister_class(ecid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Eunregister_class(ecid);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Eunregister_class");
 
@@ -3491,7 +3524,10 @@ test_misc19(void)
     VERIFY(rc, 0, "H5Idec_ref");
 
     /* Try closing the error message again (should fail) */
-    H5E_BEGIN_TRY { ret = H5Eclose_msg(emid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Eclose_msg(emid);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Eclose_msg");
 
@@ -3526,7 +3562,10 @@ test_misc19(void)
     VERIFY(rc, 0, "H5Idec_ref");
 
     /* Try closing the error stack again (should fail) */
-    H5E_BEGIN_TRY { ret = H5Eclose_stack(esid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Eclose_stack(esid);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Eclose_stack");
 
@@ -3561,7 +3600,10 @@ test_misc19(void)
     VERIFY(rc, 0, "H5Idec_ref");
 
     /* Try unregistering the VFD again (should fail) */
-    H5E_BEGIN_TRY { ret = H5FDunregister(vfdid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5FDunregister(vfdid);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5FDunregister");
 
@@ -3598,7 +3640,10 @@ test_misc19(void)
     VERIFY(rc, 0, "H5Idec_ref");
 
     /* Try unregistering the VOL connector again (should fail) */
-    H5E_BEGIN_TRY { ret = H5VLunregister_connector(volid); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5VLunregister_connector(volid);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5VLunregister_connector");
 
@@ -4036,7 +4081,10 @@ test_misc23(void)
      * test the old APIs
      **********************************************************************/
 
-    H5E_BEGIN_TRY { tmp_id = H5Gcreate1(file_id, "/A/B00a/grp", (size_t)0); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Gcreate1(file_id, "/A/B00a/grp", (size_t)0);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Gcreate1");
 
@@ -4046,7 +4094,10 @@ test_misc23(void)
     status = H5Gclose(tmp_id);
     CHECK(status, FAIL, "H5Gclose");
 
-    H5E_BEGIN_TRY { tmp_id = H5Dcreate1(file_id, "/A/B00c/dset", type_id, space_id, create_id); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Dcreate1(file_id, "/A/B00c/dset", type_id, space_id, create_id);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Dcreate1");
 
@@ -4379,51 +4430,87 @@ test_misc24(void)
     CHECK(ret, FAIL, "H5Tclose");
 
     /* Attempt to open each kind of object with wrong API, including using soft links */
-    H5E_BEGIN_TRY { tmp_id = H5Dopen2(file_id, MISC24_GROUP_NAME, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Dopen2(file_id, MISC24_GROUP_NAME, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Dopen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Dopen2(file_id, MISC24_GROUP_LINK, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Dopen2(file_id, MISC24_GROUP_LINK, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Dopen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Topen2(file_id, MISC24_GROUP_NAME, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Topen2(file_id, MISC24_GROUP_NAME, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Topen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Topen2(file_id, MISC24_GROUP_LINK, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Topen2(file_id, MISC24_GROUP_LINK, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Topen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Gopen2(file_id, MISC24_DATASET_NAME, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Gopen2(file_id, MISC24_DATASET_NAME, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Gopen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Gopen2(file_id, MISC24_DATASET_LINK, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Gopen2(file_id, MISC24_DATASET_LINK, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Gopen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Topen2(file_id, MISC24_DATASET_NAME, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Topen2(file_id, MISC24_DATASET_NAME, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Topen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Topen2(file_id, MISC24_DATASET_LINK, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Topen2(file_id, MISC24_DATASET_LINK, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Topen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Gopen2(file_id, MISC24_DATATYPE_NAME, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Gopen2(file_id, MISC24_DATATYPE_NAME, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Gopen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Gopen2(file_id, MISC24_DATATYPE_LINK, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Gopen2(file_id, MISC24_DATATYPE_LINK, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Gopen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Dopen2(file_id, MISC24_DATATYPE_NAME, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Dopen2(file_id, MISC24_DATATYPE_NAME, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Dopen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Dopen2(file_id, MISC24_DATATYPE_LINK, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Dopen2(file_id, MISC24_DATATYPE_LINK, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Dopen2");
 
@@ -4432,19 +4519,31 @@ test_misc24(void)
     group_id = H5Gopen2(file_id, MISC24_GROUP_NAME, H5P_DEFAULT);
     CHECK(group_id, FAIL, "H5Gopen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Dopen2(file_id, MISC24_GROUP_NAME, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Dopen2(file_id, MISC24_GROUP_NAME, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Dopen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Dopen2(file_id, MISC24_GROUP_LINK, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Dopen2(file_id, MISC24_GROUP_LINK, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Dopen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Topen2(file_id, MISC24_GROUP_NAME, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Topen2(file_id, MISC24_GROUP_NAME, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Topen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Topen2(file_id, MISC24_GROUP_LINK, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Topen2(file_id, MISC24_GROUP_LINK, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Topen2");
 
@@ -4455,19 +4554,31 @@ test_misc24(void)
     dset_id = H5Dopen2(file_id, MISC24_DATASET_NAME, H5P_DEFAULT);
     CHECK(dset_id, FAIL, "H5Dopen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Gopen2(file_id, MISC24_DATASET_NAME, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Gopen2(file_id, MISC24_DATASET_NAME, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Gopen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Gopen2(file_id, MISC24_DATASET_LINK, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Gopen2(file_id, MISC24_DATASET_LINK, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Gopen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Topen2(file_id, MISC24_DATASET_NAME, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Topen2(file_id, MISC24_DATASET_NAME, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Topen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Topen2(file_id, MISC24_DATASET_LINK, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Topen2(file_id, MISC24_DATASET_LINK, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Topen2");
 
@@ -4478,19 +4589,31 @@ test_misc24(void)
     type_id = H5Topen2(file_id, MISC24_DATATYPE_NAME, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Topen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Gopen2(file_id, MISC24_DATATYPE_NAME, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Gopen2(file_id, MISC24_DATATYPE_NAME, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Gopen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Gopen2(file_id, MISC24_DATATYPE_LINK, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Gopen2(file_id, MISC24_DATATYPE_LINK, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Gopen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Dopen2(file_id, MISC24_DATATYPE_NAME, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Dopen2(file_id, MISC24_DATATYPE_NAME, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Dopen2");
 
-    H5E_BEGIN_TRY { tmp_id = H5Dopen2(file_id, MISC24_DATATYPE_LINK, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        tmp_id = H5Dopen2(file_id, MISC24_DATATYPE_LINK, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(tmp_id, FAIL, "H5Dopen2");
 
@@ -5076,7 +5199,10 @@ test_misc27(void)
 
 #ifdef H5_STRICT_FORMAT_CHECKS
     /* Open group with incorrect # of object header messages (should fail) */
-    H5E_BEGIN_TRY { gid = H5Gopen2(fid, MISC27_GROUP, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        gid = H5Gopen2(fid, MISC27_GROUP, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(gid, FAIL, "H5Gopen2");
 #else  /* H5_STRICT_FORMAT_CHECKS */
@@ -5569,17 +5695,26 @@ test_misc33(void)
     CHECK(fid, FAIL, "H5Fopen");
 
     /* Case (1) */
-    H5E_BEGIN_TRY { ret = H5Oget_info_by_name3(fid, "/soft_two", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Oget_info_by_name3(fid, "/soft_two", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Oget_info_by_name3");
 
     /* Case (2) */
-    H5E_BEGIN_TRY { ret = H5Oget_info_by_name3(fid, "/dsetA", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Oget_info_by_name3(fid, "/dsetA", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Oget_info_by_name3");
 
     /* Case (3) */
-    H5E_BEGIN_TRY { ret = H5Oget_info_by_name3(fid, "/soft_one", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Oget_info_by_name3(fid, "/soft_one", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Oget_info_by_name3");
 

--- a/test/trefer.c
+++ b/test/trefer.c
@@ -1358,7 +1358,10 @@ test_reference_region(H5F_libver_t libver_low, H5F_libver_t libver_high)
         /*
          * Dereference an undefined reference (should fail)
          */
-        H5E_BEGIN_TRY { dset2 = H5Ropen_object(&rdata_NA[0], H5P_DEFAULT, H5P_DEFAULT); }
+        H5E_BEGIN_TRY
+        {
+            dset2 = H5Ropen_object(&rdata_NA[0], H5P_DEFAULT, H5P_DEFAULT);
+        }
         H5E_END_TRY;
         VERIFY(dset2, H5I_INVALID_HID, "H5Ropen_object");
 
@@ -1368,7 +1371,10 @@ test_reference_region(H5F_libver_t libver_low, H5F_libver_t libver_high)
 
         /* This close should fail since H5Ropen_object never created
          * the id of the referenced object. */
-        H5E_BEGIN_TRY { ret = H5Dclose(dset2); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Dclose(dset2);
+        }
         H5E_END_TRY;
         VERIFY(ret, FAIL, "H5Dclose");
 
@@ -1520,7 +1526,10 @@ test_reference_region(H5F_libver_t libver_low, H5F_libver_t libver_high)
 
         /* Attempting to retrieve type of object using non-valid refs */
         for (j = 0; j < 3; j++) {
-            H5E_BEGIN_TRY { ret = H5Rget_obj_type3(&nvrbuf[j], H5P_DEFAULT, &obj_type); }
+            H5E_BEGIN_TRY
+            {
+                ret = H5Rget_obj_type3(&nvrbuf[j], H5P_DEFAULT, &obj_type);
+            }
             H5E_END_TRY;
             VERIFY(ret, FAIL, "H5Rget_obj_type3");
         } /* end for */

--- a/test/trefer_deprec.c
+++ b/test/trefer_deprec.c
@@ -456,7 +456,10 @@ test_reference_obj(void)
 
     /* Attempting to retrieve type of object using non-valid refs */
     for (j = 0; j < 3; j++) {
-        H5E_BEGIN_TRY { ret = H5Rget_obj_type2(dataset, H5R_OBJECT, &nvrbuf[j], &obj_type); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Rget_obj_type2(dataset, H5R_OBJECT, &nvrbuf[j], &obj_type);
+        }
         H5E_END_TRY;
         VERIFY(ret, FAIL, "H5Rget_obj_type2");
     } /* end for */
@@ -653,7 +656,10 @@ test_reference_region(H5F_libver_t libver_low, H5F_libver_t libver_high)
     VERIFY(hssize_ret, (hssize_t)H5S_UNLIMITED, "H5Sget_select_npoints");
 
     /* Store third dataset region */
-    H5E_BEGIN_TRY { ret = H5Rcreate(&wbuf[2], fid1, "/Dataset2", H5R_DATASET_REGION, sid2); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Rcreate(&wbuf[2], fid1, "/Dataset2", H5R_DATASET_REGION, sid2);
+    }
     H5E_END_TRY;
 
     if (libver_high < H5F_LIBVER_V110)
@@ -728,7 +734,10 @@ test_reference_region(H5F_libver_t libver_low, H5F_libver_t libver_high)
     /*
      * Dereference an undefined reference (should fail)
      */
-    H5E_BEGIN_TRY { dset2 = H5Rdereference2(dset_NA, H5P_DEFAULT, H5R_DATASET_REGION, &rdata_NA[0]); }
+    H5E_BEGIN_TRY
+    {
+        dset2 = H5Rdereference2(dset_NA, H5P_DEFAULT, H5R_DATASET_REGION, &rdata_NA[0]);
+    }
     H5E_END_TRY;
     VERIFY(dset2, FAIL, "H5Rdereference2");
 
@@ -738,7 +747,10 @@ test_reference_region(H5F_libver_t libver_low, H5F_libver_t libver_high)
 
     /* This close should fail since H5Rdereference2 never created
      * the id of the referenced object. */
-    H5E_BEGIN_TRY { ret = H5Dclose(dset2); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dclose(dset2);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Dclose");
 
@@ -892,7 +904,10 @@ test_reference_region(H5F_libver_t libver_low, H5F_libver_t libver_high)
 
     /* Attempting to retrieve type of object using non-valid refs */
     for (j = 0; j < 3; j++) {
-        H5E_BEGIN_TRY { ret = H5Rget_obj_type2(dset1, H5R_DATASET_REGION, &nvrbuf[j], &obj_type); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Rget_obj_type2(dset1, H5R_DATASET_REGION, &nvrbuf[j], &obj_type);
+        }
         H5E_END_TRY;
         VERIFY(ret, FAIL, "H5Rget_obj_type2");
     } /* end for */

--- a/test/tselect.c
+++ b/test/tselect.c
@@ -287,7 +287,10 @@ test_select_hyper(hid_t xfer_plist)
     block[0]  = 1;
     block[1]  = 1;
     block[2]  = 1;
-    H5E_BEGIN_TRY { ret = H5Sselect_hyperslab(sid1, H5S_SELECT_SET, start, stride, count, block); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Sselect_hyperslab(sid1, H5S_SELECT_SET, start, stride, count, block);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Sselect_hyperslab");
 
@@ -304,7 +307,10 @@ test_select_hyper(hid_t xfer_plist)
     block[0]  = 2;
     block[1]  = 2;
     block[2]  = 2;
-    H5E_BEGIN_TRY { ret = H5Sselect_hyperslab(sid1, H5S_SELECT_SET, start, stride, count, block); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Sselect_hyperslab(sid1, H5S_SELECT_SET, start, stride, count, block);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Sselect_hyperslab");
 
@@ -344,10 +350,16 @@ test_select_hyper(hid_t xfer_plist)
     CHECK(ret, FAIL, "H5Dwrite");
 
     /* Exercise checks for NULL buffer and valid selection */
-    H5E_BEGIN_TRY { ret = H5Dwrite(dataset, H5T_NATIVE_UCHAR, sid2, sid1, xfer_plist, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dwrite(dataset, H5T_NATIVE_UCHAR, sid2, sid1, xfer_plist, NULL);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Dwrite");
-    H5E_BEGIN_TRY { ret = H5Dwrite(dataset, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL, xfer_plist, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dwrite(dataset, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL, xfer_plist, NULL);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Dwrite");
 
@@ -388,10 +400,16 @@ test_select_hyper(hid_t xfer_plist)
     CHECK(ret, FAIL, "H5Dread");
 
     /* Exercise checks for NULL buffer and valid selection */
-    H5E_BEGIN_TRY { ret = H5Dread(dataset, H5T_NATIVE_UCHAR, sid2, sid1, xfer_plist, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dread(dataset, H5T_NATIVE_UCHAR, sid2, sid1, xfer_plist, NULL);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Dread");
-    H5E_BEGIN_TRY { ret = H5Dread(dataset, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL, xfer_plist, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dread(dataset, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL, xfer_plist, NULL);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Dread");
 
@@ -8166,14 +8184,20 @@ test_scalar_select2(void)
 
     /* Select one element in memory with a point selection */
     coord1[0] = 0;
-    H5E_BEGIN_TRY { ret = H5Sselect_elements(sid, H5S_SELECT_SET, (size_t)1, (const hsize_t *)&coord1); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Sselect_elements(sid, H5S_SELECT_SET, (size_t)1, (const hsize_t *)&coord1);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Sselect_elements");
 
     /* Select one element in memory with a hyperslab selection */
     start[0] = 0;
     count[0] = 0;
-    H5E_BEGIN_TRY { ret = H5Sselect_hyperslab(sid, H5S_SELECT_SET, start, NULL, count, NULL); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Sselect_hyperslab(sid, H5S_SELECT_SET, start, NULL, count, NULL);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Sselect_hyperslab");
 
@@ -13835,7 +13859,10 @@ test_select_bounds(void)
     CHECK(ret, FAIL, "H5Sselect_none");
 
     /* Get bounds for 'none' selection */
-    H5E_BEGIN_TRY { ret = H5Sget_select_bounds(sid, low_bounds, high_bounds); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Sget_select_bounds(sid, low_bounds, high_bounds);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Sget_select_bo unds");
 
@@ -13866,7 +13893,10 @@ test_select_bounds(void)
     CHECK(ret, FAIL, "H5Soffset_simple");
 
     /* Get bounds for hyperslab selection with negative offset */
-    H5E_BEGIN_TRY { ret = H5Sget_select_bounds(sid, low_bounds, high_bounds); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Sget_select_bounds(sid, low_bounds, high_bounds);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Sget_select_bounds");
 
@@ -13917,7 +13947,10 @@ test_select_bounds(void)
     CHECK(ret, FAIL, "H5Soffset_simple");
 
     /* Get bounds for hyperslab selection with negative offset */
-    H5E_BEGIN_TRY { ret = H5Sget_select_bounds(sid, low_bounds, high_bounds); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Sget_select_bounds(sid, low_bounds, high_bounds);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Sget_select_bounds");
 
@@ -13968,7 +14001,10 @@ test_select_bounds(void)
     CHECK(ret, FAIL, "H5Soffset_simple");
 
     /* Get bounds for hyperslab selection with negative offset */
-    H5E_BEGIN_TRY { ret = H5Sget_select_bounds(sid, low_bounds, high_bounds); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Sget_select_bounds(sid, low_bounds, high_bounds);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Sget_select_bounds");
 
@@ -14030,12 +14066,18 @@ test_hyper_regular(void)
     CHECK(sid, FAIL, "H5Screate_simple");
 
     /* Query if 'all' selection is regular hyperslab (should fail) */
-    H5E_BEGIN_TRY { is_regular = H5Sis_regular_hyperslab(sid); }
+    H5E_BEGIN_TRY
+    {
+        is_regular = H5Sis_regular_hyperslab(sid);
+    }
     H5E_END_TRY;
     VERIFY(is_regular, FAIL, "H5Sis_regular_hyperslab");
 
     /* Query regular hyperslab selection info (should fail) */
-    H5E_BEGIN_TRY { ret = H5Sget_regular_hyperslab(sid, q_start, q_stride, q_count, q_block); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Sget_regular_hyperslab(sid, q_start, q_stride, q_count, q_block);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Sget_regular_hyperslab");
 
@@ -14044,12 +14086,18 @@ test_hyper_regular(void)
     CHECK(ret, FAIL, "H5Sselect_none");
 
     /* Query if 'none' selection is regular hyperslab (should fail) */
-    H5E_BEGIN_TRY { is_regular = H5Sis_regular_hyperslab(sid); }
+    H5E_BEGIN_TRY
+    {
+        is_regular = H5Sis_regular_hyperslab(sid);
+    }
     H5E_END_TRY;
     VERIFY(is_regular, FAIL, "H5Sis_regular_hyperslab");
 
     /* Query regular hyperslab selection info (should fail) */
-    H5E_BEGIN_TRY { ret = H5Sget_regular_hyperslab(sid, q_start, q_stride, q_count, q_block); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Sget_regular_hyperslab(sid, q_start, q_stride, q_count, q_block);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Sget_regular_hyperslab");
 
@@ -14070,12 +14118,18 @@ test_hyper_regular(void)
     CHECK(ret, FAIL, "H5Sselect_elements");
 
     /* Query if 'point' selection is regular hyperslab (should fail) */
-    H5E_BEGIN_TRY { is_regular = H5Sis_regular_hyperslab(sid); }
+    H5E_BEGIN_TRY
+    {
+        is_regular = H5Sis_regular_hyperslab(sid);
+    }
     H5E_END_TRY;
     VERIFY(is_regular, FAIL, "H5Sis_regular_hyperslab");
 
     /* Query regular hyperslab selection info (should fail) */
-    H5E_BEGIN_TRY { ret = H5Sget_regular_hyperslab(sid, q_start, q_stride, q_count, q_block); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Sget_regular_hyperslab(sid, q_start, q_stride, q_count, q_block);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Sget_regular_hyperslab");
 
@@ -14130,7 +14184,10 @@ test_hyper_regular(void)
     VERIFY(is_regular, FALSE, "H5Sis_regular_hyperslab");
 
     /* Query regular hyperslab selection info (should fail) */
-    H5E_BEGIN_TRY { ret = H5Sget_regular_hyperslab(sid, q_start, q_stride, q_count, q_block); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Sget_regular_hyperslab(sid, q_start, q_stride, q_count, q_block);
+    }
     H5E_END_TRY;
     VERIFY(ret, FAIL, "H5Sget_regular_hyperslab");
 
@@ -15108,10 +15165,16 @@ test_sel_iter(void)
         CHECK(iter_id, FAIL, "H5Ssel_iter_create");
 
         /* Try resetting selection iterator with bad parameters */
-        H5E_BEGIN_TRY { ret = H5Ssel_iter_reset(H5I_INVALID_HID, sid); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Ssel_iter_reset(H5I_INVALID_HID, sid);
+        }
         H5E_END_TRY;
         VERIFY(ret, FAIL, "H5Ssel_iter_reset");
-        H5E_BEGIN_TRY { ret = H5Ssel_iter_reset(iter_id, H5I_INVALID_HID); }
+        H5E_BEGIN_TRY
+        {
+            ret = H5Ssel_iter_reset(iter_id, H5I_INVALID_HID);
+        }
         H5E_END_TRY;
         VERIFY(ret, FAIL, "H5Ssel_iter_reset");
 

--- a/test/tvltypes.c
+++ b/test/tvltypes.c
@@ -136,7 +136,10 @@ test_vltypes_dataset_create(void)
     CHECK(ret, FAIL, "H5Pset_fill_time");
 
     /* Create a dataset, supposed to fail */
-    H5E_BEGIN_TRY { dataset = H5Dcreate2(fid1, "Dataset1", tid1, sid1, H5P_DEFAULT, dcpl, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        dataset = H5Dcreate2(fid1, "Dataset1", tid1, sid1, H5P_DEFAULT, dcpl, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     VERIFY(dataset, FAIL, "H5Dcreate2");
 
@@ -202,11 +205,17 @@ test_vltypes_funcs(void)
     ret = H5Tset_offset(type, (size_t)16);
     CHECK(ret, FAIL, "H5Tset_offset");
 
-    H5E_BEGIN_TRY { cset = H5Tget_cset(type); }
+    H5E_BEGIN_TRY
+    {
+        cset = H5Tget_cset(type);
+    }
     H5E_END_TRY;
     VERIFY(cset, FAIL, "H5Tget_cset");
 
-    H5E_BEGIN_TRY { strpad = H5Tget_strpad(type); }
+    H5E_BEGIN_TRY
+    {
+        strpad = H5Tget_strpad(type);
+    }
     H5E_END_TRY;
     VERIFY(strpad, FAIL, "H5Tget_strpad");
 
@@ -476,7 +485,10 @@ test_vltypes_vlen_atomic(void)
     VERIFY(size, ((SPACE1_DIM1 * (SPACE1_DIM1 + 1)) / 2) * sizeof(unsigned int), "H5Dvlen_get_buf_size");
 
     /* Try to call H5Dvlen_get_buf with bad dataspace */
-    H5E_BEGIN_TRY { ret = H5Dvlen_get_buf_size(dataset, tid1, sid2, &size); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dvlen_get_buf_size(dataset, tid1, sid2, &size);
+    }
     H5E_END_TRY
     VERIFY(ret, FAIL, "H5Dvlen_get_buf_size");
 
@@ -507,7 +519,10 @@ test_vltypes_vlen_atomic(void)
 
     /* Try to reclaim read data using "bad" dataspace with no extent
      * Should fail */
-    H5E_BEGIN_TRY { ret = H5Treclaim(tid1, sid2, xfer_pid, rdata); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Treclaim(tid1, sid2, xfer_pid, rdata);
+    }
     H5E_END_TRY
     VERIFY(ret, FAIL, "H5Treclaim");
 

--- a/test/unlink.c
+++ b/test/unlink.c
@@ -117,7 +117,10 @@ test_one(hid_t file)
     TESTING("unlink without a name");
     if ((grp = H5Gcreate2(work, "foo", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         FAIL_STACK_ERROR
-    H5E_BEGIN_TRY { status = H5Ldelete(grp, ".", H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Ldelete(grp, ".", H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (status >= 0)
         FAIL_PUTS_ERROR("    Unlinking object w/o a name should have failed.")
@@ -287,7 +290,10 @@ test_symlink(hid_t file)
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Gclose(work); }
+    H5E_BEGIN_TRY
+    {
+        H5Gclose(work);
+    }
     H5E_END_TRY;
     return 1;
 } /* end test_symlink() */
@@ -1288,7 +1294,10 @@ test_filespace(hid_t fapl)
         FAIL_STACK_ERROR
 
     /* Create another group with same name */
-    H5E_BEGIN_TRY { group = H5Gcreate2(file, GROUPNAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        group = H5Gcreate2(file, GROUPNAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (group >= 0) {
         H5Gclose(group);
@@ -1335,7 +1344,10 @@ test_filespace(hid_t fapl)
         FAIL_STACK_ERROR
 
     /* Create another named datatype with same name */
-    H5E_BEGIN_TRY { status = H5Tcommit2(file, TYPENAME, type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        status = H5Tcommit2(file, TYPENAME, type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (status >= 0)
         TEST_ERROR
@@ -1789,12 +1801,18 @@ error:
         /* Close any open groups */
         for (n = 0; n < ngroups; n++)
             if (gids[n]) {
-                H5E_BEGIN_TRY { H5Gclose(gids[n]); }
+                H5E_BEGIN_TRY
+                {
+                    H5Gclose(gids[n]);
+                }
                 H5E_END_TRY;
             } /* end if */
         HDfree(gids);
     } /* end if */
-    H5E_BEGIN_TRY { H5Gclose(rootid); }
+    H5E_BEGIN_TRY
+    {
+        H5Gclose(rootid);
+    }
     H5E_END_TRY;
 
     return 1;
@@ -1875,12 +1893,18 @@ error:
         /* Close any open groups */
         for (n = 0; n < ngroups; n++)
             if (gids[n]) {
-                H5E_BEGIN_TRY { H5Gclose(gids[n]); }
+                H5E_BEGIN_TRY
+                {
+                    H5Gclose(gids[n]);
+                }
                 H5E_END_TRY;
             } /* end if */
         HDfree(gids);
     } /* end if */
-    H5E_BEGIN_TRY { H5Gclose(rootid); }
+    H5E_BEGIN_TRY
+    {
+        H5Gclose(rootid);
+    }
     H5E_END_TRY;
 
     return 1;
@@ -2247,12 +2271,18 @@ error:
         /* Close any open groups */
         for (n = 0; n < ngroups; n++)
             if (gids[n]) {
-                H5E_BEGIN_TRY { H5Gclose(gids[n]); }
+                H5E_BEGIN_TRY
+                {
+                    H5Gclose(gids[n]);
+                }
                 H5E_END_TRY;
             } /* end if */
         HDfree(gids);
     } /* end if */
-    H5E_BEGIN_TRY { H5Gclose(rootid); }
+    H5E_BEGIN_TRY
+    {
+        H5Gclose(rootid);
+    }
     H5E_END_TRY;
 
     return 1;

--- a/test/unregister.c
+++ b/test/unregister.c
@@ -148,7 +148,10 @@ test_unregister_filters(hid_t fapl_id)
         goto error;
 
     /* Unregister the filter before closing the group.  It should fail */
-    H5E_BEGIN_TRY { ret = H5Zunregister(H5Z_FILTER_DUMMY); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Zunregister(H5Z_FILTER_DUMMY);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         H5_FAILED();
@@ -196,7 +199,10 @@ test_unregister_filters(hid_t fapl_id)
         goto error;
 
     /* Unregister the filter before closing the dataset.  It should fail */
-    H5E_BEGIN_TRY { ret = H5Zunregister(H5Z_FILTER_DUMMY); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Zunregister(H5Z_FILTER_DUMMY);
+    }
     H5E_END_TRY;
     if (ret >= 0) {
         H5_FAILED();

--- a/test/vds.c
+++ b/test/vds.c
@@ -323,7 +323,10 @@ vds_check_mapping(hid_t dcpl, size_t i, hid_t vspace, hid_t srcspace, const char
     return 0;
 
 error:
-    H5E_BEGIN_TRY { H5Sclose(space_out); }
+    H5E_BEGIN_TRY
+    {
+        H5Sclose(space_out);
+    }
     H5E_END_TRY
 
     return -1;
@@ -999,7 +1002,10 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
         TEST_ERROR
 
     /* Attempt to add virtual layout mapping */
-    H5E_BEGIN_TRY { ret = H5Pset_virtual(dcpl, vspace[0], src_file[0], src_dset[0], srcspace[0]); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_virtual(dcpl, vspace[0], src_file[0], src_dset[0], srcspace[0]);
+    }
     H5E_END_TRY
     if (ret >= 0)
         TEST_ERROR
@@ -3549,7 +3555,10 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[1] = 9;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
         TEST_ERROR_SUPPRESSED
-    H5E_BEGIN_TRY { ret = H5Dwrite(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dwrite(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]);
+    }
     H5E_END_TRY
     if (ret >= 0)
         TEST_ERROR_SUPPRESSED

--- a/test/vfd.c
+++ b/test/vfd.c
@@ -636,7 +636,10 @@ test_direct(void)
     if (H5Pset_alignment(fapl, (hsize_t)THRESHOLD, (hsize_t)FBSIZE) < 0)
         TEST_ERROR;
 
-    H5E_BEGIN_TRY { file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl); }
+    H5E_BEGIN_TRY
+    {
+        file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+    }
     H5E_END_TRY;
     if (file < 0) {
         H5Pclose(fapl);
@@ -836,13 +839,19 @@ test_family_opens(char *fname, hid_t fa_pl)
     /* Case 1: reopen file with 1st member file name and default property list */
     HDsnprintf(first_name, sizeof(first_name), fname, 0);
 
-    H5E_BEGIN_TRY { file = H5Fopen(first_name, H5F_ACC_RDWR, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        file = H5Fopen(first_name, H5F_ACC_RDWR, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (file >= 0)
         TEST_ERROR
 
     /* Case 2: reopen file with correct name template but default property list */
-    H5E_BEGIN_TRY { file = H5Fopen(fname, H5F_ACC_RDWR, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        file = H5Fopen(fname, H5F_ACC_RDWR, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (file >= 0)
         TEST_ERROR
@@ -851,7 +860,10 @@ test_family_opens(char *fname, hid_t fa_pl)
     if (H5Pset_fapl_family(fa_pl, (hsize_t)128, H5P_DEFAULT) < 0)
         TEST_ERROR;
 
-    H5E_BEGIN_TRY { file = H5Fopen(fname, H5F_ACC_RDWR, fa_pl); }
+    H5E_BEGIN_TRY
+    {
+        file = H5Fopen(fname, H5F_ACC_RDWR, fa_pl);
+    }
     H5E_END_TRY;
     if (file >= 0)
         TEST_ERROR
@@ -867,7 +879,10 @@ test_family_opens(char *fname, hid_t fa_pl)
     if (H5Pset_fapl_family(fa_pl, (hsize_t)FAMILY_SIZE, H5P_DEFAULT) < 0)
         TEST_ERROR;
 
-    H5E_BEGIN_TRY { file = H5Fopen(wrong_name, H5F_ACC_RDWR, fa_pl); }
+    H5E_BEGIN_TRY
+    {
+        file = H5Fopen(wrong_name, H5F_ACC_RDWR, fa_pl);
+    }
     H5E_END_TRY;
     if (file >= 0)
         TEST_ERROR
@@ -1341,7 +1356,10 @@ test_multi_opens(char *fname)
     HDsnprintf(super_name, sizeof(super_name), "%%s-%c.h5", 's');
     HDsnprintf(sf_name, sizeof(sf_name), super_name, fname);
 
-    H5E_BEGIN_TRY { fid = H5Fopen(sf_name, H5F_ACC_RDWR, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        fid = H5Fopen(sf_name, H5F_ACC_RDWR, H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     return (fid >= 0 ? FAIL : SUCCEED);
@@ -2529,7 +2547,10 @@ driver_is_splitter_compatible(hid_t fapl_id)
     HDstrncpy(vfd_config->wo_path, "nonesuch", H5FD_SPLITTER_PATH_MAX);
     vfd_config->log_file_path[0] = '\0';
 
-    H5E_BEGIN_TRY { ret = H5Pset_fapl_splitter(split_fapl_id, vfd_config); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_fapl_splitter(split_fapl_id, vfd_config);
+    }
     H5E_END_TRY;
     if (SUCCEED == ret) {
         ret_value = -1;
@@ -2545,7 +2566,10 @@ driver_is_splitter_compatible(hid_t fapl_id)
     return ret_value;
 
 error:
-    H5E_BEGIN_TRY { H5Pclose(split_fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(split_fapl_id);
+    }
     H5E_END_TRY;
 
     HDfree(vfd_config);
@@ -2606,7 +2630,10 @@ splitter_RO_test(const struct splitter_dataset_def *data, hid_t child_fapl_id)
      * Should fail.
      */
 
-    H5E_BEGIN_TRY { file_id = H5Fopen(filename_rw, H5F_ACC_RDONLY, fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        file_id = H5Fopen(filename_rw, H5F_ACC_RDONLY, fapl_id);
+    }
     H5E_END_TRY;
     if (file_id >= 0) {
         SPLITTER_TEST_FAULT("R/O open on nonexistent files unexpectedly successful\n");
@@ -2619,7 +2646,10 @@ splitter_RO_test(const struct splitter_dataset_def *data, hid_t child_fapl_id)
     if (splitter_create_single_file_at(vfd_config->wo_path, vfd_config->wo_fapl_id, data) < 0) {
         SPLITTER_TEST_FAULT("can't write W/O file\n");
     }
-    H5E_BEGIN_TRY { file_id = H5Fopen(filename_rw, H5F_ACC_RDONLY, fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        file_id = H5Fopen(filename_rw, H5F_ACC_RDONLY, fapl_id);
+    }
     H5E_END_TRY;
     if (file_id >= 0) {
         SPLITTER_TEST_FAULT("R/O open with extant W/O file unexpectedly successful\n");
@@ -2633,7 +2663,10 @@ splitter_RO_test(const struct splitter_dataset_def *data, hid_t child_fapl_id)
     if (splitter_create_single_file_at(filename_rw, vfd_config->rw_fapl_id, data) < 0) {
         SPLITTER_TEST_FAULT("can't create R/W file\n");
     }
-    H5E_BEGIN_TRY { file_id = H5Fopen(filename_rw, H5F_ACC_RDONLY, fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        file_id = H5Fopen(filename_rw, H5F_ACC_RDONLY, fapl_id);
+    }
     H5E_END_TRY;
     if (file_id >= 0) {
         SPLITTER_TEST_FAULT("R/O open with extant R/W file unexpectedly successful\n");
@@ -2868,7 +2901,10 @@ splitter_compare_expected_data(hid_t file_id, const struct splitter_dataset_def 
 
 done:
     if (ret_value < 0) {
-        H5E_BEGIN_TRY { H5Dclose(dset_id); }
+        H5E_BEGIN_TRY
+        {
+            H5Dclose(dset_id);
+        }
         H5E_END_TRY;
     }
     return ret_value;
@@ -2966,7 +3002,10 @@ splitter_tentative_open_test(hid_t child_fapl_id)
      * Should fail.
      */
 
-    H5E_BEGIN_TRY { file_id = H5Fopen(filename_rw, H5F_ACC_RDWR, fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        file_id = H5Fopen(filename_rw, H5F_ACC_RDWR, fapl_id);
+    }
     H5E_END_TRY;
     if (file_id != H5I_INVALID_HID) {
         SPLITTER_TEST_FAULT("open with both nonexistent files unexpectedly succeeded\n");
@@ -2987,7 +3026,10 @@ splitter_tentative_open_test(hid_t child_fapl_id)
     if (h5_duplicate_file_by_bytes(filename_tmp, vfd_config->wo_path) < 0) {
         SPLITTER_TEST_FAULT("Can't create W/O file copy.\n");
     }
-    H5E_BEGIN_TRY { file_id = H5Fopen(filename_rw, H5F_ACC_RDWR, fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        file_id = H5Fopen(filename_rw, H5F_ACC_RDWR, fapl_id);
+    }
     H5E_END_TRY;
     if (file_id != H5I_INVALID_HID) {
         SPLITTER_TEST_FAULT("open with nonexistent R/W file unexpectedly succeeded\n");
@@ -3012,7 +3054,10 @@ splitter_tentative_open_test(hid_t child_fapl_id)
     if (h5_duplicate_file_by_bytes(filename_tmp, filename_rw) < 0) {
         SPLITTER_TEST_FAULT("Can't create R/W file copy.\n");
     }
-    H5E_BEGIN_TRY { file_id = H5Fopen(filename_rw, H5F_ACC_RDWR, fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        file_id = H5Fopen(filename_rw, H5F_ACC_RDWR, fapl_id);
+    }
     H5E_END_TRY;
     if (file_id != H5I_INVALID_HID) {
         SPLITTER_TEST_FAULT("open with nonexistent W/O unexpectedly succeeded\n");
@@ -3178,7 +3223,10 @@ file_exists(const char *filename, hid_t fapl_id)
     hid_t file_id   = H5I_INVALID_HID;
     int   ret_value = 0;
 
-    H5E_BEGIN_TRY { file_id = H5Fopen(filename, H5F_ACC_RDONLY, fapl_id); }
+    H5E_BEGIN_TRY
+    {
+        file_id = H5Fopen(filename, H5F_ACC_RDONLY, fapl_id);
+    }
     H5E_END_TRY;
     if (file_id != H5I_INVALID_HID) {
         ret_value = 1;
@@ -3190,7 +3238,10 @@ file_exists(const char *filename, hid_t fapl_id)
     return ret_value;
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(file_id); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file_id);
+    }
     H5E_END_TRY;
     return ret_value;
 } /* end file_exists() */

--- a/test/vol.c
+++ b/test/vol.c
@@ -199,7 +199,10 @@ test_vol_registration(void)
     /* Test registering a connector with an incorrect property list (SHOULD FAIL) */
     if ((lapl_id = H5Pcreate(H5P_LINK_ACCESS)) < 0)
         TEST_ERROR;
-    H5E_BEGIN_TRY { vol_id = H5VLregister_connector(&fake_vol_g, lapl_id); }
+    H5E_BEGIN_TRY
+    {
+        vol_id = H5VLregister_connector(&fake_vol_g, lapl_id);
+    }
     H5E_END_TRY;
     if (H5I_INVALID_HID != vol_id)
         FAIL_PUTS_ERROR("should not be able to register a connector with an incorrect property list");
@@ -211,7 +214,10 @@ test_vol_registration(void)
         TEST_ERROR;
     HDmemcpy(bad_fake_vol_class, &fake_vol_g, sizeof(H5VL_class_t));
     bad_fake_vol_class->version = H5VL_VERSION + 1;
-    H5E_BEGIN_TRY { vol_id = H5VLregister_connector(bad_fake_vol_class, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        vol_id = H5VLregister_connector(bad_fake_vol_class, H5P_DEFAULT);
+    }
     H5E_END_TRY;
     if (H5I_INVALID_HID != vol_id)
         FAIL_PUTS_ERROR("should not be able to register a connector with an incompatible version #");
@@ -275,7 +281,10 @@ test_vol_registration(void)
     /* Try to unregister the native VOL connector (should fail) */
     if (H5I_INVALID_HID == (native_id = H5VLget_connector_id_by_name(H5VL_NATIVE_NAME)))
         TEST_ERROR;
-    H5E_BEGIN_TRY { ret = H5VLunregister_connector(native_id); }
+    H5E_BEGIN_TRY
+    {
+        ret = H5VLunregister_connector(native_id);
+    }
     H5E_END_TRY;
     if (FAIL != ret)
         FAIL_PUTS_ERROR("should not be able to unregister the native VOL connector");

--- a/test/vol_plugin.c
+++ b/test/vol_plugin.c
@@ -71,7 +71,10 @@ test_registration_by_value(void)
     return SUCCEED;
 
 error:
-    H5E_BEGIN_TRY { H5VLunregister_connector(vol_id); }
+    H5E_BEGIN_TRY
+    {
+        H5VLunregister_connector(vol_id);
+    }
     H5E_END_TRY;
     return FAIL;
 
@@ -125,7 +128,10 @@ test_registration_by_name(void)
     return SUCCEED;
 
 error:
-    H5E_BEGIN_TRY { H5VLunregister_connector(vol_id); }
+    H5E_BEGIN_TRY
+    {
+        H5VLunregister_connector(vol_id);
+    }
     H5E_END_TRY;
     return FAIL;
 

--- a/testpar/t_file.c
+++ b/testpar/t_file.c
@@ -151,7 +151,10 @@ test_page_buffer_access(void)
     VRFY((ret == 0), "");
 
     /* This should fail because collective metadata writes are not supported with page buffering */
-    H5E_BEGIN_TRY { file_id = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl); }
+    H5E_BEGIN_TRY
+    {
+        file_id = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl);
+    }
     H5E_END_TRY;
     VRFY((file_id < 0), "H5Fcreate failed");
 

--- a/tools/lib/h5diff_array.c
+++ b/tools/lib/h5diff_array.c
@@ -3137,7 +3137,10 @@ ull2float(unsigned long long ull_value, float *f_value)
     HDmemcpy(f_value, buf, dst_size);
 
 done:
-    H5E_BEGIN_TRY { H5Pclose(dxpl_id); }
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(dxpl_id);
+    }
     H5E_END_TRY;
 
     if (buf)

--- a/tools/lib/h5tools.c
+++ b/tools/lib/h5tools.c
@@ -885,7 +885,10 @@ h5tools_fopen(const char *fname, unsigned flags, hid_t fapl_id, hbool_t use_spec
         fid = H5Fopen(fname, flags, fapl_id);
     }
     else {
-        H5E_BEGIN_TRY { fid = H5Fopen(fname, flags, fapl_id); }
+        H5E_BEGIN_TRY
+        {
+            fid = H5Fopen(fname, flags, fapl_id);
+        }
         H5E_END_TRY;
     }
 

--- a/tools/lib/h5tools_str.c
+++ b/tools/lib/h5tools_str.c
@@ -439,7 +439,10 @@ h5tools_str_dump_space_blocks(h5tools_str_t *str, hid_t rspace, const h5tool_for
     /*
      * This function fails if the rspace does not have blocks.
      */
-    H5E_BEGIN_TRY { snblocks = H5Sget_select_hyper_nblocks(rspace); }
+    H5E_BEGIN_TRY
+    {
+        snblocks = H5Sget_select_hyper_nblocks(rspace);
+    }
     H5E_END_TRY;
 
     /* Print block information */
@@ -496,7 +499,10 @@ h5tools_str_dump_space_points(h5tools_str_t *str, hid_t rspace, const h5tool_for
     /*
      * This function fails if the rspace does not have points.
      */
-    H5E_BEGIN_TRY { snpoints = H5Sget_select_elem_npoints(rspace); }
+    H5E_BEGIN_TRY
+    {
+        snpoints = H5Sget_select_elem_npoints(rspace);
+    }
     H5E_END_TRY;
 
     /* Print point information */

--- a/tools/src/h5repack/h5repack_copy.c
+++ b/tools/src/h5repack/h5repack_copy.c
@@ -1337,7 +1337,10 @@ done:
             H5TOOLS_ERROR((-1), "named_datatype_free failed");
     }
     else {
-        H5E_BEGIN_TRY { named_datatype_free(&named_dt_head, 1); }
+        H5E_BEGIN_TRY
+        {
+            named_datatype_free(&named_dt_head, 1);
+        }
         H5E_END_TRY;
     }
 

--- a/tools/src/misc/h5repart.c
+++ b/tools/src/misc/h5repart.c
@@ -483,7 +483,10 @@ main(int argc, char *argv[])
      * file and the new file can only be a single file, reopen the new file should fail.
      * There's nothing to do in this case.
      */
-    H5E_BEGIN_TRY { file = H5Fopen(dst_gen_name, H5F_ACC_RDWR, fapl); }
+    H5E_BEGIN_TRY
+    {
+        file = H5Fopen(dst_gen_name, H5F_ACC_RDWR, fapl);
+    }
     H5E_END_TRY;
 
     if (file >= 0) {

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -5375,7 +5375,10 @@ make_dset(hid_t loc_id, const char *name, hid_t sid, hid_t tid, hid_t dcpl, void
     return 0;
 
 out:
-    H5E_BEGIN_TRY { H5Dclose(dsid); }
+    H5E_BEGIN_TRY
+    {
+        H5Dclose(dsid);
+    }
     H5E_END_TRY;
     return -1;
 }

--- a/tools/test/h5repack/h5repacktst.c
+++ b/tools/test/h5repack/h5repacktst.c
@@ -5813,7 +5813,10 @@ make_dset(hid_t loc_id, const char *name, hid_t sid, hid_t dcpl, void *buf)
     return 0;
 
 out:
-    H5E_BEGIN_TRY { H5Dclose(did); }
+    H5E_BEGIN_TRY
+    {
+        H5Dclose(did);
+    }
     H5E_END_TRY;
     return -1;
 }

--- a/tools/test/misc/repart_test.c
+++ b/tools/test/misc/repart_test.c
@@ -113,7 +113,10 @@ test_single_h5repart_opens(void)
     return SUCCEED;
 
 error:
-    H5E_BEGIN_TRY { H5Fclose(fid); }
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(fid);
+    }
     H5E_END_TRY;
 
     return FAIL;

--- a/tools/test/misc/talign.c
+++ b/tools/test/misc/talign.c
@@ -63,7 +63,10 @@ main(void)
         return 1;
     }
 
-    H5E_BEGIN_TRY { (void)H5Ldelete(fil, setname, H5P_DEFAULT); }
+    H5E_BEGIN_TRY
+    {
+        (void)H5Ldelete(fil, setname, H5P_DEFAULT);
+    }
     H5E_END_TRY;
 
     cs6 = H5Tcopy(H5T_C_S1);

--- a/utils/mirror_vfd/mirror_writer.c
+++ b/utils/mirror_vfd/mirror_writer.c
@@ -591,7 +591,10 @@ do_open(struct mirror_session *session, const H5FD_mirror_xmit_open_t *xmit_open
 
 error:
     if (fapl_id > 0) {
-        H5E_BEGIN_TRY { (void)H5Pclose(fapl_id); }
+        H5E_BEGIN_TRY
+        {
+            (void)H5Pclose(fapl_id);
+        }
         H5E_END_TRY;
     }
     return -1;


### PR DESCRIPTION
Put H5E_BEGIN_TRY / H5E_END_TRY on separate lines, empty C++ methods on separate lines, understand that ALL_MEMBERS / UNIQUE_MEMBERS are foreach macros, and properly skip the 'config' directory in the find command without emiting a warning