### PR TITLE
Removed -fanalyzer from the gcc 10 developer options

### DIFF
--- a/config/gnu-warnings/developer-10
+++ b/config/gnu-warnings/developer-10
@@ -1,6 +1,2 @@
 # New warning
 -Warith-conversion
-
-# Enable static analysis of program flow
--fanalyzer
--fdiagnostics-path-format=none


### PR DESCRIPTION
This is extremely slow and generates a LOT of false positives. It's also
not really a warning flag, but an analysis feature and thus belongs in
a separate configure option, not lumped in with the warnings.