### PR TITLE
OESS-168:Remove implicit conversion warnings.

### DIFF
--- a/hl/test/test_table.c
+++ b/hl/test/test_table.c
@@ -199,7 +199,7 @@ test_table(hid_t fid, int do_write)
     hsize_t    chunk_size   = 10;
     int        compress     = 0;
     int *      fill         = NULL;
-    particle_t fill1[1]     = {{"no data", -1, -99.0f, -99.0f, -1}};
+    particle_t fill1[1]     = {{"no data", -1, -99.0, -99.0, -1}};
     int        fill1_new[1] = {-100};
     hsize_t    position;
     char       tname[20];
@@ -227,23 +227,23 @@ test_table(hid_t fid, int do_write)
     particle2_t rbuf2[NRECORDS];
     particle3_t rbuf3[NRECORDS];
     particle_t  rbufc[NRECORDS * 2];
-    particle_t  abuf[2] = {{"eight", 80, 8.0f, 80.0f, 80}, {"nine", 90, 9.0f, 90.0f, 90}};
-    particle_t  ibuf[2] = {{"zero", 0, 0.0f, 0.0f, 0}, {"zero", 0, 0.0f, 0.0f, 0}};
+    particle_t  abuf[2] = {{"eight", 80, 8.0, 80.0, 80}, {"nine", 90, 9.0, 90.0, 90}};
+    particle_t  ibuf[2] = {{"zero", 0, 0.0, 0.0, 0}, {"zero", 0, 0.0, 0.0, 0}};
     particle_t  wbufd[NRECORDS];
     particle_t  wbuf[NRECORDS] = {{
                                      "zero",
                                      0,
-                                     0.0f,
-                                     0.0f,
+                                     0.0,
+                                     0.0,
                                      0,
                                  },
-                                 {"one", 10, 1.0f, 10.0f, 10},
-                                 {"two", 20, 2.0f, 20.0f, 20},
-                                 {"three", 30, 3.0f, 30.0f, 30},
-                                 {"four", 40, 4.0f, 40.0f, 40},
-                                 {"five", 50, 5.0f, 50.0f, 50},
-                                 {"six", 60, 6.0f, 60.0f, 60},
-                                 {"seven", 70, 7.0f, 70.0f, 70}};
+                                 {"one", 10, 1.0, 10.0, 10},
+                                 {"two", 20, 2.0, 20.0, 20},
+                                 {"three", 30, 3.0, 30.0, 30},
+                                 {"four", 40, 4.0, 40.0, 40},
+                                 {"five", 50, 5.0, 50.0, 50},
+                                 {"six", 60, 6.0, 60.0, 60},
+                                 {"seven", 70, 7.0, 70.0, 70}};
     /* buffers for the field "Pressure" and "New_field" */
     float pressure_in[NRECORDS] = {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f};
     float pressure_out[NRECORDS];
@@ -332,14 +332,14 @@ test_table(hid_t fid, int do_write)
                                       HOFFSET(particle4_t, aty),   HOFFSET(particle4_t, rro)};
 
     /* Define an array of Particles */
-    particle4_t p_data[NRECORDS] = {{12112, 1.4f, 2.5f, {1, 2, 3}, {4, 5, 6}, {99, 100}},
-                                    {12113, 1.4f, 2.5f, {1, 2, 3}, {4, 5, 6}, {99, 100}},
-                                    {12114, 1.4f, 2.5f, {1, 2, 3}, {4, 5, 6}, {99, 100}},
-                                    {12115, 1.4f, 2.5f, {1, 2, 3}, {4, 5, 6}, {99, 100}},
-                                    {12116, 1.4f, 2.5f, {1, 2, 3}, {4, 5, 6}, {99, 100}},
-                                    {12117, 1.4f, 2.5f, {1, 2, 3}, {4, 5, 6}, {99, 100}},
-                                    {12118, 1.4f, 2.5f, {1, 2, 3}, {4, 5, 6}, {99, 100}},
-                                    {12119, 1.4f, 2.5f, {1, 2, 3}, {4, 5, 6}, {99, 100}}};
+    particle4_t p_data[NRECORDS] = {{12112, 1.4, 2.5, {1, 2, 3}, {4, 5, 6}, {99, 100}},
+                                    {12113, 1.4, 2.5, {1, 2, 3}, {4, 5, 6}, {99, 100}},
+                                    {12114, 1.4, 2.5, {1, 2, 3}, {4, 5, 6}, {99, 100}},
+                                    {12115, 1.4, 2.5, {1, 2, 3}, {4, 5, 6}, {99, 100}},
+                                    {12116, 1.4, 2.5, {1, 2, 3}, {4, 5, 6}, {99, 100}},
+                                    {12117, 1.4, 2.5, {1, 2, 3}, {4, 5, 6}, {99, 100}},
+                                    {12118, 1.4, 2.5, {1, 2, 3}, {4, 5, 6}, {99, 100}},
+                                    {12119, 1.4, 2.5, {1, 2, 3}, {4, 5, 6}, {99, 100}}};
 
     /*-------------------------------------------------------------------------
      * initialize table parameters

--- a/test/cache.c
+++ b/test/cache.c
@@ -1046,7 +1046,7 @@ smoke_check_5(int express_test, unsigned paged)
         /* hbool_t     set_initial_size       = */ TRUE,
         /* size_t      initial_size           = */ (2 * 1024 * 1024),
 
-        /* double      min_clean_fraction     = */ 0.1f,
+        /* double      min_clean_fraction     = */ 0.1,
 
         /* size_t      max_size               = */ (32 * 1024 * 1025),
         /* size_t      min_size               = */ (512 * 1024),
@@ -1055,23 +1055,23 @@ smoke_check_5(int express_test, unsigned paged)
 
         /* enum H5C_cache_incr_mode incr_mode = */ H5C_incr__threshold,
 
-        /* double     lower_hr_threshold      = */ 0.75f,
+        /* double     lower_hr_threshold      = */ 0.75,
 
-        /* double      increment              = */ 2.0f,
+        /* double      increment              = */ 2.0,
 
         /* hbool_t     apply_max_increment    = */ TRUE,
         /* size_t      max_increment          = */ (4 * 1024 * 1024),
 
         /* enum H5C_cache_flash_incr_mode       */
         /*                    flash_incr_mode = */ H5C_flash_incr__off,
-        /* double      flash_multiple         = */ 2.0f,
-        /* double      flash_threshold        = */ 0.5f,
+        /* double      flash_multiple         = */ 2.0,
+        /* double      flash_threshold        = */ 0.5,
 
         /* enum H5C_cache_decr_mode decr_mode = */ H5C_decr__threshold,
 
-        /* double      upper_hr_threshold     = */ 0.995f,
+        /* double      upper_hr_threshold     = */ 0.995,
 
-        /* double      decrement              = */ 0.9f,
+        /* double      decrement              = */ 0.9,
 
         /* hbool_t     apply_max_decrement    = */ TRUE,
         /* size_t      max_decrement          = */ (1 * 1024 * 1024),
@@ -1079,7 +1079,7 @@ smoke_check_5(int express_test, unsigned paged)
         /* int32_t     epochs_before_eviction = */ 3,
 
         /* hbool_t     apply_empty_reserve    = */ TRUE,
-        /* double      empty_reserve          = */ 0.5f
+        /* double      empty_reserve          = */ 0.5
     };
 
     if (paged)
@@ -1278,7 +1278,7 @@ smoke_check_6(int express_test, unsigned paged)
         /* hbool_t     set_initial_size       = */ TRUE,
         /* size_t      initial_size           = */ (2 * 1024 * 1024),
 
-        /* double      min_clean_fraction     = */ 0.1f,
+        /* double      min_clean_fraction     = */ 0.1,
 
         /* size_t      max_size               = */ (32 * 1024 * 1025),
         /* size_t      min_size               = */ (512 * 1024),
@@ -1287,23 +1287,23 @@ smoke_check_6(int express_test, unsigned paged)
 
         /* enum H5C_cache_incr_mode incr_mode = */ H5C_incr__threshold,
 
-        /* double     lower_hr_threshold      = */ 0.75f,
+        /* double     lower_hr_threshold      = */ 0.75,
 
-        /* double      increment              = */ 2.0f,
+        /* double      increment              = */ 2.0,
 
         /* hbool_t     apply_max_increment    = */ TRUE,
         /* size_t      max_increment          = */ (4 * 1024 * 1024),
 
         /* enum H5C_cache_flash_incr_mode       */
         /*                    flash_incr_mode = */ H5C_flash_incr__off,
-        /* double      flash_multiple         = */ 2.0f,
-        /* double      flash_threshold        = */ 0.5f,
+        /* double      flash_multiple         = */ 2.0,
+        /* double      flash_threshold        = */ 0.5,
 
         /* enum H5C_cache_decr_mode decr_mode = */ H5C_decr__threshold,
 
-        /* double      upper_hr_threshold     = */ 0.995f,
+        /* double      upper_hr_threshold     = */ 0.995,
 
-        /* double      decrement              = */ 0.9f,
+        /* double      decrement              = */ 0.9,
 
         /* hbool_t     apply_max_decrement    = */ TRUE,
         /* size_t      max_decrement          = */ (1 * 1024 * 1024),
@@ -1311,7 +1311,7 @@ smoke_check_6(int express_test, unsigned paged)
         /* int32_t     epochs_before_eviction = */ 3,
 
         /* hbool_t     apply_empty_reserve    = */ TRUE,
-        /* double      empty_reserve          = */ 0.05f
+        /* double      empty_reserve          = */ 0.05
     };
 
     if (paged)
@@ -1510,7 +1510,7 @@ smoke_check_7(int express_test, unsigned paged)
         /* hbool_t     set_initial_size       = */ TRUE,
         /* size_t      initial_size           = */ (2 * 1024 * 1024),
 
-        /* double      min_clean_fraction     = */ 0.1f,
+        /* double      min_clean_fraction     = */ 0.1,
 
         /* size_t      max_size               = */ (32 * 1024 * 1025),
         /* size_t      min_size               = */ (512 * 1024),
@@ -1519,24 +1519,24 @@ smoke_check_7(int express_test, unsigned paged)
 
         /* enum H5C_cache_incr_mode incr_mode = */ H5C_incr__threshold,
 
-        /* double     lower_hr_threshold      = */ 0.75f,
+        /* double     lower_hr_threshold      = */ 0.75,
 
-        /* double      increment              = */ 2.0f,
+        /* double      increment              = */ 2.0,
 
         /* hbool_t     apply_max_increment    = */ TRUE,
         /* size_t      max_increment          = */ (8 * 1024 * 1024),
 
         /* enum H5C_cache_flash_incr_mode       */
         /*                    flash_incr_mode = */ H5C_flash_incr__off,
-        /* double      flash_multiple         = */ 2.0f,
-        /* double      flash_threshold        = */ 0.5f,
+        /* double      flash_multiple         = */ 2.0,
+        /* double      flash_threshold        = */ 0.5,
 
         /* enum H5C_cache_decr_mode decr_mode = */
         H5C_decr__age_out_with_threshold,
 
-        /* double      upper_hr_threshold     = */ 0.995f,
+        /* double      upper_hr_threshold     = */ 0.995,
 
-        /* double      decrement              = */ 0.9f,
+        /* double      decrement              = */ 0.9,
 
         /* hbool_t     apply_max_decrement    = */ TRUE,
         /* size_t      max_decrement          = */ (1 * 1024 * 1024),
@@ -1544,7 +1544,7 @@ smoke_check_7(int express_test, unsigned paged)
         /* int32_t     epochs_before_eviction = */ 3,
 
         /* hbool_t     apply_empty_reserve    = */ TRUE,
-        /* double      empty_reserve          = */ 0.1f
+        /* double      empty_reserve          = */ 0.1
     };
 
     if (paged)
@@ -1743,7 +1743,7 @@ smoke_check_8(int express_test, unsigned paged)
         /* hbool_t     set_initial_size       = */ TRUE,
         /* size_t      initial_size           = */ (2 * 1024 * 1024),
 
-        /* double      min_clean_fraction     = */ 0.1f,
+        /* double      min_clean_fraction     = */ 0.1,
 
         /* size_t      max_size               = */ (32 * 1024 * 1025),
         /* size_t      min_size               = */ (512 * 1024),
@@ -1752,24 +1752,24 @@ smoke_check_8(int express_test, unsigned paged)
 
         /* enum H5C_cache_incr_mode incr_mode = */ H5C_incr__threshold,
 
-        /* double     lower_hr_threshold      = */ 0.75f,
+        /* double     lower_hr_threshold      = */ 0.75,
 
-        /* double      increment              = */ 2.0f,
+        /* double      increment              = */ 2.0,
 
         /* hbool_t     apply_max_increment    = */ TRUE,
         /* size_t      max_increment          = */ (4 * 1024 * 1024),
 
         /* enum H5C_cache_flash_incr_mode       */
         /*                    flash_incr_mode = */ H5C_flash_incr__off,
-        /* double      flash_multiple         = */ 2.0f,
-        /* double      flash_threshold        = */ 0.5f,
+        /* double      flash_multiple         = */ 2.0,
+        /* double      flash_threshold        = */ 0.5,
 
         /* enum H5C_cache_decr_mode decr_mode = */
         H5C_decr__age_out_with_threshold,
 
-        /* double      upper_hr_threshold     = */ 0.995f,
+        /* double      upper_hr_threshold     = */ 0.995,
 
-        /* double      decrement              = */ 0.9f,
+        /* double      decrement              = */ 0.9,
 
         /* hbool_t     apply_max_decrement    = */ TRUE,
         /* size_t      max_decrement          = */ (1 * 1024 * 1024),
@@ -1777,7 +1777,7 @@ smoke_check_8(int express_test, unsigned paged)
         /* int32_t     epochs_before_eviction = */ 3,
 
         /* hbool_t     apply_empty_reserve    = */ TRUE,
-        /* double      empty_reserve          = */ 0.1f
+        /* double      empty_reserve          = */ 0.1
     };
 
     if (paged)
@@ -17004,7 +17004,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         /* hbool_t     set_initial_size       = */ TRUE,
         /* size_t      initial_size           = */ (512 * 1024),
 
-        /* double      min_clean_fraction     = */ 0.5f,
+        /* double      min_clean_fraction     = */ 0.5,
 
         /* size_t      max_size               = */ (14 * 1024 * 1024),
         /* size_t      min_size               = */ (512 * 1024),
@@ -17013,23 +17013,23 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
 
         /* enum H5C_cache_incr_mode incr_mode = */ H5C_incr__threshold,
 
-        /* double     lower_hr_threshold      = */ 0.75f,
+        /* double     lower_hr_threshold      = */ 0.75,
 
-        /* double      increment              = */ 2.0f,
+        /* double      increment              = */ 2.0,
 
         /* hbool_t     apply_max_increment    = */ TRUE,
         /* size_t      max_increment          = */ (4 * 1024 * 1024),
 
         /* enum H5C_cache_flash_incr_mode       */
         /*                    flash_incr_mode = */ H5C_flash_incr__off,
-        /* double      flash_multiple         = */ 2.0f,
-        /* double      flash_threshold        = */ 0.5f,
+        /* double      flash_multiple         = */ 2.0,
+        /* double      flash_threshold        = */ 0.5,
 
         /* enum H5C_cache_decr_mode decr_mode = */ H5C_decr__threshold,
 
-        /* double      upper_hr_threshold     = */ 0.995f,
+        /* double      upper_hr_threshold     = */ 0.995,
 
-        /* double      decrement              = */ 0.1f,
+        /* double      decrement              = */ 0.1,
 
         /* hbool_t     apply_max_decrement    = */ TRUE,
         /* size_t      max_decrement          = */ (1 * 1024 * 1024),
@@ -17037,7 +17037,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         /* int32_t     epochs_before_eviction = */ 3,
 
         /* hbool_t     apply_empty_reserve    = */ TRUE,
-        /* double      empty_reserve          = */ 0.05f};
+        /* double      empty_reserve          = */ 0.05};
 
     if (paged)
         TESTING("automatic cache resizing (paged aggregation)")
@@ -17361,7 +17361,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 4 * 1000 * 1000 + 10;
 
-        auto_size_ctl.min_clean_fraction = 0.1f;
+        auto_size_ctl.min_clean_fraction = 0.1;
 
         auto_size_ctl.max_size = 8 * 1000 * 1000;
         auto_size_ctl.min_size = 500 * 1000;
@@ -17370,22 +17370,22 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (4 * 1000 * 1000);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (1 * 1000 * 1000);
@@ -17393,7 +17393,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
         if (result != SUCCEED) {
@@ -17676,7 +17676,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 16 * 1024 * 1024;
         auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -17685,22 +17685,22 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 4.0f;
+        auto_size_ctl.increment = 4.0;
 
         auto_size_ctl.apply_max_increment = FALSE;
         auto_size_ctl.max_increment       = (4 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.25f;
+        auto_size_ctl.decrement = 0.25;
 
         auto_size_ctl.apply_max_decrement = FALSE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -17708,7 +17708,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
         if (result != SUCCEED) {
@@ -17852,7 +17852,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 8 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 8 * 1024 * 1024;
         auto_size_ctl.min_size = 512 * 1024;
@@ -17861,22 +17861,22 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (4 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__age_out;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = FALSE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -17884,7 +17884,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = FALSE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
         if (result != SUCCEED) {
@@ -18220,7 +18220,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 8 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 8 * 1024 * 1024;
         auto_size_ctl.min_size = 512 * 1024;
@@ -18229,22 +18229,22 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (4 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__age_out;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -18252,7 +18252,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = FALSE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -18702,7 +18702,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 8 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 8 * 1024 * 1024;
         auto_size_ctl.min_size = 512 * 1024;
@@ -18711,22 +18711,22 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (4 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__age_out;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = FALSE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -18734,7 +18734,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.5f; /* for ease of testing */
+        auto_size_ctl.empty_reserve       = 0.5; /* for ease of testing */
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -19079,7 +19079,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 8 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 8 * 1024 * 1024;
         auto_size_ctl.min_size = 512 * 1024;
@@ -19088,16 +19088,16 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__off;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (4 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__age_out_with_threshold;
 
@@ -19106,7 +19106,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
          */
         auto_size_ctl.upper_hr_threshold = 0.999; /* for ease of testing */
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = FALSE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -19114,7 +19114,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.epochs_before_eviction = 1; /* for ease of testing */
 
         auto_size_ctl.apply_empty_reserve = FALSE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
         if (result != SUCCEED) {
@@ -19326,7 +19326,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 8 * 1000 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 8 * 1000 * 1024;
         auto_size_ctl.min_size = 512 * 1024;
@@ -19335,22 +19335,22 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (4 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__age_out_with_threshold;
 
-        auto_size_ctl.upper_hr_threshold = 0.999f; /* for ease of testing */
+        auto_size_ctl.upper_hr_threshold = 0.999; /* for ease of testing */
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (1 * 1000 * 1024);
@@ -19358,7 +19358,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.epochs_before_eviction = 1; /* for ease of testing */
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.5f; /* for ease of testing */
+        auto_size_ctl.empty_reserve       = 0.5; /* for ease of testing */
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
         if (result != SUCCEED) {
@@ -19868,7 +19868,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 64 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 1024 * 1024;
         auto_size_ctl.min_size = 5 * 1024;
@@ -19877,22 +19877,22 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (32 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__add_space;
-        auto_size_ctl.flash_multiple  = 1.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 1.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__age_out_with_threshold;
 
-        auto_size_ctl.upper_hr_threshold = 0.999f; /* for ease of testing */
+        auto_size_ctl.upper_hr_threshold = 0.999; /* for ease of testing */
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (1 * 1000 * 1024);
@@ -19900,7 +19900,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.epochs_before_eviction = 1; /* for ease of testing */
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.5f; /* for ease of testing */
+        auto_size_ctl.empty_reserve       = 0.5; /* for ease of testing */
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
         if (result != SUCCEED) {
@@ -20602,7 +20602,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 4 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 20 * 1024;
         auto_size_ctl.min_size = 4 * 1024;
@@ -20611,22 +20611,22 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (4 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__add_space;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.4f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.4;
 
         auto_size_ctl.decr_mode = H5C_decr__age_out_with_threshold;
 
-        auto_size_ctl.upper_hr_threshold = 0.999f; /* for ease of testing */
+        auto_size_ctl.upper_hr_threshold = 0.999; /* for ease of testing */
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (2 * 1024);
@@ -20634,7 +20634,7 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         auto_size_ctl.epochs_before_eviction = 1; /* for ease of testing */
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.5f; /* for ease of testing */
+        auto_size_ctl.empty_reserve       = 0.5; /* for ease of testing */
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
         if (result != SUCCEED) {
@@ -20859,7 +20859,7 @@ check_auto_cache_resize_disable(unsigned paged)
         /* hbool_t     set_initial_size       = */ TRUE,
         /* size_t      initial_size           = */ (512 * 1024),
 
-        /* double      min_clean_fraction     = */ 0.5f,
+        /* double      min_clean_fraction     = */ 0.5,
 
         /* size_t      max_size               = */ (14 * 1024 * 1024),
         /* size_t      min_size               = */ (512 * 1024),
@@ -20868,23 +20868,23 @@ check_auto_cache_resize_disable(unsigned paged)
 
         /* enum H5C_cache_incr_mode incr_mode = */ H5C_incr__threshold,
 
-        /* double     lower_hr_threshold      = */ 0.75f,
+        /* double     lower_hr_threshold      = */ 0.75,
 
-        /* double      increment              = */ 2.0f,
+        /* double      increment              = */ 2.0,
 
         /* hbool_t     apply_max_increment    = */ TRUE,
         /* size_t      max_increment          = */ (4 * 1024 * 1024),
 
         /* enum H5C_cache_flash_incr_mode       */
         /*                    flash_incr_mode = */ H5C_flash_incr__off,
-        /* double      flash_multiple         = */ 1.0f,
-        /* double      flash_threshold        = */ 0.25f,
+        /* double      flash_multiple         = */ 1.0,
+        /* double      flash_threshold        = */ 0.25,
 
         /* enum H5C_cache_decr_mode decr_mode = */ H5C_decr__threshold,
 
-        /* double      upper_hr_threshold     = */ 0.995f,
+        /* double      upper_hr_threshold     = */ 0.995,
 
-        /* double      decrement              = */ 0.1f,
+        /* double      decrement              = */ 0.1,
 
         /* hbool_t     apply_max_decrement    = */ TRUE,
         /* size_t      max_decrement          = */ (1 * 1024 * 1024),
@@ -20892,7 +20892,7 @@ check_auto_cache_resize_disable(unsigned paged)
         /* int32_t     epochs_before_eviction = */ 3,
 
         /* hbool_t     apply_empty_reserve    = */ TRUE,
-        /* double      empty_reserve          = */ 0.05f};
+        /* double      empty_reserve          = */ 0.05};
 
     if (paged)
         TESTING("automatic cache resize disable (paged aggregation)")
@@ -20964,7 +20964,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 16 * 1024 * 1024;
         auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -20973,22 +20973,22 @@ check_auto_cache_resize_disable(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 1.0f; /* disable size increases */
+        auto_size_ctl.increment = 1.0; /* disable size increases */
 
         auto_size_ctl.apply_max_increment = FALSE;
         auto_size_ctl.max_increment       = (4 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = FALSE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -20996,7 +20996,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -21116,7 +21116,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 16 * 1024 * 1024;
         auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -21125,21 +21125,21 @@ check_auto_cache_resize_disable(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.0f; /* disable size increases */
+        auto_size_ctl.lower_hr_threshold = 0.0; /* disable size increases */
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = FALSE;
         auto_size_ctl.max_increment       = (4 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
-        auto_size_ctl.decrement          = 0.5f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
+        auto_size_ctl.decrement          = 0.5;
 
         auto_size_ctl.apply_max_decrement = FALSE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -21147,7 +21147,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -21267,7 +21267,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 16 * 1024 * 1024;
         auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -21276,22 +21276,22 @@ check_auto_cache_resize_disable(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__off;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = FALSE;
         auto_size_ctl.max_increment       = (4 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = FALSE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -21299,7 +21299,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -21418,7 +21418,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 16 * 1024 * 1024;
         auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -21427,22 +21427,22 @@ check_auto_cache_resize_disable(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 1.0f; /* disable size decreases */
+        auto_size_ctl.decrement = 1.0; /* disable size decreases */
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -21450,7 +21450,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -21572,7 +21572,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 16 * 1024 * 1024;
         auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -21581,22 +21581,22 @@ check_auto_cache_resize_disable(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        auto_size_ctl.upper_hr_threshold = 1.0f; /* disable size decreases */
+        auto_size_ctl.upper_hr_threshold = 1.0; /* disable size decreases */
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -21604,7 +21604,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -21722,7 +21722,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 16 * 1024 * 1024;
         auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -21731,22 +21731,22 @@ check_auto_cache_resize_disable(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__off;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -21754,7 +21754,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -21874,7 +21874,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 16 * 1024 * 1024;
         auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -21883,22 +21883,22 @@ check_auto_cache_resize_disable(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__age_out;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = 0; /* disable decrement */
@@ -21906,7 +21906,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 1;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -22091,7 +22091,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 16 * 1024 * 1024;
         auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -22100,22 +22100,22 @@ check_auto_cache_resize_disable(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__age_out;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -22123,7 +22123,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 1;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 1.0f; /* disable decrement */
+        auto_size_ctl.empty_reserve       = 1.0; /* disable decrement */
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -22315,7 +22315,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 16 * 1024 * 1024;
         auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -22324,22 +22324,22 @@ check_auto_cache_resize_disable(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__age_out_with_threshold;
 
-        auto_size_ctl.upper_hr_threshold = 1.0f;
+        auto_size_ctl.upper_hr_threshold = 1.0;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -22347,7 +22347,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 1;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -22541,7 +22541,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 2 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 16 * 1024 * 1024;
         auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -22550,22 +22550,22 @@ check_auto_cache_resize_disable(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.0f; /* disable size increases */
+        auto_size_ctl.lower_hr_threshold = 0.0; /* disable size increases */
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        auto_size_ctl.upper_hr_threshold = 1.0f; /* disable size decreases */
+        auto_size_ctl.upper_hr_threshold = 1.0; /* disable size decreases */
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -22573,7 +22573,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -22661,7 +22661,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.25f;
+        auto_size_ctl.min_clean_fraction = 0.25;
 
         auto_size_ctl.max_size = 16 * 1024 * 1024;
         auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -22670,22 +22670,22 @@ check_auto_cache_resize_disable(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 1.0f; /* disable size increment */
+        auto_size_ctl.increment = 1.0; /* disable size increment */
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 1.0f; /* disable size decrement */
+        auto_size_ctl.decrement = 1.0; /* disable size decrement */
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -22693,7 +22693,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -22781,7 +22781,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.set_initial_size = FALSE;
         auto_size_ctl.initial_size     = 2 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 6 * 1024 * 1024; /* no resize */
         auto_size_ctl.min_size = 6 * 1024 * 1024; /* no resize */
@@ -22790,22 +22790,22 @@ check_auto_cache_resize_disable(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -22813,7 +22813,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -22901,7 +22901,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.25f;
+        auto_size_ctl.min_clean_fraction = 0.25;
 
         auto_size_ctl.max_size = 16 * 1024 * 1024;
         auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -22910,22 +22910,22 @@ check_auto_cache_resize_disable(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 1.0f; /* disable size increment */
+        auto_size_ctl.increment = 1.0; /* disable size increment */
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        auto_size_ctl.upper_hr_threshold = 1.0f; /* disable size decrement */
+        auto_size_ctl.upper_hr_threshold = 1.0; /* disable size decrement */
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -22933,7 +22933,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -23021,7 +23021,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 16 * 1024 * 1024;
         auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -23030,22 +23030,22 @@ check_auto_cache_resize_disable(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.0f; /* disable size increment */
+        auto_size_ctl.lower_hr_threshold = 0.0; /* disable size increment */
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 1.0f; /* disable size decrement */
+        auto_size_ctl.decrement = 1.0; /* disable size decrement */
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -23053,7 +23053,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -23141,7 +23141,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 16 * 1024 * 1024;
         auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -23150,22 +23150,22 @@ check_auto_cache_resize_disable(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__off;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__off;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -23173,7 +23173,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -23288,7 +23288,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 64 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 256 * 1024;
         auto_size_ctl.min_size = 32 * 1024;
@@ -23297,22 +23297,22 @@ check_auto_cache_resize_disable(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (2 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 1.0f;
-        auto_size_ctl.flash_threshold = 0.25f;
+        auto_size_ctl.flash_multiple  = 1.0;
+        auto_size_ctl.flash_threshold = 0.25;
 
         auto_size_ctl.decr_mode = H5C_decr__age_out_with_threshold;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = TRUE;
         auto_size_ctl.max_decrement       = (1 * 1024);
@@ -23320,7 +23320,7 @@ check_auto_cache_resize_disable(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 3;
 
         auto_size_ctl.apply_empty_reserve = TRUE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -23458,7 +23458,7 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
         /* hbool_t     set_initial_size       = */ TRUE,
         /* size_t      initial_size           = */ (512 * 1024),
 
-        /* double      min_clean_fraction     = */ 0.5f,
+        /* double      min_clean_fraction     = */ 0.5,
 
         /* size_t      max_size               = */ (14 * 1024 * 1024),
         /* size_t      min_size               = */ (512 * 1024),
@@ -23467,23 +23467,23 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
 
         /* enum H5C_cache_incr_mode incr_mode = */ H5C_incr__threshold,
 
-        /* double     lower_hr_threshold      = */ 0.75f,
+        /* double     lower_hr_threshold      = */ 0.75,
 
-        /* double      increment              = */ 2.0f,
+        /* double      increment              = */ 2.0,
 
         /* hbool_t     apply_max_increment    = */ TRUE,
         /* size_t      max_increment          = */ (4 * 1024 * 1024),
 
         /* enum H5C_cache_flash_incr_mode       */
         /*                    flash_incr_mode = */ H5C_flash_incr__off,
-        /* double      flash_multiple         = */ 2.0f,
-        /* double      flash_threshold        = */ 0.5f,
+        /* double      flash_multiple         = */ 2.0,
+        /* double      flash_threshold        = */ 0.5,
 
         /* enum H5C_cache_decr_mode decr_mode = */ H5C_decr__threshold,
 
-        /* double      upper_hr_threshold     = */ 0.995f,
+        /* double      upper_hr_threshold     = */ 0.995,
 
-        /* double      decrement              = */ 0.1f,
+        /* double      decrement              = */ 0.1,
 
         /* hbool_t     apply_max_decrement    = */ TRUE,
         /* size_t      max_decrement          = */ (1 * 1024 * 1024),
@@ -23491,7 +23491,7 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
         /* int32_t     epochs_before_eviction = */ 3,
 
         /* hbool_t     apply_empty_reserve    = */ TRUE,
-        /* double      empty_reserve          = */ 0.05f};
+        /* double      empty_reserve          = */ 0.05};
 
     if (paged)
         TESTING("automatic cache resize epoch marker management (paged aggr)")
@@ -23545,7 +23545,7 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 8 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 8 * 1024 * 1024;
         auto_size_ctl.min_size = 512 * 1024;
@@ -23554,22 +23554,22 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__off;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (4 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__age_out;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = FALSE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -23577,7 +23577,7 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 10;
 
         auto_size_ctl.apply_empty_reserve = FALSE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -23709,7 +23709,7 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 8 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 8 * 1024 * 1024;
         auto_size_ctl.min_size = 512 * 1024;
@@ -23718,22 +23718,22 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__off;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (4 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__age_out;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = FALSE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -23741,7 +23741,7 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 1;
 
         auto_size_ctl.apply_empty_reserve = FALSE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -23827,7 +23827,7 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 8 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 8 * 1024 * 1024;
         auto_size_ctl.min_size = 512 * 1024;
@@ -23836,22 +23836,22 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__off;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (4 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = FALSE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -23859,7 +23859,7 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 1;
 
         auto_size_ctl.apply_empty_reserve = FALSE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -23905,7 +23905,7 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 8 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 8 * 1024 * 1024;
         auto_size_ctl.min_size = 512 * 1024;
@@ -23914,22 +23914,22 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__off;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (4 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__age_out_with_threshold;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = FALSE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -23937,7 +23937,7 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 10;
 
         auto_size_ctl.apply_empty_reserve = FALSE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -24014,7 +24014,7 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
         auto_size_ctl.set_initial_size = TRUE;
         auto_size_ctl.initial_size     = 8 * 1024 * 1024;
 
-        auto_size_ctl.min_clean_fraction = 0.5f;
+        auto_size_ctl.min_clean_fraction = 0.5;
 
         auto_size_ctl.max_size = 8 * 1024 * 1024;
         auto_size_ctl.min_size = 512 * 1024;
@@ -24023,22 +24023,22 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
 
         auto_size_ctl.incr_mode = H5C_incr__off;
 
-        auto_size_ctl.lower_hr_threshold = 0.75f;
+        auto_size_ctl.lower_hr_threshold = 0.75;
 
-        auto_size_ctl.increment = 2.0f;
+        auto_size_ctl.increment = 2.0;
 
         auto_size_ctl.apply_max_increment = TRUE;
         auto_size_ctl.max_increment       = (4 * 1024 * 1024);
 
         auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        auto_size_ctl.flash_multiple  = 2.0f;
-        auto_size_ctl.flash_threshold = 0.5f;
+        auto_size_ctl.flash_multiple  = 2.0;
+        auto_size_ctl.flash_threshold = 0.5;
 
         auto_size_ctl.decr_mode = H5C_decr__off;
 
-        auto_size_ctl.upper_hr_threshold = 0.995f;
+        auto_size_ctl.upper_hr_threshold = 0.995;
 
-        auto_size_ctl.decrement = 0.5f;
+        auto_size_ctl.decrement = 0.5;
 
         auto_size_ctl.apply_max_decrement = FALSE;
         auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -24046,7 +24046,7 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
         auto_size_ctl.epochs_before_eviction = 10;
 
         auto_size_ctl.apply_empty_reserve = FALSE;
-        auto_size_ctl.empty_reserve       = 0.05f;
+        auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &auto_size_ctl);
 
@@ -24146,7 +24146,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         /* hbool_t     set_initial_size       = */ TRUE,
         /* size_t      initial_size           = */ (512 * 1024),
 
-        /* double      min_clean_fraction     = */ 0.5f,
+        /* double      min_clean_fraction     = */ 0.5,
 
         /* size_t      max_size               = */ (16 * 1024 * 1024),
         /* size_t      min_size               = */ (512 * 1024),
@@ -24155,23 +24155,23 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         /* enum H5C_cache_incr_mode incr_mode = */ H5C_incr__threshold,
 
-        /* double     lower_hr_threshold      = */ 0.75f,
+        /* double     lower_hr_threshold      = */ 0.75,
 
-        /* double      increment              = */ 2.0f,
+        /* double      increment              = */ 2.0,
 
         /* hbool_t     apply_max_increment    = */ TRUE,
         /* size_t      max_increment          = */ (4 * 1024 * 1024),
 
         /* enum H5C_cache_flash_incr_mode       */
         /*                    flash_incr_mode = */ H5C_flash_incr__off,
-        /* double      flash_multiple         = */ 2.0f,
-        /* double      flash_threshold        = */ 0.5f,
+        /* double      flash_multiple         = */ 2.0,
+        /* double      flash_threshold        = */ 0.5,
 
         /* enum H5C_cache_decr_mode decr_mode = */ H5C_decr__threshold,
 
-        /* double      upper_hr_threshold     = */ 0.995f,
+        /* double      upper_hr_threshold     = */ 0.995,
 
-        /* double      decrement              = */ 0.1f,
+        /* double      decrement              = */ 0.1,
 
         /* hbool_t     apply_max_decrement    = */ TRUE,
         /* size_t      max_decrement          = */ (1 * 1024 * 1024),
@@ -24179,7 +24179,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         /* int32_t     epochs_before_eviction = */ 3,
 
         /* hbool_t     apply_empty_reserve    = */ TRUE,
-        /* double      empty_reserve          = */ 0.05f};
+        /* double      empty_reserve          = */ 0.05};
 
     H5C_auto_size_ctl_t invalid_auto_size_ctl;
     H5C_auto_size_ctl_t test_auto_size_ctl;
@@ -24249,7 +24249,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.5f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.5;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -24258,22 +24258,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.7f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.7;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.5f;
+        invalid_auto_size_ctl.decrement = 0.5;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -24281,7 +24281,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(NULL, &invalid_auto_size_ctl);
 
@@ -24318,7 +24318,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.5f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.5;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -24327,22 +24327,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.7f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.7;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.5f;
+        invalid_auto_size_ctl.decrement = 0.5;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -24350,7 +24350,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -24388,7 +24388,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.initial_size     = 16 * 1024 * 1024 + 1;
         /* INVALID */
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.5f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.5;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -24397,22 +24397,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.5f;
+        invalid_auto_size_ctl.decrement = 0.5;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -24420,7 +24420,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -24456,7 +24456,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.initial_size     = 1 * 1024 * 1024 - 1;
         /* INVALID */
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.5f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.5;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -24465,22 +24465,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.5f;
+        invalid_auto_size_ctl.decrement = 0.5;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -24488,7 +24488,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -24525,7 +24525,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 1.00001f; /* INVALID */
+        invalid_auto_size_ctl.min_clean_fraction = 1.00001; /* INVALID */
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -24534,22 +24534,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.5f;
+        invalid_auto_size_ctl.decrement = 0.5;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -24557,7 +24557,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -24592,7 +24592,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = -0.00001f; /* INVALID */
+        invalid_auto_size_ctl.min_clean_fraction = -0.00001; /* INVALID */
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -24601,22 +24601,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.5f;
+        invalid_auto_size_ctl.decrement = 0.5;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -24624,7 +24624,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -24661,7 +24661,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.5f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.5;
 
         invalid_auto_size_ctl.max_size = H5C__MAX_MAX_CACHE_SIZE + 1;
         /* INVALID */
@@ -24671,22 +24671,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.5f;
+        invalid_auto_size_ctl.decrement = 0.5;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -24694,7 +24694,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -24729,7 +24729,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.5f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.5;
 
         invalid_auto_size_ctl.max_size = 1 * 1024 * 1024;     /* INVALID */
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024 + 1; /*PAIR */
@@ -24738,22 +24738,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.5f;
+        invalid_auto_size_ctl.decrement = 0.5;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -24761,7 +24761,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -24796,7 +24796,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.5f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.5;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = H5C__MIN_MAX_CACHE_SIZE - 1;
@@ -24805,22 +24805,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.5f;
+        invalid_auto_size_ctl.decrement = 0.5;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -24828,7 +24828,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -24865,7 +24865,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -24875,22 +24875,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.9f;
+        invalid_auto_size_ctl.decrement = 0.9;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -24898,7 +24898,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -24933,7 +24933,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -24943,22 +24943,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.9f;
+        invalid_auto_size_ctl.decrement = 0.9;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -24966,7 +24966,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -25003,7 +25003,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -25012,22 +25012,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = (enum H5C_cache_incr_mode) - 1; /* INVALID */
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.9f;
+        invalid_auto_size_ctl.decrement = 0.9;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -25035,7 +25035,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -25070,7 +25070,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -25079,22 +25079,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = (enum H5C_cache_incr_mode)2; /* INVALID */
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.9f;
+        invalid_auto_size_ctl.decrement = 0.9;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -25102,7 +25102,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -25139,7 +25139,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.5f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.5;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -25148,22 +25148,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.7f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.7;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 1.01f; /* INVALID */
+        invalid_auto_size_ctl.upper_hr_threshold = 1.01; /* INVALID */
 
-        invalid_auto_size_ctl.decrement = 0.5f;
+        invalid_auto_size_ctl.decrement = 0.5;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -25171,7 +25171,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -25206,7 +25206,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.5f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.5;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -25215,22 +25215,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.8f; /* INVALID */
+        invalid_auto_size_ctl.lower_hr_threshold = 0.8; /* INVALID */
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.7f; /* INVALID */
+        invalid_auto_size_ctl.upper_hr_threshold = 0.7; /* INVALID */
 
-        invalid_auto_size_ctl.decrement = 0.5f;
+        invalid_auto_size_ctl.decrement = 0.5;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -25238,7 +25238,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -25273,7 +25273,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.5f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.5;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -25282,22 +25282,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = -0.0001f; /* INVALID */
+        invalid_auto_size_ctl.lower_hr_threshold = -0.0001; /* INVALID */
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.5f;
+        invalid_auto_size_ctl.decrement = 0.5;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -25305,7 +25305,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -25342,7 +25342,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -25351,22 +25351,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 0.99999f; /* INVALID */
+        invalid_auto_size_ctl.increment = 0.99999; /* INVALID */
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.5f;
+        invalid_auto_size_ctl.decrement = 0.5;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -25374,7 +25374,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -25411,7 +25411,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -25420,22 +25420,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = (enum H5C_cache_flash_incr_mode) - 1; /* INVALID */
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.9f;
+        invalid_auto_size_ctl.decrement = 0.9;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -25443,7 +25443,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -25480,7 +25480,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -25489,22 +25489,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__add_space;
-        invalid_auto_size_ctl.flash_multiple  = 0.09f; /* INVALID */
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 0.09; /* INVALID */
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.9f;
+        invalid_auto_size_ctl.decrement = 0.9;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -25512,7 +25512,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -25547,7 +25547,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -25556,22 +25556,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__add_space;
-        invalid_auto_size_ctl.flash_multiple  = 10.01f; /* INVALID */
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 10.01; /* INVALID */
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.9f;
+        invalid_auto_size_ctl.decrement = 0.9;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -25579,7 +25579,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -25616,7 +25616,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -25625,22 +25625,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__add_space;
-        invalid_auto_size_ctl.flash_multiple  = 1.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.09f; /* INVALID */
+        invalid_auto_size_ctl.flash_multiple  = 1.0;
+        invalid_auto_size_ctl.flash_threshold = 0.09; /* INVALID */
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.9f;
+        invalid_auto_size_ctl.decrement = 0.9;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -25648,7 +25648,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -25683,7 +25683,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -25692,22 +25692,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__add_space;
-        invalid_auto_size_ctl.flash_multiple  = 1.0f;
-        invalid_auto_size_ctl.flash_threshold = 1.001f; /* INVALID */
+        invalid_auto_size_ctl.flash_multiple  = 1.0;
+        invalid_auto_size_ctl.flash_threshold = 1.001; /* INVALID */
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.9f;
+        invalid_auto_size_ctl.decrement = 0.9;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -25715,7 +25715,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -25752,7 +25752,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -25761,22 +25761,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = (enum H5C_cache_decr_mode) - 1; /* INVALID */
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.9f;
+        invalid_auto_size_ctl.decrement = 0.9;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -25784,7 +25784,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -25819,7 +25819,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -25828,22 +25828,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = (enum H5C_cache_decr_mode)4; /* INVALID */
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.9f;
+        invalid_auto_size_ctl.decrement = 0.9;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -25851,7 +25851,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -25888,7 +25888,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -25897,22 +25897,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 1.000001f; /* INVALID */
+        invalid_auto_size_ctl.decrement = 1.000001; /* INVALID */
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -25920,7 +25920,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -25955,7 +25955,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -25964,22 +25964,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = -0.000001f; /* INVALID */
+        invalid_auto_size_ctl.decrement = -0.000001; /* INVALID */
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -25987,7 +25987,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -26024,7 +26024,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -26033,22 +26033,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__age_out;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.9f;
+        invalid_auto_size_ctl.decrement = 0.9;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -26056,7 +26056,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 0; /* INVALID */
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -26091,7 +26091,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -26100,22 +26100,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__age_out_with_threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.9f;
+        invalid_auto_size_ctl.decrement = 0.9;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -26123,7 +26123,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = H5C__MAX_EPOCH_MARKERS + 1; /* INVALID */
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -26160,7 +26160,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -26169,22 +26169,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__age_out;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.9f;
+        invalid_auto_size_ctl.decrement = 0.9;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -26192,7 +26192,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = 3;
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = -0.0000001f; /* INVALID */
+        invalid_auto_size_ctl.empty_reserve       = -0.0000001; /* INVALID */
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -26227,7 +26227,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.set_initial_size = TRUE;
         invalid_auto_size_ctl.initial_size     = 4 * 1024 * 1024;
 
-        invalid_auto_size_ctl.min_clean_fraction = 0.1f;
+        invalid_auto_size_ctl.min_clean_fraction = 0.1;
 
         invalid_auto_size_ctl.max_size = 16 * 1024 * 1024;
         invalid_auto_size_ctl.min_size = 1 * 1024 * 1024;
@@ -26236,22 +26236,22 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
         invalid_auto_size_ctl.incr_mode = H5C_incr__threshold;
 
-        invalid_auto_size_ctl.lower_hr_threshold = 0.75f;
+        invalid_auto_size_ctl.lower_hr_threshold = 0.75;
 
-        invalid_auto_size_ctl.increment = 2.0f;
+        invalid_auto_size_ctl.increment = 2.0;
 
         invalid_auto_size_ctl.apply_max_increment = TRUE;
         invalid_auto_size_ctl.max_increment       = (2 * 1024 * 1024);
 
         invalid_auto_size_ctl.flash_incr_mode = H5C_flash_incr__off;
-        invalid_auto_size_ctl.flash_multiple  = 2.0f;
-        invalid_auto_size_ctl.flash_threshold = 0.5f;
+        invalid_auto_size_ctl.flash_multiple  = 2.0;
+        invalid_auto_size_ctl.flash_threshold = 0.5;
 
         invalid_auto_size_ctl.decr_mode = H5C_decr__age_out_with_threshold;
 
-        invalid_auto_size_ctl.upper_hr_threshold = 0.999f;
+        invalid_auto_size_ctl.upper_hr_threshold = 0.999;
 
-        invalid_auto_size_ctl.decrement = 0.9f;
+        invalid_auto_size_ctl.decrement = 0.9;
 
         invalid_auto_size_ctl.apply_max_decrement = TRUE;
         invalid_auto_size_ctl.max_decrement       = (1 * 1024 * 1024);
@@ -26259,7 +26259,7 @@ check_auto_cache_resize_input_errs(unsigned paged)
         invalid_auto_size_ctl.epochs_before_eviction = H5C__MAX_EPOCH_MARKERS + 1; /* INVALID */
 
         invalid_auto_size_ctl.apply_empty_reserve = TRUE;
-        invalid_auto_size_ctl.empty_reserve       = 0.05f;
+        invalid_auto_size_ctl.empty_reserve       = 0.05;
 
         result = H5C_set_cache_auto_resize_config(cache_ptr, &invalid_auto_size_ctl);
 
@@ -26387,7 +26387,7 @@ check_auto_cache_resize_aux_fcns(unsigned paged)
         /* hbool_t     set_initial_size       = */ TRUE,
         /* size_t      initial_size           = */ (1 * 1024 * 1024),
 
-        /* double      min_clean_fraction     = */ 0.5f,
+        /* double      min_clean_fraction     = */ 0.5,
 
         /* size_t      max_size               = */ (16 * 1024 * 1025),
         /* size_t      min_size               = */ (512 * 1024),
@@ -26396,23 +26396,23 @@ check_auto_cache_resize_aux_fcns(unsigned paged)
 
         /* enum H5C_cache_incr_mode incr_mode = */ H5C_incr__off,
 
-        /* double     lower_hr_threshold      = */ 0.75f,
+        /* double     lower_hr_threshold      = */ 0.75,
 
-        /* double      increment              = */ 2.0f,
+        /* double      increment              = */ 2.0,
 
         /* hbool_t     apply_max_increment    = */ TRUE,
         /* size_t      max_increment          = */ (4 * 1024 * 1024),
 
         /* enum H5C_cache_flash_incr_mode       */
         /*                    flash_incr_mode = */ H5C_flash_incr__off,
-        /* double      flash_multiple         = */ 2.0f,
-        /* double      flash_threshold        = */ 0.5f,
+        /* double      flash_multiple         = */ 2.0,
+        /* double      flash_threshold        = */ 0.5,
 
         /* enum H5C_cache_decr_mode decr_mode = */ H5C_decr__off,
 
-        /* double      upper_hr_threshold     = */ 0.995f,
+        /* double      upper_hr_threshold     = */ 0.995,
 
-        /* double      decrement              = */ 0.9f,
+        /* double      decrement              = */ 0.9,
 
         /* hbool_t     apply_max_decrement    = */ TRUE,
         /* size_t      max_decrement          = */ (1 * 1024 * 1024),
@@ -26420,7 +26420,7 @@ check_auto_cache_resize_aux_fcns(unsigned paged)
         /* int32_t     epochs_before_eviction = */ 3,
 
         /* hbool_t     apply_empty_reserve    = */ TRUE,
-        /* double      empty_reserve          = */ 0.5f
+        /* double      empty_reserve          = */ 0.5
     };
 
     if (paged)
@@ -34313,7 +34313,7 @@ cedds__H5C__autoadjust__ageout__evict_aged_out_entries(H5F_t *file_ptr)
         /* hbool_t     set_initial_size       = */ TRUE,
         /* size_t      initial_size           = */ (2 * 1024 * 1024),
 
-        /* double      min_clean_fraction     = */ 0.5f,
+        /* double      min_clean_fraction     = */ 0.5,
 
         /* size_t      max_size               = */ (8 * 1024 * 1024),
         /* size_t      min_size               = */ (1 * 1024 * 1024),
@@ -34322,23 +34322,23 @@ cedds__H5C__autoadjust__ageout__evict_aged_out_entries(H5F_t *file_ptr)
 
         /* enum H5C_cache_incr_mode incr_mode = */ H5C_incr__threshold,
 
-        /* double     lower_hr_threshold      = */ 0.75f,
+        /* double     lower_hr_threshold      = */ 0.75,
 
-        /* double      increment              = */ 2.0f,
+        /* double      increment              = */ 2.0,
 
         /* hbool_t     apply_max_increment    = */ TRUE,
         /* size_t      max_increment          = */ (4 * 1024 * 1024),
 
         /* enum H5C_cache_flash_incr_mode       */
         /*                    flash_incr_mode = */ H5C_flash_incr__off,
-        /* double      flash_multiple         = */ 2.0f,
-        /* double      flash_threshold        = */ 0.5f,
+        /* double      flash_multiple         = */ 2.0,
+        /* double      flash_threshold        = */ 0.5,
 
         /* enum H5C_cache_decr_mode decr_mode = */ H5C_decr__age_out,
 
-        /* double      upper_hr_threshold     = */ 0.995f,
+        /* double      upper_hr_threshold     = */ 0.995,
 
-        /* double      decrement              = */ 0.5f,
+        /* double      decrement              = */ 0.5,
 
         /* hbool_t     apply_max_decrement    = */ FALSE,
         /* size_t      max_decrement          = */ (1 * 1024 * 1024),
@@ -34346,7 +34346,7 @@ cedds__H5C__autoadjust__ageout__evict_aged_out_entries(H5F_t *file_ptr)
         /* int32_t     epochs_before_eviction = */ 1,
 
         /* hbool_t     apply_empty_reserve    = */ TRUE,
-        /* double      empty_reserve          = */ 0.05f};
+        /* double      empty_reserve          = */ 0.05};
 
     if (pass) {
 


### PR DESCRIPTION
This will reduce clang warnings from 561 to 2 for test/cache.c.