### PR TITLE
Fix problem in gnu-cxxflags;  

### DIFF
--- a/config/gnu-cxxflags
+++ b/config/gnu-cxxflags
@@ -268,10 +268,7 @@ if test "X-g++" = "X-$cxx_vendor"; then
     fi
 
     # gcc >= 9.3
-    if test $cc_vers_major -ge 10 -o $cc_vers_major -eq 9 -a $cc_vers_minor -ge 3; then
-        # do not use C warnings, $(load_gnu_arguments 9.3), no cxx warnings
-        # H5_CXXFLAGS="$H5_CXXFLAGS $(load_gnu_arguments cxx-9.3)"
-    fi
+        # no cxx warnings, do NOT use C warnings
 
     # gcc >= 10
     if test $cc_vers_major -ge 10; then


### PR DESCRIPTION
remove empty if block that throws away all C++ flags.