### PR TITLE
Suppresses the tcheck_version test's abort dialog on Windows

### DIFF
--- a/test/tcheck_version.c
+++ b/test/tcheck_version.c
@@ -118,8 +118,7 @@ abort_intercept(int H5_ATTR_UNUSED sig)
  * Returning TRUE here lets Windows know that we've handled the abort() and that there
  * is no need to alert the user with a modal dialog box.
  */
-int __cdecl
-handle_crt_abort(int reportType, char *message, int *returnValue)
+int __cdecl handle_crt_abort(int reportType, char *message, int *returnValue)
 {
     return TRUE;
 }

--- a/test/tcheck_version.c
+++ b/test/tcheck_version.c
@@ -29,6 +29,10 @@
 
 #include "h5test.h"
 
+#ifdef H5_HAVE_WIN32_API
+#include <crtdbg.h>
+#endif
+
 #define progname "tcheck_version"
 
 /* prototypes */
@@ -108,12 +112,31 @@ abort_intercept(int H5_ATTR_UNUSED sig)
     HDexit(6);
 }
 
+#ifdef H5_HAVE_WIN32_API
+/* Turns off the modal dialog that is raised when the Windows CRT calls abort().
+ *
+ * Returning TRUE here lets Windows know that we've handled the abort() and that there
+ * is no need to alert the user with a modal dialog box.
+ */
+int __cdecl
+handle_crt_abort(int reportType, char *message, int *returnValue)
+{
+    return TRUE;
+}
+#endif
+
 int
 main(int ac, char **av)
 {
+#ifdef H5_HAVE_WIN32_API
+    (void)_CrtSetReportHook2(_CRT_RPTHOOK_INSTALL, handle_crt_abort);
+#endif
     parse(ac, av);
     HDsignal(SIGABRT, &abort_intercept);
     H5check_version(major, minor, release);
     HDsignal(SIGABRT, SIG_DFL);
+#ifdef H5_HAVE_WIN32_API
+    (void)_CrtSetReportHook2(_CRT_RPTHOOK_REMOVE, handle_crt_abort);
+#endif
     return 0;
 }

--- a/test/tcheck_version.c
+++ b/test/tcheck_version.c
@@ -118,7 +118,8 @@ abort_intercept(int H5_ATTR_UNUSED sig)
  * Returning TRUE here lets Windows know that we've handled the abort() and that there
  * is no need to alert the user with a modal dialog box.
  */
-int __cdecl handle_crt_abort(int reportType, char *message, int *returnValue)
+int
+handle_crt_abort(int reportType, char *message, int *returnValue)
 {
     return TRUE;
 }


### PR DESCRIPTION
Windows raises a modal abort/retry/ignore dialog box when CRT
calls abort(). This change installs a report hook that suppresses
the dialog so that the CMake tests don't time out waiting for a
nonexistent user to click a dialog box.