### PR TITLE
Adds __STDC_FORMAT_MACROS before including inttypes.h w/ C++

### DIFF
--- a/src/H5public.h
+++ b/src/H5public.h
@@ -43,6 +43,10 @@
 #include <stdarg.h> /* For variadic functions in H5VLpublic.h   */
 
 #include <stdint.h>   /* For C9x types */
+
+#ifdef __cplusplus
+#define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h> /* C99/POSIX.1 header for uint64_t, PRIu64 */
 
 #ifdef H5_HAVE_STDDEF_H

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -42,7 +42,7 @@
 #include <limits.h> /* For H5T_NATIVE_CHAR defn in H5Tpublic.h  */
 #include <stdarg.h> /* For variadic functions in H5VLpublic.h   */
 
-#include <stdint.h>   /* For C9x types */
+#include <stdint.h> /* For C9x types */
 
 #ifdef __cplusplus
 #define __STDC_FORMAT_MACROS


### PR DESCRIPTION
Allows C++ library to be built on older versions of gcc.