### PR TITLE
Use internal version of H5Eprint2 to avoid possible stack overflow

### DIFF
--- a/src/H5E.c
+++ b/src/H5E.c
@@ -85,6 +85,7 @@ static H5E_t *    H5E__get_current_stack(void);
 static herr_t     H5E__set_current_stack(H5E_t *estack);
 static herr_t     H5E__close_stack(H5E_t *err_stack, void **request);
 static ssize_t    H5E__get_num(const H5E_t *err_stack);
+static herr_t     H5E__print2(hid_t err_stack, FILE *stream);
 static herr_t     H5E__append_stack(H5E_t *dst_estack, const H5E_t *src_stack);
 
 /*********************/
@@ -312,10 +313,10 @@ H5E__set_default_auto(H5E_t *stk)
 #endif /* H5_USE_16_API_DEFAULT */
 
     stk->auto_op.func1 = stk->auto_op.func1_default = (H5E_auto1_t)H5Eprint1;
-    stk->auto_op.func2 = stk->auto_op.func2_default = (H5E_auto2_t)H5Eprint2;
+    stk->auto_op.func2 = stk->auto_op.func2_default = (H5E_auto2_t)H5E__print2;
     stk->auto_op.is_default                         = TRUE;
 #else  /* H5_NO_DEPRECATED_SYMBOLS */
-    stk->auto_op.func2 = (H5E_auto2_t)H5Eprint2;
+    stk->auto_op.func2 = (H5E_auto2_t)H5E__print2;
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
 
     stk->auto_data = NULL;
@@ -1433,12 +1434,36 @@ done:
 herr_t
 H5Eprint2(hid_t err_stack, FILE *stream)
 {
-    H5E_t *estack;              /* Error stack to operate on */
     herr_t ret_value = SUCCEED; /* Return value */
 
     /* Don't clear the error stack! :-) */
     FUNC_ENTER_API_NOCLEAR(FAIL)
     /*NO TRACE*/
+
+    /* Print error stack */
+    if ((ret_value = H5E__print2(err_stack, stream)) < 0)
+        HGOTO_ERROR(H5E_ERROR, H5E_CANTLIST, FAIL, "can't display error stack")
+
+done:
+    FUNC_LEAVE_API(ret_value)
+} /* end H5Eprint2() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5E__print2
+ *
+ * Purpose:     Internal helper routine for H5Eprint2.
+ *
+ * Return:      Non-negative on success/Negative on failure
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5E__print2(hid_t err_stack, FILE *stream)
+{
+    H5E_t *estack;              /* Error stack to operate on */
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_STATIC
 
     /* Need to check for errors */
     if (err_stack == H5E_DEFAULT) {
@@ -1459,8 +1484,8 @@ H5Eprint2(hid_t err_stack, FILE *stream)
         HGOTO_ERROR(H5E_ERROR, H5E_CANTLIST, FAIL, "can't display error stack")
 
 done:
-    FUNC_LEAVE_API(ret_value)
-} /* end H5Eprint2() */
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5E__print2() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5Ewalk2

--- a/test/err_compat.c
+++ b/test/err_compat.c
@@ -238,16 +238,14 @@ test_error1(void)
     if ((space = H5Screate_simple(2, dims, NULL)) < 0)
         TEST_ERROR;
 
-    /* Use H5Eget_auto2 to query the default printing function.  The library
-     *should indicate H5Eprint2 as the default. */
+    /* Use H5Eget_auto2 to query the default printing function. */
     if (H5Eget_auto2(H5E_DEFAULT, &old_func2, &old_data) < 0)
         TEST_ERROR;
     if (old_data != NULL)
         TEST_ERROR;
-    if (!old_func2 || (H5E_auto2_t)H5Eprint2 != old_func2)
+    if (old_func2 == NULL)
         TEST_ERROR;
 
-    /* This function sets the default printing function to be H5Eprint2. */
     if (H5Eset_auto2(H5E_DEFAULT, old_func2, old_data) < 0)
         TEST_ERROR;
 
@@ -292,12 +290,12 @@ test_error1(void)
     if (dataset >= 0)
         TEST_ERROR;
 
-    /* This function changes the new-style printing function back to the default H5Eprint2. */
-    if (H5Eset_auto2(H5E_DEFAULT, (H5E_auto2_t)H5Eprint2, NULL) < 0)
+    /* This function changes the new-style printing function to the original. */
+    if (H5Eset_auto2(H5E_DEFAULT, old_func2, NULL) < 0)
         TEST_ERROR;
 
-    /* This call should work because the H5Eset_auto2 above restored the default printing
-     * function H5Eprint2.  It simply returns user_print1. */
+    /* This call should work because the H5Eset_auto2 above set the default printing
+     * function to H5Eprint2.  It simply returns user_print1. */
     if ((ret = H5Eget_auto1(&old_func1, &old_data)) < 0)
         TEST_ERROR;
     if (old_data != NULL)
@@ -315,7 +313,7 @@ test_error1(void)
         TEST_ERROR;
     if (old_data != NULL)
         TEST_ERROR;
-    if (!old_func2 || (H5E_auto2_t)H5Eprint2 != old_func2)
+    if (old_func2 == NULL)
         TEST_ERROR;
 
     /* Try the printing function. Dataset creation should fail because the file

--- a/test/error_test.c
+++ b/test/error_test.c
@@ -129,7 +129,7 @@ test_error(hid_t file)
         TEST_ERROR;
     if (old_data != NULL)
         TEST_ERROR;
-    if (old_func != (H5E_auto2_t)H5Eprint2)
+    if (old_func == NULL)
         TEST_ERROR;
 
     if (H5Eset_auto2(H5E_DEFAULT, NULL, NULL) < 0)


### PR DESCRIPTION
Looking for feedback on whether this is the right way to go or not. If H5Eprint2 happens to fail, the FUNC_LEAVE_API on the way out will try to print the error stack by calling H5E_dump_api_stack. This will call the error stack's printing function, which is likely to be H5Eprint2. Then, H5Eprint2 will likely fail in the same way again and we've suddenly created a stack overflow. By using an internal non-API version of H5Eprint2 for the library's default printing function, we can at least avoid this chain for most use cases.

The main issue I can see is that if a user happens to manually set H5Eprint2 as the library's default printing function again, the issue can crop up once again. Alternatively, maybe H5Eprint2 should just not use FUNC_ENTER/FUNC_LEAVE macros at all? It seems to serve the dual purpose of being a user API to print the current error stack, as well as serving as the library's default printing function. Perhaps we should have two separate functions, where the user API-level call uses FUNC_ENTER/FUNC_LEAVE and the library callback version does not (or at least does not use FUNC_ENTER_API)?