### PR TITLE
Normalization of CMake H5pubconf.h with Autotools

### DIFF
--- a/config/cmake/H5pubconf.h.in
+++ b/config/cmake/H5pubconf.h.in
@@ -32,6 +32,10 @@
 /* Define if dev_t is a scalar */
 #cmakedefine H5_DEV_T_IS_SCALAR @H5_DEV_T_IS_SCALAR@
 
+/* Define if your system is IBM ppc64le and cannot convert some long double
+   values correctly. */
+#cmakedefine H5_DISABLE_SOME_LDOUBLE_CONV @H5_DISABLE_SOME_LDOUBLE_CONV@
+
 /* Define to dummy `main' function (if any) required to link to the Fortran
    libraries. */
 #cmakedefine H5_FC_DUMMY_MAIN @H5_FC_DUMMY_MAIN@
@@ -108,7 +112,7 @@
 #cmakedefine H5_HAVE_CODESTACK @H5_HAVE_CODESTACK@
 
 /* Define to 1 if you have the <curl/curl.h> header file. */
-#cmakedefine H5_HAVE_CURL_H @H5_HAVE_CURL_H@
+#cmakedefine H5_HAVE_CURL_CURL_H @H5_HAVE_CURL_H@
 
 /* Define if Darwin or Mac OS X */
 #cmakedefine H5_HAVE_DARWIN @H5_HAVE_DARWIN@
@@ -325,7 +329,7 @@
 /* Define to 1 if you have the `stat64' function. */
 #cmakedefine H5_HAVE_STAT64 @H5_HAVE_STAT64@
 
-/* Define if `struct stat' has the `st_blocks' field */
+/* Define if struct stat has the st_blocks field */
 #cmakedefine H5_HAVE_STAT_ST_BLOCKS @H5_HAVE_STAT_ST_BLOCKS@
 
 /* Define to 1 if you have the <stddef.h> header file. */
@@ -447,9 +451,6 @@
 /* Define if your system can convert (unsigned) long to long double values
    with special algorithm. */
 #cmakedefine H5_LONG_TO_LDOUBLE_SPECIAL @H5_LONG_TO_LDOUBLE_SPECIAL@
-
-/* Define if your system is power6 and cannot convert some long double values. */
-#cmakedefine H5_DISABLE_SOME_LDOUBLE_CONV @H5_DISABLE_SOME_LDOUBLE_CONV@
 
 /* Define to the sub-directory where libtool stores uninstalled libraries. */
 #cmakedefine H5_LT_OBJDIR @H5_LT_OBJDIR@
@@ -666,12 +667,6 @@
 /* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
 #cmakedefine H5_TIME_WITH_SYS_TIME @H5_TIME_WITH_SYS_TIME@
 
-/* Define using v1.6 public API symbols by default */
-#cmakedefine H5_USE_16_API_DEFAULT @H5_USE_16_API_DEFAULT@
-
-/* Define using v1.8 public API symbols by default */
-#cmakedefine H5_USE_18_API_DEFAULT @H5_USE_18_API_DEFAULT@
-
 /* Define using v1.10 public API symbols by default */
 #cmakedefine H5_USE_110_API_DEFAULT @H5_USE_110_API_DEFAULT@
 
@@ -680,6 +675,12 @@
 
 /* Define using v1.14 public API symbols by default */
 #cmakedefine H5_USE_114_API_DEFAULT @H5_USE_114_API_DEFAULT@
+
+/* Define using v1.6 public API symbols by default */
+#cmakedefine H5_USE_16_API_DEFAULT @H5_USE_16_API_DEFAULT@
+
+/* Define using v1.8 public API symbols by default */
+#cmakedefine H5_USE_18_API_DEFAULT @H5_USE_18_API_DEFAULT@
 
 /* Define if the library will use file locking */
 #cmakedefine H5_USE_FILE_LOCKING @H5_USE_FILE_LOCKING@


### PR DESCRIPTION
Mostly just moving things around and changing the comments to keep the
delta small. The only symbol change is that for curl/curl.h which I
changed to H5_HAVE_CURL_CURL_H to match the Autotools. This symbol
is not used in the library and is just an artifact of the checks.