### PR TITLE
Replaces the H5_OVERRIDE macro with override

### DIFF
--- a/c++/src/H5ArrayType.h
+++ b/c++/src/H5ArrayType.h
@@ -37,7 +37,7 @@ class H5_DLLCPP ArrayType : public DataType {
 
     // Returns an ArrayType object via DataType* by decoding the
     // binary object description of this type.
-    virtual DataType *decode() const H5_OVERRIDE;
+    virtual DataType *decode() const override;
 
     // Returns the number of dimensions of this array datatype.
     int getArrayNDims() const;
@@ -49,7 +49,7 @@ class H5_DLLCPP ArrayType : public DataType {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("ArrayType");
     }
@@ -61,7 +61,7 @@ class H5_DLLCPP ArrayType : public DataType {
     ArrayType(const hid_t existing_id);
 
     // Noop destructor
-    virtual ~ArrayType() H5_OVERRIDE;
+    virtual ~ArrayType() override;
 
     // Default constructor
     ArrayType();

--- a/c++/src/H5AtomType.h
+++ b/c++/src/H5AtomType.h
@@ -58,7 +58,7 @@ class H5_DLLCPP AtomType : public DataType {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("AtomType");
     }
@@ -68,7 +68,7 @@ class H5_DLLCPP AtomType : public DataType {
     AtomType(const AtomType &original);
 
     // Noop destructor
-    virtual ~AtomType() H5_OVERRIDE;
+    virtual ~AtomType() override;
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
   protected:

--- a/c++/src/H5Attribute.h
+++ b/c++/src/H5Attribute.h
@@ -38,7 +38,7 @@ class H5_DLLCPP Attribute : public AbstractDs, public H5Location {
     Attribute(const hid_t attr_id);
 
     // Closes this attribute.
-    virtual void close() H5_OVERRIDE;
+    virtual void close() override;
 
     // Gets the name of this attribute.
     ssize_t      getName(char *attr_name, size_t buf_size = 0) const;
@@ -50,13 +50,13 @@ class H5_DLLCPP Attribute : public AbstractDs, public H5Location {
     ssize_t getName(size_t buf_size, H5std_string &attr_name) const;
 
     // Gets a copy of the dataspace for this attribute.
-    virtual DataSpace getSpace() const H5_OVERRIDE;
+    virtual DataSpace getSpace() const override;
 
     // Returns the amount of storage size required for this attribute.
-    virtual hsize_t getStorageSize() const H5_OVERRIDE;
+    virtual hsize_t getStorageSize() const override;
 
     // Returns the in memory size of this attribute's data.
-    virtual size_t getInMemDataSize() const H5_OVERRIDE;
+    virtual size_t getInMemDataSize() const override;
 
     // Reads data from this attribute.
     void read(const DataType &mem_type, void *buf) const;
@@ -68,21 +68,21 @@ class H5_DLLCPP Attribute : public AbstractDs, public H5Location {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("Attribute");
     }
 
     // Gets the attribute id.
-    virtual hid_t getId() const H5_OVERRIDE;
+    virtual hid_t getId() const override;
 
     // Destructor: properly terminates access to this attribute.
-    virtual ~Attribute() H5_OVERRIDE;
+    virtual ~Attribute() override;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
   protected:
     // Sets the attribute id.
-    virtual void p_setId(const hid_t new_id) H5_OVERRIDE;
+    virtual void p_setId(const hid_t new_id) override;
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
   private:
@@ -92,7 +92,7 @@ class H5_DLLCPP Attribute : public AbstractDs, public H5Location {
     // getTypeClass and various API functions getXxxType
     // defined in AbstractDs for generic datatype and specific
     // sub-types
-    virtual hid_t p_get_type() const H5_OVERRIDE;
+    virtual hid_t p_get_type() const override;
 
     // Reads variable or fixed len strings from this attribute.
     void p_read_variable_len(const DataType &mem_type, H5std_string &strg) const;

--- a/c++/src/H5CompType.h
+++ b/c++/src/H5CompType.h
@@ -45,7 +45,7 @@ class H5_DLLCPP CompType : public DataType {
 
     // Returns a CompType object via DataType* by decoding the binary
     // object description of this type.
-    virtual DataType *decode() const H5_OVERRIDE;
+    virtual DataType *decode() const override;
 
     // Returns the type class of the specified member of this compound
     // datatype.  It provides to the user a way of knowing what type
@@ -108,13 +108,13 @@ class H5_DLLCPP CompType : public DataType {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("CompType");
     }
 
     // Noop destructor.
-    virtual ~CompType() H5_OVERRIDE;
+    virtual ~CompType() override;
 
   private:
     // Contains common code that is used by the member functions

--- a/c++/src/H5DaccProp.h
+++ b/c++/src/H5DaccProp.h
@@ -38,7 +38,7 @@ class H5_DLLCPP DSetAccPropList : public LinkAccPropList {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("DSetAccPropList");
     }
@@ -51,7 +51,7 @@ class H5_DLLCPP DSetAccPropList : public LinkAccPropList {
     DSetAccPropList(const hid_t plist_id);
 
     // Noop destructor.
-    virtual ~DSetAccPropList() H5_OVERRIDE;
+    virtual ~DSetAccPropList() override;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/c++/src/H5DataSet.h
+++ b/c++/src/H5DataSet.h
@@ -28,7 +28,7 @@ namespace H5 {
 class H5_DLLCPP DataSet : public H5Object, public AbstractDs {
   public:
     // Close this dataset.
-    virtual void close() H5_OVERRIDE;
+    virtual void close() override;
 
     // Extends the dataset with unlimited dimension.
     void extend(const hsize_t *size) const;
@@ -53,16 +53,16 @@ class H5_DLLCPP DataSet : public H5Object, public AbstractDs {
     haddr_t getOffset() const;
 
     // Gets the dataspace of this dataset.
-    virtual DataSpace getSpace() const H5_OVERRIDE;
+    virtual DataSpace getSpace() const override;
 
     // Determines whether space has been allocated for a dataset.
     void getSpaceStatus(H5D_space_status_t &status) const;
 
     // Returns the amount of storage size required for this dataset.
-    virtual hsize_t getStorageSize() const H5_OVERRIDE;
+    virtual hsize_t getStorageSize() const override;
 
     // Returns the in memory size of this attribute's data.
-    virtual size_t getInMemDataSize() const H5_OVERRIDE;
+    virtual size_t getInMemDataSize() const override;
 
     // Returns the number of bytes required to store VL data.
     hsize_t getVlenBufSize(const DataType &type, const DataSpace &space) const;
@@ -100,7 +100,7 @@ class H5_DLLCPP DataSet : public H5Object, public AbstractDs {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("DataSet");
     }
@@ -124,15 +124,15 @@ class H5_DLLCPP DataSet : public H5Object, public AbstractDs {
     DataSet(const hid_t existing_id);
 
     // Gets the dataset id.
-    virtual hid_t getId() const H5_OVERRIDE;
+    virtual hid_t getId() const override;
 
     // Destructor: properly terminates access to this dataset.
-    virtual ~DataSet() H5_OVERRIDE;
+    virtual ~DataSet() override;
 
   protected:
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
     // Sets the dataset id.
-    virtual void p_setId(const hid_t new_id) H5_OVERRIDE;
+    virtual void p_setId(const hid_t new_id) override;
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
   private:
@@ -142,7 +142,7 @@ class H5_DLLCPP DataSet : public H5Object, public AbstractDs {
     // getTypeClass and various API functions getXxxType
     // defined in AbstractDs for generic datatype and specific
     // sub-types
-    virtual hid_t p_get_type() const H5_OVERRIDE;
+    virtual hid_t p_get_type() const override;
 
     // Reads variable or fixed len strings from this dataset.
     void p_read_fixed_len(const hid_t mem_type_id, const hid_t mem_space_id, const hid_t file_space_id,

--- a/c++/src/H5DataSpace.h
+++ b/c++/src/H5DataSpace.h
@@ -43,7 +43,7 @@ class H5_DLLCPP DataSpace : public IdComponent {
     DataSpace &operator=(const DataSpace &rhs);
 
     // Closes this dataspace.
-    virtual void close() H5_OVERRIDE;
+    virtual void close() override;
 
     // Makes copy of an existing dataspace.
     void copy(const DataSpace &like_space);
@@ -115,25 +115,25 @@ class H5_DLLCPP DataSpace : public IdComponent {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("DataSpace");
     }
 
     // Gets the dataspace id.
-    virtual hid_t getId() const H5_OVERRIDE;
+    virtual hid_t getId() const override;
 
     // Deletes the global constant
     static void deleteConstants();
 
     // Destructor: properly terminates access to this dataspace.
-    virtual ~DataSpace() H5_OVERRIDE;
+    virtual ~DataSpace() override;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
   protected:
     // Sets the dataspace id.
-    virtual void p_setId(const hid_t new_id) H5_OVERRIDE;
+    virtual void p_setId(const hid_t new_id) override;
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 

--- a/c++/src/H5DataType.h
+++ b/c++/src/H5DataType.h
@@ -50,7 +50,7 @@ class H5_DLLCPP DataType : public H5Object {
     //        PropList& plist = PropList::DEFAULT);
 
     // Closes this datatype.
-    virtual void close() H5_OVERRIDE;
+    virtual void close() override;
 
     // Copies an existing datatype to this datatype object.
     void copy(const DataType &like_type);
@@ -136,7 +136,7 @@ class H5_DLLCPP DataType : public H5Object {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("DataType");
     }
@@ -151,10 +151,10 @@ class H5_DLLCPP DataType : public H5Object {
     bool hasBinaryDesc() const;
 
     // Gets the datatype id.
-    virtual hid_t getId() const H5_OVERRIDE;
+    virtual hid_t getId() const override;
 
     // Destructor: properly terminates access to this datatype.
-    virtual ~DataType() H5_OVERRIDE;
+    virtual ~DataType() override;
 
   protected:
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -165,7 +165,7 @@ class H5_DLLCPP DataType : public H5Object {
     hid_t p_decode() const;
 
     // Sets the datatype id.
-    virtual void p_setId(const hid_t new_id) H5_OVERRIDE;
+    virtual void p_setId(const hid_t new_id) override;
 
     // Opens a datatype and returns the id.
     hid_t p_opentype(const H5Location &loc, const char *dtype_name) const;

--- a/c++/src/H5DcreatProp.h
+++ b/c++/src/H5DcreatProp.h
@@ -128,7 +128,7 @@ class H5_DLLCPP DSetCreatPropList : public ObjCreatPropList {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("DSetCreatPropList");
     }
@@ -141,7 +141,7 @@ class H5_DLLCPP DSetCreatPropList : public ObjCreatPropList {
     DSetCreatPropList(const hid_t plist_id);
 
     // Noop destructor.
-    virtual ~DSetCreatPropList() H5_OVERRIDE;
+    virtual ~DSetCreatPropList() override;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/c++/src/H5DxferProp.h
+++ b/c++/src/H5DxferProp.h
@@ -100,7 +100,7 @@ class H5_DLLCPP DSetMemXferPropList : public PropList {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("DSetMemXferPropList");
     }
@@ -113,7 +113,7 @@ class H5_DLLCPP DSetMemXferPropList : public PropList {
     DSetMemXferPropList(const hid_t plist_id);
 
     // Noop destructor
-    virtual ~DSetMemXferPropList() H5_OVERRIDE;
+    virtual ~DSetMemXferPropList() override;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/c++/src/H5EnumType.h
+++ b/c++/src/H5EnumType.h
@@ -41,7 +41,7 @@ class H5_DLLCPP EnumType : public DataType {
 
     // Returns an EnumType object via DataType* by decoding the
     // binary object description of this type.
-    virtual DataType *decode() const H5_OVERRIDE;
+    virtual DataType *decode() const override;
 
     // Returns the number of members in this enumeration datatype.
     int getNmembers() const;
@@ -68,7 +68,7 @@ class H5_DLLCPP EnumType : public DataType {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("EnumType");
     }
@@ -82,7 +82,7 @@ class H5_DLLCPP EnumType : public DataType {
     // Copy constructor: same as the original EnumType.
     EnumType(const EnumType &original);
 
-    virtual ~EnumType() H5_OVERRIDE;
+    virtual ~EnumType() override;
 
 }; // end of EnumType
 } // namespace H5

--- a/c++/src/H5Exception.h
+++ b/c++/src/H5Exception.h
@@ -90,84 +90,84 @@ class H5_DLLCPP FileIException : public Exception {
   public:
     FileIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     FileIException();
-    virtual ~FileIException() throw() H5_OVERRIDE;
+    virtual ~FileIException() throw() override;
 };
 
 class H5_DLLCPP GroupIException : public Exception {
   public:
     GroupIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     GroupIException();
-    virtual ~GroupIException() throw() H5_OVERRIDE;
+    virtual ~GroupIException() throw() override;
 };
 
 class H5_DLLCPP DataSpaceIException : public Exception {
   public:
     DataSpaceIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     DataSpaceIException();
-    virtual ~DataSpaceIException() throw() H5_OVERRIDE;
+    virtual ~DataSpaceIException() throw() override;
 };
 
 class H5_DLLCPP DataTypeIException : public Exception {
   public:
     DataTypeIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     DataTypeIException();
-    virtual ~DataTypeIException() throw() H5_OVERRIDE;
+    virtual ~DataTypeIException() throw() override;
 };
 
 class H5_DLLCPP ObjHeaderIException : public Exception {
   public:
     ObjHeaderIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     ObjHeaderIException();
-    virtual ~ObjHeaderIException() throw() H5_OVERRIDE;
+    virtual ~ObjHeaderIException() throw() override;
 };
 
 class H5_DLLCPP PropListIException : public Exception {
   public:
     PropListIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     PropListIException();
-    virtual ~PropListIException() throw() H5_OVERRIDE;
+    virtual ~PropListIException() throw() override;
 };
 
 class H5_DLLCPP DataSetIException : public Exception {
   public:
     DataSetIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     DataSetIException();
-    virtual ~DataSetIException() throw() H5_OVERRIDE;
+    virtual ~DataSetIException() throw() override;
 };
 
 class H5_DLLCPP AttributeIException : public Exception {
   public:
     AttributeIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     AttributeIException();
-    virtual ~AttributeIException() throw() H5_OVERRIDE;
+    virtual ~AttributeIException() throw() override;
 };
 
 class H5_DLLCPP ReferenceException : public Exception {
   public:
     ReferenceException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     ReferenceException();
-    virtual ~ReferenceException() throw() H5_OVERRIDE;
+    virtual ~ReferenceException() throw() override;
 };
 
 class H5_DLLCPP LibraryIException : public Exception {
   public:
     LibraryIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     LibraryIException();
-    virtual ~LibraryIException() throw() H5_OVERRIDE;
+    virtual ~LibraryIException() throw() override;
 };
 
 class H5_DLLCPP LocationException : public Exception {
   public:
     LocationException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     LocationException();
-    virtual ~LocationException() throw() H5_OVERRIDE;
+    virtual ~LocationException() throw() override;
 };
 
 class H5_DLLCPP IdComponentException : public Exception {
   public:
     IdComponentException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     IdComponentException();
-    virtual ~IdComponentException() throw() H5_OVERRIDE;
+    virtual ~IdComponentException() throw() override;
 
 }; // end of IdComponentException
 } // namespace H5

--- a/c++/src/H5FaccProp.h
+++ b/c++/src/H5FaccProp.h
@@ -137,7 +137,7 @@ class H5_DLLCPP FileAccPropList : public PropList {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("FileAccPropList");
     }
@@ -150,7 +150,7 @@ class H5_DLLCPP FileAccPropList : public PropList {
     FileAccPropList(const hid_t plist_id);
 
     // Noop destructor
-    virtual ~FileAccPropList() H5_OVERRIDE;
+    virtual ~FileAccPropList() override;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/c++/src/H5FcreatProp.h
+++ b/c++/src/H5FcreatProp.h
@@ -78,7 +78,7 @@ class H5_DLLCPP FileCreatPropList : public PropList {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("FileCreatPropList");
     }
@@ -91,7 +91,7 @@ class H5_DLLCPP FileCreatPropList : public PropList {
     FileCreatPropList(const hid_t plist_id);
 
     // Noop destructor
-    virtual ~FileCreatPropList() H5_OVERRIDE;
+    virtual ~FileCreatPropList() override;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/c++/src/H5File.h
+++ b/c++/src/H5File.h
@@ -39,7 +39,7 @@ class H5_DLLCPP H5File : public Group {
                   const FileAccPropList &access_plist = FileAccPropList::DEFAULT);
 
     // Close this file.
-    virtual void close() H5_OVERRIDE;
+    virtual void close() override;
 
     // Gets a copy of the access property list of this file.
     FileAccPropList getAccessPlist() const;
@@ -96,16 +96,16 @@ class H5_DLLCPP H5File : public Group {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("H5File");
     }
 
     // Throw file exception.
-    virtual void throwException(const H5std_string &func_name, const H5std_string &msg) const H5_OVERRIDE;
+    virtual void throwException(const H5std_string &func_name, const H5std_string &msg) const override;
 
     // For CommonFG to get the file id.
-    virtual hid_t getLocId() const H5_OVERRIDE;
+    virtual hid_t getLocId() const override;
 
     // Default constructor
     H5File();
@@ -114,15 +114,15 @@ class H5_DLLCPP H5File : public Group {
     H5File(const H5File &original);
 
     // Gets the HDF5 file id.
-    virtual hid_t getId() const H5_OVERRIDE;
+    virtual hid_t getId() const override;
 
     // H5File destructor.
-    virtual ~H5File() H5_OVERRIDE;
+    virtual ~H5File() override;
 
   protected:
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
     // Sets the HDF5 file id.
-    virtual void p_setId(const hid_t new_id) H5_OVERRIDE;
+    virtual void p_setId(const hid_t new_id) override;
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
   private:

--- a/c++/src/H5FloatType.h
+++ b/c++/src/H5FloatType.h
@@ -36,7 +36,7 @@ class H5_DLLCPP FloatType : public AtomType {
 
     // Returns an FloatType object via DataType* by decoding the
     // binary object description of this type.
-    virtual DataType *decode() const H5_OVERRIDE;
+    virtual DataType *decode() const override;
 
     // Retrieves the exponent bias of a floating-point type.
     size_t getEbias() const;
@@ -64,7 +64,7 @@ class H5_DLLCPP FloatType : public AtomType {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("FloatType");
     }
@@ -79,7 +79,7 @@ class H5_DLLCPP FloatType : public AtomType {
     FloatType(const FloatType &original);
 
     // Noop destructor.
-    virtual ~FloatType() H5_OVERRIDE;
+    virtual ~FloatType() override;
 
 }; // end of FloatType
 } // namespace H5

--- a/c++/src/H5Group.h
+++ b/c++/src/H5Group.h
@@ -24,20 +24,20 @@ namespace H5 {
 class H5_DLLCPP Group : public H5Object, public CommonFG {
   public:
     // Close this group.
-    virtual void close() H5_OVERRIDE;
+    virtual void close() override;
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("Group");
     }
 
     // Throw group exception.
-    virtual void throwException(const H5std_string &func_name, const H5std_string &msg) const H5_OVERRIDE;
+    virtual void throwException(const H5std_string &func_name, const H5std_string &msg) const override;
 
     // for CommonFG to get the file id.
-    virtual hid_t getLocId() const H5_OVERRIDE;
+    virtual hid_t getLocId() const override;
 
     // Creates a group by way of dereference.
     Group(const H5Location &loc, const void *ref, H5R_type_t ref_type = H5R_OBJECT,
@@ -63,10 +63,10 @@ class H5_DLLCPP Group : public H5Object, public CommonFG {
     Group(const Group &original);
 
     // Gets the group id.
-    virtual hid_t getId() const H5_OVERRIDE;
+    virtual hid_t getId() const override;
 
     // Destructor
-    virtual ~Group() H5_OVERRIDE;
+    virtual ~Group() override;
 
     // Creates a copy of an existing group using its id.
     Group(const hid_t group_id);
@@ -74,7 +74,7 @@ class H5_DLLCPP Group : public H5Object, public CommonFG {
   protected:
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
     // Sets the group id.
-    virtual void p_setId(const hid_t new_id) H5_OVERRIDE;
+    virtual void p_setId(const hid_t new_id) override;
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
   private:

--- a/c++/src/H5Include.h
+++ b/c++/src/H5Include.h
@@ -24,10 +24,3 @@
  *      magic number as prefix and checksum as suffix for all chunks.
  */
 #define H5O_VERSION_2 2
-
-// Define H5_OVERRIDE to override for C++11.
-#if defined(__cplusplus) && (201103L <= __cplusplus)
-#define H5_OVERRIDE override
-#else
-#define H5_OVERRIDE
-#endif

--- a/c++/src/H5IntType.h
+++ b/c++/src/H5IntType.h
@@ -36,7 +36,7 @@ class H5_DLLCPP IntType : public AtomType {
 
     // Returns an IntType object via DataType* by decoding the
     // binary object description of this type.
-    virtual DataType *decode() const H5_OVERRIDE;
+    virtual DataType *decode() const override;
 
     // Retrieves the sign type for an integer type
     H5T_sign_t getSign() const;
@@ -46,7 +46,7 @@ class H5_DLLCPP IntType : public AtomType {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("IntType");
     }
@@ -61,7 +61,7 @@ class H5_DLLCPP IntType : public AtomType {
     IntType(const IntType &original);
 
     // Noop destructor.
-    virtual ~IntType() H5_OVERRIDE;
+    virtual ~IntType() override;
 
 }; // end of IntType
 } // namespace H5

--- a/c++/src/H5LaccProp.h
+++ b/c++/src/H5LaccProp.h
@@ -32,7 +32,7 @@ class H5_DLLCPP LinkAccPropList : public PropList {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("LinkAccPropList");
     }
@@ -52,7 +52,7 @@ class H5_DLLCPP LinkAccPropList : public PropList {
     size_t getNumLinks() const;
 
     // Noop destructor
-    virtual ~LinkAccPropList() H5_OVERRIDE;
+    virtual ~LinkAccPropList() override;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/c++/src/H5LcreatProp.h
+++ b/c++/src/H5LcreatProp.h
@@ -32,7 +32,7 @@ class H5_DLLCPP LinkCreatPropList : public PropList {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("LinkCreatPropList");
     }
@@ -59,7 +59,7 @@ class H5_DLLCPP LinkCreatPropList : public PropList {
     H5T_cset_t getCharEncoding() const;
 
     // Noop destructor
-    virtual ~LinkCreatPropList() H5_OVERRIDE;
+    virtual ~LinkCreatPropList() override;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/c++/src/H5Object.h
+++ b/c++/src/H5Object.h
@@ -106,7 +106,7 @@ class H5_DLLCPP H5Object : public H5Location {
     void removeAttr(const H5std_string &name) const;
 
     // Returns an identifier.
-    virtual hid_t getId() const H5_OVERRIDE = 0;
+    virtual hid_t getId() const override = 0;
 
     // Gets the name of this HDF5 object, i.e., Group, DataSet, or
     // DataType.
@@ -122,10 +122,10 @@ class H5_DLLCPP H5Object : public H5Location {
 
     // Sets the identifier of this object to a new value. - this one
     // doesn't increment reference count
-    virtual void p_setId(const hid_t new_id) H5_OVERRIDE = 0;
+    virtual void p_setId(const hid_t new_id) override = 0;
 
     // Noop destructor.
-    virtual ~H5Object() H5_OVERRIDE;
+    virtual ~H5Object() override;
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 

--- a/c++/src/H5OcreatProp.h
+++ b/c++/src/H5OcreatProp.h
@@ -44,7 +44,7 @@ class H5_DLLCPP ObjCreatPropList : public PropList {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("ObjCreatPropList");
     }
@@ -57,7 +57,7 @@ class H5_DLLCPP ObjCreatPropList : public PropList {
     ObjCreatPropList(const hid_t plist_id);
 
     // Noop destructor
-    virtual ~ObjCreatPropList() H5_OVERRIDE;
+    virtual ~ObjCreatPropList() override;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 

--- a/c++/src/H5PredType.h
+++ b/c++/src/H5PredType.h
@@ -29,7 +29,7 @@ class H5_DLLCPP PredType : public AtomType {
   public:
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("PredType");
     }
@@ -42,7 +42,7 @@ class H5_DLLCPP PredType : public AtomType {
     PredType(const PredType &original);
 
     // Noop destructor
-    virtual ~PredType() H5_OVERRIDE;
+    virtual ~PredType() override;
 
     /*! \brief This dummy function do not inherit from DataType - it will
         throw a DataTypeIException if invoked.

--- a/c++/src/H5PropList.h
+++ b/c++/src/H5PropList.h
@@ -38,7 +38,7 @@ class H5_DLLCPP PropList : public IdComponent {
     bool operator==(const PropList &rhs) const;
 
     // Close this property list.
-    virtual void close() H5_OVERRIDE;
+    virtual void close() override;
 
     // Close a property list class.
     void closeClass() const;
@@ -102,7 +102,7 @@ class H5_DLLCPP PropList : public IdComponent {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("PropList");
     }
@@ -114,10 +114,10 @@ class H5_DLLCPP PropList : public IdComponent {
     PropList(const PropList &original);
 
     // Gets the property list id.
-    virtual hid_t getId() const H5_OVERRIDE;
+    virtual hid_t getId() const override;
 
     // Destructor: properly terminates access to this property list.
-    virtual ~PropList() H5_OVERRIDE;
+    virtual ~PropList() override;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
@@ -128,7 +128,7 @@ class H5_DLLCPP PropList : public IdComponent {
     hid_t id; // HDF5 property list id
 
     // Sets the property list id.
-    virtual void p_setId(const hid_t new_id) H5_OVERRIDE;
+    virtual void p_setId(const hid_t new_id) override;
 
   private:
     static PropList *DEFAULT_;

--- a/c++/src/H5StrType.h
+++ b/c++/src/H5StrType.h
@@ -42,7 +42,7 @@ class H5_DLLCPP StrType : public AtomType {
 
     // Returns an StrType object via DataType* by decoding the
     // binary object description of this type.
-    virtual DataType *decode() const H5_OVERRIDE;
+    virtual DataType *decode() const override;
 
     // Retrieves the character set type of this string datatype.
     H5T_cset_t getCset() const;
@@ -58,7 +58,7 @@ class H5_DLLCPP StrType : public AtomType {
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("StrType");
     }
@@ -73,7 +73,7 @@ class H5_DLLCPP StrType : public AtomType {
     StrType(const StrType &original);
 
     // Noop destructor.
-    virtual ~StrType() H5_OVERRIDE;
+    virtual ~StrType() override;
 
 }; // end of StrType
 } // namespace H5

--- a/c++/src/H5VarLenType.h
+++ b/c++/src/H5VarLenType.h
@@ -33,11 +33,11 @@ class H5_DLLCPP VarLenType : public DataType {
 
     // Returns an VarLenType object via DataType* by decoding the
     // binary object description of this type.
-    virtual DataType *decode() const H5_OVERRIDE;
+    virtual DataType *decode() const override;
 
     ///\brief Returns this class name.
     virtual H5std_string
-    fromClass() const H5_OVERRIDE
+    fromClass() const override
     {
         return ("VarLenType");
     }
@@ -53,7 +53,7 @@ class H5_DLLCPP VarLenType : public DataType {
     VarLenType(const H5Location &loc, const H5std_string &name);
 
     // Noop destructor
-    virtual ~VarLenType() H5_OVERRIDE;
+    virtual ~VarLenType() override;
 
     // Default constructor
     VarLenType();


### PR DESCRIPTION
The macro is no longer necessary now that we require C++11.

This change cannot go to 1.12 or 1.10 as those branches do not require C++11.