### PR TITLE
Fix H5Eget_auto2/H5Eauto_is_v2 to not clear error stack

### DIFF
--- a/src/H5E.c
+++ b/src/H5E.c
@@ -245,6 +245,20 @@ H5E_term_package(void)
         nstk = H5I_nmembers(H5I_ERROR_STACK);
 
         if ((ncls + nmsg + nstk) > 0) {
+            /* Clear the default error stack. Note that
+             * the following H5I_clear_type calls do not
+             * force the clears and will not be able to
+             * clear any error message IDs that are still
+             * in use by the default error stack unless we
+             * clear that stack manually.
+             *
+             * Error message IDs will typically still be
+             * in use by the default error stack when the
+             * application does H5E_BEGIN/END_TRY cleanup
+             * at the very end.
+             */
+            H5E_clear_stack(NULL);
+
             /* Clear any outstanding error stacks */
             if (nstk > 0)
                 (void)H5I_clear_type(H5I_ERROR_STACK, FALSE, FALSE);
@@ -1532,7 +1546,8 @@ H5Eget_auto2(hid_t estack_id, H5E_auto2_t *func /*out*/, void **client_data /*ou
     H5E_auto_op_t op;                  /* Error stack function */
     herr_t        ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_API(FAIL)
+    /* Don't clear the error stack! :-) */
+    FUNC_ENTER_API_NOCLEAR(FAIL)
     H5TRACE3("e", "ixx", estack_id, func, client_data);
 
     if (estack_id == H5E_DEFAULT) {
@@ -1540,8 +1555,13 @@ H5Eget_auto2(hid_t estack_id, H5E_auto2_t *func /*out*/, void **client_data /*ou
                                                        non-threaded case */
             HGOTO_ERROR(H5E_ERROR, H5E_CANTGET, FAIL, "can't get current error stack")
     } /* end if */
-    else if (NULL == (estack = (H5E_t *)H5I_object_verify(estack_id, H5I_ERROR_STACK)))
-        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a error stack ID")
+    else {
+        /* Only clear the error stack if it's not the default stack */
+        H5E_clear_stack(NULL);
+
+        if (NULL == (estack = (H5E_t *)H5I_object_verify(estack_id, H5I_ERROR_STACK)))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a error stack ID")
+    } /* end else */
 
     /* Get the automatic error reporting information */
     if (H5E__get_auto(estack, &op, client_data) < 0)
@@ -1598,8 +1618,13 @@ H5Eset_auto2(hid_t estack_id, H5E_auto2_t func, void *client_data)
                                                        non-threaded case */
             HGOTO_ERROR(H5E_ERROR, H5E_CANTGET, FAIL, "can't get current error stack")
     } /* end if */
-    else if (NULL == (estack = (H5E_t *)H5I_object_verify(estack_id, H5I_ERROR_STACK)))
-        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a error stack ID")
+    else {
+        /* Only clear the error stack if it's not the default stack */
+        H5E_clear_stack(NULL);
+
+        if (NULL == (estack = (H5E_t *)H5I_object_verify(estack_id, H5I_ERROR_STACK)))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a error stack ID")
+    } /* end else */
 
 #ifndef H5_NO_DEPRECATED_SYMBOLS
     /* Get the automatic error reporting information */
@@ -1646,7 +1671,8 @@ H5Eauto_is_v2(hid_t estack_id, unsigned *is_stack)
     H5E_t *estack;              /* Error stack to operate on */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_API(FAIL)
+    /* Don't clear the error stack! :-) */
+    FUNC_ENTER_API_NOCLEAR(FAIL)
     H5TRACE2("e", "i*Iu", estack_id, is_stack);
 
     if (estack_id == H5E_DEFAULT) {
@@ -1654,8 +1680,13 @@ H5Eauto_is_v2(hid_t estack_id, unsigned *is_stack)
                                                        non-threaded case */
             HGOTO_ERROR(H5E_ERROR, H5E_CANTGET, FAIL, "can't get current error stack")
     } /* end if */
-    else if (NULL == (estack = (H5E_t *)H5I_object_verify(estack_id, H5I_ERROR_STACK)))
-        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a error stack ID")
+    else {
+        /* Only clear the error stack if it's not the default stack */
+        H5E_clear_stack(NULL);
+
+        if (NULL == (estack = (H5E_t *)H5I_object_verify(estack_id, H5I_ERROR_STACK)))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a error stack ID")
+    } /* end else */
 
     /* Check if the error stack reporting function is the "newer" stack type */
     if (is_stack)

--- a/test/testfiles/err_compat_1
+++ b/test/testfiles/err_compat_1
@@ -40,7 +40,19 @@ HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
         minor: Unable to create file
 
 ********* Print error stack in customized way *********
-    error #000: (file name) in H5Eget_auto(1 or 2)(): line (number)
+    error #000: (file name) in H5VL_vol_object(): line (number)
+        major: Invalid arguments to routine
+        minor: Inappropriate type
+    error #001: (file name) in H5VL_setup_acc_args(): line (number)
+        major: Invalid arguments to routine
+        minor: Inappropriate type
+    error #002: (file name) in H5D__create_api_common(): line (number)
+        major: Dataset
+        minor: Can't set value
+    error #003: (file name) in H5Dcreate2(): line (number)
+        major: Dataset
+        minor: Unable to create file
+    error #004: (file name) in H5Eget_auto(1 or 2)(): line (number)
         major: Error API
         minor: Can't get value
 


### PR DESCRIPTION
Split this change out of VFD plugin PR. These changes fix an issue where information might be lost from the error stack under certain circumstances.

The fact that H5Eget_auto2/H5Eauto_is_v2 clear the error stack seems a little weird to me, especially considering that H5Eset_auto2 does not clear the error stack. It seems like things may have been engineered this way so that the H5Eset_auto2 call in H5E_END_TRY does not clear errors from what's inside the H5E_BEGIN/END_TRY block, but then you realize that any following H5E_BEGIN/END_TRY block will clear that anyway. Since H5Eget_auto2/H5Eauto_is_v2 are just "checking" things, it makes sense to me that they shouldn't clear the error stack.