### PR TITLE
BUG: DataSet assignment operator is missing

### DIFF
--- a/c++/src/H5DataSet.cpp
+++ b/c++/src/H5DataSet.cpp
@@ -42,7 +42,6 @@ using std::endl;
 //--------------------------------------------------------------------------
 // Function:    DataSet default constructor
 ///\brief       Default constructor: creates a stub DataSet.
-// Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
 DataSet::DataSet() : H5Object(), AbstractDs(), id(H5I_INVALID_HID)
 {
@@ -52,7 +51,6 @@ DataSet::DataSet() : H5Object(), AbstractDs(), id(H5I_INVALID_HID)
 // Function:    DataSet overloaded constructor
 ///\brief       Creates an DataSet object using the id of an existing dataset.
 ///\param       existing_id - IN: Id of an existing dataset
-// Programmer   Binh-Minh Ribler - 2000
 // Description
 //              incRefCount() is needed here to prevent the id from being closed
 //              prematurely.  That is, when application uses the id of an
@@ -69,7 +67,6 @@ DataSet::DataSet(const hid_t existing_id) : H5Object(), AbstractDs(), id(existin
 // Function:    DataSet copy constructor
 ///\brief       Copy constructor: same HDF5 object as \a original
 ///\param       original - IN: DataSet instance to copy
-// Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
 DataSet::DataSet(const DataSet &original) : H5Object(), AbstractDs(), id(original.id)
 {
@@ -80,7 +77,6 @@ DataSet::DataSet(const DataSet &original) : H5Object(), AbstractDs(), id(origina
 // Function:    DataSet assignment operator
 ///\brief       Assignment operator: same HDF5 object as \a original
 ///\param       original - IN: DataSet instance to copy
-// Programmer   Lee Newberg - 2021
 //--------------------------------------------------------------------------
 DataSet &
 DataSet::operator=(const DataSet &original)
@@ -104,7 +100,6 @@ DataSet::operator=(const DataSet &original)
 ///\par Description
 ///             \c loc can be DataSet, Group, H5File, or named DataType, that
 ///             is a datatype that has been named by DataType::commit.
-// Programmer   Binh-Minh Ribler - Oct, 2006
 //--------------------------------------------------------------------------
 DataSet::DataSet(const H5Location &loc, const void *ref, H5R_type_t ref_type, const PropList &plist)
     : H5Object(), AbstractDs(), id(H5I_INVALID_HID)
@@ -121,7 +116,6 @@ DataSet::DataSet(const H5Location &loc, const void *ref, H5R_type_t ref_type, co
 ///\param       ref_type - IN: Reference type - default to H5R_OBJECT
 ///\param       plist - IN: Property list - default to PropList::DEFAULT
 ///\exception   H5::ReferenceException
-// Programmer   Binh-Minh Ribler - Oct, 2006
 //--------------------------------------------------------------------------
 DataSet::DataSet(const Attribute &attr, const void *ref, H5R_type_t ref_type, const PropList &plist)
     : H5Object(), AbstractDs(), id(H5I_INVALID_HID)
@@ -134,7 +128,6 @@ DataSet::DataSet(const Attribute &attr, const void *ref, H5R_type_t ref_type, co
 ///\brief       Gets a copy of the dataspace of this dataset.
 ///\return      DataSpace instance
 ///\exception   H5::DataSetIException
-// Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
 DataSpace
 DataSet::getSpace() const
@@ -171,7 +164,6 @@ DataSet::p_get_type() const
 ///\brief       Gets the dataset creation property list.
 ///\return      DSetCreatPropList instance
 ///\exception   H5::DataSetIException
-// Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
 DSetCreatPropList
 DataSet::getCreatePlist() const
@@ -215,7 +207,6 @@ DataSet::getAccessPlist() const
 ///\exception   H5::DataSetIException
 // Note:        H5Dget_storage_size returns 0 when there is no data.  This
 //              function should have no failure. (from SLU)
-// Programmer   Binh-Minh Ribler - Mar, 2005
 //--------------------------------------------------------------------------
 hsize_t
 DataSet::getStorageSize() const
@@ -229,7 +220,6 @@ DataSet::getStorageSize() const
 ///\brief       Gets the size in memory of the dataset's data.
 ///\return      Size of data (in memory)
 ///\exception   H5::DataSetIException
-// Programmer   Binh-Minh Ribler - Apr 2009
 //--------------------------------------------------------------------------
 size_t
 DataSet::getInMemDataSize() const
@@ -287,7 +277,6 @@ DataSet::getInMemDataSize() const
 ///\brief       Returns the address of this dataset in the file.
 ///\return      Address of dataset
 ///\exception   H5::DataSetIException
-// Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
 haddr_t
 DataSet::getOffset() const
@@ -306,7 +295,6 @@ DataSet::getOffset() const
 ///\brief       Determines whether space has been allocated for a dataset.
 ///\param       status - OUT: Space allocation status
 ///\exception   H5::DataSetIException
-// Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
 void
 DataSet::getSpaceStatus(H5D_space_status_t &status) const
@@ -324,7 +312,6 @@ DataSet::getSpaceStatus(H5D_space_status_t &status) const
 ///\param       space - IN: Selection for the memory buffer
 ///\return      Amount of storage
 ///\exception   H5::DataSetIException
-// Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
 hsize_t
 DataSet::getVlenBufSize(const DataType &type, const DataSpace &space) const
@@ -349,7 +336,6 @@ DataSet::getVlenBufSize(const DataType &type, const DataSpace &space) const
 //              misses const's.  This wrapper will be removed in future release.
 // Return       Amount of storage
 // Exception    H5::DataSetIException
-// Programmer   Binh-Minh Ribler - 2000
 // Modification
 //              Modified to call its replacement. -BMR, 2014/04/16
 //              Removed from documentation. -BMR, 2016/03/07 1.8.17 and 1.10.0
@@ -369,7 +355,6 @@ DataSet::getVlenBufSize(const DataType &type, const DataSpace &space) const
 ///\param       xfer_plist - IN: Property list used to create the buffer
 ///\param       buf - IN: Pointer to the buffer to be reclaimed
 ///\exception   H5::DataSetIException
-// Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
 void
 DataSet::vlenReclaim(const DataType &type, const DataSpace &space, const DSetMemXferPropList &xfer_plist,
@@ -395,7 +380,6 @@ DataSet::vlenReclaim(const DataType &type, const DataSpace &space, const DSetMem
 ///\param       xfer_plist - IN: Property list used to create the buffer
 ///\param       buf - IN: Pointer to the buffer to be reclaimed
 ///\exception   H5::DataSetIException
-// Programmer   Binh-Minh Ribler - 2000
 //\parDescription
 //              This function has better prototype for the users than the
 //              other, which might be removed at some point. BMR - 2006/12/20
@@ -428,7 +412,6 @@ DataSet::vlenReclaim(void *buf, const DataType &type, const DataSpace &space,
 ///             This function reads raw data from this dataset into the
 ///             buffer \a buf, converting from file datatype and dataspace
 ///             to memory datatype \a mem_type and dataspace \a mem_space.
-// Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
 void
 DataSet::read(void *buf, const DataType &mem_type, const DataSpace &mem_space, const DataSpace &file_space,
@@ -456,7 +439,6 @@ DataSet::read(void *buf, const DataType &mem_type, const DataSpace &mem_space, c
 ///\param       file_space - IN: Dataset's dataspace in the file
 ///\param       xfer_plist - IN: Transfer property list for this I/O operation
 ///\exception   H5::DataSetIException
-// Programmer   Binh-Minh Ribler - 2000
 // Modification
 //      Jul 2009
 //              Follow the change to Attribute::read and use the following
@@ -505,7 +487,6 @@ DataSet::read(H5std_string &strg, const DataType &mem_type, const DataSpace &mem
 ///             \a buf to a dataset, converting from memory datatype
 ///             \a mem_type and dataspace \a mem_space to file datatype
 ///             and dataspace.
-// Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
 void
 DataSet::write(const void *buf, const DataType &mem_type, const DataSpace &mem_space,
@@ -527,7 +508,6 @@ DataSet::write(const void *buf, const DataType &mem_type, const DataSpace &mem_s
 // Function:    DataSet::write
 ///\brief       This is an overloaded member function, provided for convenience.
 ///             It takes a reference to a \c H5std_string for the buffer.
-// Programmer   Binh-Minh Ribler - 2000
 // Modification
 //      Jul 2009
 //              Modified to pass the buffer into H5Dwrite properly depending
@@ -583,7 +563,6 @@ DataSet::write(const H5std_string &strg, const DataType &mem_type, const DataSpa
 ///\exception   H5::DataSetIException
 ///\note        This function may not work correctly yet - it's still
 ///             under development.
-// Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
 int
 DataSet::iterateElems(void *buf, const DataType &type, const DataSpace &space, H5D_operator_t op,
@@ -609,7 +588,6 @@ DataSet::iterateElems(void *buf, const DataType &type, const DataSpace &space, H
 ///\par Description
 ///             For information, please refer to the H5Dset_extent API in
 ///             the HDF5 C Reference Manual.
-// Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
 void
 DataSet::extend(const hsize_t *size) const
@@ -628,7 +606,6 @@ DataSet::extend(const hsize_t *size) const
 ///\param       buf_type - IN: Datatype of the elements in buffer
 ///\param       space - IN: Dataspace describing memory buffer & containing selection to use
 ///\exception   H5::DataSetIException
-// Programmer   Binh-Minh Ribler - 2014
 //--------------------------------------------------------------------------
 void
 DataSet::fillMemBuf(const void *fill, const DataType &fill_type, void *buf, const DataType &buf_type,
@@ -654,7 +631,6 @@ DataSet::fillMemBuf(const void *fill, const DataType &fill_type, void *buf, cons
 // Param        buf_type - IN: Datatype of the elements in buffer
 // Param        space - IN: Dataspace describing memory buffer & containing selection to use
 // Exception    H5::DataSetIException
-// Programmer   Binh-Minh Ribler - 2000
 // Modification
 //              Modified to call its replacement. -BMR, 2014/04/16
 //              Removed from documentation. -BMR, 2016/03/07 1.8.17 and 1.10.0
@@ -673,7 +649,6 @@ DataSet::fillMemBuf(const void *fill, const DataType &fill_type, void *buf, cons
 ///\param       buf_type - IN: Datatype of the elements in buffer
 ///\param       space - IN: Dataspace describing memory buffer & containing selection to use
 ///\exception   H5::DataSetIException
-// Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
 void
 DataSet::fillMemBuf(void *buf, const DataType &buf_type, const DataSpace &space) const
@@ -695,7 +670,6 @@ DataSet::fillMemBuf(void *buf, const DataType &buf_type, const DataSpace &space)
 // Param        buf_type - IN: Datatype of the elements in buffer
 // Param        space - IN: Dataspace describing memory buffer & containing selection to use
 // Exception    H5::DataSetIException
-// Programmer   Binh-Minh Ribler - 2000
 // Modification
 //              Modified to call its replacement. -BMR, 2014/04/16
 //              Removed from documentation. -BMR, 2016/03/07 1.8.17 and 1.10.0
@@ -715,7 +689,6 @@ DataSet::fillMemBuf(void *buf, const DataType &buf_type, const DataSpace &space)
 //              AbstractDs and Attribute are moved out of H5Object.  In
 //              addition, member IdComponent::id is moved into subclasses, and
 //              IdComponent::getId now becomes pure virtual function.
-// Programmer   Binh-Minh Ribler - May, 2008
 //--------------------------------------------------------------------------
 hid_t
 DataSet::getId() const
@@ -725,11 +698,10 @@ DataSet::getId() const
 
 //--------------------------------------------------------------------------
 // Function:    DataSet::p_read_fixed_len (private)
-// brief       Reads a fixed length \a H5std_string from a dataset.
-// param       mem_type  - IN: DataSet datatype (in memory)
-// param       strg      - IN: Buffer for read string
-// exception   H5::DataSetIException
-// Programmer   Binh-Minh Ribler - Jul, 2009
+// brief        Reads a fixed length \a H5std_string from a dataset.
+// param        mem_type  - IN: DataSet datatype (in memory)
+// param        strg      - IN: Buffer for read string
+// exceptio n   H5::DataSetIException
 // Modification
 //      Jul 2009
 //              Added in follow to the change in Attribute::read
@@ -763,11 +735,10 @@ DataSet::p_read_fixed_len(const hid_t mem_type_id, const hid_t mem_space_id, con
 
 //--------------------------------------------------------------------------
 // Function:    DataSet::p_read_variable_len (private)
-// brief       Reads a variable length \a H5std_string from an dataset.
-// param       mem_type  - IN: DataSet datatype (in memory)
-// param       strg      - IN: Buffer for read string
-// exception   H5::DataSetIException
-// Programmer   Binh-Minh Ribler - Jul, 2009
+// brief        Reads a variable length \a H5std_string from an dataset.
+// param        mem_type  - IN: DataSet datatype (in memory)
+// param        strg      - IN: Buffer for read string
+// exception    H5::DataSetIException
 // Modification
 //      Jul 2009
 //              Added in follow to the change in Attribute::read
@@ -802,7 +773,6 @@ DataSet::p_read_variable_len(const hid_t mem_type_id, const hid_t mem_space_id, 
 //              The underlaying reference counting in the C library ensures
 //              that the current valid id of this object is properly closed.
 //              Then the object's id is reset to the new id.
-// Programmer   Binh-Minh Ribler - 2000
 //--------------------------------------------------------------------------
 void
 DataSet::p_setId(const hid_t new_id)
@@ -826,7 +796,6 @@ DataSet::p_setId(const hid_t new_id)
 //              Applications shouldn't need to use it.
 // param        dset   - IN/OUT: DataSet object to be changed
 // param        new_id - IN: New id to set
-// Programmer   Binh-Minh Ribler - 2015
 //--------------------------------------------------------------------------
 void
 f_PropList_setId(PropList *plist, hid_t new_id)
@@ -841,7 +810,6 @@ f_PropList_setId(PropList *plist, hid_t new_id)
 ///\brief       Closes this dataset.
 ///
 ///\exception   H5::DataSetIException
-// Programmer   Binh-Minh Ribler - Mar 9, 2005
 //--------------------------------------------------------------------------
 void
 DataSet::close()
@@ -859,7 +827,6 @@ DataSet::close()
 //--------------------------------------------------------------------------
 // Function:    DataSet destructor
 ///\brief       Properly terminates access to this dataset.
-// Programmer   Binh-Minh Ribler - 2000
 // Modification
 //              - Replaced resetIdComponent() with decRefCount() to use C
 //              library ID reference counting mechanism - BMR, Jun 1, 2004

--- a/c++/src/H5DataSet.cpp
+++ b/c++/src/H5DataSet.cpp
@@ -85,16 +85,10 @@ DataSet::DataSet(const DataSet &original) : H5Object(), AbstractDs(), id(origina
 DataSet &
 DataSet::operator=(const DataSet &original)
 {
-    // Wrap the changes to `*this` by an incremented reference count for
-    // `original` to prevent trouble in the case that `*this` and
-    // `original` share reference counts or memory in any relevant
-    // sense.
-    original.incRefCount();
-    decRefCount(); // for old value of id
-    id = original.id;
-    incRefCount(); // for new value of id
-    original.decRefCount();
-    return *this;
+    if (this != &original) {
+        setId(original.id);
+    }
+    return (*this);
 }
 
 //--------------------------------------------------------------------------

--- a/c++/src/H5DataSet.cpp
+++ b/c++/src/H5DataSet.cpp
@@ -77,6 +77,27 @@ DataSet::DataSet(const DataSet &original) : H5Object(), AbstractDs(), id(origina
 }
 
 //--------------------------------------------------------------------------
+// Function:    DataSet assignment operator
+///\brief       Assignment operator: same HDF5 object as \a original
+///\param       original - IN: DataSet instance to copy
+// Programmer   Lee Newberg - 2021
+//--------------------------------------------------------------------------
+DataSet &
+DataSet::operator=(const DataSet &original)
+{
+    // Wrap the changes to `*this` by an incremented reference count for
+    // `original` to prevent trouble in the case that `*this` and
+    // `original` share reference counts or memory in any relevant
+    // sense.
+    original.incRefCount();
+    decRefCount(); // for old value of id
+    id = original.id;
+    incRefCount(); // for new value of id
+    original.decRefCount();
+    return *this;
+}
+
+//--------------------------------------------------------------------------
 // Function:    DataSet overload constructor - dereference
 ///\brief       Given a reference, ref, to an hdf5 location, creates a
 ///             DataSet object

--- a/c++/src/H5DataSet.h
+++ b/c++/src/H5DataSet.h
@@ -117,6 +117,9 @@ class H5_DLLCPP DataSet : public H5Object, public AbstractDs {
     // Copy constructor - same as the original DataSet.
     DataSet(const DataSet &original);
 
+    // Assignment operator
+    DataSet &operator=(const DataSet &original);
+
     // Creates a copy of an existing DataSet using its id.
     DataSet(const hid_t existing_id);
 

--- a/c++/test/dsets.cpp
+++ b/c++/test/dsets.cpp
@@ -1326,9 +1326,6 @@ test_operator(H5File &file)
         // Try operator= to make another dataset
         DataSet copied_dataset = another_dataset;
 
-        hid_t copied_dataset_id  = copied_dataset.getId();
-        hid_t another_dataset_id = another_dataset.getId();
-
         H5std_string copied_dataset_name  = copied_dataset.getObjName();
         H5std_string another_dataset_name = another_dataset.getObjName();
 

--- a/c++/test/dsets.cpp
+++ b/c++/test/dsets.cpp
@@ -1326,10 +1326,10 @@ test_operator(H5File &file)
         // Try operator= to make another dataset
         DataSet copied_dataset = another_dataset;
 
-        hid_t copied_dataset_id = copied_dataset.getId();
+        hid_t copied_dataset_id  = copied_dataset.getId();
         hid_t another_dataset_id = another_dataset.getId();
 
-        H5std_string copied_dataset_name = copied_dataset.getObjName();
+        H5std_string copied_dataset_name  = copied_dataset.getObjName();
         H5std_string another_dataset_name = another_dataset.getObjName();
 
         PASSED();
@@ -1344,7 +1344,6 @@ test_operator(H5File &file)
         return -1;
     }
 } // test_operator
-
 
 /*-------------------------------------------------------------------------
  * Function:    test_dset

--- a/c++/test/dsets.cpp
+++ b/c++/test/dsets.cpp
@@ -42,6 +42,8 @@ const H5std_string DSET_SIMPLE_IO_NAME("simple_io");
 const H5std_string DSET_TCONV_NAME("tconv");
 const H5std_string DSET_COMPRESS_NAME("compressed");
 const H5std_string DSET_BOGUS_NAME("bogus");
+const H5std_string DSET_OPERATOR("testing operator=");
+const H5std_string DSET_OPERATOR_PATH("/testing operator=");
 
 /* Temporary filter IDs used for testing */
 const int H5Z_FILTER_BOGUS = 305;
@@ -58,9 +60,6 @@ static size_t filter_bogus(unsigned int flags, size_t cd_nelmts, const unsigned 
  * Return       Success: 0
  *
  *              Failure: -1
- *
- * Programmer   Binh-Minh Ribler (using C version)
- *              Friday, January 5, 2001
  *-------------------------------------------------------------------------
  */
 static herr_t
@@ -182,9 +181,6 @@ test_create(H5File &file)
  * Return       Success: 0
  *
  *              Failure: -1
- *
- * Programmer   Binh-Minh Ribler (using C version)
- *              Friday, January 5, 2001
  *-------------------------------------------------------------------------
  */
 static herr_t
@@ -260,9 +256,6 @@ test_simple_io(H5File &file)
  * Return       Success: 0
  *
  *              Failure: -1
- *
- * Programmer   Binh-Minh Ribler
- *              Thursday, March 22, 2012
  *-------------------------------------------------------------------------
  */
 static herr_t
@@ -322,9 +315,6 @@ test_datasize(FileAccPropList &fapl)
  * Return       Success: 0
  *
  *              Failure: -1
- *
- * Programmer   Binh-Minh Ribler (using C version)
- *              Friday, January 5, 2001
  *-------------------------------------------------------------------------
  */
 static herr_t
@@ -432,9 +422,6 @@ filter_bogus(unsigned int flags, size_t cd_nelmts, const unsigned int cd_values[
  * Return       Success: 0
  *
  *              Failure: -1
- *
- * Programmer   Binh-Minh Ribler (using C version)
- *              Friday, January 5, 2001
  *-------------------------------------------------------------------------
  */
 static herr_t
@@ -703,10 +690,6 @@ test_compression(H5File &file)
  * Return       Success: 0
  *
  *              Failure: -1
- *
- * Programmer   Binh-Minh Ribler
- *              Friday, April 22, 2016
- *
  *-------------------------------------------------------------------------
  */
 const H5std_string DSET_NBIT_NAME("nbit_dataset");
@@ -818,9 +801,6 @@ test_nbit_compression(H5File &file)
  * Return       Success: 0
  *
  *              Failure: -1
- *
- * Programmer   Binh-Minh Ribler (using C version)
- *              Saturday, February 17, 2001
  *-------------------------------------------------------------------------
  */
 static herr_t
@@ -893,9 +873,6 @@ test_multiopen(H5File &file)
  * Return       Success: 0
  *
  *              Failure: -1
- *
- * Programmer   Binh-Minh Ribler (using C version)
- *              February 17, 2001
  *-------------------------------------------------------------------------
  */
 static herr_t
@@ -1246,10 +1223,6 @@ test_chunk_cache(const FileAccPropList &fapl)
  *
  * Return       Success:        0
  *              Failure:        number of errors
- *
- * Programmer   Binh-Minh Ribler
- *              Friday, March 10, 2017
- *
  *-------------------------------------------------------------------------
  */
 const int RANK = 2;
@@ -1316,6 +1289,64 @@ test_virtual()
 } // test_virtual
 
 /*-------------------------------------------------------------------------
+ * Function:    test_operator
+ *
+ * Purpose      Tests DataSet::operator=
+ *
+ * Return       Success: 0
+ *
+ *              Failure: -1
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+test_operator(H5File &file)
+{
+    SUBTEST("DataSet::operator=");
+
+    try {
+        // Create a data space
+        hsize_t dims[2];
+        dims[0] = 256;
+        dims[1] = 512;
+        DataSpace space(2, dims, NULL);
+
+        // Create a dataset using the default dataset creation properties.
+        // We're not sure what they are, so we won't check.
+        DataSet dataset = file.createDataSet(DSET_OPERATOR, PredType::NATIVE_DOUBLE, space);
+
+        // Add a comment to the dataset
+        file.setComment(DSET_OPERATOR, "Dataset using operator=");
+
+        // Close the dataset
+        dataset.close();
+
+        // Re-open the dataset
+        DataSet another_dataset(file.openDataSet(DSET_OPERATOR));
+
+        // Try operator= to make another dataset
+        DataSet copied_dataset = another_dataset;
+
+        hid_t copied_dataset_id = copied_dataset.getId();
+        hid_t another_dataset_id = another_dataset.getId();
+
+        H5std_string copied_dataset_name = copied_dataset.getObjName();
+        H5std_string another_dataset_name = another_dataset.getObjName();
+
+        PASSED();
+        return 0;
+    } // try block
+
+    // catch all other exceptions
+    catch (Exception &E) {
+        issue_fail_msg("test_operator", __LINE__, __FILE__);
+
+        // clean up and return with failure
+        return -1;
+    }
+} // test_operator
+
+
+/*-------------------------------------------------------------------------
  * Function:    test_dset
  *
  * Purpose      Tests the dataset interface (H5D)
@@ -1323,9 +1354,6 @@ test_virtual()
  * Return       Success: 0
  *
  *              Failure: -1
- *
- * Programmer   Binh-Minh Ribler (using C version)
- *              Friday, January 5, 2001
  *
  * Modifications:
  *        Nov 12, 01:
@@ -1364,6 +1392,7 @@ test_dset()
         nerrors += test_multiopen(file) < 0 ? 1 : 0;
         nerrors += test_types(file) < 0 ? 1 : 0;
         nerrors += test_virtual() < 0 ? 1 : 0;
+        nerrors += test_operator(file) < 0 ? 1 : 0;
         nerrors += test_chunk_cache(fapl) < 0 ? 1 : 0;
 
         // Close group "emit diagnostics".

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -1062,7 +1062,12 @@ Bug Fixes since HDF5-1.12.0 release
 
     C++ APIs
     --------
-    -
+    - Added DataSet::operator=
+
+        Some compilers complain if the copy constructor is given explicitly
+        but the assignment operator is implicitly set to default.
+
+        (2021/05/19)
 
 
     Testing


### PR DESCRIPTION
* Some compilers complain if the copy constructor is given explicitly but the assignment operator is implicitly set to default.
* Explicitly defining the assignment operator allows us to properly handle reference counters for shared resources.
