### PR TITLE
Moves gcc warning macros from H5public.h to H5private.h

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -463,6 +463,19 @@ New Features
 
     Library:
     --------
+    - gcc warning suppression macros were moved out of H5public.h
+
+      The HDF5 library uses a set of macros to suppress warnings on gcc.
+      These warnings were originally located in H5public.h so that the
+      multi VFD (which only uses public headers) could also make use of them
+      but internal macros should not be publicly exposed like this.
+
+      These macros have now been moved to H5private.h. Pending future multi
+      VFD refactoring, the macros have been duplicated in H5FDmulti.c to
+      suppress the format string warnings there.
+
+        (DER - 2021/06/03)
+
     - H5Gcreate1() now rejects size_hint parameters larger than UINT32_MAX
 
       The size_hint value is ultimately stored in a uint32_t struct field,

--- a/src/H5FDmulti.c
+++ b/src/H5FDmulti.c
@@ -45,6 +45,28 @@
 #define my_strdup strdup
 #endif
 
+/* Macros for enabling/disabling particular GCC warnings
+ *
+ * These are (renamed) duplicates of macros in H5private.h. If you make changes
+ * here, be sure to update those as well.
+ *
+ * (see the following web-sites for more info:
+ *      http://www.dbp-consulting.com/tutorials/SuppressingGCCWarnings.html
+ *      http://gcc.gnu.org/onlinedocs/gcc/Diagnostic-Pragmas.html#Diagnostic-Pragmas
+ */
+/* These pragmas are only implemented usefully in gcc 4.6+ */
+#if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 406
+#define H5_MULTI_GCC_DIAG_JOINSTR(x, y) x y
+#define H5_MULTI_GCC_DIAG_DO_PRAGMA(x)  _Pragma(#x)
+#define H5_MULTI_GCC_DIAG_PRAGMA(x)     H5_MULTI_GCC_DIAG_DO_PRAGMA(GCC diagnostic x)
+
+#define H5_MULTI_GCC_DIAG_OFF(x) H5_MULTI_GCC_DIAG_PRAGMA(push) H5_MULTI_GCC_DIAG_PRAGMA(ignored H5_MULTI_GCC_DIAG_JOINSTR("-W", x))
+#define H5_MULTI_GCC_DIAG_ON(x)  H5_MULTI_GCC_DIAG_PRAGMA(pop)
+#else
+#define H5_MULTI_GCC_DIAG_OFF(x)
+#define H5_MULTI_GCC_DIAG_ON(x)
+#endif
+
 /* Loop through all mapped files */
 #define UNIQUE_MEMBERS_CORE(MAP, ITER, SEEN, LOOPVAR)                                                        \
     {                                                                                                        \
@@ -1959,7 +1981,7 @@ compute_next(H5FD_multi_t *file)
  *      tmp in the code below, but early (4.4.7, at least) gcc only
  *      allows diagnostic pragmas to be toggled outside of functions.
  */
-H5_GCC_DIAG_OFF("format-nonliteral")
+H5_MULTI_GCC_DIAG_OFF("format-nonliteral")
 static int
 open_members(H5FD_multi_t *file)
 {
@@ -2044,7 +2066,7 @@ H5FD_multi_delete(const char *filename, hid_t fapl_id)
 
     return 0;
 } /* end H5FD_multi_delete() */
-H5_GCC_DIAG_ON("format-nonliteral")
+H5_MULTI_GCC_DIAG_ON("format-nonliteral")
 
 #ifdef H5private_H
 /*

--- a/src/H5FDmulti.c
+++ b/src/H5FDmulti.c
@@ -60,8 +60,9 @@
 #define H5_MULTI_GCC_DIAG_DO_PRAGMA(x)  _Pragma(#x)
 #define H5_MULTI_GCC_DIAG_PRAGMA(x)     H5_MULTI_GCC_DIAG_DO_PRAGMA(GCC diagnostic x)
 
-#define H5_MULTI_GCC_DIAG_OFF(x) H5_MULTI_GCC_DIAG_PRAGMA(push) H5_MULTI_GCC_DIAG_PRAGMA(ignored H5_MULTI_GCC_DIAG_JOINSTR("-W", x))
-#define H5_MULTI_GCC_DIAG_ON(x)  H5_MULTI_GCC_DIAG_PRAGMA(pop)
+#define H5_MULTI_GCC_DIAG_OFF(x)                                                                             \
+    H5_MULTI_GCC_DIAG_PRAGMA(push) H5_MULTI_GCC_DIAG_PRAGMA(ignored H5_MULTI_GCC_DIAG_JOINSTR("-W", x))
+#define H5_MULTI_GCC_DIAG_ON(x) H5_MULTI_GCC_DIAG_PRAGMA(pop)
 #else
 #define H5_MULTI_GCC_DIAG_OFF(x)
 #define H5_MULTI_GCC_DIAG_ON(x)

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -558,6 +558,29 @@ typedef long int32_t;
 #define LOCK_UN 0x08
 #endif /* H5_HAVE_FLOCK */
 
+/* Macros for enabling/disabling particular GCC warnings
+ *
+ * These are duplicated in H5FDmulti.c (we don't want to put them in the
+ * public header and the multi VFD can't use private headers). If you make
+ * changes here, be sure to update those as well.
+ *
+ * (see the following web-sites for more info:
+ *      http://www.dbp-consulting.com/tutorials/SuppressingGCCWarnings.html
+ *      http://gcc.gnu.org/onlinedocs/gcc/Diagnostic-Pragmas.html#Diagnostic-Pragmas
+ */
+/* These pragmas are only implemented usefully in gcc 4.6+ */
+#if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 406
+#define H5_GCC_DIAG_JOINSTR(x, y) x y
+#define H5_GCC_DIAG_DO_PRAGMA(x)  _Pragma(#x)
+#define H5_GCC_DIAG_PRAGMA(x)     H5_GCC_DIAG_DO_PRAGMA(GCC diagnostic x)
+
+#define H5_GCC_DIAG_OFF(x) H5_GCC_DIAG_PRAGMA(push) H5_GCC_DIAG_PRAGMA(ignored H5_GCC_DIAG_JOINSTR("-W", x))
+#define H5_GCC_DIAG_ON(x)  H5_GCC_DIAG_PRAGMA(pop)
+#else
+#define H5_GCC_DIAG_OFF(x)
+#define H5_GCC_DIAG_ON(x)
+#endif
+
 /* Typedefs and functions for timing certain parts of the library. */
 
 /* A set of elapsed/user/system times emitted as a time point by the

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -59,31 +59,6 @@
 #endif
 #endif
 
-/* Include the Windows API adapter header early */
-#include "H5api_adpt.h"
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/* Macros for enabling/disabling particular GCC warnings */
-/* (see the following web-sites for more info:
- *      http://www.dbp-consulting.com/tutorials/SuppressingGCCWarnings.html
- *      http://gcc.gnu.org/onlinedocs/gcc/Diagnostic-Pragmas.html#Diagnostic-Pragmas
- */
-/* These pragmas are only implemented usefully in gcc 4.6+ */
-#if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 406
-#define H5_GCC_DIAG_JOINSTR(x, y) x y
-#define H5_GCC_DIAG_DO_PRAGMA(x)  _Pragma(#x)
-#define H5_GCC_DIAG_PRAGMA(x)     H5_GCC_DIAG_DO_PRAGMA(GCC diagnostic x)
-
-#define H5_GCC_DIAG_OFF(x) H5_GCC_DIAG_PRAGMA(push) H5_GCC_DIAG_PRAGMA(ignored H5_GCC_DIAG_JOINSTR("-W", x))
-#define H5_GCC_DIAG_ON(x)  H5_GCC_DIAG_PRAGMA(pop)
-#else
-#define H5_GCC_DIAG_OFF(x)
-#define H5_GCC_DIAG_ON(x)
-#endif
-
 /* Macro to hide a symbol from further preprocessor substitutions */
 #define H5_NO_EXPAND(x) (x)
 
@@ -367,6 +342,13 @@ typedef struct H5_alloc_stats_t {
  * Library shutdown callback, used by H5atclose().
  */
 typedef void (*H5_atclose_func_t)(void *ctx);
+
+/* API adapter header (defines H5_DLL, etc.) */
+#include "H5api_adpt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Functions in H5.c */
 /**


### PR DESCRIPTION
These do not belong in the public API. They were originally put there for use in the multi VFD (which can only use public headers). Pending future multi VFD refactoring, the macros have been duplicated in H5FDmulti.c.