### PR TITLE
1.12: Fixes an array issue flagged by PGI in a C++ test

### DIFF
--- a/c++/test/ttypes.cpp
+++ b/c++/test/ttypes.cpp
@@ -726,8 +726,11 @@ test_named()
 
         // It should be possible to define an attribute for the named type
         Attribute attr1 = itype.createAttribute("attr1", PredType::NATIVE_UCHAR, space);
-        for (i = 0; i < ds_size[0] * ds_size[1]; i++)
-            attr_data[0][i] = (int)i; /*tricky*/
+        for (hsize_t i = 0; i < ds_size[0]; i++) {
+            for (hsize_t j = 0; j < ds_size[1]; j++) {
+                attr_data[i][j] = static_cast<unsigned>(i * ds_size[1] + j);
+            }
+        }
         attr1.write(PredType::NATIVE_UINT, attr_data);
         attr1.close();
 


### PR DESCRIPTION
This was already fixed in develop. PGI's array sanitizer gets grumpy when [10][20] and [1][200] arrays are treated as equal.