### PR TITLE
Removes remaining H5_TIME_WITH_SYS_TIME cruft

### DIFF
--- a/config/cmake/H5pubconf.h.in
+++ b/config/cmake/H5pubconf.h.in
@@ -634,9 +634,6 @@
    PTHREAD_SCOPE_SYSTEM) call. */
 #cmakedefine H5_SYSTEM_SCOPE_THREADS @H5_SYSTEM_SCOPE_THREADS@
 
-/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
-#cmakedefine H5_TIME_WITH_SYS_TIME @H5_TIME_WITH_SYS_TIME@
-
 /* Define using v1.10 public API symbols by default */
 #cmakedefine H5_USE_110_API_DEFAULT @H5_USE_110_API_DEFAULT@
 

--- a/config/cmake_ext_mod/ConfigureChecks.cmake
+++ b/config/cmake_ext_mod/ConfigureChecks.cmake
@@ -412,7 +412,6 @@ if (MINGW OR NOT WINDOWS)
   #-----------------------------------------------------------------------------
   CHECK_STRUCT_HAS_MEMBER("struct tm" tm_gmtoff "time.h" ${HDF_PREFIX}_HAVE_TM_GMTOFF)
   CHECK_STRUCT_HAS_MEMBER("struct tm" __tm_gmtoff "time.h" ${HDF_PREFIX}_HAVE___TM_GMTOFF)
-  CHECK_STRUCT_HAS_MEMBER("struct tm" tm_sec "sys/types.h;sys/time.h;time.h" ${HDF_PREFIX}_TIME_WITH_SYS_TIME)
   if (${HDF_PREFIX}_HAVE_SYS_TIME_H)
     CHECK_STRUCT_HAS_MEMBER("struct tm" tz_minuteswest "sys/types.h;sys/time.h;time.h" ${HDF_PREFIX}_HAVE_STRUCT_TIMEZONE)
   else ()

--- a/tools/lib/io_timer.h
+++ b/tools/lib/io_timer.h
@@ -16,18 +16,15 @@
 
 #include "hdf5.h"
 
-#if defined(H5_TIME_WITH_SYS_TIME)
-#include <sys/time.h>
 #include <time.h>
-#elif defined(H5_HAVE_SYS_TIME_H)
+
+#ifdef H5_HAVE_SYS_TIME_H
 #include <sys/time.h>
-#else
-#include <time.h>
 #endif
 
 #ifdef H5_HAVE_WINSOCK2_H
 #include <winsock2.h>
-#endif /* H5_HAVE_WINSOCK2_H */
+#endif
 
 /* The different types of timers we can have */
 typedef enum timer_type_ {

--- a/tools/test/perform/direct_write_perf.c
+++ b/tools/test/perform/direct_write_perf.c
@@ -28,23 +28,22 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-#ifdef H5_HAVE_UNISTD_H
-#include <sys/types.h>
-#include <unistd.h>
-#endif
+#include <time.h>
 
 #ifdef H5_HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
 
-#if defined(H5_TIME_WITH_SYS_TIME)
+#ifdef H5_HAVE_SYS_TIME_H
 #include <sys/time.h>
-#include <time.h>
-#elif defined(H5_HAVE_SYS_TIME_H)
-#include <sys/time.h>
-#else
-#include <time.h>
+#endif
+
+#ifdef H5_HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+
+#ifdef H5_HAVE_UNISTD_H
+#include <unistd.h>
 #endif
 
 const char *FILENAME[] = {"direct_write", "unix.raw", NULL};
@@ -52,8 +51,7 @@ const char *FILENAME[] = {"direct_write", "unix.raw", NULL};
 /*
  * Print the current location on the standard output stream.
  */
-#define FUNC __func__
-#define AT() printf("   at %s:%d in %s()...\n", __FILE__, __LINE__, FUNC);
+#define AT() printf("   at %s:%d in %s()...\n", __FILE__, __LINE__, __func__);
 #define H5_FAILED()                                                                                          \
     {                                                                                                        \
         puts("*FAILED*");                                                                                    \

--- a/tools/test/perform/perf.c
+++ b/tools/test/perform/perf.c
@@ -31,23 +31,22 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#ifdef H5_HAVE_UNISTD_H
-#include <sys/types.h>
-#include <unistd.h>
-#endif
+#include <time.h>
 
 #ifdef H5_HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
 
-#if defined(H5_TIME_WITH_SYS_TIME)
+#ifdef H5_HAVE_SYS_TIME_H
 #include <sys/time.h>
-#include <time.h>
-#elif defined(H5_HAVE_SYS_TIME_H)
-#include <sys/time.h>
-#else
-#include <time.h>
+#endif
+
+#ifdef H5_HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+
+#ifdef H5_HAVE_UNISTD_H
+#include <unistd.h>
 #endif
 
 #include <mpi.h>


### PR DESCRIPTION
We previously removed some archaic checking to see if it was safe to include time.h with sys/time.h. This removes the last of that code. These last bits involved some CMake changes and some changes to the include statements in some perform tests.