### PR TITLE
Removes C++ dependency on H5private.h

### DIFF
--- a/c++/src/H5Attribute.cpp
+++ b/c++/src/H5Attribute.cpp
@@ -14,7 +14,6 @@
 #include <iostream>
 #include <string>
 
-#include "H5private.h" // for HDfree
 #include "H5Include.h"
 #include "H5Exception.h"
 #include "H5IdComponent.h"
@@ -313,7 +312,7 @@ Attribute::getName() const
     H5std_string attr_name; // attribute name to return
 
     // Preliminary call to get the size of the attribute name
-    ssize_t name_size = H5Aget_name(id, static_cast<size_t>(0), NULL);
+    ssize_t name_size = H5Aget_name(id, 0, NULL);
 
     // If H5Aget_name failed, throw exception
     if (name_size < 0) {
@@ -324,8 +323,8 @@ Attribute::getName() const
     }
     // Attribute's name exists, retrieve it
     else if (name_size > 0) {
-        char *name_C = new char[name_size + 1]; // temporary C-string
-        HDmemset(name_C, 0, name_size + 1);     // clear buffer
+        // Create buffer for C string
+        char *name_C = new char[name_size + 1]();
 
         // Use overloaded function
         name_size = getName(name_C, name_size + 1);
@@ -336,6 +335,7 @@ Attribute::getName() const
         // Clean up resource
         delete[] name_C;
     }
+
     // Return attribute's name
     return (attr_name);
 }
@@ -393,8 +393,8 @@ Attribute::getName(H5std_string &attr_name, size_t len) const
     }
     // If length is provided, get that number of characters in name
     else {
-        char *name_C = new char[len + 1]; // temporary C-string
-        HDmemset(name_C, 0, len + 1);     // clear buffer
+        // Create buffer for C string
+        char *name_C = new char[len + 1]();
 
         // Use overloaded function
         name_size = getName(name_C, len + 1);
@@ -551,7 +551,7 @@ Attribute::p_read_variable_len(const DataType &mem_type, H5std_string &strg) con
 
     // Get string from the C char* and release resource allocated by C API
     strg = strg_C;
-    HDfree(strg_C);
+    free(strg_C);
 }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/c++/src/H5CommonFG.cpp
+++ b/c++/src/H5CommonFG.cpp
@@ -13,7 +13,6 @@
 
 #include <string>
 
-#include "H5private.h" // for HDstrcpy
 #include "H5Include.h"
 #include "H5Exception.h"
 #include "H5IdComponent.h"

--- a/c++/src/H5DataSet.cpp
+++ b/c++/src/H5DataSet.cpp
@@ -14,7 +14,6 @@
 #include <iostream>
 #include <string>
 
-#include "H5private.h" // for HDfree
 #include "H5Include.h"
 #include "H5Exception.h"
 #include "H5IdComponent.h"
@@ -717,8 +716,8 @@ DataSet::p_read_fixed_len(const hid_t mem_type_id, const hid_t mem_space_id, con
 
     // If there is data, allocate buffer and read it.
     if (data_size > 0) {
-        char *strg_C = new char[data_size + 1];
-        HDmemset(strg_C, 0, data_size + 1); // clear buffer
+        // Create buffer for C string
+        char *strg_C = new char[data_size + 1]();
 
         herr_t ret_value = H5Dread(id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, strg_C);
 
@@ -759,7 +758,7 @@ DataSet::p_read_variable_len(const hid_t mem_type_id, const hid_t mem_space_id, 
 
     // Get string from the C char* and release resource allocated by C API
     strg = strg_C;
-    HDfree(strg_C);
+    free(strg_C);
 }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/c++/src/H5DataType.cpp
+++ b/c++/src/H5DataType.cpp
@@ -317,7 +317,7 @@ DataType::encode()
     if (buf_size > 0) {
         encoded_buf = new unsigned char[buf_size]();
 
-        ret_value   = H5Tencode(id, encoded_buf, &buf_size);
+        ret_value = H5Tencode(id, encoded_buf, &buf_size);
         if (ret_value < 0) {
             throw DataTypeIException("DataType::encode", "H5Tencode failed");
         }

--- a/c++/src/H5DataType.cpp
+++ b/c++/src/H5DataType.cpp
@@ -32,7 +32,6 @@
 #include "H5DataType.h"
 #include "H5AtomType.h"
 #include "H5PredType.h"
-#include "H5private.h"
 #include "H5AbstractDs.h"
 #include "H5DataSet.h"
 #include "H5Attribute.h"
@@ -316,7 +315,8 @@ DataType::encode()
 
     // Allocate buffer and call C function again to encode
     if (buf_size > 0) {
-        encoded_buf = static_cast<unsigned char *>(HDcalloc(1, buf_size));
+        encoded_buf = new unsigned char[buf_size]();
+
         ret_value   = H5Tencode(id, encoded_buf, &buf_size);
         if (ret_value < 0) {
             throw DataTypeIException("DataType::encode", "H5Tencode failed");
@@ -970,7 +970,7 @@ DataType::close()
 
         // Free and reset buffer of encoded object description if it's been used
         if (encoded_buf != NULL) {
-            HDfree(encoded_buf);
+            delete[] encoded_buf;
             buf_size = 0;
         }
     }

--- a/c++/src/H5DxferProp.cpp
+++ b/c++/src/H5DxferProp.cpp
@@ -13,7 +13,6 @@
 
 #include <string>
 
-#include "H5private.h" // for HDmemset
 #include "H5Include.h"
 #include "H5Exception.h"
 #include "H5IdComponent.h"
@@ -324,8 +323,7 @@ DSetMemXferPropList::getDataTransform() const
     // If expression exists, calls C routine again to get it
     else if (exp_len > 0) {
         // Temporary buffer for char* expression
-        char *exp_C = new char[exp_len + 1];
-        HDmemset(exp_C, 0, exp_len + 1); // clear buffer
+        char *exp_C = new char[exp_len + 1]();
 
         // Used overloaded function
         exp_len = getDataTransform(exp_C, exp_len + 1);

--- a/c++/src/H5EnumType.cpp
+++ b/c++/src/H5EnumType.cpp
@@ -13,7 +13,6 @@
 
 #include <string>
 
-#include "H5private.h" // for HDmemset
 #include "H5Include.h"
 #include "H5Exception.h"
 #include "H5IdComponent.h"
@@ -219,8 +218,7 @@ EnumType::insert(const H5std_string &name, void *value) const
 H5std_string
 EnumType::nameOf(void *value, size_t size) const
 {
-    char *name_C = new char[size + 1]; // temporary C-string for C API
-    HDmemset(name_C, 0, size + 1);     // clear buffer
+    char *name_C = new char[size + 1](); // temporary C-string for C API
 
     // Calls C routine H5Tenum_nameof to get the name of the specified enum type
     herr_t ret_value = H5Tenum_nameof(id, value, name_C, size);

--- a/c++/src/H5IdComponent.cpp
+++ b/c++/src/H5IdComponent.cpp
@@ -13,7 +13,6 @@
 
 #include <string>
 
-#include "H5private.h" // for HDmemset
 #include "H5Include.h"
 #include "H5Exception.h"
 #include "H5Library.h"
@@ -399,8 +398,7 @@ IdComponent::p_get_file_name() const
     }
 
     // Call H5Fget_name again to get the actual file name
-    char *name_C = new char[name_size + 1]; // temporary C-string for C API
-    HDmemset(name_C, 0, name_size + 1);     // clear buffer
+    char *name_C = new char[name_size + 1]();
 
     name_size = H5Fget_name(temp_id, name_C, name_size + 1);
 

--- a/c++/src/H5Location.cpp
+++ b/c++/src/H5Location.cpp
@@ -15,7 +15,6 @@
 #include <iostream>
 using namespace std;
 
-#include "H5private.h" // for HDmemset
 #include "H5Include.h"
 #include "H5Exception.h"
 #include "H5IdComponent.h"
@@ -367,8 +366,7 @@ H5Location::getComment(const char *name, size_t buf_size) const
             tmp_len = comment_len;
 
         // Temporary buffer for char* comment
-        char *comment_C = new char[tmp_len + 1];
-        HDmemset(comment_C, 0, tmp_len + 1); // clear buffer
+        char *comment_C = new char[tmp_len + 1]();
 
         // Used overloaded function
         ssize_t temp_len = getComment(name, tmp_len + 1, comment_C);
@@ -1835,8 +1833,8 @@ H5Location::getLinkval(const char *name, size_t size) const
 
     // if link has value, retrieve the value, otherwise, return null string
     if (val_size > 0) {
-        value_C = new char[val_size + 1];   // temporary C-string for C API
-        HDmemset(value_C, 0, val_size + 1); // clear buffer
+        // Create buffer for C string
+        value_C = new char[val_size + 1]();
 
         ret_value = H5Lget_val(getId(), name, value_C, val_size, H5P_DEFAULT);
         if (ret_value < 0) {
@@ -2046,9 +2044,8 @@ H5Location::getObjnameByIdx(hsize_t idx) const
     if (name_len < 0)
         throwException("getObjnameByIdx", "H5Lget_name_by_idx failed");
 
-    // now, allocate C buffer to get the name
-    char *name_C = new char[name_len + 1];
-    HDmemset(name_C, 0, name_len + 1); // clear buffer
+    // Create buffer for C string
+    char *name_C = new char[name_len + 1]();
 
     name_len =
         H5Lget_name_by_idx(getId(), ".", H5_INDEX_NAME, H5_ITER_INC, idx, name_C, name_len + 1, H5P_DEFAULT);
@@ -2102,8 +2099,8 @@ H5Location::getObjnameByIdx(hsize_t idx, char *name, size_t size) const
 ssize_t
 H5Location::getObjnameByIdx(hsize_t idx, H5std_string &name, size_t size) const
 {
-    char *name_C = new char[size + 1]; // temporary C-string for object name
-    HDmemset(name_C, 0, size + 1);     // clear buffer
+    // Create buffer for C string
+    char *name_C = new char[size + 1]();
 
     // call overloaded function to get the name
     ssize_t name_len = getObjnameByIdx(idx, name_C, size + 1);

--- a/c++/src/H5Object.cpp
+++ b/c++/src/H5Object.cpp
@@ -44,8 +44,7 @@ namespace H5 {
 extern "C" {
 
 static herr_t
-userAttrOpWrpr(hid_t loc_id, const char *attr_name, const H5A_info_t *ainfo,
-               void *op_data)
+userAttrOpWrpr(hid_t loc_id, const char *attr_name, const H5A_info_t *ainfo, void *op_data)
 {
     // Unused
     (void)loc_id;
@@ -60,8 +59,7 @@ userAttrOpWrpr(hid_t loc_id, const char *attr_name, const H5A_info_t *ainfo,
 // userVisitOpWrpr interfaces between the user's function and the
 // C library function H5Ovisit3
 static herr_t
-userVisitOpWrpr(hid_t obj_id, const char *attr_name, const H5O_info2_t *obj_info,
-                void *op_data)
+userVisitOpWrpr(hid_t obj_id, const char *attr_name, const H5O_info2_t *obj_info, void *op_data)
 {
     // Unused
     (void)obj_id;

--- a/c++/src/H5Object.cpp
+++ b/c++/src/H5Object.cpp
@@ -13,7 +13,6 @@
 
 #include <string>
 
-#include "H5private.h" // for HDmemset
 #include "H5Include.h"
 #include "H5Exception.h"
 #include "H5IdComponent.h"
@@ -45,9 +44,13 @@ namespace H5 {
 extern "C" {
 
 static herr_t
-userAttrOpWrpr(H5_ATTR_UNUSED hid_t loc_id, const char *attr_name, H5_ATTR_UNUSED const H5A_info_t *ainfo,
+userAttrOpWrpr(hid_t loc_id, const char *attr_name, const H5A_info_t *ainfo,
                void *op_data)
 {
+    // Unused
+    (void)loc_id;
+    (void)ainfo;
+
     H5std_string       s_attr_name = H5std_string(attr_name);
     UserData4Aiterate *myData      = reinterpret_cast<UserData4Aiterate *>(op_data);
     myData->op(*myData->location, s_attr_name, myData->opData);
@@ -57,9 +60,12 @@ userAttrOpWrpr(H5_ATTR_UNUSED hid_t loc_id, const char *attr_name, H5_ATTR_UNUSE
 // userVisitOpWrpr interfaces between the user's function and the
 // C library function H5Ovisit3
 static herr_t
-userVisitOpWrpr(H5_ATTR_UNUSED hid_t obj_id, const char *attr_name, const H5O_info2_t *obj_info,
+userVisitOpWrpr(hid_t obj_id, const char *attr_name, const H5O_info2_t *obj_info,
                 void *op_data)
 {
+    // Unused
+    (void)obj_id;
+
     H5std_string    s_attr_name = H5std_string(attr_name);
     UserData4Visit *myData      = reinterpret_cast<UserData4Visit *>(op_data);
     int             status      = myData->op(*myData->obj, s_attr_name, obj_info, myData->opData);
@@ -482,7 +488,7 @@ H5Object::getObjName() const
     H5std_string obj_name; // object name to return
 
     // Preliminary call to get the size of the object name
-    ssize_t name_size = H5Iget_name(getId(), NULL, static_cast<size_t>(0));
+    ssize_t name_size = H5Iget_name(getId(), NULL, 0);
 
     // If H5Iget_name failed, throw exception
     if (name_size < 0) {
@@ -493,8 +499,8 @@ H5Object::getObjName() const
     }
     // Object's name exists, retrieve it
     else if (name_size > 0) {
-        char *name_C = new char[name_size + 1]; // temporary C-string
-        HDmemset(name_C, 0, name_size + 1);     // clear buffer
+        // Create buffer for C string
+        char *name_C = new char[name_size + 1]();
 
         // Use overloaded function
         name_size = getObjName(name_C, name_size + 1);
@@ -534,8 +540,8 @@ H5Object::getObjName(H5std_string &obj_name, size_t len) const
     }
     // If length is provided, get that number of characters in name
     else {
-        char *name_C = new char[len + 1]; // temporary C-string
-        HDmemset(name_C, 0, len + 1);     // clear buffer
+        // Create buffer for C string
+        char *name_C = new char[len + 1]();
 
         // Use overloaded function
         name_size = getObjName(name_C, len + 1);

--- a/c++/src/H5PredType.cpp
+++ b/c++/src/H5PredType.cpp
@@ -27,7 +27,6 @@
 #include "H5DataType.h"
 #include "H5AtomType.h"
 #include "H5PredType.h"
-#include "H5private.h"
 
 namespace H5 {
 
@@ -90,8 +89,12 @@ PredType::operator=(const PredType &rhs)
 // These dummy functions do not inherit from DataType - they'll
 // throw an DataTypeIException if invoked.
 void
-PredType::commit(H5_ATTR_UNUSED H5Location &loc, H5_ATTR_UNUSED const char *name)
+PredType::commit(H5Location &loc, const char *name)
 {
+    // Unused
+    (void)loc;
+    (void)name;
+
     throw DataTypeIException("PredType::commit",
                              "Error: Attempted to commit a predefined datatype.  Invalid operation!");
 }

--- a/c++/src/H5PropList.cpp
+++ b/c++/src/H5PropList.cpp
@@ -15,7 +15,6 @@
 
 #include <string>
 
-#include "H5private.h" // for HDmemset
 #include "H5Include.h"
 #include "H5Exception.h"
 #include "H5IdComponent.h"
@@ -458,8 +457,7 @@ PropList::getProperty(const char *name) const
     size_t size = getPropSize(name);
 
     // Allocate buffer then get the property
-    char *prop_strg_C = new char[size + 1]; // temporary C-string for C API
-    HDmemset(prop_strg_C, 0, size + 1);     // clear buffer
+    char *prop_strg_C = new char[size + 1]();
 
     herr_t ret_value = H5Pget(id, name, prop_strg_C); // call C API
 

--- a/c++/src/H5StrType.cpp
+++ b/c++/src/H5StrType.cpp
@@ -32,7 +32,6 @@
 #include "H5StrType.h"
 #include "H5DataSet.h"
 #include "H5PredType.h"
-#include "H5private.h"
 
 namespace H5 {
 
@@ -105,8 +104,11 @@ StrType::StrType(const PredType &pred_type, const size_t &size) : AtomType()
 //              This constructor replaced the previous one.
 // Programmer   Binh-Minh Ribler - Nov 28, 2005
 //--------------------------------------------------------------------------
-StrType::StrType(H5_ATTR_UNUSED const int dummy, const size_t &size) : AtomType()
+StrType::StrType(const int dummy, const size_t &size) : AtomType()
 {
+    // Unused
+    (void)dummy;
+
     // use DataType::copy to make a copy of the string predefined type
     // then set its length
     copy(PredType::C_S1);


### PR DESCRIPTION
Most C API calls have been removed, aside from a few uses of free, where we just dropped the 'HD'. A couple of H5_ATTR_UNUSED macros were also replaced with (void) statements.

Only applies to the code in src. The code in test uses a bunch of H5private.h functionality which is imported via h5test.h.