### PR TITLE
DO NOT MERGE: Example of using tagged unions for VOL

### DIFF
--- a/src/H5Gdeprec.c
+++ b/src/H5Gdeprec.c
@@ -307,7 +307,7 @@ herr_t
 H5Glink(hid_t cur_loc_id, H5G_link_t type, const char *cur_name, const char *new_name)
 {
     H5VL_link_create_args_t create_args;
-    herr_t ret_value = SUCCEED; /* Return value */
+    herr_t                  ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
     H5TRACE4("e", "iLl*s*s", cur_loc_id, type, cur_name, new_name);
@@ -348,7 +348,7 @@ H5Glink(hid_t cur_loc_id, H5G_link_t type, const char *cur_name, const char *new
 
         /* Setup link creation arguments */
         create_args.hard.vol_obj_data = vol_obj->data;
-        create_args.hard.loc_params = &loc_params1;
+        create_args.hard.loc_params   = &loc_params1;
 
         /* Create the link through the VOL */
         if (H5VL_link_create(H5VL_LINK_CREATE_HARD, &create_args, &tmp_vol_obj, &loc_params2,
@@ -373,8 +373,9 @@ H5Glink(hid_t cur_loc_id, H5G_link_t type, const char *cur_name, const char *new
         create_args.soft.link_target = cur_name;
 
         /* Create the link through the VOL */
-        if (H5VL_link_create(H5VL_LINK_CREATE_SOFT, &create_args, vol_obj, &loc_params, H5P_LINK_CREATE_DEFAULT,
-                             H5P_LINK_ACCESS_DEFAULT, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL) < 0)
+        if (H5VL_link_create(H5VL_LINK_CREATE_SOFT, &create_args, vol_obj, &loc_params,
+                             H5P_LINK_CREATE_DEFAULT, H5P_LINK_ACCESS_DEFAULT, H5P_DATASET_XFER_DEFAULT,
+                             H5_REQUEST_NULL) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_CANTINIT, FAIL, "unable to create link")
     } /* end else-if */
     else
@@ -396,7 +397,7 @@ herr_t
 H5Glink2(hid_t cur_loc_id, const char *cur_name, H5G_link_t type, hid_t new_loc_id, const char *new_name)
 {
     H5VL_link_create_args_t create_args;
-    herr_t ret_value = SUCCEED; /* Return value */
+    herr_t                  ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
     H5TRACE5("e", "i*sLli*s", cur_loc_id, cur_name, type, new_loc_id, new_name);
@@ -436,11 +437,12 @@ H5Glink2(hid_t cur_loc_id, const char *cur_name, H5G_link_t type, hid_t new_loc_
 
         /* Setup link creation arguments */
         create_args.hard.vol_obj_data = vol_obj1->data;
-        create_args.hard.loc_params = &loc_params1;
+        create_args.hard.loc_params   = &loc_params1;
 
         /* Create the link through the VOL */
-        if (H5VL_link_create(H5VL_LINK_CREATE_HARD, &create_args, vol_obj2, &loc_params2, H5P_LINK_CREATE_DEFAULT,
-                             H5P_LINK_ACCESS_DEFAULT, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL) < 0)
+        if (H5VL_link_create(H5VL_LINK_CREATE_HARD, &create_args, vol_obj2, &loc_params2,
+                             H5P_LINK_CREATE_DEFAULT, H5P_LINK_ACCESS_DEFAULT, H5P_DATASET_XFER_DEFAULT,
+                             H5_REQUEST_NULL) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_CANTINIT, FAIL, "unable to create link")
     } /* end if */
     else if (type == H5L_TYPE_SOFT) {
@@ -465,8 +467,9 @@ H5Glink2(hid_t cur_loc_id, const char *cur_name, H5G_link_t type, hid_t new_loc_
         create_args.soft.link_target = cur_name;
 
         /* Create the link through the VOL */
-        if (H5VL_link_create(H5VL_LINK_CREATE_SOFT, &create_args, vol_obj, &loc_params, H5P_LINK_CREATE_DEFAULT,
-                             H5P_LINK_ACCESS_DEFAULT, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL) < 0)
+        if (H5VL_link_create(H5VL_LINK_CREATE_SOFT, &create_args, vol_obj, &loc_params,
+                             H5P_LINK_CREATE_DEFAULT, H5P_LINK_ACCESS_DEFAULT, H5P_DATASET_XFER_DEFAULT,
+                             H5_REQUEST_NULL) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_CANTINIT, FAIL, "unable to create link")
     } /* end else-if */
     else

--- a/src/H5Gdeprec.c
+++ b/src/H5Gdeprec.c
@@ -306,6 +306,7 @@ done:
 herr_t
 H5Glink(hid_t cur_loc_id, H5G_link_t type, const char *cur_name, const char *new_name)
 {
+    H5VL_link_create_args_t create_args;
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -345,10 +346,14 @@ H5Glink(hid_t cur_loc_id, H5G_link_t type, const char *cur_name, const char *new
         tmp_vol_obj.data      = NULL;
         tmp_vol_obj.connector = vol_obj->connector;
 
+        /* Setup link creation arguments */
+        create_args.hard.vol_obj_data = vol_obj->data;
+        create_args.hard.loc_params = &loc_params1;
+
         /* Create the link through the VOL */
-        if (H5VL_link_create(H5VL_LINK_CREATE_HARD, &tmp_vol_obj, &loc_params2, H5P_LINK_CREATE_DEFAULT,
-                             H5P_LINK_ACCESS_DEFAULT, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL,
-                             vol_obj->data, &loc_params1) < 0)
+        if (H5VL_link_create(H5VL_LINK_CREATE_HARD, &create_args, &tmp_vol_obj, &loc_params2,
+                             H5P_LINK_CREATE_DEFAULT, H5P_LINK_ACCESS_DEFAULT, H5P_DATASET_XFER_DEFAULT,
+                             H5_REQUEST_NULL) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_CANTINIT, FAIL, "unable to create link")
     } /* end if */
     else if (type == H5L_TYPE_SOFT) {
@@ -364,10 +369,12 @@ H5Glink(hid_t cur_loc_id, H5G_link_t type, const char *cur_name, const char *new
         if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(cur_loc_id)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier")
 
+        /* Setup link creation arguments */
+        create_args.soft.link_target = cur_name;
+
         /* Create the link through the VOL */
-        if (H5VL_link_create(H5VL_LINK_CREATE_SOFT, vol_obj, &loc_params, H5P_LINK_CREATE_DEFAULT,
-                             H5P_LINK_ACCESS_DEFAULT, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL,
-                             cur_name) < 0)
+        if (H5VL_link_create(H5VL_LINK_CREATE_SOFT, &create_args, vol_obj, &loc_params, H5P_LINK_CREATE_DEFAULT,
+                             H5P_LINK_ACCESS_DEFAULT, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_CANTINIT, FAIL, "unable to create link")
     } /* end else-if */
     else
@@ -388,6 +395,7 @@ done:
 herr_t
 H5Glink2(hid_t cur_loc_id, const char *cur_name, H5G_link_t type, hid_t new_loc_id, const char *new_name)
 {
+    H5VL_link_create_args_t create_args;
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -426,10 +434,13 @@ H5Glink2(hid_t cur_loc_id, const char *cur_name, H5G_link_t type, hid_t new_loc_
         if (NULL == (vol_obj2 = (H5VL_object_t *)H5I_object(new_loc_id)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier")
 
+        /* Setup link creation arguments */
+        create_args.hard.vol_obj_data = vol_obj1->data;
+        create_args.hard.loc_params = &loc_params1;
+
         /* Create the link through the VOL */
-        if (H5VL_link_create(H5VL_LINK_CREATE_HARD, vol_obj2, &loc_params2, H5P_LINK_CREATE_DEFAULT,
-                             H5P_LINK_ACCESS_DEFAULT, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL,
-                             vol_obj1->data, &loc_params1) < 0)
+        if (H5VL_link_create(H5VL_LINK_CREATE_HARD, &create_args, vol_obj2, &loc_params2, H5P_LINK_CREATE_DEFAULT,
+                             H5P_LINK_ACCESS_DEFAULT, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_CANTINIT, FAIL, "unable to create link")
     } /* end if */
     else if (type == H5L_TYPE_SOFT) {
@@ -450,10 +461,12 @@ H5Glink2(hid_t cur_loc_id, const char *cur_name, H5G_link_t type, hid_t new_loc_
         if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(new_loc_id)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier")
 
+        /* Setup link creation arguments */
+        create_args.soft.link_target = cur_name;
+
         /* Create the link through the VOL */
-        if (H5VL_link_create(H5VL_LINK_CREATE_SOFT, vol_obj, &loc_params, H5P_LINK_CREATE_DEFAULT,
-                             H5P_LINK_ACCESS_DEFAULT, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL,
-                             cur_name) < 0)
+        if (H5VL_link_create(H5VL_LINK_CREATE_SOFT, &create_args, vol_obj, &loc_params, H5P_LINK_CREATE_DEFAULT,
+                             H5P_LINK_ACCESS_DEFAULT, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_CANTINIT, FAIL, "unable to create link")
     } /* end else-if */
     else

--- a/src/H5L.c
+++ b/src/H5L.c
@@ -452,8 +452,8 @@ H5L__create_soft_api_common(const char *link_target, hid_t link_loc_id, const ch
                             hid_t lapl_id, void **token_ptr, H5VL_object_t **_vol_obj_ptr)
 {
     H5VL_link_create_args_t create_args;
-    H5VL_object_t * tmp_vol_obj = NULL; /* Object for loc_id */
-    H5VL_object_t **vol_obj_ptr =
+    H5VL_object_t *         tmp_vol_obj = NULL; /* Object for loc_id */
+    H5VL_object_t **        vol_obj_ptr =
         (_vol_obj_ptr ? _vol_obj_ptr : &tmp_vol_obj); /* Ptr to object ptr for loc_id */
     H5VL_loc_params_t loc_params;                     /* Location parameters for object access */
     herr_t            ret_value = SUCCEED;            /* Return value */
@@ -491,8 +491,8 @@ H5L__create_soft_api_common(const char *link_target, hid_t link_loc_id, const ch
     create_args.soft.link_target = link_target;
 
     /* Create the link */
-    if (H5VL_link_create(H5VL_LINK_CREATE_SOFT, &create_args, *vol_obj_ptr, &loc_params,
-                         lcpl_id, lapl_id, H5P_DATASET_XFER_DEFAULT, token_ptr) < 0)
+    if (H5VL_link_create(H5VL_LINK_CREATE_SOFT, &create_args, *vol_obj_ptr, &loc_params, lcpl_id, lapl_id,
+                         H5P_DATASET_XFER_DEFAULT, token_ptr) < 0)
         HGOTO_ERROR(H5E_LINK, H5E_CANTCREATE, FAIL, "unable to create soft link")
 
 done:
@@ -591,11 +591,11 @@ H5L__create_hard_api_common(hid_t cur_loc_id, const char *cur_name, hid_t new_lo
                             hid_t lcpl_id, hid_t lapl_id, void **token_ptr, H5VL_object_t **_vol_obj_ptr)
 {
     H5VL_link_create_args_t create_args;
-    H5VL_object_t * vol_obj1 = NULL;                /* Object of cur_loc_id */
-    H5VL_object_t * vol_obj2 = NULL;                /* Object of new_loc_id */
-    H5VL_object_t   tmp_vol_obj;                    /* Temporary object */
-    H5VL_object_t * tmp_vol_obj_ptr = &tmp_vol_obj; /* Ptr to temporary object */
-    H5VL_object_t **tmp_vol_obj_ptr_ptr =
+    H5VL_object_t *         vol_obj1 = NULL;                /* Object of cur_loc_id */
+    H5VL_object_t *         vol_obj2 = NULL;                /* Object of new_loc_id */
+    H5VL_object_t           tmp_vol_obj;                    /* Temporary object */
+    H5VL_object_t *         tmp_vol_obj_ptr = &tmp_vol_obj; /* Ptr to temporary object */
+    H5VL_object_t **        tmp_vol_obj_ptr_ptr =
         (_vol_obj_ptr ? _vol_obj_ptr : &tmp_vol_obj_ptr); /* Ptr to ptr to temporary object */
     H5VL_loc_params_t loc_params1;         /* Location parameters for cur_loc_id object access */
     H5VL_loc_params_t loc_params2;         /* Location parameters for new_loc_id object access */
@@ -660,12 +660,11 @@ H5L__create_hard_api_common(hid_t cur_loc_id, const char *cur_name, hid_t new_lo
 
     /* Setup link creation arguments */
     create_args.hard.vol_obj_data = (vol_obj1 ? vol_obj1->data : NULL);
-    create_args.hard.loc_params = &loc_params1;
+    create_args.hard.loc_params   = &loc_params1;
 
     /* Create the link */
-    if (H5VL_link_create(H5VL_LINK_CREATE_HARD, &create_args, *tmp_vol_obj_ptr_ptr,
-                         &loc_params2, lcpl_id, lapl_id, H5P_DATASET_XFER_DEFAULT,
-                         token_ptr) < 0)
+    if (H5VL_link_create(H5VL_LINK_CREATE_HARD, &create_args, *tmp_vol_obj_ptr_ptr, &loc_params2, lcpl_id,
+                         lapl_id, H5P_DATASET_XFER_DEFAULT, token_ptr) < 0)
         HGOTO_ERROR(H5E_LINK, H5E_CANTCREATE, FAIL, "unable to create hard link")
 
 done:
@@ -782,16 +781,16 @@ H5Lcreate_external(const char *file_name, const char *obj_name, hid_t link_loc_i
                    hid_t lcpl_id, hid_t lapl_id)
 {
     H5VL_link_create_args_t create_args;
-    H5VL_object_t *   vol_obj = NULL; /* Object of loc_id */
-    H5VL_loc_params_t loc_params;
-    char *            norm_obj_name = NULL; /* Pointer to normalized current name */
-    void *            ext_link_buf  = NULL; /* Buffer to contain external link */
-    size_t            buf_size;             /* Size of buffer to hold external link */
-    size_t            file_name_len;        /* Length of file name string */
-    size_t            norm_obj_name_len;    /* Length of normalized object name string */
-    uint8_t *         p;                    /* Pointer into external link buffer */
-    H5L_type_t        link_type = H5L_TYPE_EXTERNAL;
-    herr_t            ret_value = SUCCEED; /* Return value */
+    H5VL_object_t *         vol_obj = NULL; /* Object of loc_id */
+    H5VL_loc_params_t       loc_params;
+    char *                  norm_obj_name = NULL; /* Pointer to normalized current name */
+    void *                  ext_link_buf  = NULL; /* Buffer to contain external link */
+    size_t                  buf_size;             /* Size of buffer to hold external link */
+    size_t                  file_name_len;        /* Length of file name string */
+    size_t                  norm_obj_name_len;    /* Length of normalized object name string */
+    uint8_t *               p;                    /* Pointer into external link buffer */
+    H5L_type_t              link_type = H5L_TYPE_EXTERNAL;
+    herr_t                  ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
     H5TRACE6("e", "*s*si*sii", file_name, obj_name, link_loc_id, link_name, lcpl_id, lapl_id);
@@ -843,13 +842,13 @@ H5Lcreate_external(const char *file_name, const char *obj_name, hid_t link_loc_i
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid object identifier")
 
     /* Setup link creation arguments */
-    create_args.ud.link_type = link_type;
-    create_args.ud.udata = ext_link_buf;
+    create_args.ud.link_type  = link_type;
+    create_args.ud.udata      = ext_link_buf;
     create_args.ud.udata_size = buf_size;
 
     /* Create an external link */
-    if (H5VL_link_create(H5VL_LINK_CREATE_UD, &create_args, vol_obj, &loc_params, lcpl_id,
-                         lapl_id, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL) < 0)
+    if (H5VL_link_create(H5VL_LINK_CREATE_UD, &create_args, vol_obj, &loc_params, lcpl_id, lapl_id,
+                         H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL) < 0)
         HGOTO_ERROR(H5E_LINK, H5E_CANTINIT, FAIL, "unable to create external link")
 
 done:
@@ -888,9 +887,9 @@ H5Lcreate_ud(hid_t link_loc_id, const char *link_name, H5L_type_t link_type, con
              size_t udata_size, hid_t lcpl_id, hid_t lapl_id)
 {
     H5VL_link_create_args_t create_args;
-    H5VL_object_t *   vol_obj = NULL; /* Object of loc_id */
-    H5VL_loc_params_t loc_params;
-    herr_t            ret_value = SUCCEED; /* Return value */
+    H5VL_object_t *         vol_obj = NULL; /* Object of loc_id */
+    H5VL_loc_params_t       loc_params;
+    herr_t                  ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
     H5TRACE7("e", "i*sLl*xzii", link_loc_id, link_name, link_type, udata, udata_size, lcpl_id, lapl_id);
@@ -924,8 +923,8 @@ H5Lcreate_ud(hid_t link_loc_id, const char *link_name, H5L_type_t link_type, con
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier")
 
     /* Setup link creation arguments */
-    create_args.ud.link_type = link_type;
-    create_args.ud.udata = udata;
+    create_args.ud.link_type  = link_type;
+    create_args.ud.udata      = udata;
     create_args.ud.udata_size = udata_size;
 
     /* Create external link */

--- a/src/H5O.c
+++ b/src/H5O.c
@@ -830,12 +830,12 @@ herr_t
 H5Olink(hid_t obj_id, hid_t new_loc_id, const char *new_name, hid_t lcpl_id, hid_t lapl_id)
 {
     H5VL_link_create_args_t create_args;
-    H5VL_object_t *   vol_obj1 = NULL; /* object of obj_id */
-    H5VL_object_t *   vol_obj2 = NULL; /* object of new_loc_id */
-    H5VL_object_t     tmp_vol_obj;     /* Temporary object */
-    H5VL_loc_params_t loc_params1;
-    H5VL_loc_params_t loc_params2;
-    herr_t            ret_value = SUCCEED; /* Return value */
+    H5VL_object_t *         vol_obj1 = NULL; /* object of obj_id */
+    H5VL_object_t *         vol_obj2 = NULL; /* object of new_loc_id */
+    H5VL_object_t           tmp_vol_obj;     /* Temporary object */
+    H5VL_loc_params_t       loc_params1;
+    H5VL_loc_params_t       loc_params2;
+    herr_t                  ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
     H5TRACE5("e", "ii*sii", obj_id, new_loc_id, new_name, lcpl_id, lapl_id);
@@ -894,11 +894,11 @@ H5Olink(hid_t obj_id, hid_t new_loc_id, const char *new_name, hid_t lcpl_id, hid
 
     /* Setup link creation arguments */
     create_args.hard.vol_obj_data = vol_obj1->data;
-    create_args.hard.loc_params = &loc_params1;
+    create_args.hard.loc_params   = &loc_params1;
 
     /* Create a link to the object */
-    if (H5VL_link_create(H5VL_LINK_CREATE_HARD, &create_args, &tmp_vol_obj, &loc_params2, lcpl_id,
-                         lapl_id, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL) < 0)
+    if (H5VL_link_create(H5VL_LINK_CREATE_HARD, &create_args, &tmp_vol_obj, &loc_params2, lcpl_id, lapl_id,
+                         H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL) < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTCREATE, FAIL, "unable to create link")
 
 done:

--- a/src/H5O.c
+++ b/src/H5O.c
@@ -829,6 +829,7 @@ done:
 herr_t
 H5Olink(hid_t obj_id, hid_t new_loc_id, const char *new_name, hid_t lcpl_id, hid_t lapl_id)
 {
+    H5VL_link_create_args_t create_args;
     H5VL_object_t *   vol_obj1 = NULL; /* object of obj_id */
     H5VL_object_t *   vol_obj2 = NULL; /* object of new_loc_id */
     H5VL_object_t     tmp_vol_obj;     /* Temporary object */
@@ -891,9 +892,13 @@ H5Olink(hid_t obj_id, hid_t new_loc_id, const char *new_name, hid_t lcpl_id, hid
     tmp_vol_obj.data      = vol_obj2->data;
     tmp_vol_obj.connector = (vol_obj1 != NULL ? vol_obj1->connector : vol_obj2->connector);
 
+    /* Setup link creation arguments */
+    create_args.hard.vol_obj_data = vol_obj1->data;
+    create_args.hard.loc_params = &loc_params1;
+
     /* Create a link to the object */
-    if (H5VL_link_create(H5VL_LINK_CREATE_HARD, &tmp_vol_obj, &loc_params2, lcpl_id, lapl_id,
-                         H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL, vol_obj1->data, &loc_params1) < 0)
+    if (H5VL_link_create(H5VL_LINK_CREATE_HARD, &create_args, &tmp_vol_obj, &loc_params2, lcpl_id,
+                         lapl_id, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL) < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTCREATE, FAIL, "unable to create link")
 
 done:

--- a/src/H5VLcallback.c
+++ b/src/H5VLcallback.c
@@ -133,9 +133,10 @@ static herr_t H5VL__group_specific(void *obj, const H5VL_class_t *cls, H5VL_grou
 static herr_t H5VL__group_optional(void *obj, const H5VL_class_t *cls, H5VL_group_optional_t opt_type,
                                    hid_t dxpl_id, void **req, va_list arguments);
 static herr_t H5VL__group_close(void *obj, const H5VL_class_t *cls, hid_t dxpl_id, void **req);
-static herr_t H5VL__link_create(H5VL_link_create_type_t create_type, const H5VL_link_create_args_t *create_args,
-                                void *obj, const H5VL_loc_params_t *loc_params, const H5VL_class_t *cls,
-                                hid_t lcpl_id, hid_t lapl_id, hid_t dxpl_id, void **req);
+static herr_t H5VL__link_create(H5VL_link_create_type_t        create_type,
+                                const H5VL_link_create_args_t *create_args, void *obj,
+                                const H5VL_loc_params_t *loc_params, const H5VL_class_t *cls, hid_t lcpl_id,
+                                hid_t lapl_id, hid_t dxpl_id, void **req);
 static herr_t H5VL__link_copy(void *src_obj, const H5VL_loc_params_t *loc_params1, void *dst_obj,
                               const H5VL_loc_params_t *loc_params2, const H5VL_class_t *cls, hid_t lcpl_id,
                               hid_t lapl_id, hid_t dxpl_id, void **req);
@@ -4672,9 +4673,9 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5VL__link_create(H5VL_link_create_type_t create_type, const H5VL_link_create_args_t *create_args,
-                  void *obj, const H5VL_loc_params_t *loc_params, const H5VL_class_t *cls,
-                  hid_t lcpl_id, hid_t lapl_id, hid_t dxpl_id, void **req)
+H5VL__link_create(H5VL_link_create_type_t create_type, const H5VL_link_create_args_t *create_args, void *obj,
+                  const H5VL_loc_params_t *loc_params, const H5VL_class_t *cls, hid_t lcpl_id, hid_t lapl_id,
+                  hid_t dxpl_id, void **req)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
@@ -4754,9 +4755,9 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VLlink_create(H5VL_link_create_type_t create_type, const H5VL_link_create_args_t *create_args,
-                void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id, hid_t lcpl_id,
-                hid_t lapl_id, hid_t dxpl_id, void **req /*out*/)
+H5VLlink_create(H5VL_link_create_type_t create_type, const H5VL_link_create_args_t *create_args, void *obj,
+                const H5VL_loc_params_t *loc_params, hid_t connector_id, hid_t lcpl_id, hid_t lapl_id,
+                hid_t dxpl_id, void **req /*out*/)
 {
     H5VL_class_t *cls;                 /* VOL connector's class struct */
     herr_t        ret_value = SUCCEED; /* Return value */

--- a/src/H5VLconnector.h
+++ b/src/H5VLconnector.h
@@ -195,7 +195,7 @@ typedef enum H5VL_link_create_type_t {
 typedef union H5VL_link_create_args_t {
     struct {
         H5VL_loc_params_t *loc_params;
-        void *vol_obj_data;
+        void *             vol_obj_data;
     } hard;
 
     struct {
@@ -203,9 +203,9 @@ typedef union H5VL_link_create_args_t {
     } soft;
 
     struct {
-        H5L_type_t link_type;
+        H5L_type_t  link_type;
         const void *udata;
-        size_t udata_size;
+        size_t      udata_size;
     } ud;
 } H5VL_link_create_args_t;
 

--- a/src/H5VLconnector_passthru.h
+++ b/src/H5VLconnector_passthru.h
@@ -161,8 +161,8 @@ H5_DLL herr_t H5VLgroup_close(void *grp, hid_t connector_id, hid_t dxpl_id, void
 
 /* Public wrappers for link callbacks */
 H5_DLL herr_t H5VLlink_create(H5VL_link_create_type_t create_type, const H5VL_link_create_args_t *create_args,
-                              void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id, hid_t lcpl_id,
-                              hid_t lapl_id, hid_t dxpl_id, void **req);
+                              void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id,
+                              hid_t lcpl_id, hid_t lapl_id, hid_t dxpl_id, void **req);
 H5_DLL herr_t H5VLlink_copy(void *src_obj, const H5VL_loc_params_t *loc_params1, void *dst_obj,
                             const H5VL_loc_params_t *loc_params2, hid_t connector_id, hid_t lcpl_id,
                             hid_t lapl_id, hid_t dxpl_id, void **req);

--- a/src/H5VLconnector_passthru.h
+++ b/src/H5VLconnector_passthru.h
@@ -160,9 +160,9 @@ H5_DLL herr_t H5VLgroup_optional(void *obj, hid_t connector_id, H5VL_group_optio
 H5_DLL herr_t H5VLgroup_close(void *grp, hid_t connector_id, hid_t dxpl_id, void **req);
 
 /* Public wrappers for link callbacks */
-H5_DLL herr_t H5VLlink_create(H5VL_link_create_type_t create_type, void *obj,
-                              const H5VL_loc_params_t *loc_params, hid_t connector_id, hid_t lcpl_id,
-                              hid_t lapl_id, hid_t dxpl_id, void **req, va_list arguments);
+H5_DLL herr_t H5VLlink_create(H5VL_link_create_type_t create_type, const H5VL_link_create_args_t *create_args,
+                              void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id, hid_t lcpl_id,
+                              hid_t lapl_id, hid_t dxpl_id, void **req);
 H5_DLL herr_t H5VLlink_copy(void *src_obj, const H5VL_loc_params_t *loc_params1, void *dst_obj,
                             const H5VL_loc_params_t *loc_params2, hid_t connector_id, hid_t lcpl_id,
                             hid_t lapl_id, hid_t dxpl_id, void **req);

--- a/src/H5VLnative_link.c
+++ b/src/H5VLnative_link.c
@@ -39,7 +39,8 @@
 herr_t
 H5VL__native_link_create(H5VL_link_create_type_t create_type, const H5VL_link_create_args_t *create_args,
                          void *obj, const H5VL_loc_params_t *loc_params, hid_t lcpl_id,
-                         hid_t H5_ATTR_UNUSED lapl_id, hid_t H5_ATTR_UNUSED dxpl_id, void H5_ATTR_UNUSED **req)
+                         hid_t H5_ATTR_UNUSED lapl_id, hid_t H5_ATTR_UNUSED dxpl_id,
+                         void H5_ATTR_UNUSED **req)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 

--- a/src/H5VLnative_link.c
+++ b/src/H5VLnative_link.c
@@ -37,9 +37,9 @@
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VL__native_link_create(H5VL_link_create_type_t create_type, void *obj, const H5VL_loc_params_t *loc_params,
-                         hid_t lcpl_id, hid_t H5_ATTR_UNUSED lapl_id, hid_t H5_ATTR_UNUSED dxpl_id,
-                         void H5_ATTR_UNUSED **req, va_list arguments)
+H5VL__native_link_create(H5VL_link_create_type_t create_type, const H5VL_link_create_args_t *create_args,
+                         void *obj, const H5VL_loc_params_t *loc_params, hid_t lcpl_id,
+                         hid_t H5_ATTR_UNUSED lapl_id, hid_t H5_ATTR_UNUSED dxpl_id, void H5_ATTR_UNUSED **req)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
@@ -49,8 +49,8 @@ H5VL__native_link_create(H5VL_link_create_type_t create_type, void *obj, const H
         case H5VL_LINK_CREATE_HARD: {
             H5G_loc_t          cur_loc;
             H5G_loc_t          link_loc;
-            void *             cur_obj    = HDva_arg(arguments, void *);
-            H5VL_loc_params_t *cur_params = HDva_arg(arguments, H5VL_loc_params_t *);
+            void *             cur_obj    = create_args->hard.vol_obj_data;
+            H5VL_loc_params_t *cur_params = create_args->hard.loc_params;
 
             if (NULL != cur_obj && H5G_loc_real(cur_obj, cur_params->obj_type, &cur_loc) < 0)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file or file object")
@@ -87,7 +87,7 @@ H5VL__native_link_create(H5VL_link_create_type_t create_type, void *obj, const H
         }
 
         case H5VL_LINK_CREATE_SOFT: {
-            char *    target_name = HDva_arg(arguments, char *);
+            char *    target_name = create_args->soft.link_target;
             H5G_loc_t link_loc; /* Group location for new link */
 
             if (H5G_loc_real(obj, loc_params->obj_type, &link_loc) < 0)
@@ -102,9 +102,9 @@ H5VL__native_link_create(H5VL_link_create_type_t create_type, void *obj, const H
 
         case H5VL_LINK_CREATE_UD: {
             H5G_loc_t  link_loc; /* Group location for new link */
-            H5L_type_t link_type  = (H5L_type_t)HDva_arg(arguments, int);
-            void *     udata      = HDva_arg(arguments, void *);
-            size_t     udata_size = HDva_arg(arguments, size_t);
+            H5L_type_t link_type  = create_args->ud.link_type;
+            void *     udata      = create_args->ud.udata;
+            size_t     udata_size = create_args->ud.udata_size;
 
             if (H5G_loc_real(obj, loc_params->obj_type, &link_loc) < 0)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file or file object")

--- a/src/H5VLnative_private.h
+++ b/src/H5VLnative_private.h
@@ -116,8 +116,9 @@ H5_DLL herr_t H5VL__native_group_optional(void *obj, H5VL_group_optional_t opt_t
 H5_DLL herr_t H5VL__native_group_close(void *grp, hid_t dxpl_id, void **req);
 
 /* Link callbacks */
-H5_DLL herr_t H5VL__native_link_create(H5VL_link_create_type_t create_type, const H5VL_link_create_args_t *create_args,
-                                       void *obj, const H5VL_loc_params_t *loc_params, hid_t lcpl_id, hid_t lapl_id,
+H5_DLL herr_t H5VL__native_link_create(H5VL_link_create_type_t        create_type,
+                                       const H5VL_link_create_args_t *create_args, void *obj,
+                                       const H5VL_loc_params_t *loc_params, hid_t lcpl_id, hid_t lapl_id,
                                        hid_t dxpl_id, void **req);
 H5_DLL herr_t H5VL__native_link_copy(void *src_obj, const H5VL_loc_params_t *loc_params1, void *dst_obj,
                                      const H5VL_loc_params_t *loc_params2, hid_t lcpl_id, hid_t lapl_id,

--- a/src/H5VLnative_private.h
+++ b/src/H5VLnative_private.h
@@ -116,9 +116,9 @@ H5_DLL herr_t H5VL__native_group_optional(void *obj, H5VL_group_optional_t opt_t
 H5_DLL herr_t H5VL__native_group_close(void *grp, hid_t dxpl_id, void **req);
 
 /* Link callbacks */
-H5_DLL herr_t H5VL__native_link_create(H5VL_link_create_type_t create_type, void *obj,
-                                       const H5VL_loc_params_t *loc_params, hid_t lcpl_id, hid_t lapl_id,
-                                       hid_t dxpl_id, void **req, va_list arguments);
+H5_DLL herr_t H5VL__native_link_create(H5VL_link_create_type_t create_type, const H5VL_link_create_args_t *create_args,
+                                       void *obj, const H5VL_loc_params_t *loc_params, hid_t lcpl_id, hid_t lapl_id,
+                                       hid_t dxpl_id, void **req);
 H5_DLL herr_t H5VL__native_link_copy(void *src_obj, const H5VL_loc_params_t *loc_params1, void *dst_obj,
                                      const H5VL_loc_params_t *loc_params2, hid_t lcpl_id, hid_t lapl_id,
                                      hid_t dxpl_id, void **req);

--- a/src/H5VLpassthru.c
+++ b/src/H5VLpassthru.c
@@ -77,11 +77,11 @@ typedef struct H5VL_pass_through_wrap_ctx_t {
 /********************* */
 
 /* Helper routines */
-static herr_t H5VL_pass_through_file_specific_reissue(void *obj, hid_t connector_id,
-                                                      H5VL_file_specific_t specific_type, hid_t dxpl_id,
-                                                      void **req, ...);
-static herr_t H5VL_pass_through_request_specific_reissue(void *obj, hid_t connector_id,
-                                                         H5VL_request_specific_t specific_type, ...);
+static herr_t               H5VL_pass_through_file_specific_reissue(void *obj, hid_t connector_id,
+                                                                    H5VL_file_specific_t specific_type, hid_t dxpl_id,
+                                                                    void **req, ...);
+static herr_t               H5VL_pass_through_request_specific_reissue(void *obj, hid_t connector_id,
+                                                                       H5VL_request_specific_t specific_type, ...);
 static H5VL_pass_through_t *H5VL_pass_through_new_obj(void *under_obj, hid_t under_vol_id);
 static herr_t               H5VL_pass_through_free_obj(H5VL_pass_through_t *obj);
 
@@ -183,8 +183,9 @@ static herr_t H5VL_pass_through_group_optional(void *obj, H5VL_group_optional_t 
 static herr_t H5VL_pass_through_group_close(void *grp, hid_t dxpl_id, void **req);
 
 /* Link callbacks */
-static herr_t H5VL_pass_through_link_create(H5VL_link_create_type_t create_type, const H5VL_link_create_args_t *create_args,
-                                            void *obj, const H5VL_loc_params_t *loc_params, hid_t lcpl_id, hid_t lapl_id,
+static herr_t H5VL_pass_through_link_create(H5VL_link_create_type_t        create_type,
+                                            const H5VL_link_create_args_t *create_args, void *obj,
+                                            const H5VL_loc_params_t *loc_params, hid_t lcpl_id, hid_t lapl_id,
                                             hid_t dxpl_id, void **req);
 static herr_t H5VL_pass_through_link_copy(void *src_obj, const H5VL_loc_params_t *loc_params1, void *dst_obj,
                                           const H5VL_loc_params_t *loc_params2, hid_t lcpl_id, hid_t lapl_id,
@@ -2164,11 +2165,11 @@ H5VL_pass_through_link_create(H5VL_link_create_type_t create_type, const H5VL_li
                               void *obj, const H5VL_loc_params_t *loc_params, hid_t lcpl_id, hid_t lapl_id,
                               hid_t dxpl_id, void **req)
 {
-    H5VL_pass_through_t *o            = (H5VL_pass_through_t *)obj;
+    H5VL_pass_through_t *   o = (H5VL_pass_through_t *)obj;
     H5VL_link_create_args_t new_create_args;
-    hbool_t              use_new_args = false;
-    hid_t                under_vol_id = -1;
-    herr_t               ret_value;
+    hbool_t                 use_new_args = false;
+    hid_t                   under_vol_id = -1;
+    herr_t                  ret_value;
 
 #ifdef ENABLE_PASSTHRU_LOGGING
     printf("------- PASS THROUGH VOL LINK Create\n");
@@ -2180,7 +2181,7 @@ H5VL_pass_through_link_create(H5VL_link_create_type_t create_type, const H5VL_li
 
     /* Fix up the link target object for hard link creation */
     if (H5VL_LINK_CREATE_HARD == create_type) {
-        void *             cur_obj;
+        void *cur_obj;
 
         /* Retrieve the object & loc params for the link target */
         cur_obj = create_args->hard.vol_obj_data;
@@ -2199,12 +2200,12 @@ H5VL_pass_through_link_create(H5VL_link_create_type_t create_type, const H5VL_li
 
             use_new_args = true;
         } /* end if */
-    } /* end if */
+    }     /* end if */
 
     /* Re-issue 'link create' call */
     ret_value = H5VLlink_create(create_type, use_new_args ? &new_create_args : create_args,
-                               (o ? o->under_object : NULL), loc_params, under_vol_id,
-                               lcpl_id, lapl_id, dxpl_id, req);
+                                (o ? o->under_object : NULL), loc_params, under_vol_id, lcpl_id, lapl_id,
+                                dxpl_id, req);
 
     /* Check for async request */
     if (req && *req)

--- a/src/H5VLprivate.h
+++ b/src/H5VLprivate.h
@@ -224,9 +224,10 @@ H5_DLL herr_t H5VL_group_optional(const H5VL_object_t *vol_obj, H5VL_group_optio
 H5_DLL herr_t H5VL_group_close(const H5VL_object_t *vol_obj, hid_t dxpl_id, void **req);
 
 /* Link functions */
-H5_DLL herr_t H5VL_link_create(H5VL_link_create_type_t create_type, const H5VL_link_create_args_t *create_args,
-                               const H5VL_object_t *vol_obj, const H5VL_loc_params_t *loc_params, hid_t lcpl_id,
-                               hid_t lapl_id, hid_t dxpl_id, void **req);
+H5_DLL herr_t H5VL_link_create(H5VL_link_create_type_t        create_type,
+                               const H5VL_link_create_args_t *create_args, const H5VL_object_t *vol_obj,
+                               const H5VL_loc_params_t *loc_params, hid_t lcpl_id, hid_t lapl_id,
+                               hid_t dxpl_id, void **req);
 H5_DLL herr_t H5VL_link_copy(const H5VL_object_t *src_vol_obj, const H5VL_loc_params_t *loc_params1,
                              const H5VL_object_t *dst_vol_obj, const H5VL_loc_params_t *loc_params2,
                              hid_t lcpl_id, hid_t lapl_id, hid_t dxpl_id, void **req);

--- a/src/H5VLprivate.h
+++ b/src/H5VLprivate.h
@@ -224,9 +224,9 @@ H5_DLL herr_t H5VL_group_optional(const H5VL_object_t *vol_obj, H5VL_group_optio
 H5_DLL herr_t H5VL_group_close(const H5VL_object_t *vol_obj, hid_t dxpl_id, void **req);
 
 /* Link functions */
-H5_DLL herr_t H5VL_link_create(H5VL_link_create_type_t create_type, const H5VL_object_t *vol_obj,
-                               const H5VL_loc_params_t *loc_params, hid_t lcpl_id, hid_t lapl_id,
-                               hid_t dxpl_id, void **req, ...);
+H5_DLL herr_t H5VL_link_create(H5VL_link_create_type_t create_type, const H5VL_link_create_args_t *create_args,
+                               const H5VL_object_t *vol_obj, const H5VL_loc_params_t *loc_params, hid_t lcpl_id,
+                               hid_t lapl_id, hid_t dxpl_id, void **req);
 H5_DLL herr_t H5VL_link_copy(const H5VL_object_t *src_vol_obj, const H5VL_loc_params_t *loc_params1,
                              const H5VL_object_t *dst_vol_obj, const H5VL_loc_params_t *loc_params2,
                              hid_t lcpl_id, hid_t lapl_id, hid_t dxpl_id, void **req);


### PR DESCRIPTION
This PR is intended to spark discussion around using tagged unions instead of var. args for all non-optional VOL infrastructure. My reasoning is:

- All non-optional VOL callback functions that currently accept a va_list are already accompanied by a "tag" for a union, e.g. "link get" has H5VL_link_get_t
- All of the non-optional VOL callbacks currently use a fixed, small amount of known arguments, which are just as easy to pass with a union. They are also just as easy to unpack and can sometimes be easier.
- Using a union eliminates the need for passthrough connectors to deal with var. args completely, except for the case of "optional" operations, where I think it makes sense to keep them, as the arguments to be passed will be arbitrary and generally outside of THG's control. If passthrough connectors don't need to modify any arguments, they will be able to directly pass them through to the reissuing call. If they do need to modify them, they can simply take a copy of the arguments with a struct assignment to a local struct, modify them, and pass the local struct through to the same reissuing call.
- Many HDF5 operations can still be added to these unions without making them unreadably large; each operation's arguments can be put in a separate struct that gets included in the union.
- Might be more peformant than variadic functions - only loosely based on https://blog.nelhage.com/2010/10/amd64-and-va_arg/ and other research