### PR TITLE
Removes outdated checks for ways inline might be defined

### DIFF
--- a/config/cmake/H5pubconf.h.in
+++ b/config/cmake/H5pubconf.h.in
@@ -188,9 +188,6 @@
 /* Define to 1 if you have the <hdfs.h> header file. */
 #cmakedefine H5_HAVE_HDFS_H @H5_HAVE_HDFS_H@
 
-/* Define if the compiler understands inline */
-#cmakedefine H5_HAVE_INLINE @H5_HAVE_INLINE@
-
 /* Define if parallel library will contain instrumentation to detect correct
    optimization operation */
 #cmakedefine H5_HAVE_INSTRUMENTED_LIBRARY @H5_HAVE_INSTRUMENTED_LIBRARY@
@@ -431,12 +428,6 @@
 
 /* Define to 1 if you have the `_scrsize' function. */
 #cmakedefine H5_HAVE__SCRSIZE @H5_HAVE__SCRSIZE@
-
-/* Define if the compiler understands __inline */
-#cmakedefine H5_HAVE___INLINE @H5_HAVE___INLINE@
-
-/* Define if the compiler understands __inline__ */
-#cmakedefine H5_HAVE___INLINE__ @H5_HAVE___INLINE__@
 
 /* Define if the library will ignore file locks when disabled */
 #cmakedefine H5_IGNORE_DISABLED_FILE_LOCKS @H5_IGNORE_DISABLED_FILE_LOCKS@

--- a/config/cmake_ext_mod/ConfigureChecks.cmake
+++ b/config/cmake_ext_mod/ConfigureChecks.cmake
@@ -592,14 +592,6 @@ if (WINDOWS)
 endif ()
 
 #-----------------------------------------------------------------------------
-# Determine how 'inline' is used
-#-----------------------------------------------------------------------------
-foreach (inline_test inline __inline__ __inline)
-  string (TOUPPER ${inline_test} INLINE_TEST_MACRO)
-  HDF_FUNCTION_TEST (HAVE_${INLINE_TEST_MACRO})
-endforeach ()
-
-#-----------------------------------------------------------------------------
 # Check how to print a Long Long integer
 #-----------------------------------------------------------------------------
 if (NOT ${HDF_PREFIX}_PRINTF_LL_WIDTH OR ${HDF_PREFIX}_PRINTF_LL_WIDTH MATCHES "unknown")

--- a/config/cmake_ext_mod/HDFTests.c
+++ b/config/cmake_ext_mod/HDFTests.c
@@ -331,20 +331,3 @@ int main ()
 }
 
 #endif /* HAVE_IOEO */
-
-#if defined( HAVE_INLINE ) || defined( HAVE___INLINE__ ) || defined( HAVE___INLINE )
-#ifndef __cplusplus
-#if defined( HAVE_INLINE )
-#  define INLINE_KW inline
-#elif defined ( HAVE___INLINE__ )
-#  define INLINE_KW __inline__
-#elif defined ( HAVE___INLINE )
-#  define INLINE_KW __inline
-#endif /* HAVE_INLINE */
-typedef int foo_t;
-static INLINE_KW foo_t static_foo () { return 0; }
-INLINE_KW foo_t foo () {return 0; }
-int main(void) { return 0; }
-#endif /* __cplusplus */
-#endif /* defined( HAVE_INLINE ) || defined( HAVE___INLINE__ ) || defined( HAVE___INLINE ) */
-

--- a/configure.ac
+++ b/configure.ac
@@ -2037,27 +2037,6 @@ AC_CHECK_FUNCS([tmpfile asprintf vasprintf waitpid])
 ##
 AC_C_CONST
 
-AC_MSG_CHECKING([if the compiler understands  __inline__])
-AC_COMPILE_IFELSE(
-    [AC_LANG_SOURCE([[static __inline__ void f(void){return;};]])],
-    [AC_DEFINE([HAVE___INLINE__], [1], [Define if the compiler understands __inline__]) AC_MSG_RESULT([yes])],
-    [AC_MSG_RESULT([no])]
-)
-
-AC_MSG_CHECKING([if the compiler understands __inline])
-AC_COMPILE_IFELSE(
-    [AC_LANG_SOURCE([[static __inline void f(void){return;};]])],
-    [AC_DEFINE([HAVE___INLINE], [1], [Define if the compiler understands __inline]) AC_MSG_RESULT([yes])],
-    [AC_MSG_RESULT([no])]
-)
-
-AC_MSG_CHECKING([if the compiler understands inline])
-AC_COMPILE_IFELSE(
-    [AC_LANG_SOURCE([[static inline void f(void){return;};]])],
-    [AC_DEFINE([HAVE_INLINE], [1], [Define if the compiler understands inline]) AC_MSG_RESULT([yes])],
-    [AC_MSG_RESULT([no])]
-)
-
 AC_MSG_CHECKING([for __attribute__ extension])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]],[[int __attribute__((unused)) x]])],
                [AC_DEFINE([HAVE_ATTRIBUTE], [1],


### PR DESCRIPTION
These are obsolete now that we require C99 and the symbols defined by the checks are no longer present in the library.