### PR TITLE
Further simplifies Autotools type size checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1351,16 +1351,6 @@ CFLAGS="$H5_CFLAGS $AM_CFLAGS $CFLAGS"
 ## Checkpoint the cache
 AC_CACHE_SAVE
 
-## Write the confdefs.h header for checking sizes
-cat >>confdefs.h <<\EOF
-#include <stdbool.h>
-#include <stdint.h>
-#ifdef HAVE_UNISTD_H
-#include <sys/types.h>
-#endif
-#include <time.h>
-EOF
-
 AC_CHECK_SIZEOF(        [int8_t])
 AC_CHECK_SIZEOF(       [uint8_t])
 AC_CHECK_SIZEOF(  [int_least8_t])
@@ -1389,12 +1379,12 @@ AC_CHECK_SIZEOF([uint_least64_t])
 AC_CHECK_SIZEOF(  [int_fast64_t])
 AC_CHECK_SIZEOF( [uint_fast64_t])
 
-AC_CHECK_SIZEOF([bool])
+AC_CHECK_SIZEOF([bool], [], [#include <stdbool.h>])
 AC_CHECK_SIZEOF([off_t])
 AC_CHECK_SIZEOF([ptrdiff_t])
 AC_CHECK_SIZEOF([size_t])
 AC_CHECK_SIZEOF([ssize_t])
-AC_CHECK_SIZEOF([time_t])
+AC_CHECK_SIZEOF([time_t], [], [#include <time.h>])
 
 ## Checkpoint the cache
 AC_CACHE_SAVE


### PR DESCRIPTION
Also fixes an issue where clock_gettime and difftime are not detected
due to earlier simplifications of this code.