### PR TITLE
Revert addition of & to 2 parameters in DSetCreatPropList::setVirtual

### DIFF
--- a/c++/src/H5DcreatProp.cpp
+++ b/c++/src/H5DcreatProp.cpp
@@ -775,8 +775,8 @@ DSetCreatPropList::setVirtual(const DataSpace &vspace, const char *src_fname, co
 // Programmer   Binh-Minh Ribler - Mar, 2017
 //--------------------------------------------------------------------------
 void
-DSetCreatPropList::setVirtual(const DataSpace &vspace, const H5std_string &src_fname,
-                              const H5std_string &src_dsname, const DataSpace &sspace) const
+DSetCreatPropList::setVirtual(const DataSpace &vspace, const H5std_string src_fname,
+                              const H5std_string src_dsname, const DataSpace &sspace) const
 {
     setVirtual(vspace, src_fname.c_str(), src_dsname.c_str(), sspace);
 }

--- a/c++/src/H5DcreatProp.h
+++ b/c++/src/H5DcreatProp.h
@@ -123,7 +123,7 @@ class H5_DLLCPP DSetCreatPropList : public ObjCreatPropList {
     // Maps elements of a virtual dataset to elements of the source dataset.
     void setVirtual(const DataSpace &vspace, const char *src_fname, const char *src_dsname,
                     const DataSpace &sspace) const;
-    void setVirtual(const DataSpace &vspace, const H5std_string &src_fname, const H5std_string &src_dsname,
+    void setVirtual(const DataSpace &vspace, const H5std_string src_fname, const H5std_string src_dsname,
                     const DataSpace &sspace) const;
 
     ///\brief Returns this class name.


### PR DESCRIPTION
from PR #448 Various clang tidy warning fixes, to maintain binary
compatibility in hdf5_1_12.