### PR TITLE
Fix several warnings

### DIFF
--- a/hl/src/H5LT.c
+++ b/hl/src/H5LT.c
@@ -2206,7 +2206,7 @@ realloc_and_append(hbool_t _no_user_buf, size_t *len, char *buf, const char *str
          */
         if (size_str < *len - 1) {
             if (size_str + size_str_to_add < *len - 1) {
-                HDstrncat(buf, str_to_add, size_str_to_add);
+                HDstrcat(buf, str_to_add);
             }
             else {
                 HDstrncat(buf, str_to_add, (*len - 1) - size_str);

--- a/java/src/jni/h5util.c
+++ b/java/src/jni/h5util.c
@@ -870,11 +870,8 @@ h5str_sprintf(JNIEnv *env, h5str_t *out_str, hid_t container, hid_t tid, void *i
             }
             else {
                 if (typeSize > 0) {
-                    if (NULL == (this_str = (char *)HDmalloc(typeSize + 1)))
+                    if (NULL == (this_str = HDstrdup(tmp_str)))
                         H5_OUT_OF_MEMORY_ERROR(ENVONLY, "h5str_sprintf: failed to allocate string buffer");
-
-                    HDstrncpy(this_str, tmp_str, typeSize);
-                    this_str[typeSize] = '\0';
                 }
             }
 
@@ -3664,18 +3661,13 @@ obj_info_all(hid_t loc_id, const char *name, const H5L_info2_t *info, void *op_d
     info_all_t *datainfo = (info_all_t *)op_data;
     H5O_info2_t object_info;
     htri_t      object_exists;
-    size_t      str_len;
 
     datainfo->otype[datainfo->count]     = -1;
     datainfo->ltype[datainfo->count]     = -1;
     datainfo->obj_token[datainfo->count] = H5O_TOKEN_UNDEF;
 
-    str_len = HDstrlen(name);
-    if (NULL == (datainfo->objname[datainfo->count] = (char *)HDmalloc(str_len + 1)))
+    if (NULL == (datainfo->objname[datainfo->count] = HDstrdup(name)))
         goto done;
-
-    HDstrncpy(datainfo->objname[datainfo->count], name, str_len);
-    (datainfo->objname[datainfo->count])[str_len] = '\0';
 
     if ((object_exists = H5Oexists_by_name(loc_id, name, H5P_DEFAULT)) < 0)
         goto done;
@@ -3702,7 +3694,6 @@ obj_info_max(hid_t loc_id, const char *name, const H5L_info2_t *info, void *op_d
 {
     info_all_t *datainfo = (info_all_t *)op_data;
     H5O_info2_t object_info;
-    size_t      str_len;
 
     datainfo->otype[datainfo->count]     = -1;
     datainfo->ltype[datainfo->count]     = -1;
@@ -3710,12 +3701,8 @@ obj_info_max(hid_t loc_id, const char *name, const H5L_info2_t *info, void *op_d
     datainfo->obj_token[datainfo->count] = H5O_TOKEN_UNDEF;
 
     /* This will be freed by h5str_array_free(oName, n) */
-    str_len = HDstrlen(name);
-    if (NULL == (datainfo->objname[datainfo->count] = (char *)HDmalloc(str_len + 1)))
+    if (NULL == (datainfo->objname[datainfo->count] = HDstrdup(name)))
         goto done;
-
-    HDstrncpy(datainfo->objname[datainfo->count], name, str_len);
-    (datainfo->objname[datainfo->count])[str_len] = '\0';
 
     if (H5Oget_info3(loc_id, &object_info, H5O_INFO_ALL) < 0)
         goto done;

--- a/src/H5Dio.c
+++ b/src/H5Dio.c
@@ -856,28 +856,40 @@ H5D__ioinfo_adjust(H5D_io_info_t *io_info, const H5D_t *dset, const H5S_t *file_
                 for (cause = 1, idx = 0;
                      (cause < H5D_MPIO_NO_COLLECTIVE_MAX_CAUSE) && (idx < cause_strings_len);
                      cause <<= 1, idx++) {
-                    size_t cause_strlen = HDstrlen(cause_strings[idx]);
-
                     if (cause & local_no_collective_cause) {
+                        size_t local_buffer_space = sizeof(local_no_collective_cause_string) -
+                                                    HDstrlen(local_no_collective_cause_string) - 1;
+
                         /* Check if there were any previous error messages included. If so, prepend a
                          * semicolon to separate the messages.
                          */
-                        if (local_error_message_previously_written)
-                            HDstrncat(local_no_collective_cause_string, "; ", 2);
+                        if (local_buffer_space && local_error_message_previously_written) {
+                            HDstrncat(local_no_collective_cause_string, "; ", local_buffer_space);
+                            local_buffer_space -= MIN(local_buffer_space, 2);
+                        }
 
-                        HDstrncat(local_no_collective_cause_string, cause_strings[idx], cause_strlen);
+                        if (local_buffer_space)
+                            HDstrncat(local_no_collective_cause_string, cause_strings[idx],
+                                      local_buffer_space);
 
                         local_error_message_previously_written = TRUE;
                     } /* end if */
 
                     if (cause & global_no_collective_cause) {
+                        size_t global_buffer_space = sizeof(global_no_collective_cause_string) -
+                                                     HDstrlen(global_no_collective_cause_string) - 1;
+
                         /* Check if there were any previous error messages included. If so, prepend a
                          * semicolon to separate the messages.
                          */
-                        if (global_error_message_previously_written)
-                            HDstrncat(global_no_collective_cause_string, "; ", 2);
+                        if (global_buffer_space && global_error_message_previously_written) {
+                            HDstrncat(global_no_collective_cause_string, "; ", global_buffer_space);
+                            global_buffer_space -= MIN(global_buffer_space, 2);
+                        }
 
-                        HDstrncat(global_no_collective_cause_string, cause_strings[idx], cause_strlen);
+                        if (global_buffer_space)
+                            HDstrncat(global_no_collective_cause_string, cause_strings[idx],
+                                      global_buffer_space);
 
                         global_error_message_previously_written = TRUE;
                     } /* end if */

--- a/src/H5E.c
+++ b/src/H5E.c
@@ -639,7 +639,7 @@ H5E__get_class_name(const H5E_cls_t *cls, char *name, size_t size)
 
     /* Set the user's buffer, if provided */
     if (name) {
-        HDstrncpy(name, cls->cls_name, MIN((size_t)(len + 1), size));
+        HDstrncpy(name, cls->cls_name, size);
         if ((size_t)len >= size)
             name[size - 1] = '\0';
     } /* end if */

--- a/src/H5Eint.c
+++ b/src/H5Eint.c
@@ -129,7 +129,7 @@ H5E__get_msg(const H5E_msg_t *msg, H5E_type_t *type, char *msg_str, size_t size)
 
     /* Copy the message into the user's buffer, if given */
     if (msg_str) {
-        HDstrncpy(msg_str, msg->msg, MIN((size_t)(len + 1), size));
+        HDstrncpy(msg_str, msg->msg, size);
         if ((size_t)len >= size)
             msg_str[size - 1] = '\0';
     } /* end if */

--- a/src/H5FDmulti.c
+++ b/src/H5FDmulti.c
@@ -646,7 +646,7 @@ H5FD_multi_sb_encode(H5FD_t *_file, char *name /*out*/, unsigned char *buf /*out
     H5Eclear2(H5E_DEFAULT);
 
     /* Name and version number */
-    strncpy(name, "NCSAmulti", (size_t)8);
+    strncpy(name, "NCSAmult", (size_t)9);
     name[8] = '\0';
 
     assert(7 == H5FD_MEM_NTYPES);
@@ -682,7 +682,7 @@ H5FD_multi_sb_encode(H5FD_t *_file, char *name /*out*/, unsigned char *buf /*out
     p = buf + 8 + nseen * 2 * 8;
     UNIQUE_MEMBERS (file->fa.memb_map, mt) {
         size_t n = strlen(file->fa.memb_name[mt]) + 1;
-        strncpy((char *)p, file->fa.memb_name[mt], n);
+        strcpy((char *)p, file->fa.memb_name[mt]);
         p += n;
         for (i = n; i % 8; i++)
             *p++ = '\0';

--- a/src/H5FDsplitter.c
+++ b/src/H5FDsplitter.c
@@ -340,10 +340,12 @@ H5Pset_fapl_splitter(hid_t fapl_id, H5FD_splitter_vfd_config_t *vfd_config)
         HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, "unable to allocate file access property list struct")
 
     info->ignore_wo_errs = vfd_config->ignore_wo_errs;
-    HDstrncpy(info->wo_path, vfd_config->wo_path, H5FD_SPLITTER_PATH_MAX);
-    HDstrncpy(info->log_file_path, vfd_config->log_file_path, H5FD_SPLITTER_PATH_MAX);
-    info->rw_fapl_id = H5P_FILE_ACCESS_DEFAULT; /* pre-set value */
-    info->wo_fapl_id = H5P_FILE_ACCESS_DEFAULT; /* pre-set value */
+    HDstrncpy(info->wo_path, vfd_config->wo_path, H5FD_SPLITTER_PATH_MAX + 1);
+    info->wo_path[H5FD_SPLITTER_PATH_MAX] = '\0';
+    HDstrncpy(info->log_file_path, vfd_config->log_file_path, H5FD_SPLITTER_PATH_MAX + 1);
+    info->log_file_path[H5FD_SPLITTER_PATH_MAX] = '\0';
+    info->rw_fapl_id                            = H5P_FILE_ACCESS_DEFAULT; /* pre-set value */
+    info->wo_fapl_id                            = H5P_FILE_ACCESS_DEFAULT; /* pre-set value */
 
     /* Set non-default channel FAPL IDs in splitter configuration info */
     if (H5P_DEFAULT != vfd_config->rw_fapl_id) {
@@ -412,8 +414,8 @@ H5Pget_fapl_splitter(hid_t fapl_id, H5FD_splitter_vfd_config_t *config /*out*/)
     if (NULL == (fapl_ptr = (const H5FD_splitter_fapl_t *)H5P_peek_driver_info(plist_ptr)))
         HGOTO_ERROR(H5E_PLIST, H5E_BADVALUE, FAIL, "unable to get specific-driver info")
 
-    HDstrncpy(config->wo_path, fapl_ptr->wo_path, H5FD_SPLITTER_PATH_MAX);
-    HDstrncpy(config->log_file_path, fapl_ptr->log_file_path, H5FD_SPLITTER_PATH_MAX);
+    HDstrncpy(config->wo_path, fapl_ptr->wo_path, H5FD_SPLITTER_PATH_MAX + 1);
+    HDstrncpy(config->log_file_path, fapl_ptr->log_file_path, H5FD_SPLITTER_PATH_MAX + 1);
     config->ignore_wo_errs = fapl_ptr->ignore_wo_errs;
 
     /* Copy R/W and W/O FAPLs */
@@ -587,8 +589,8 @@ H5FD__splitter_fapl_copy(const void *_old_fa)
         HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "unable to allocate log file FAPL")
 
     H5MM_memcpy(new_fa_ptr, old_fa_ptr, sizeof(H5FD_splitter_fapl_t));
-    HDstrncpy(new_fa_ptr->wo_path, old_fa_ptr->wo_path, H5FD_SPLITTER_PATH_MAX);
-    HDstrncpy(new_fa_ptr->log_file_path, old_fa_ptr->log_file_path, H5FD_SPLITTER_PATH_MAX);
+    HDstrncpy(new_fa_ptr->wo_path, old_fa_ptr->wo_path, H5FD_SPLITTER_PATH_MAX + 1);
+    HDstrncpy(new_fa_ptr->log_file_path, old_fa_ptr->log_file_path, H5FD_SPLITTER_PATH_MAX + 1);
 
     /* Copy R/W and W/O FAPLs */
     if (H5FD__copy_plist(old_fa_ptr->rw_fapl_id, &(new_fa_ptr->rw_fapl_id)) < 0)
@@ -688,8 +690,8 @@ H5FD__splitter_open(const char *name, unsigned flags, hid_t splitter_fapl_id, ha
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, NULL, "unable to get VFL driver info")
 
     /* Copy simpler info */
-    HDstrncpy(file_ptr->fa.wo_path, fapl_ptr->wo_path, H5FD_SPLITTER_PATH_MAX);
-    HDstrncpy(file_ptr->fa.log_file_path, fapl_ptr->log_file_path, H5FD_SPLITTER_PATH_MAX);
+    HDstrncpy(file_ptr->fa.wo_path, fapl_ptr->wo_path, H5FD_SPLITTER_PATH_MAX + 1);
+    HDstrncpy(file_ptr->fa.log_file_path, fapl_ptr->log_file_path, H5FD_SPLITTER_PATH_MAX + 1);
     file_ptr->fa.ignore_wo_errs = fapl_ptr->ignore_wo_errs;
 
     /* Copy R/W and W/O channel FAPLs. */

--- a/src/H5Fsuper.c
+++ b/src/H5Fsuper.c
@@ -1043,7 +1043,7 @@ done:
                 HDONE_ERROR(H5E_FILE, H5E_CANTUNPIN, FAIL, "unable to unpin driver info")
 
             /* Evict the driver info block from the cache */
-            if (H5AC_expunge_entry(f, H5AC_DRVRINFO, sblock->driver_addr, H5AC__NO_FLAGS_SET) < 0)
+            if (sblock && H5AC_expunge_entry(f, H5AC_DRVRINFO, sblock->driver_addr, H5AC__NO_FLAGS_SET) < 0)
                 HDONE_ERROR(H5E_FILE, H5E_CANTEXPUNGE, FAIL, "unable to expunge driver info block")
         } /* end if */
 

--- a/src/H5PL.c
+++ b/src/H5PL.c
@@ -359,7 +359,7 @@ H5PLget(unsigned int idx, char *path_buf, size_t buf_size)
 
     /* If the path buffer is not NULL, copy the path to the buffer */
     if (path_buf) {
-        HDstrncpy(path_buf, path, MIN((size_t)(path_len + 1), buf_size));
+        HDstrncpy(path_buf, path, buf_size);
         if ((size_t)path_len >= buf_size)
             path_buf[buf_size - 1] = '\0';
     } /* end if */

--- a/src/H5Pdapl.c
+++ b/src/H5Pdapl.c
@@ -1453,7 +1453,7 @@ H5Pget_efile_prefix(hid_t plist_id, char *prefix /*out*/, size_t size)
         /* Copy to user's buffer, if given */
         len = HDstrlen(my_prefix);
         if (prefix) {
-            HDstrncpy(prefix, my_prefix, MIN(len + 1, size));
+            HDstrncpy(prefix, my_prefix, size);
             if (len >= size)
                 prefix[size - 1] = '\0';
         } /* end if */
@@ -1543,7 +1543,7 @@ H5Pget_virtual_prefix(hid_t plist_id, char *prefix /*out*/, size_t size)
         /* Copy to user's buffer, if given */
         len = HDstrlen(my_prefix);
         if (prefix) {
-            HDstrncpy(prefix, my_prefix, MIN(len + 1, size));
+            HDstrncpy(prefix, my_prefix, size);
             if (len >= size)
                 prefix[size - 1] = '\0';
         } /* end if */

--- a/src/H5Pdxpl.c
+++ b/src/H5Pdxpl.c
@@ -1052,7 +1052,7 @@ H5Pget_data_transform(hid_t plist_id, char *expression /*out*/, size_t size)
     /* Copy into application buffer */
     len = HDstrlen(pexp);
     if (expression) {
-        HDstrncpy(expression, pexp, MIN(len + 1, size));
+        HDstrncpy(expression, pexp, size);
         if (len >= size)
             expression[size - 1] = '\0';
     } /* end if */

--- a/src/H5Pencdec.c
+++ b/src/H5Pencdec.c
@@ -333,7 +333,7 @@ H5P__encode_cb(H5P_genprop_t *prop, void *_udata)
         /* Encode (or not, if the 'encode' flag is off) the property's name */
         prop_name_len = HDstrlen(prop->name) + 1;
         if (udata->encode) {
-            HDstrncpy((char *)*(udata->pp), prop->name, prop_name_len);
+            HDstrcpy((char *)*(udata->pp), prop->name);
             *(uint8_t **)(udata->pp) += prop_name_len;
         } /* end if */
         *(udata->enc_size_ptr) += prop_name_len;

--- a/src/H5Plapl.c
+++ b/src/H5Plapl.c
@@ -1044,7 +1044,7 @@ H5Pget_elink_prefix(hid_t plist_id, char *prefix /*out*/, size_t size)
         /* Copy to user's buffer, if given */
         len = HDstrlen(my_prefix);
         if (prefix) {
-            HDstrncpy(prefix, my_prefix, MIN(len + 1, size));
+            HDstrncpy(prefix, my_prefix, size);
             if (len >= size)
                 prefix[size - 1] = '\0';
         } /* end if */

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -1757,7 +1757,7 @@ H5VL__get_connector_name(hid_t id, char *name /*out*/, size_t size)
 
     len = HDstrlen(cls->name);
     if (name) {
-        HDstrncpy(name, cls->name, MIN(len + 1, size));
+        HDstrncpy(name, cls->name, size);
         if (len >= size)
             name[size - 1] = '\0';
     } /* end if */

--- a/src/H5system.c
+++ b/src/H5system.c
@@ -732,8 +732,8 @@ H5_build_extpath(const char *name, char **extpath /*out*/)
 
             HDstrncpy(full_path, cwdpath, cwdlen + 1);
             if (!H5_CHECK_DELIMITER(cwdpath[cwdlen - 1]))
-                HDstrncat(full_path, H5_DIR_SEPS, HDstrlen(H5_DIR_SEPS));
-            HDstrncat(full_path, new_name, HDstrlen(new_name));
+                HDstrncat(full_path, H5_DIR_SEPS, path_len - (cwdlen + 1));
+            HDstrncat(full_path, new_name, path_len - (cwdlen + 1) - HDstrlen(H5_DIR_SEPS));
         } /* end if */
     }     /* end else */
 

--- a/test/ohdr.c
+++ b/test/ohdr.c
@@ -541,7 +541,7 @@ test_unknown(unsigned bogus_id, char *filename, hid_t fapl)
        done in the source directory. */
     HDstrncpy(testfile, FILE_BOGUS, TESTFILE_LEN);
     testfile[TESTFILE_LEN - 1] = '\0';
-    HDstrncat(testfile, ".copy", 5);
+    HDstrncat(testfile, ".copy", sizeof(testfile) - HDstrlen(testfile) - 1);
 
     /* Make a copy of the data file from svn. */
     if (h5_make_local_copy(FILE_BOGUS, testfile) < 0)

--- a/tools/lib/h5tools_str.c
+++ b/tools/lib/h5tools_str.c
@@ -258,7 +258,8 @@ h5tools_str_fmt(h5tools_str_t *str /*in,out*/, size_t start, const char *fmt)
             HDassert(temp);
         }
 
-        HDstrncpy(temp, str->s + start, n);
+        HDstrncpy(temp, str->s + start, n - 1);
+        temp[n - 1] = '\0';
     }
 
     /* Reset the output string and append a formatted version */

--- a/tools/src/h5dump/h5dump_ddl.c
+++ b/tools/src/h5dump/h5dump_ddl.c
@@ -1343,13 +1343,21 @@ attr_search(hid_t oid, const char *attr_name, const H5A_info_t H5_ATTR_UNUSED *a
                 ret = FAIL;
             }
             else {
+                size_t buffer_space = w - 1;
+
                 HDmemset(obj_name, '\0', w);
                 if (op_name[0] != '/') {
-                    HDstrncat(obj_name, buf, u + 1);
-                    if (buf[u - 1] != '/')
-                        HDstrncat(obj_name, "/", (size_t)2);
+                    HDstrncat(obj_name, buf, buffer_space);
+                    buffer_space -= MIN(buffer_space, u);
+
+                    if (buf[u - 1] != '/') {
+                        HDstrncat(obj_name, "/", buffer_space);
+                        buffer_space -= MIN(buffer_space, 2);
+                    }
                 }
-                HDstrncat(obj_name, op_name, v + 1);
+
+                HDstrncat(obj_name, op_name, buffer_space);
+                buffer_space -= MIN(buffer_space, v);
 
                 handle_attributes(oid, obj_name, NULL, 0, NULL);
                 HDfree(obj_name);
@@ -1421,10 +1429,10 @@ lnk_search(const char *path, const H5L_info2_t *li, void *_op_data)
     else {
         if (k == 2) {
             HDstrcpy(search_name, "/");
-            HDstrncat(search_name, op_name, search_len + 1);
+            HDstrcat(search_name, op_name);
         }
         else
-            HDstrncpy(search_name, op_name, search_len + 1);
+            HDstrcpy(search_name, op_name);
         search_name[search_len + k - 1] = '\0';
 
         if (HDstrcmp(path, search_name) == 0) {

--- a/tools/src/h5import/h5import.c
+++ b/tools/src/h5import/h5import.c
@@ -3771,6 +3771,7 @@ getCompressionParameter(struct Input *in, FILE *strm)
 static int
 getExternalFilename(struct Input *in, FILE *strm)
 {
+    size_t      temp_len;
     char        temp[255];
     const char *err1 = "Unable to get 'string' value.\n";
 
@@ -3779,8 +3780,10 @@ getExternalFilename(struct Input *in, FILE *strm)
         return (-1);
     }
 
-    in->externFilename = (char *)HDmalloc((size_t)(HDstrlen(temp) + 1) * sizeof(char));
-    (void)HDstrncpy(in->externFilename, temp, HDstrlen(temp) + 1);
+    temp_len           = HDstrlen(temp);
+    in->externFilename = (char *)HDmalloc((temp_len + 1) * sizeof(char));
+    (void)HDstrcpy(in->externFilename, temp);
+    in->externFilename[temp_len] = '\0';
     return (0);
 }
 


### PR DESCRIPTION
Fixes a few issues uncovered from GCC's static analysis, along with several pesky warnings such as strncpy with a size equal to the source object's size, all of the unused H5FD package variable warnings, etc.