### PR TITLE
H5fget_name_f len_trim fix

### DIFF
--- a/fortran/src/H5Fff.F90
+++ b/fortran/src/H5Fff.F90
@@ -844,7 +844,7 @@ CONTAINS
          CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(OUT) :: buf
        END FUNCTION h5fget_name_c
     END INTERFACE
-    buflen = LEN_TRIM(buf)
+    buflen = LEN(buf)
     hdferr = h5fget_name_c(obj_id, size, buf, buflen)
   END SUBROUTINE h5fget_name_f
 !****s* H5F/h5fget_filesize_f

--- a/fortran/test/fortranlib_test.F90
+++ b/fortran/test/fortranlib_test.F90
@@ -74,6 +74,10 @@ PROGRAM fortranlibtest
   CALL write_test_status(ret_total_error, ' Reopen test', total_error)
 
   ret_total_error = 0
+  CALL get_name_test(cleanup, ret_total_error)
+  CALL write_test_status(ret_total_error, ' Get name test', total_error)
+
+  ret_total_error = 0
   CALL file_close(cleanup, ret_total_error)
   CALL write_test_status(ret_total_error, ' File open/close test', total_error)
 

--- a/fortran/test/tH5F.F90
+++ b/fortran/test/tH5F.F90
@@ -545,9 +545,11 @@ CONTAINS
               CALL check("h5fget_name_f",error,total_error)
               IF(name_size /= 9) THEN
                  write(*,*) "file name obtained from the dataset id has wrong length"
+                 call check("h5fget_name_f",-1,total_error)
               END IF
-              IF(file_name(1:name_size) .NE. fix_filename(1:name_size)) THEN
+              IF(file_name(1:name_size) /= fix_filename(1:name_size)) THEN
                  write(*,*) "file name obtained from the dataset id is incorrect"
+                 call check("h5fget_name_f",-1,total_error)
               END IF
 
          !

--- a/fortran/test/tH5F.F90
+++ b/fortran/test/tH5F.F90
@@ -543,6 +543,9 @@ CONTAINS
          !
          CALL h5fget_name_f(dset_id, file_name, name_size, error)
               CALL check("h5fget_name_f",error,total_error)
+              IF(name_size /= 9) THEN
+                 write(*,*) "file name obtained from the dataset id has wrong length"
+              END IF
               IF(file_name(1:name_size) .NE. fix_filename(1:name_size)) THEN
                  write(*,*) "file name obtained from the dataset id is incorrect"
               END IF

--- a/fortran/test/tH5F.F90
+++ b/fortran/test/tH5F.F90
@@ -532,6 +532,12 @@ CONTAINS
          !
          CALL h5dopen_f(reopen_id, dsetname, dset_id, error)
               CALL check("h5dopen_f",error,total_error)
+
+         ! Populate filename buffer with whitespace
+         do i = 1,80
+            filename(i:i) = " "
+         end do
+
          !
          !Get file name from the dataset identifier
          !

--- a/fortran/test/tH5F.F90
+++ b/fortran/test/tH5F.F90
@@ -535,7 +535,7 @@ CONTAINS
 
          ! Populate filename buffer with whitespace
          do i = 1,80
-            filename(i:i) = " "
+            file_name(i:i) = " "
          end do
 
          !

--- a/fortran/test/tH5F.F90
+++ b/fortran/test/tH5F.F90
@@ -607,7 +607,7 @@ CONTAINS
             total_error = total_error + 1
          ENDIF
          IF(file_name(1:name_size) .NE. TRIM(fix_filename)) THEN
-            WRITE(*,*) "  file name obtained from the dataset id is incorrect"
+            WRITE(*,*) "  file name obtained from the object id is incorrect"
             total_error = total_error + 1
          END IF
 
@@ -616,7 +616,7 @@ CONTAINS
          CALL h5fget_name_f(obj_id, file_name, name_size, error)
          CALL check("h5fget_name_f",error,total_error)
          IF(name_size .NE. LEN_TRIM(fix_filename))THEN
-            WRITE(*,*) "  file name size obtained from the dataset id is incorrect"
+            WRITE(*,*) "  file name size obtained from the object id is incorrect"
             total_error = total_error + 1
          ENDIF
          IF(file_name(1:name_size) .NE. TRIM(fix_filename)) THEN
@@ -629,11 +629,11 @@ CONTAINS
          CALL h5fget_name_f(obj_id, file_name, name_size, error)
          CALL check("h5fget_name_f",error,total_error)
          IF(name_size .NE. LEN_TRIM(fix_filename))THEN
-            WRITE(*,*) "  file name size obtained from the dataset id is incorrect"
+            WRITE(*,*) "  file name size obtained from the object id is incorrect"
             total_error = total_error + 1
          ENDIF
          IF(file_name(1:name_size) .NE. TRIM(fix_filename)) THEN
-            WRITE(*,*) "  file name obtained from the dataset id is incorrect"
+            WRITE(*,*) "  file name obtained from the object id is incorrect"
             total_error = total_error + 1
          END IF
 

--- a/fortran/test/tH5F.F90
+++ b/fortran/test/tH5F.F90
@@ -655,7 +655,7 @@ CONTAINS
           CHARACTER(LEN=*), PARAMETER :: filename = "filename"
           CHARACTER(LEN=80)  :: fix_filename
 
-          INTEGER(HID_T) :: file_id, reopen_id  ! File identifiers
+          INTEGER(HID_T) :: file_id             ! File identifier
           INTEGER(HID_T) :: dset_id             ! Dataset identifier
 
           !
@@ -686,27 +686,7 @@ CONTAINS
           INTEGER     ::   error
 
           !
-          !general purpose integer
-          !
-          INTEGER     ::  i, j
-
-          !
-          !array to store data
-          !
-          INTEGER, DIMENSION(4,6) :: dset_data
-          INTEGER(HSIZE_T)  :: file_size
-
-          !
-          !initialize the dset_data array which will be written to the "/dset"
-          !
-          do j = 1, NY
-               do i = 1, NX
-                    dset_data(i,j) = (i-1)*6 + j;
-               end do
-          end do
-
-          !
-          !Create file "reopen.h5" using default properties.
+          !Create file "filename.h5" using default properties.
           !
           CALL h5_fixname_f(filename, fix_filename, H5P_DEFAULT_F, error)
           if (error .ne. 0) then
@@ -729,35 +709,6 @@ CONTAINS
                dset_id, error)
               CALL check("h5dcreate_f",error,total_error)
 
-         !
-         !close the dataset.
-         !
-         CALL h5dclose_f(dset_id, error)
-              CALL check("h5dclose_f",error,total_error)
-
-         !
-         !close the dataspace.
-         !
-         CALL h5sclose_f(dataspace, error)
-              CALL check("h5sclose_f",error,total_error)
-
-         !
-         !Reopen file dsetf.h5.
-         !
-         CALL h5freopen_f(file_id, reopen_id, error)
-              CALL check("h5freopen_f",error,total_error)
-         !
-         !Check file size
-         !
-         CALL h5fget_filesize_f(file_id, file_size, error)
-              CALL check("h5fget_filesize_f",error,total_error)
-
-         !
-         !Open the dataset based on the reopen_id.
-         !
-         CALL h5dopen_f(reopen_id, dsetname, dset_id, error)
-              CALL check("h5dopen_f",error,total_error)
-
          CALL check_get_name(file_id, fix_filename, total_error)
          CALL check_get_name(dset_id, fix_filename, total_error)
 
@@ -771,9 +722,6 @@ CONTAINS
          !
          CALL h5fclose_f(file_id, error)
               CALL check("h5fclose_f",error,total_error)
-         CALL h5fclose_f(reopen_id, error)
-              CALL check("h5fclose_f",error,total_error)
-
 
           if(cleanup) CALL h5_cleanup_f(filename, H5P_DEFAULT_F, error)
               CALL check("h5_cleanup_f", error, total_error)


### PR DESCRIPTION
`h5fget_name_f` was calling the intrinsic `len_trim` to determine the length of the passed buffer. This can cause problems if the passed buffer contains trailing whitespace (in which case the h5fget_name_f will limit itself to the length of the non-whitespace characters currently in the passed buffer, even if the buffer's capacity is larger), or if the passed buffer was freshly allocated (in which case the resulting buffer length is unpredictable).

The pull request replaces the call to `len_trim` with a call to `len`, which returns the total buffer length regardless of the passed contents of the buffer, and is safe to call on a freshly allocated (i.e. unassigned) buffer.

This fixes #825.