### PR TITLE
Fix for github issue #729.

### DIFF
--- a/hl/c++/src/H5PacketTable.h
+++ b/hl/c++/src/H5PacketTable.h
@@ -33,7 +33,7 @@ class H5_HLCPPDLL PacketTable {
     /* Null constructor
      * Sets table_id to "invalid"
      */
-    PacketTable() : table_id{H5I_INVALID_HID}
+    PacketTable() : table_id(H5I_INVALID_HID)
     {
     }
 


### PR DESCRIPTION
line 36 of hl/c++/src/H5PacketTable.h:
PacketTable() : table_id{H5I_INVALID_HID}
should be?
PacketTable() : table_id(H5I_INVALID_HID)

the change fixes these errors for make installcheck with PGI compilers on jelly:
/scr/hdftest/snapshots-hdf5/TestDir/jelly/hdf5/bin/h5c++ -o ptExampleFL /home/hdftest/snapshots-hdf5/current/hl/c++/examples/ptExampleFL.cpp
"/scr/hdftest/snapshots-hdf5/TestDir/jelly/hdf5/include/H5PacketTable.h", line
37: error: expected a declaration
{
^

"/scr/hdftest/snapshots-hdf5/TestDir/jelly/hdf5/include/H5PacketTable.h", line
36: error: expected a "("
PacketTable() : table_id{H5I_INVALID_HID}
^

"/scr/hdftest/snapshots-hdf5/TestDir/jelly/hdf5/include/H5PacketTable.h", line
36: error: expected a ";"
PacketTable() : table_id{H5I_INVALID_HID}