### PR TITLE
Add selection I/O to chunk code

### DIFF
--- a/src/H5.c
+++ b/src/H5.c
@@ -83,6 +83,8 @@ hbool_t H5_libinit_g = FALSE; /* Library hasn't been initialized */
 hbool_t H5_libterm_g = FALSE; /* Library isn't being shutdown */
 #endif
 
+hbool_t H5_use_selection_io_g = FALSE;
+
 #ifdef H5_HAVE_MPE
 hbool_t H5_MPEinit_g = FALSE; /* MPE Library hasn't been initialized */
 #endif

--- a/src/H5FDprivate.h
+++ b/src/H5FDprivate.h
@@ -141,7 +141,7 @@ H5_DLL herr_t  H5FD_read_selection(H5FD_t *file, uint32_t count, H5FD_mem_t type
                                    void *bufs[] /* out */);
 H5_DLL herr_t  H5FD_write_selection(H5FD_t *file, uint32_t count, H5FD_mem_t type, H5S_t *mem_spaces[],
                                     H5S_t *file_spaces[], haddr_t offsets[], size_t element_sizes[],
-                                    const void *bufs[] /* out */);
+                                    const void *bufs[]);
 H5_DLL herr_t  H5FD_flush(H5FD_t *file, hbool_t closing);
 H5_DLL herr_t  H5FD_truncate(H5FD_t *file, hbool_t closing);
 H5_DLL herr_t  H5FD_lock(H5FD_t *file, hbool_t rw);

--- a/src/H5FScache.c
+++ b/src/H5FScache.c
@@ -1005,10 +1005,10 @@ H5FS__cache_sinfo_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED l
     if (fspace->serial_sect_count > 0) {
         hsize_t old_tot_sect_count; /* Total section count from header */
         hsize_t H5_ATTR_NDEBUG_UNUSED
-            old_serial_sect_count;                          /* Total serializable section count from header */
-        hsize_t H5_ATTR_NDEBUG_UNUSED old_ghost_sect_count; /* Total ghost section count from header */
-        hsize_t H5_ATTR_NDEBUG_UNUSED old_tot_space;        /* Total space managed from header */
-        unsigned                      sect_cnt_size;        /* The size of the section size counts */
+                                      old_serial_sect_count; /* Total serializable section count from header */
+        hsize_t H5_ATTR_NDEBUG_UNUSED old_ghost_sect_count;  /* Total ghost section count from header */
+        hsize_t H5_ATTR_NDEBUG_UNUSED old_tot_space;         /* Total space managed from header */
+        unsigned                      sect_cnt_size;         /* The size of the section size counts */
 
         /* Compute the size of the section counts */
         sect_cnt_size = H5VM_limit_enc_size((uint64_t)fspace->serial_sect_count);

--- a/src/H5FScache.c
+++ b/src/H5FScache.c
@@ -1005,10 +1005,10 @@ H5FS__cache_sinfo_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED l
     if (fspace->serial_sect_count > 0) {
         hsize_t old_tot_sect_count; /* Total section count from header */
         hsize_t H5_ATTR_NDEBUG_UNUSED
-                                      old_serial_sect_count; /* Total serializable section count from header */
-        hsize_t H5_ATTR_NDEBUG_UNUSED old_ghost_sect_count;  /* Total ghost section count from header */
-        hsize_t H5_ATTR_NDEBUG_UNUSED old_tot_space;         /* Total space managed from header */
-        unsigned                      sect_cnt_size;         /* The size of the section size counts */
+            old_serial_sect_count;                          /* Total serializable section count from header */
+        hsize_t H5_ATTR_NDEBUG_UNUSED old_ghost_sect_count; /* Total ghost section count from header */
+        hsize_t H5_ATTR_NDEBUG_UNUSED old_tot_space;        /* Total space managed from header */
+        unsigned                      sect_cnt_size;        /* The size of the section size counts */
 
         /* Compute the size of the section counts */
         sect_cnt_size = H5VM_limit_enc_size((uint64_t)fspace->serial_sect_count);

--- a/src/H5Fio.c
+++ b/src/H5Fio.c
@@ -233,10 +233,100 @@ H5F_block_write(H5F_t *f, H5FD_mem_t type, haddr_t addr, size_t size, const void
     /* Pass through page buffer layer */
     if (H5PB_write(f->shared, map_type, addr, size, buf) < 0)
         HGOTO_ERROR(H5E_IO, H5E_WRITEERROR, FAIL, "write through page buffer failed")
-
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5F_block_write() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5F_shared_select_read
+ *
+ * Purpose:     Reads some data from a file/server/etc into a buffer.
+ *              The location of the data is defined by the mem_spaces and
+ *              file_spaces dataspace arrays, along with the offsets
+ *              array.  The addresses is relative to the base address for
+ *              the file.
+ *
+ * Return:      Non-negative on success/Negative on failure
+ *
+ * Programmer:  Neil Fortner
+ *              May 3 2021
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5F_shared_select_read(H5F_shared_t *f_sh, uint32_t count, H5FD_mem_t type, H5S_t *mem_spaces[],
+                       H5S_t *file_spaces[], haddr_t offsets[], size_t element_sizes[],
+                       void *bufs[] /* out */)
+{
+    H5FD_mem_t map_type;            /* Mapped memory type */
+    herr_t     ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    /* Sanity checks */
+    HDassert(f_sh);
+    HDassert((mem_spaces) || (count == 0));
+    HDassert((file_spaces) || (count == 0));
+    HDassert((offsets) || (count == 0));
+    HDassert((element_sizes) || (count == 0));
+    HDassert((bufs) || (count == 0));
+
+    /* Treat global heap as raw data */
+    map_type = (type == H5FD_MEM_GHEAP) ? H5FD_MEM_DRAW : type;
+
+    /* Pass down to file driver layer (bypass page buffer for now) */
+    if (H5FD_read_selection(f_sh->lf, count, map_type, mem_spaces, file_spaces, offsets, element_sizes,
+                            bufs) < 0)
+        HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "selection read through file driver failed")
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5F_shared_select_read() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5F_shared_select_write
+ *
+ * Purpose:     Writes some data from a buffer to a file/server/etc.
+ *              The location of the data is defined by the mem_spaces and
+ *              file_spaces dataspace arrays, along with the offsets
+ *              array.  The addresses is relative to the base address for
+ *              the file.
+ *
+ * Return:      Non-negative on success/Negative on failure
+ *
+ * Programmer:  Neil Fortner
+ *              May 4 2021
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5F_shared_select_write(H5F_shared_t *f_sh, uint32_t count, H5FD_mem_t type, H5S_t *mem_spaces[],
+                        H5S_t *file_spaces[], haddr_t offsets[], size_t element_sizes[], const void *bufs[])
+{
+    H5FD_mem_t map_type;            /* Mapped memory type */
+    herr_t     ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    /* Sanity checks */
+    HDassert(f_sh);
+    HDassert((mem_spaces) || (count == 0));
+    HDassert((file_spaces) || (count == 0));
+    HDassert((offsets) || (count == 0));
+    HDassert((element_sizes) || (count == 0));
+    HDassert((bufs) || (count == 0));
+
+    /* Treat global heap as raw data */
+    map_type = (type == H5FD_MEM_GHEAP) ? H5FD_MEM_DRAW : type;
+
+    /* Pass down to file driver layer (bypass page buffer for now) */
+    if (H5FD_write_selection(f_sh->lf, count, map_type, mem_spaces, file_spaces, offsets, element_sizes,
+                             bufs) < 0)
+        HGOTO_ERROR(H5E_IO, H5E_WRITEERROR, FAIL, "selection write through file driver failed")
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5F_shared_select_write() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5F_flush_tagged_metadata

--- a/src/H5Fprivate.h
+++ b/src/H5Fprivate.h
@@ -759,6 +759,7 @@ struct H5O_loc_t;
 struct H5HG_heap_t;
 struct H5VL_class_t;
 struct H5P_genplist_t;
+struct H5S_t;
 
 /* Forward declarations for anonymous H5F objects */
 
@@ -920,6 +921,14 @@ H5_DLL herr_t H5F_block_read(H5F_t *f, H5FD_mem_t type, haddr_t addr, size_t siz
 H5_DLL herr_t H5F_shared_block_write(H5F_shared_t *f_sh, H5FD_mem_t type, haddr_t addr, size_t size,
                                      const void *buf);
 H5_DLL herr_t H5F_block_write(H5F_t *f, H5FD_mem_t type, haddr_t addr, size_t size, const void *buf);
+
+/* Functions that operate on selections of elements in the file */
+H5_DLL herr_t H5F_shared_select_read(H5F_shared_t *f_sh, uint32_t count, H5FD_mem_t type,
+                                     struct H5S_t *mem_spaces[], struct H5S_t *file_spaces[],
+                                     haddr_t offsets[], size_t element_sizes[], void *bufs[] /* out */);
+H5_DLL herr_t H5F_shared_select_write(H5F_shared_t *f_sh, uint32_t count, H5FD_mem_t type,
+                                      struct H5S_t *mem_spaces[], struct H5S_t *file_spaces[],
+                                      haddr_t offsets[], size_t element_sizes[], const void *bufs[]);
 
 /* Functions that flush or evict */
 H5_DLL herr_t H5F_flush_tagged_metadata(H5F_t *f, haddr_t tag);

--- a/src/H5PBprivate.h
+++ b/src/H5PBprivate.h
@@ -91,6 +91,7 @@ H5_DLL herr_t H5PB_update_entry(H5PB_t *page_buf, haddr_t addr, size_t size, con
 H5_DLL herr_t H5PB_remove_entry(const H5F_shared_t *f_sh, haddr_t addr);
 H5_DLL herr_t H5PB_read(H5F_shared_t *f_sh, H5FD_mem_t type, haddr_t addr, size_t size, void *buf /*out*/);
 H5_DLL herr_t H5PB_write(H5F_shared_t *f_sh, H5FD_mem_t type, haddr_t addr, size_t size, const void *buf);
+H5_DLL htri_t H5PB_enabled(H5F_shared_t *f_sh, H5FD_mem_t type);
 
 /* Statistics routines */
 H5_DLL herr_t H5PB_reset_stats(H5PB_t *page_buf);

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -2125,6 +2125,11 @@ extern hbool_t H5_libterm_g; /* Is the library being shutdown? */
 
 #endif /* H5_HAVE_THREADSAFE */
 
+/* Extern global to determine if we shoudl use selection I/O if available (this
+ * variable should be removed once selection I/O performs as well as the
+ * previous scalar I/O implementation */
+extern hbool_t H5_use_selection_io_g;
+
 #ifdef H5_HAVE_CODESTACK
 
 /* Include required function stack header */


### PR DESCRIPTION
Used when: not using chunk cache, no datatype conversion, no I/O filters, no page buffer, not using collective
I/O.  Requires global variable H5_use_selection_io_g be set to TRUE.
Also implemented selection to vector I/O translation at the file driver
layer.