### PR TITLE
Moves H5PacketTable default ctor inside source file

### DIFF
--- a/config/commence.am
+++ b/config/commence.am
@@ -45,7 +45,7 @@ LIBH5CPP_HL=$(top_builddir)/hl/c++/src/libhdf5_hl_cpp.la
 docdir = $(exec_prefix)/doc
 
 # Note that in svn revision 19400 the '/' after DESTDIR in H5* variables below
-# has been removed. According to the official description of DESTDIR by Gnu at
+# has been removed. According to the official description of DESTDIR by GNU at
 # http://www.gnu.org/prep/standards/html_node/DESTDIR.html, DESTDIR is
 # prepended to the normal and complete install path that it precedes for the
 # purpose of installing in a temporary directory which is useful for building

--- a/hl/c++/src/H5PacketTable.cpp
+++ b/hl/c++/src/H5PacketTable.cpp
@@ -28,6 +28,13 @@
 /* PacketTable superclass       */
 /********************************/
 
+/* Null constructor
+ * Sets table_id to "invalid"
+ */
+PacketTable::PacketTable() : table_id{H5I_INVALID_HID}
+{
+}
+
 /* "Open" Constructor
  * Opens an existing packet table, which can contain either fixed-length or
  * variable-length packets.

--- a/hl/c++/src/H5PacketTable.h
+++ b/hl/c++/src/H5PacketTable.h
@@ -31,11 +31,9 @@
 class H5_HLCPPDLL PacketTable {
   public:
     /* Null constructor
-     * Sets table_id to "invalid"
+     * Sets table_id to H5I_INVALID_HID
      */
-    PacketTable() : table_id{H5I_INVALID_HID}
-    {
-    }
+    PacketTable();
 
     /* "Open" Constructor
      * Opens an existing packet table, which can contain either fixed-length or


### PR DESCRIPTION
Allows the packet table example to be built by h5c++ on creaky old g++ 4.8.5 (default on Centos 7).