### PR TITLE
Removes checks for (v)snprintf, which are C99

### DIFF
--- a/config/cmake/H5pubconf.h.in
+++ b/config/cmake/H5pubconf.h.in
@@ -322,9 +322,6 @@
 /* Define to 1 if you have the `sigsetjmp' function. */
 #cmakedefine H5_HAVE_SIGSETJMP @H5_HAVE_SIGSETJMP@
 
-/* Define to 1 if you have the `snprintf' function. */
-#cmakedefine H5_HAVE_SNPRINTF @H5_HAVE_SNPRINTF@
-
 /* Define to 1 if you have the `srandom' function. */
 #cmakedefine H5_HAVE_SRANDOM @H5_HAVE_SRANDOM@
 
@@ -413,9 +410,6 @@
 
 /* Define to 1 if you have the `vasprintf' function. */
 #cmakedefine H5_HAVE_VASPRINTF @H5_HAVE_VASPRINTF@
-
-/* Define to 1 if you have the `vsnprintf' function. */
-#cmakedefine H5_HAVE_VSNPRINTF @H5_HAVE_VSNPRINTF@
 
 /* Define to 1 if you have the `waitpid' function. */
 #cmakedefine H5_HAVE_WAITPID @H5_HAVE_WAITPID@

--- a/config/cmake_ext_mod/ConfigureChecks.cmake
+++ b/config/cmake_ext_mod/ConfigureChecks.cmake
@@ -491,7 +491,6 @@ CHECK_FUNCTION_EXISTS (siglongjmp        ${HDF_PREFIX}_HAVE_SIGLONGJMP)
 CHECK_FUNCTION_EXISTS (sigsetjmp         ${HDF_PREFIX}_HAVE_SIGSETJMP)
 CHECK_FUNCTION_EXISTS (sigprocmask       ${HDF_PREFIX}_HAVE_SIGPROCMASK)
 
-CHECK_FUNCTION_EXISTS (snprintf          ${HDF_PREFIX}_HAVE_SNPRINTF)
 CHECK_FUNCTION_EXISTS (srandom           ${HDF_PREFIX}_HAVE_SRANDOM)
 CHECK_FUNCTION_EXISTS (strdup            ${HDF_PREFIX}_HAVE_STRDUP)
 CHECK_FUNCTION_EXISTS (symlink           ${HDF_PREFIX}_HAVE_SYMLINK)
@@ -501,13 +500,6 @@ CHECK_FUNCTION_EXISTS (tmpfile           ${HDF_PREFIX}_HAVE_TMPFILE)
 CHECK_FUNCTION_EXISTS (asprintf          ${HDF_PREFIX}_HAVE_ASPRINTF)
 CHECK_FUNCTION_EXISTS (vasprintf         ${HDF_PREFIX}_HAVE_VASPRINTF)
 CHECK_FUNCTION_EXISTS (waitpid           ${HDF_PREFIX}_HAVE_WAITPID)
-
-CHECK_FUNCTION_EXISTS (vsnprintf         ${HDF_PREFIX}_HAVE_VSNPRINTF)
-if (MINGW OR NOT WINDOWS)
-  if (${HDF_PREFIX}_HAVE_VSNPRINTF)
-    HDF_FUNCTION_TEST (VSNPRINTF_WORKS)
-  endif ()
-endif ()
 
 #-----------------------------------------------------------------------------
 # sigsetjmp is special; may actually be a macro

--- a/config/cmake_ext_mod/HDFTests.c
+++ b/config/cmake_ext_mod/HDFTests.c
@@ -64,31 +64,6 @@ main ()
 
 #endif
 
-#ifdef VSNPRINTF_WORKS
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdarg.h>
-
-int test_vsnprintf(const char *fmt,...)
-{
-    va_list     ap;
-    char *s = malloc(16);
-    int ret;
-
-    va_start(ap, fmt);
-    ret=vsnprintf(s,16,"%s",ap);
-    va_end(ap);
-
-    return(ret!=42 ? 1 : 0);
-}
-
-int main(void)
-{
-    return(test_vsnprintf("%s","A string that is longer than 16 characters"));
-}
-#endif
-
-
 #ifdef HAVE_ATTRIBUTE
 
 #if 0

--- a/configure.ac
+++ b/configure.ac
@@ -2029,8 +2029,8 @@ AC_CHECK_FUNCS([alarm clock_gettime difftime fcntl flock fork frexpf])
 AC_CHECK_FUNCS([frexpl gethostname getrusage gettimeofday])
 AC_CHECK_FUNCS([lstat rand_r random setsysinfo])
 AC_CHECK_FUNCS([signal longjmp setjmp siglongjmp sigsetjmp sigprocmask])
-AC_CHECK_FUNCS([snprintf srandom strdup symlink system])
-AC_CHECK_FUNCS([tmpfile asprintf vasprintf vsnprintf waitpid])
+AC_CHECK_FUNCS([srandom strdup symlink system])
+AC_CHECK_FUNCS([tmpfile asprintf vasprintf waitpid])
 
 ## ----------------------------------------------------------------------
 ## Check compiler characteristics


### PR DESCRIPTION
There is no need for these checks now that we require a C99 compiler.