### PR TITLE
Fixes some H5SL include statements

### DIFF
--- a/src/H5Gint.c
+++ b/src/H5Gint.c
@@ -38,6 +38,7 @@
 #include "H5Iprivate.h"  /* IDs                                      */
 #include "H5Lprivate.h"  /* Links                                    */
 #include "H5MMprivate.h" /* Memory management                        */
+#include "H5SLprivate.h" /* Skip lists                               */
 
 /****************/
 /* Local Macros */

--- a/src/H5Gpkg.h
+++ b/src/H5Gpkg.h
@@ -35,7 +35,6 @@
 #include "H5HFprivate.h" /* Fractal heaps            */
 #include "H5HLprivate.h" /* Local Heaps                */
 #include "H5Oprivate.h"  /* Object headers              */
-#include "H5SLprivate.h" /* Skip lists                */
 
 /**************************/
 /* Package Private Macros */

--- a/src/H5HFpkg.h
+++ b/src/H5HFpkg.h
@@ -34,7 +34,6 @@
 #include "H5B2private.h" /* v2 B-trees				*/
 #include "H5FLprivate.h" /* Free Lists                           */
 #include "H5FSprivate.h" /* Free space manager			*/
-#include "H5SLprivate.h" /* Skip lists				*/
 
 /**************************/
 /* Package Private Macros */


### PR DESCRIPTION
Just a few things I noticed while grepping around the library looking for skip list usage.