### PR TITLE
Hdf5 1 12 1 doxygen version correction (#658) and RELEASE.txt updates

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -881,15 +881,22 @@ The following platforms are not supported but have been tested for this release.
     #1 SMP ppc64le GNU/Linux      gcc/7.3
     (ray)                         xl/2016,2019
 
-    Fedora33 5.10.10-200.fc33.x86_64
-    #1 SMP x86_64  GNU/Linux         GNU gcc (GCC) 10.2.1 20201125 (Red Hat 10.2.1-9)
-                                     GNU Fortran (GCC) 10.2.1 20201125 (Red Hat 10.2.1-9)
+    Fedora33 5.11.18-200.fc33.x86_64
+    #1 SMP x86_64  GNU/Linux         GNU gcc (GCC) 10.3.1 20210422 (Red Hat 10.3.1-1)
+                                     GNU Fortran (GCC) 10.3.1 20210422 (Red Hat 10.3.1-1)
                                      clang version 11.0.0 (Fedora 11.0.0-2.fc33)
                                      (cmake and autotools)
 
-    Ubuntu20.10 5.8.0-41-generic-x86_64
-    #46-Ubuntu SMP x86_64  GNU/Linux GNU gcc (GCC) 10.2.0-13ubuntu1
+    Ubuntu20.04 5.8.0-53-generic-x86_64
+    #60~20.04-Ubuntu SMP x86_64  GNU/Linux GNU gcc (GCC) 9.3.0-17ubuntu1
+                                     GNU Fortran (GCC) 9.3.0-17ubuntu1
+                                     clang version 10.0.0-4ubuntu1
+                                     (cmake and autotools)
+
+    Ubuntu20.10 5.8.0-53-generic-x86_64
+    #60-Ubuntu SMP x86_64  GNU/Linux GNU gcc (GCC) 10.2.0-13ubuntu1
                                      GNU Fortran (GCC) 10.2.0-13ubuntu1
+                                     Ubuntu clang version 11.0.0-2
                                      (cmake and autotools)
 
     SUSE15sp2 5.3.18-22-default

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -49,35 +49,35 @@ New Features
     -------------
     - Added an option to make the global thread-safe lock a recursive R/W lock
 
-        Prior to this release, the HDF5 library supported multi-threaded
-        applications by placing a recursive global lock on the entire library,
-        thus allowing only one thread into the library at a time.
+      Prior to this release, the HDF5 library supported multi-threaded
+      applications by placing a recursive global lock on the entire library,
+      thus allowing only one thread into the library at a time.
 
-        While this is still the default, the library can now be built with the
-        recursive global lock replaced with a recursive read / write (R/W) lock
-        that allows recursive writer locks.
+      While this is still the default, the library can now be built with the
+      recursive global lock replaced with a recursive read / write (R/W) lock
+      that allows recursive writer locks.
 
-        Currently, this change results in no functional change in the HDF5
-        library, as all threads will have to acquire a write lock on entry, and
-        thus obtain exclusive access to the HDF5 library as before. However, the
-        addition of the recursive R/W lock is a prerequisite for further work
-        directed at allowing some subset of the HDF5 API calls to enter the
-        library with read locks.
+      Currently, this change results in no functional change in the HDF5
+      library, as all threads will have to acquire a write lock on entry, and
+      thus obtain exclusive access to the HDF5 library as before. However, the
+      addition of the recursive R/W lock is a prerequisite for further work
+      directed at allowing some subset of the HDF5 API calls to enter the
+      library with read locks.
 
-        CMake:      HDF5_USE_RECURSIVE_RW_LOCKS (default: OFF, advanced)
+      CMake:      HDF5_USE_RECURSIVE_RW_LOCKS (default: OFF, advanced)
 
-        Autotools:  --enable-recursive-rw-locks [default=no]
+      Autotools:  --enable-recursive-rw-locks [default=no]
 
-        This feature only works with Pthreads. Win32 threads are not supported.
+      This feature only works with Pthreads. Win32 threads are not supported.
 
-      (DER - 2021/05/10)
+      (2021/05/10)
 
     - CMake no longer builds the C++ library by default
 
       HDF5_BUILD_CPP_LIB now defaults to OFF, which is in line with the
       Autotools build defaults.
 
-      (DER - 2021/04/20)
+      (2021/04/20)
 
     - Removal of pre-VS2015 work-arounds
 
@@ -91,7 +91,7 @@ New Features
       * va_copy
       * struct timespec
 
-      (DER - 2021/03/22)
+      (2021/03/22)
 
     - Add CMake variable HDF5_LIB_INFIX
 
@@ -100,14 +100,14 @@ New Features
       This name is used in packages on debian based systems.
       (see https://packages.debian.org/jessie/amd64/libhdf5-openmpi-8/filelist)
 
-      (barcode - 2021/03/22)
+      (2021/03/22)
 
     - On macOS, Universal Binaries can now be built, allowing native execution on
       both Intel and Apple Silicon (ARM) based Macs.
 
       To do so, set CMAKE_OSX_ARCHITECTURES="x86_64;arm64"
 
-      (SAM - 2021/02/07, https://github.com/HDFGroup/hdf5/issues/311)
+      (2021/02/07, https://github.com/HDFGroup/hdf5/issues/311)
 
     - Added a configure-time option to control certain compiler warnings
       diagnostics
@@ -126,23 +126,23 @@ New Features
 
       CMake:        HDF5_ENABLE_BUILD_DIAGS
 
-      (ADB - 2021/02/05, HDFFV-11213)
+      (2021/02/05, HDFFV-11213)
 
     - CMake option to build the HDF filter plugins project as an external project
 
-        The HDF filter plugins project is a collection of registered compression
-        filters that can be dynamically loaded when needed to access data stored
-        in a hdf5 file. This CMake-only option allows the plugins to be built and
-        distributed with the hdf5 library and tools. Like the options for szip and
-        zlib, either a tgz file or a git repository can be specified for the source.
+      The HDF filter plugins project is a collection of registered compression
+      filters that can be dynamically loaded when needed to access data stored
+      in a hdf5 file. This CMake-only option allows the plugins to be built and
+      distributed with the hdf5 library and tools. Like the options for szip and
+      zlib, either a tgz file or a git repository can be specified for the source.
 
-        The option was refactored to use the CMake FetchContent process. This allows
-        more control over the filter targets, but required external project command
-        options to be moved to a CMake include file, HDF5PluginCache.cmake. Also
-        enabled the filter examples to be used as tests for operation of the
-        filter plugins.
+      The option was refactored to use the CMake FetchContent process. This allows
+      more control over the filter targets, but required external project command
+      options to be moved to a CMake include file, HDF5PluginCache.cmake. Also
+      enabled the filter examples to be used as tests for operation of the
+      filter plugins.
 
-        (ADB - 2020/12/10, OESS-98)
+      (2020/12/10, OESS-98)
 
     - FreeBSD Autotools configuration now defaults to 'cc' and 'c++' compilers
 
@@ -156,7 +156,7 @@ New Features
       and g++ options will now be set if that compiler is being used (an
       omission from the former functionality).
 
-      (DER - 2020/11/28, HDFFV-11193)
+      (2020/11/28, HDFFV-11193)
 
     - Fixed POSIX problems when building w/ gcc on Solaris
 
@@ -169,7 +169,7 @@ New Features
       differs slightly from the gcc norm, where we set the standard to c99
       and manually set POSIX #define symbols.
 
-      (DER - 2020/11/25, HDFFV-11191)
+      (2020/11/25, HDFFV-11191)
 
     - Added a configure-time option to consider certain compiler warnings
       as errors
@@ -191,120 +191,120 @@ New Features
 
       CMake:        HDF5_ENABLE_WARNINGS_AS_ERRORS
 
-      (DER - 2020/11/23, HDFFV-11189)
+      (2020/11/23, HDFFV-11189)
 
     - Autotools and CMake target added to produce doxygen generated documentation
 
-        The default is OFF or disabled.
-        Autoconf option is '--enable-doxygen'
+      The default is OFF or disabled.
+      Autoconf option is '--enable-doxygen'
           autotools make target is 'doxygen' and will build all doxygen targets
-        CMake configure option is 'HDF5_BUILD_DOC'.
+          CMake configure option is 'HDF5_BUILD_DOC'.
           CMake target is 'doxygen' for all available doxygen targets
           CMake target is 'hdf5lib_doc' for the src subdirectory
 
-        (ADB - 2020/11/13)
+      (2020/11/13)
 
     - CMake option to use MSVC naming conventions with MinGW
 
-        HDF5_MSVC_NAMING_CONVENTION option enable to use MSVC naming conventions
-        when using a MinGW toolchain
+      HDF5_MSVC_NAMING_CONVENTION option enable to use MSVC naming conventions
+      when using a MinGW toolchain
 
-        (xan - 2020/10/30)
+      (2020/10/30)
 
     - CMake option to statically link gcc libs with MinGW
 
-        HDF5_MINGW_STATIC_GCC_LIBS allows to statically link libg/libstdc++
-        with the MinGW toolchain
+      HDF5_MINGW_STATIC_GCC_LIBS allows to statically link libg/libstdc++
+      with the MinGW toolchain
 
-        (xan - 2020/10/30)
+      (2020/10/30)
 
     - CMake option to build the HDF filter plugins project as an external project
 
-        The HDF filter plugins project is a collection of registered compression
-        filters that can be dynamically loaded when needed to access data stored
-        in a hdf5 file. This CMake-only option allows the plugins to be built and
-        distributed with the hdf5 library and tools. Like the options for szip and
-        zlib, either a tgz file or a git repository can be specified for the source.
+      The HDF filter plugins project is a collection of registered compression
+      filters that can be dynamically loaded when needed to access data stored
+      in a hdf5 file. This CMake-only option allows the plugins to be built and
+      distributed with the hdf5 library and tools. Like the options for szip and
+      zlib, either a tgz file or a git repository can be specified for the source.
 
-        The necessary options are (see the INSTALL_CMake.txt file):
+      The necessary options are (see the INSTALL_CMake.txt file):
           HDF5_ENABLE_PLUGIN_SUPPORT
           PLUGIN_TGZ_NAME or PLUGIN_GIT_URL
-        There are more options necessary for various filters and the plugin project
-        documents should be referenced.
+      There are more options necessary for various filters and the plugin project
+      documents should be referenced.
 
-        (ADB - 2020/10/16, OESS-98)
+      (2020/10/16, OESS-98)
 
     - Added CMake option to format source files
 
-        HDF5_ENABLE_FORMATTERS option will enable creation of targets using the
-        pattern - HDF5_*_SRC_FORMAT - where * corresponds to the source folder
-        or tool folder. All sources can be formatted by executing the format target;
-        make format
+      HDF5_ENABLE_FORMATTERS option will enable creation of targets using the
+      pattern - HDF5_*_SRC_FORMAT - where * corresponds to the source folder
+      or tool folder. All sources can be formatted by executing the format target;
+      make format
 
-        (ADB - 2020/09/24)
+      (2020/09/24)
 
     - CMake option to link the generated Fortran MOD files into the include
       directory.
 
-        The Fortran generation of MOD files by a Fortran compile can produce
-        different binary files between SHARED and STATIC compiles with different
-        compilers and/or different platforms. Note that it has been found that
-        different versions of Fortran compilers will produce incompatible MOD
-        files. Currently, CMake will locate these MOD files in subfolders of
-        the include directory and add that path to the Fortran library target
-        in the CMake config file, which can be used by the CMake find library
-        process. For other build systems using the binary from a CMake install,
-        a new CMake configuration can be used to copy the pre-chosen version
-        of the Fortran MOD files into the install include directory.
+      The Fortran generation of MOD files by a Fortran compile can produce
+      different binary files between SHARED and STATIC compiles with different
+      compilers and/or different platforms. Note that it has been found that
+      different versions of Fortran compilers will produce incompatible MOD
+      files. Currently, CMake will locate these MOD files in subfolders of
+      the include directory and add that path to the Fortran library target
+      in the CMake config file, which can be used by the CMake find library
+      process. For other build systems using the binary from a CMake install,
+      a new CMake configuration can be used to copy the pre-chosen version
+      of the Fortran MOD files into the install include directory.
 
-        The default will depend on the configuration of
-        BUILD_STATIC_LIBS and BUILD_SHARED_LIBS:
+      The default will depend on the configuration of
+      BUILD_STATIC_LIBS and BUILD_SHARED_LIBS:
             YES                   YES         Default to SHARED
             YES                   NO          Default to STATIC
             NO                    YES         Default to SHARED
             NO                    NO          Default to SHARED
-        The defaults can be overridden by setting the config option
+      The defaults can be overridden by setting the config option
             HDF5_INSTALL_MOD_FORTRAN to one of NO, SHARED, or STATIC
 
-        (ADB - 2020/07/09, HDFFV-11116)
+      (2020/07/09, HDFFV-11116)
 
     - CMake option to use AEC (open source SZip) library instead of SZip
 
-        The open source AEC library is a replacement library for SZip. In
-        order to use it for hdf5 the libaec CMake source was changed to add
-        "-fPIC" and exclude test files. Autotools does not build the
-        compression libraries within hdf5 builds. New option USE_LIBAEC is
-        required to compensate for the different files produced by AEC build.
+      The open source AEC library is a replacement library for SZip. In
+      order to use it for hdf5 the libaec CMake source was changed to add
+      "-fPIC" and exclude test files. Autotools does not build the
+      compression libraries within hdf5 builds. New option USE_LIBAEC is
+      required to compensate for the different files produced by AEC build.
 
-        (ADB - 2020/04/22, OESS-65)
+      (2020/04/22, OESS-65)
 
     - CMake ConfigureChecks.cmake file now uses CHECK_STRUCT_HAS_MEMBER
 
-        Some handcrafted tests in HDFTests.c has been removed and the CMake
-        CHECK_STRUCT_HAS_MEMBER module has been used.
+      Some handcrafted tests in HDFTests.c has been removed and the CMake
+      CHECK_STRUCT_HAS_MEMBER module has been used.
 
-        (ADB - 2020/03/24, TRILAB-24)
+      (2020/03/24, TRILAB-24)
 
     - Both build systems use same set of warnings flags
 
-        GNU C, C++ and gfortran warnings flags were moved to files in a config
-        sub-folder named gnu-warnings. Flags that only are available for a specific
-        version of the compiler are in files named with that version.
-        Clang C warnings flags were moved to files in a config sub-folder
-        named clang-warnings.
-        Intel C, Fortran warnings flags were moved to files in a config sub-folder
-        named intel-warnings.
+      GNU C, C++ and gfortran warnings flags were moved to files in a config
+      sub-folder named gnu-warnings. Flags that only are available for a specific
+      version of the compiler are in files named with that version.
+      Clang C warnings flags were moved to files in a config sub-folder
+      named clang-warnings.
+      Intel C, Fortran warnings flags were moved to files in a config sub-folder
+      named intel-warnings.
 
-        There are flags in named "error-xxx" files with warnings that may
-        be promoted to errors. Some source files may still need fixes.
+      There are flags in named "error-xxx" files with warnings that may
+      be promoted to errors. Some source files may still need fixes.
 
-        There are also pairs of files named "developer-xxx" and "no-developer-xxx"
-        that are chosen by the CMake option:HDF5_ENABLE_DEV_WARNINGS or the
-        configure option:--enable-developer-warnings.
+      There are also pairs of files named "developer-xxx" and "no-developer-xxx"
+      that are chosen by the CMake option:HDF5_ENABLE_DEV_WARNINGS or the
+      configure option:--enable-developer-warnings.
 
-        In addition, CMake no longer applies these warnings for examples.
+      In addition, CMake no longer applies these warnings for examples.
 
-        (ADB - 2020/03/24, TRILAB-192)
+      (2020/03/24, TRILAB-192)
 
 
     Library:
@@ -324,7 +324,7 @@ New Features
       The Doxygen documentation has been updated and passing values larger
       than UINT32_MAX for size_hint will now produce a normal HDF5 error.
       
-        (DER - 2021/04/29, HDFFV-11241)
+      (2021/04/29, HDFFV-11241)
 
 
     - H5Pset_fapl_log() no longer crashes when passed an invalid fapl ID
@@ -338,7 +338,7 @@ New Features
       The pointer is now correctly initialized and the API call now
       produces a normal HDF5 error when fed an invalid fapl ID.
 
-        (DER - 2021/04/28, HDFFV-11240)
+      (2021/04/28, HDFFV-11240)
 
     - Fixes a segfault when H5Pset_mdc_log_options() is called multiple times
 
@@ -350,7 +350,7 @@ New Features
 
       The string is now handled properly and the segfault no longer occurs.
 
-        (DER - 2021/04/27, HDFFV-11239)
+      (2021/04/27, HDFFV-11239)
       
     - HSYS_GOTO_ERROR now emits the results of GetLastError() on Windows
 
@@ -377,7 +377,7 @@ New Features
 
       for those inclined to parse it for error values.
 
-        (DER - 2021/03/21)
+      (2021/03/21)
 
     - File locking now works on Windows
 
@@ -393,241 +393,245 @@ New Features
       same scheme as POSIX systems. We lock the entire file when we set up the
       locks (by passing DWORDMAX as both size parameters to LockFileEx()).
 
-        (DER - 2021/03/19, HDFFV-10191)
+      (2021/03/19, HDFFV-10191)
 
     - H5Epush_ret() now requires a trailing semicolon
 
-        H5Epush_ret() is a function-like macro that has been changed to
-        contain a `do {} while(0)` loop. Consequently, a trailing semicolon
-        is now required to end the `while` statement. Previously, a trailing
-        semi would work, but was not mandatory. This change was made to allow
-        clang-format to correctly format the source code.
+      H5Epush_ret() is a function-like macro that has been changed to
+      contain a `do {} while(0)` loop. Consequently, a trailing semicolon
+      is now required to end the `while` statement. Previously, a trailing
+      semi would work, but was not mandatory. This change was made to allow
+      clang-format to correctly format the source code.
 
-        (SAM - 2021/03/03)
+      (2021/03/03)
 
     - Improved performance of H5Sget_select_elem_pointlist
 
-        Modified library to cache the point after the last block of points
-        retrieved by H5Sget_select_elem_pointlist, so a subsequent call to the
-        same function to retrieve the next block of points from the list can
-        proceed immediately without needing to iterate over the point list.
+      Modified library to cache the point after the last block of points
+      retrieved by H5Sget_select_elem_pointlist, so a subsequent call to the
+      same function to retrieve the next block of points from the list can
+      proceed immediately without needing to iterate over the point list.
 
-        (NAF - 2021/01/19)
+      (2021/01/19)
 
     - Added H5VL_VERSION macro that indicates the version of the VOL framework
-        implemented by a version of the library.  Currently, compatibility
-        checking enforces that the 'version' field in the H5VL_class_t for
-        a VOL connector must match the version of the VOL framework for the
-        library when it is registered or dynamically loaded.
+      implemented by a version of the library.  Currently, compatibility
+      checking enforces that the 'version' field in the H5VL_class_t for
+      a VOL connector must match the version of the VOL framework for the
+      library when it is registered or dynamically loaded.
 
-        (QAK - 2020/12/10)
+      (2020/12/10)
 
     - Added two new API routines for tracking library memory use:
-        H5get_alloc_stats() and H5get_free_list_sizes().
+      H5get_alloc_stats() and H5get_free_list_sizes().
 
-        (QAK - 2020/03/25)
+      (2020/03/25)
+
 
     Java Library:
     -------------
     - Added new H5S functions.
 
-        H5Sselect_copy, H5Sselect_shape_same, H5Sselect_adjust,
-        H5Sselect_intersect_block, H5Sselect_project_intersection,
-        H5Scombine_hyperslab, H5Smodify_select, H5Scombine_select
-        wrapper functions added.
+      H5Sselect_copy, H5Sselect_shape_same, H5Sselect_adjust,
+      H5Sselect_intersect_block, H5Sselect_project_intersection,
+      H5Scombine_hyperslab, H5Smodify_select, H5Scombine_select
+      wrapper functions added.
 
-        (ADB - 2020/10/27, HDFFV-10868)
+      (2020/10/27, HDFFV-10868)
 
 
     Tools:
     ------
     - h5repack added help text for user-defined filters.
 
-        Added help text line that states the valid values of the filter flag
-        for user-defined filters;
-            filter_flag: 1 is OPTIONAL or 0 is MANDATORY
+      Added help text line that states the valid values of the filter flag
+      for user-defined filters;
+          filter_flag: 1 is OPTIONAL or 0 is MANDATORY
 
-        (ADB - 2021/01/14, HDFFV-11099)
+      (2021/01/14, HDFFV-11099)
 
     - h5repack added options to control how external links are handled.
 
-        Currently h5repack preserves external links and cannot copy and merge
-        data from the external files. Two options, merge and prune, were added to
-        control how to merge data from an external link into the resulting file.
+      Currently h5repack preserves external links and cannot copy and merge
+      data from the external files. Two options, merge and prune, were added to
+      control how to merge data from an external link into the resulting file.
             --merge             Follow external soft link recursively and merge data.
             --prune             Do not follow external soft links and remove link.
             --merge --prune     Follow external link, merge data and remove dangling link.
 
-        (ADB - 2020/08/05, HDFFV-9984)
+      (2020/08/05, HDFFV-9984)
 
 
 Support for new platforms, languages and compilers
 ==================================================
-    -
+
+    - Added macOS 11.2 Big Sur
+
 
 Bug Fixes since HDF5-1.12.0 release
 ===================================
+
     Library
     -------
     - Fixed CVE-2018-14460
 
-        The tool h5repack produced a segfault when the rank in dataspace
-        message was corrupted, causing invalid read while decoding the
-        dimension sizes.
+      The tool h5repack produced a segfault when the rank in dataspace
+      message was corrupted, causing invalid read while decoding the
+      dimension sizes.
 
-        The problem was fixed by ensuring that decoding the dimension sizes
-        and max values will not go beyong the end of the buffer.
+      The problem was fixed by ensuring that decoding the dimension sizes
+      and max values will not go beyong the end of the buffer.
 
-        (BMR - 2021/05/12, HDFFV-11223)
+      (2021/05/12, HDFFV-11223)
 
     - Fixed CVE-2018-11206
 
-        The tool h5dump produced a segfault when the size of a fill value
-        message was corrupted and caused a buffer overflow.
+      The tool h5dump produced a segfault when the size of a fill value
+      message was corrupted and caused a buffer overflow.
 
-        The problem was fixed by verifying the fill value's size
-        against the buffer size before attempting to access the buffer.
+      The problem was fixed by verifying the fill value's size
+      against the buffer size before attempting to access the buffer.
 
-        (BMR - 2021/03/15, HDFFV-10480)
+      (2021/03/15, HDFFV-10480)
 
     - Fixed CVE-2018-14033 (same issue as CVE-2020-10811)
 
-        The tool h5dump produced a segfault when the storage size message
-        was corrupted and caused a buffer overflow.
+      The tool h5dump produced a segfault when the storage size message
+      was corrupted and caused a buffer overflow.
 
-        The problem was fixed by verifying the storage size against the
-        buffer size before attempting to access the buffer.
+      The problem was fixed by verifying the storage size against the
+      buffer size before attempting to access the buffer.
 
-        (BMR - 2021/03/15, HDFFV-11159/HDFFV-11049)
+      (2021/03/15, HDFFV-11159/HDFFV-11049)
 
     - Remove underscores on header file guards
 
-        Header file guards used a variety of underscores at the beginning of the define.
+      Header file guards used a variety of underscores at the beginning of the define.
 
-        Removed all leading (some trailing) underscores from header file guards.
+      Removed all leading (some trailing) underscores from header file guards.
 
-        (ADB - 2021/03/03, #361)
+      (2021/03/03, #361)
 
     - Fixed issue with MPI communicator and info object not being
       copied into new FAPL retrieved from H5F_get_access_plist
 
-        Added logic to copy the MPI communicator and info object into
-        the output FAPL. MPI communicator is retrieved from the VFD, while
-        the MPI info object is retrieved from the file's original FAPL.
+      Added logic to copy the MPI communicator and info object into
+      the output FAPL. MPI communicator is retrieved from the VFD, while
+      the MPI info object is retrieved from the file's original FAPL.
 
-        (JTH - 2021/02/15, HDFFV-11109)
+      (2021/02/15, HDFFV-11109)
 
     - Fixed problems with vlens and refs inside compound using
       H5VLget_file_type()
 
-        Modified library to properly ref count H5VL_object_t structs and only
-        consider file vlen and reference types to be equal if their files are
-        the same.
+      Modified library to properly ref count H5VL_object_t structs and only
+      consider file vlen and reference types to be equal if their files are
+      the same.
 
-        (NAF - 2021/01/22)
+      (2021/01/22)
 
     - Fix bug and simplify collective metadata write operation when some ranks
-        have no entries to contribute.  This fixes parallel regression test
-        failures with IBM SpectrumScale MPI on the Summit system at ORNL.
+      have no entries to contribute.  This fixes parallel regression test
+      failures with IBM SpectrumScale MPI on the Summit system at ORNL.
 
-        (QAK - 2020/09/02)
+      (2020/09/02)
 
     - Avoid setting up complex MPI types with 0-length vectors, which some
-        MPI implementations don't handle well.  (In particular, IBM
-        SpectrumScale MPI on the Summit system at ORNL)
+      MPI implementations don't handle well.  (In particular, IBM
+      SpectrumScale MPI on the Summit system at ORNL)
 
-        (QAK - 2020/08/21)
+      (2020/08/21)
 
     - Explicitly declared dlopen to use RTLD_LOCAL
 
-        dlopen documentation states that if neither RTLD_GLOBAL nor
-        RTLD_LOCAL are specified, then the default behavior is unspecified.
-        The default on linux is usually RTLD_LOCAL while macos will default
-        to RTLD_GLOBAL.
+      dlopen documentation states that if neither RTLD_GLOBAL nor
+      RTLD_LOCAL are specified, then the default behavior is unspecified.
+      The default on linux is usually RTLD_LOCAL while macos will default
+      to RTLD_GLOBAL.
 
-        (ADB - 2020/08/12, HDFFV-11127)
+      (2020/08/12, HDFFV-11127)
 
     - H5Sset_extent_none() sets the dataspace class to H5S_NO_CLASS which
       causes asserts/errors when passed to other dataspace API calls.
 
-        H5S_NO_CLASS is an internal class value that should not have been
-        exposed via a public API call.
+      H5S_NO_CLASS is an internal class value that should not have been
+      exposed via a public API call.
 
-        In debug builds of the library, this can cause assert() function to 
-        trip. In non-debug builds, it will produce normal library errors.
+      In debug builds of the library, this can cause assert() function to 
+      trip. In non-debug builds, it will produce normal library errors.
 
-        The new library behavior is for H5Sset_extent_none() to convert
-        the dataspace into one of type H5S_NULL, which is better handled
-        by the library and easier for developers to reason about.
+      The new library behavior is for H5Sset_extent_none() to convert
+      the dataspace into one of type H5S_NULL, which is better handled
+      by the library and easier for developers to reason about.
 
-        (DER - 2020/07/27, HDFFV-11027)
+      (2020/07/27, HDFFV-11027)
 
     - Fixed the segmentation fault when reading attributes with multiple threads
 
-        It was reported that the reading of attributes with variable length string
-        datatype will crash with segmentation fault particularly when the number of
-        threads is high (>16 threads).  The problem was due to the file pointer that
-        was set in the variable length string datatype for the attribute.  That file
-        pointer was already closed when the attribute was accessed.
+      It was reported that the reading of attributes with variable length string
+      datatype will crash with segmentation fault particularly when the number of
+      threads is high (>16 threads).  The problem was due to the file pointer that
+      was set in the variable length string datatype for the attribute.  That file
+      pointer was already closed when the attribute was accessed.
 
-        The problem was fixed by setting the file pointer to the current opened file pointer
-        when the attribute was accessed.  Similar patch up was done before when reading
-        dataset with variable length string datatype.
+      The problem was fixed by setting the file pointer to the current opened file pointer
+      when the attribute was accessed.  Similar patch up was done before when reading
+      dataset with variable length string datatype.
 
-        (VC - 2020/07/13, HDFFV-11080)
+      (2020/07/13, HDFFV-11080)
 
     - Reduce overhead for H5open(), which is involved in public symbols like
-        H5T_NATIVE_INT, etc.
+      H5T_NATIVE_INT, etc.
 
-        (QAK - 2020/06/18)
+      (2020/06/18)
 
     - Cache last ID looked up for an ID type (dataset, datatype, file, etc),
-        improving performance when accessing the same ID repeatedly.
+      improving performance when accessing the same ID repeatedly.
 
-        (QAK - 2020/06/11)
+      (2020/06/11)
 
     - Streamline I/O to a single element, improving performance for record
-        appends to chunked datasets.
+      appends to chunked datasets.
 
-        (QAK - 2020/06/11)
+      (2020/06/11)
 
     - Remove redundant tagging of metadata cache entries for some chunked
-        dataset operations, slightly improving performance for chunked
-        datasets.
+      dataset operations, slightly improving performance for chunked
+      datasets.
 
-        (QAK - 2020/06/10)
+      (2020/06/10)
 
     - Better detect selections with the same shape, improving performance for
-        some uses of H5DOappend (and other situations).
+      some uses of H5DOappend (and other situations).
 
-        (QAK - 2020/06/07)
+      (2020/06/07)
 
     - Don't allocate an empty (0-dimensioned) chunked dataset's chunk
-        index, until the dataset's dimensions are increased.
+      index, until the dataset's dimensions are increased.
 
-        (QAK - 2020/05/07)
+      (2020/05/07)
 
 
     Java Library
     ------------
     - JNI utility function does not handle new references.
 
-        The JNI utility function for converting reference data to string did
-        not use the new APIs. In addition to fixing that function, added new
-        java tests for using the new APIs.
+      The JNI utility function for converting reference data to string did
+      not use the new APIs. In addition to fixing that function, added new
+      java tests for using the new APIs.
 
-        (ADB - 2021/02/16, HDFFV-11212)
+      (2021/02/16, HDFFV-11212)
 
     - The H5FArray.java class, in which virtually the entire execution time
-        is spent using the HDFNativeData method that converts from an array
-        of bytes to an array of the destination Java type.
+      is spent using the HDFNativeData method that converts from an array
+      of bytes to an array of the destination Java type.
 
         1. Convert the entire byte array into a 1-d array of the desired type,
            rather than performing 1 conversion per row;
         2. Use the Java Arrays method copyOfRange to grab the section of the
            array from (1) that is desired to be inserted into the destination array.
 
-        (PGT,ADB - 2020/12/29, HDFFV-10865)
+      (2020/12/29, HDFFV-10865)
 
 
     Configuration
@@ -643,7 +647,7 @@ Bug Fixes since HDF5-1.12.0 release
       Visual Studio warnings C4100, C4706, and C4127 have been moved to
       developer warnings, HDF5_ENABLE_DEV_WARNINGS, and are disabled for normal builds.
 
-      (ADB - 2021/03/22, HDFFV-11228)
+      (2021/03/22, HDFFV-11228)
 
     - Reclassify CMake messages, to allow new modes and --log-level option
 
@@ -655,7 +659,7 @@ Bug Fixes since HDF5-1.12.0 release
       version 3.17 or above is used, the user can use the command line option
       of "--log-level" to further restrict which message commands are displayed.
 
-      (ADB - 2021/01/11, HDFFV-11144)
+      (2021/01/11, HDFFV-11144)
 
     - Fixes Autotools determination of the stat struct having an st_blocks field
 
@@ -666,47 +670,47 @@ Bug Fixes since HDF5-1.12.0 release
       CMake. This #define is only used in the tests and does not affect the
       HDF5 C library.
 
-      (DER - 2021/01/07, HDFFV-11201)
+      (2021/01/07, HDFFV-11201)
 
 
     Tools
     -----
     - Changed how h5dump and h5ls identify long double.
 
-        Long double support is not consistent across platforms. Tools will always
-        identify long double as 128-bit [little/big]-endian float nn-bit precision.
-        New test file created for datasets with attributes for float, double and
-        long double. In addition any unknown integer or float datatype will now
-        also show the number of bits for precision.
-        These files are also used in the java tests.
+      Long double support is not consistent across platforms. Tools will always
+      identify long double as 128-bit [little/big]-endian float nn-bit precision.
+      New test file created for datasets with attributes for float, double and
+      long double. In addition any unknown integer or float datatype will now
+      also show the number of bits for precision.
+      These files are also used in the java tests.
 
-        (ADB - 2021/03/24, HDFFV-11229)
+      (2021/03/24, HDFFV-11229)
 
     - Fixed tools argument parsing.
 
-        Tools parsing used the length of the option from the long array to match
-        the option from the command line. This incorrectly matched a shorter long
-        name option that happened to be a subset of another long option.
-        Changed to match whole names.
+      Tools parsing used the length of the option from the long array to match
+      the option from the command line. This incorrectly matched a shorter long
+      name option that happened to be a subset of another long option.
+      Changed to match whole names.
 
-        (ADB - 2021/01/19, HDFFV-11106)
+      (2021/01/19, HDFFV-11106)
 
 
     Fortran API
     -----------
     - Fixed configure issue when building HDF5 with NAG Fortran 7.0.
 
-        HDF5 now accounts for the addition of half-precision floating-point
-        in NAG 7.0 with a KIND=16.
+      HDF5 now accounts for the addition of half-precision floating-point
+      in NAG 7.0 with a KIND=16.
 
-        (MSB - 2020/02/28, HDFFV-11033)
+      (2020/02/28, HDFFV-11033)
 
 
     High-Level Library
     ------------------
     - Eliminated unnecessary code in H5DOappend(), improving its performance.
 
-        (QAK - 2020/06/05)
+      (2020/06/05)
 
 
     Fortran High-Level APIs
@@ -718,7 +722,7 @@ Bug Fixes since HDF5-1.12.0 release
     -------------
     - Updated doxygen comments with changes for release
 
-      (ADB - 2021/05/03)
+      (2021/05/03)
 
 
     F90 APIs
@@ -735,30 +739,24 @@ Bug Fixes since HDF5-1.12.0 release
     -------
     - Stopped java/test/junit.sh.in installing libs for testing under ${prefix}
 
-        Lib files needed are now copied to a subdirectory in the java/test
-        directory, and on Macs the loader path for libhdf5.xxxs.so is changed
-        in the temporary copy of libhdf5_java.dylib.
+      Lib files needed are now copied to a subdirectory in the java/test
+      directory, and on Macs the loader path for libhdf5.xxxs.so is changed
+      in the temporary copy of libhdf5_java.dylib.
 
-        (LRK, 2020/07/02, HDFFV-11063)
+      (2020/07/02, HDFFV-11063)
 
 
 Supported Platforms
 ===================
 
-    Linux 2.6.32-696.16.1.el6.ppc64 gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-18)
-    #1 SMP ppc64 GNU/Linux        g++ (GCC) 4.4.7 20120313 (Red Hat 4.4.7-18)
-    (ostrich)                     GNU Fortran (GCC) 4.4.7 20120313 (Red Hat 4.4.7-18)
-                                  IBM XL C/C++ V13.1
-                                  IBM XL Fortran V15.1
-
     Linux 3.10.0-327.10.1.el7   GNU C (gcc), Fortran (gfortran), C++ (g++)
     #1 SMP x86_64 GNU/Linux       compilers:
-    (kituo/moohan)                Version 4.8.5 20150623 (Red Hat 4.8.5-4)
+    (jelly/kituo/moohan)            Version 4.8.5 20150623 (Red Hat 4.8.5-4)
                                     Version 4.9.3, 5.2.0, 7.1.0
                                   Intel(R) C (icc), C++ (icpc), Fortran (icc)
                                   compilers:
                                      Version 17.0.0.098 Build 20160721
-                                  MPICH 3.1.4
+                                  MPICH 3.2, 3.3
 
     Windows 10 x64                Visual Studio 2015 w/ Intel Fortran 18 (cmake)
                                   Visual Studio 2017 w/ Intel Fortran 19 (cmake)
@@ -768,10 +766,6 @@ Supported Platforms
     MacOS High Sierra 10.13.6     Apple LLVM version 10.0.0 (clang-1000.10.44.4)
     64-bit                        gfortran GNU Fortran (GCC) 6.3.0
     (bear)                        Intel icc/icpc/ifort version 19.0.4
-
-    MacOS Mojave 10.14.6          Apple LLVM version 10.0.1 (clang-1001.0.46.4)
-    64-bit                        gfortran GNU Fortran (GCC) 6.3.0
-    (bobcat)                      Intel icc/icpc/ifort version 19.0.4
 
     MacOS Big Sur 11.2            Apple clang version 12.0.5 (clang-1205.0.22.9)
                                   gfortran GNU Fortran (Homebrew GCC 10.2.0_3) 10.2.0
@@ -792,36 +786,28 @@ Tested Configuration Features Summary
 
 Platform                              C         F90/   F90      C++  zlib  SZIP
                                       parallel  F2003  parallel
-Solaris2.11 32-bit                      n        y/y    n        y    y     y
-Solaris2.11 64-bit                      n        y/n    n        y    y     y
 Windows 10                              y        y/y    n        y    y     y
 Windows 10 x64                          y        y/y    n        y    y     y
 MacOS High Sierra 10.13.6 64-bit        n        y/y    n        y    y     y
-MacOS Mojave 10.14.6 64-bit             n        y/y    n        y    y     y
 MacOS Big Sur 11.2 64-bit               n        y/y    n        y    y     y
 CentOS 6.7 Linux 2.6.18 x86_64 GNU      n        y/y    n        y    y     y
-CentOS 6.7 Linux 2.6.18 x86_64 Intel    n        y/y    n        y    y     y
 CentOS 6.7 Linux 2.6.32 x86_64 PGI      n        y/y    n        y    y     y
 CentOS 7.2 Linux 2.6.32 x86_64 GNU      y        y/y    y        y    y     y
 CentOS 7.2 Linux 2.6.32 x86_64 Intel    n        y/y    n        y    y     y
-Linux 2.6.32-573.18.1.el6.ppc64         n        y/n    n        y    y     y
+Linux 3.10.0-1127.10.1.1.ch6.ppc64le    n        y/n    n        y    y     y
 
 
 Platform                                 Shared  Shared    Shared    Thread-
                                          C libs  F90 libs  C++ libs  safe
-Solaris2.11 32-bit                         y       y         y         y
-Solaris2.11 64-bit                         y       y         y         y
 Windows 10                                 y       y         y         y
 Windows 10 x64                             y       y         y         y
 MacOS High Sierra 10.13.6 64-bit           y       n         y         y
-MacOS Mojave 10.14.6 64-bit                y       n         y         y
 MacOS Big Sur 11.2 64-bit                  y       n         y         y
 CentOS 6.7 Linux 2.6.18 x86_64 GNU         y       y         y         y
-CentOS 6.7 Linux 2.6.18 x86_64 Intel       y       y         y         n
 CentOS 6.7 Linux 2.6.32 x86_64 PGI         y       y         y         n
 CentOS 7.2 Linux 2.6.32 x86_64 GNU         y       y         y         n
 CentOS 7.2 Linux 2.6.32 x86_64 Intel       y       y         y         n
-Linux 2.6.32-573.18.1.el6.ppc64            y       y         y         n
+Linux 3.10.0-1127.10.1.1.ch6.ppc64le       y       y         y         n
 
 Compiler versions for each platform are listed in the preceding
 "Supported Platforms" table.
@@ -829,6 +815,7 @@ Compiler versions for each platform are listed in the preceding
 
 More Tested Platforms
 =====================
+
 The following platforms are not supported but have been tested for this release.
 
     Linux 2.6.32-573.22.1.el6    GNU C (gcc), Fortran (gfortran), C++ (g++)
@@ -858,28 +845,28 @@ The following platforms are not supported but have been tested for this release.
     #1 SMP x86_64 GNU/Linux
     (moohan)
 
-    Linux-3.10.0-1127.0.0.1chaos  openmpi-4.0.0
-    #1 SMP x86_64 GNU/Linux           clang/3.9.0, 8.0.1
+    Linux-3.10.0-1127.0.0.1chaos  openmpi/4.0.0
+    #1 SMP x86_64 GNU/Linux           clang/6.0.0, 11.0.1
     (quartz)                          gcc/7.3.0, 8.1.0
-                                      intel/16.0.4
+                                      intel/16.0.4, 18.0.2, 19.0.4
 
     Linux-4.14.0-115.10.1.1       spectrum-mpi/rolling-release
-    #1 SMP ppc64le GNU/Linux          clang/coral-2018.08.08
-    (lassen)                          gcc/7.3.1
-                                      xl/2019.02.07
+    #1 SMP ppc64le GNU/Linux          clang/7.1.0, 10.0.1
+    (lassen)                          gcc/4.9.3, 8.3.1
+                                      xl/2019.02.07,2021.03.11
 
     Linux-4.12.14-150.52-default  cray-mpich/7.7.10
-    #1 SMP x86_64 GNU/Linux           gcc/7.3.0, 8.2.0
+    #1 SMP x86_64 GNU/Linux           gcc/8.3.0
     (cori)                            intel/19.0.3
 
     Linux-4.4.180-94.107-default  cray-mpich/7.7.6
     # 1SMP x86_64 GNU/Linux           gcc/7.2.0, 8.2.0
     (mutrino)                         intel/17.0.4, 18.0.2, 19.0.4
 
-    Linux-3.10.0-                 spectrum-mpi/rolling-release with cmake>3.10 and
-    862.14.4.1chaos.ch6.ppc64le   clang/3.9,8.0
-    #1 SMP ppc64le GNU/Linux      gcc/7.3
-    (ray)                         xl/2016,2019
+    Linux-3.10.0-                 spectrum-mpi/rolling-release
+    1127.10.1.1chaos.ch6.ppc64le       clang/7.1,11.0.1
+    #1 SMP ppc64le GNU/Linux           gcc/4.9.3,8.3.1
+    (ray)                              xl/2019.08.20,2021.03.11
 
     Fedora33 5.11.18-200.fc33.x86_64
     #1 SMP x86_64  GNU/Linux         GNU gcc (GCC) 10.3.1 20210422 (Red Hat 10.3.1-1)
@@ -912,6 +899,7 @@ The following platforms are not supported but have been tested for this release.
 
 Known Problems
 ==============
+
     The t_bigio test fails on several HPC platforms, generally by timeout with 
     OpenMPI 4.0.0 or with this error from spectrum-mpi: 
         *** on communicator MPI_COMM_WORLD
@@ -937,6 +925,7 @@ Known Problems
 
 CMake vs. Autotools installations
 =================================
+
 While both build systems produce similar results, there are differences.
 Each system produces the same set of folders on linux (only CMake works
 on standard Windows); bin, include, lib and share. Autotools places the

--- a/src/H5Spublic.h
+++ b/src/H5Spublic.h
@@ -70,7 +70,7 @@ typedef enum H5S_class_t {
 /* Different ways of combining selections */
 typedef enum H5S_seloper_t {
     H5S_SELECT_NOOP = -1, /* error                                     */
-    H5S_SELECT_SET  = 0,  /* Select "set" operation 		     */
+    H5S_SELECT_SET  = 0,  /* Select "set" operation              */
     H5S_SELECT_OR,        /* Binary "or" operation for hyperslabs
                            * (add new selection to existing selection)
                            * Original region:  AAAAAAAAAA
@@ -108,12 +108,12 @@ typedef enum H5S_seloper_t {
 
 /* Enumerated type for the type of selection */
 typedef enum {
-    H5S_SEL_ERROR      = -1, /* Error			*/
-    H5S_SEL_NONE       = 0,  /* Nothing selected 		*/
-    H5S_SEL_POINTS     = 1,  /* Points / elements selected	*/
+    H5S_SEL_ERROR      = -1, /* Error            */
+    H5S_SEL_NONE       = 0,  /* Nothing selected         */
+    H5S_SEL_POINTS     = 1,  /* Points / elements selected    */
     H5S_SEL_HYPERSLABS = 2,  /* Hyperslab selected           */
-    H5S_SEL_ALL        = 3,  /* Entire extent selected	*/
-    H5S_SEL_N                /*THIS MUST BE LAST		*/
+    H5S_SEL_ALL        = 3,  /* Entire extent selected    */
+    H5S_SEL_N                /*THIS MUST BE LAST        */
 } H5S_sel_type;
 
 #ifdef __cplusplus
@@ -164,7 +164,7 @@ H5_DLL herr_t H5Sclose(hid_t space_id);
  *          composing the entire current extent). If either \p stride or
  *          \p block is NULL, then it will be set to \p 1.
  *
- * \since 1.12.0
+ * \since 1.10.6
  *
  */
 H5_DLL hid_t H5Scombine_hyperslab(hid_t space_id, H5S_seloper_t op, const hsize_t start[],
@@ -187,7 +187,7 @@ H5_DLL hid_t H5Scombine_hyperslab(hid_t space_id, H5S_seloper_t op, const hsize_
  *          from \p space1_id is copied for the dataspace extent of the
  *          newly created dataspace.
  *
- * \since 1.12.0
+ * \since 1.10.6
  *
  */
 H5_DLL hid_t H5Scombine_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id);
@@ -788,7 +788,7 @@ H5_DLL htri_t H5Sis_simple(hid_t space_id);
  *          \p space2_id. The first selection is modified to contain the
  *          result of \p space1_id operated on by \p space2_id.
  *
- * \since 1.12.0
+ * \since 1.10.6
  *
  */
 H5_DLL herr_t H5Smodify_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id);
@@ -933,7 +933,7 @@ H5_DLL herr_t H5Ssel_iter_reset(hid_t sel_iter_id, hid_t space_id);
  *
  * \note This can be useful for VOL developers to implement chunked datasets.
  *
- * \since 1.12.0
+ * \since 1.10.6
  */
 H5_DLL herr_t H5Sselect_adjust(hid_t spaceid, const hssize_t *offset);
 /**
@@ -970,7 +970,7 @@ H5_DLL herr_t H5Sselect_all(hid_t spaceid);
  *          offset) from the source dataspace \p src_id to the destination
  *          dataspace \p dst_id.
  *
- * \since 1.12.0
+ * \since 1.10.6
  *
  */
 H5_DLL herr_t H5Sselect_copy(hid_t dst_id, hid_t src_id);
@@ -1198,7 +1198,7 @@ H5_DLL herr_t H5Sselect_hyperslab(hid_t space_id, H5S_seloper_t op, const hsize_
  * \note Assumes that \p start & \p end block bounds are inclusive, so
  *       \p start == \p end value is OK.
  *
- * \since 1.12.0
+ * \since 1.10.6
  *
  */
 H5_DLL htri_t H5Sselect_intersect_block(hid_t space_id, const hsize_t *start, const hsize_t *end);
@@ -1237,7 +1237,7 @@ H5_DLL herr_t H5Sselect_none(hid_t spaceid);
  *          into a third selection.This can be useful for VOL developers to
  *          implement chunked or virtual datasets.
  *
- * \since 1.12.0
+ * \since 1.10.6
  *
  */
 H5_DLL hid_t H5Sselect_project_intersection(hid_t src_space_id, hid_t dst_space_id,
@@ -1258,7 +1258,7 @@ H5_DLL hid_t H5Sselect_project_intersection(hid_t src_space_id, hid_t dst_space_
  *          This is primarily used for reading the entire selection in
  *          one swoop.
  *
- * \since 1.12.0
+ * \since 1.10.6
  *
  */
 H5_DLL htri_t H5Sselect_shape_same(hid_t space1_id, hid_t space2_id);


### PR DESCRIPTION
* OESS-98 fix tools test for plugins

* sync fork

* Merge of changes from dev

* Move problem option to bottom of the list until fixed

* HDFFV-11106 - fix parsing optional args

* HDFFV-11106 add note

* grammer fix

* Whitespace after clang formatting

* Undo format version 11 changes

* Update check to working version

* Merge workflow and minor changes from develop

* Update supported platforms

* PR#3 merge from develop

* Merge gcc 10 diagnostics option from develop

* Merge #318 OSX changes from develop

* Merge serval small changes from dev

* fix typo

* Minor non-space formatting changes

* GH #386 copyright corrections for java folder

* revert because logic requires false return

* Merges from develop

* Remove case statement for H5I_EVENTSET

* Correct call with versioning

* Remove tabs

* Double underscore change

* Merges from develop

Remove more underscores from header guards

* Merge #380 from develop

* Correct date entry

* Split format source and commit changes on repo push

* remove pre-split setting

* Change windows TS to use older VS.

* HDFFV-11212 JNI export util and Javadoc

* Suggested review changes

* Another change found

* Committing clang-format changes

* Some Javadoc warning fixes

* Committing clang-format changes

* Updated javadoc fixes

* HDFFV-11228/9 merges from develop

* remove obsolete debug comment

* Fix conflict

* HDFFV-11229 merge changes from develop

* HDFFV-11229 merge second compare from develop

* HDFFV-11229 fix reference file

* HDFFV-11229 update autotools test script for two ref files

* HDFFV-11229 merge dev changes for long double display in tools

* Committing clang-format changes

* Update with changes from develop

* Add "option" command for clang options

* Rework CMake add_custom to use the BYPRODUCTS argument

Update pkgconfig scripts for parallel builds.
Fix install COPYING file reference.
Remove unused round defines.
Change CMake default setting of BUILD_CPP to off.

* Whitespace changes

* Rework CMake add_custom to use the BYPRODUCTS argument

* Revert CMake configure checks for round defines

* With VS 2015 minimum strdup is supported

* Doxygen comments merged from develop

* doxygen build updates

* Correct version string for map functions

* TRILAB-227 and tools debug merge from develop

* TRILAB-227 Enable test

* Quote subset args

* Use MATCHES in compiler id compare, merge from dev

* Revert test enable

* Add file to list

* doxygen version errors

* if blocks needed for build modes

* Update list of test platforms

Co-authored-by: github-actions <41898282+github-actions[bot]@users.noreply.github.com>