### PR TITLE
Avoid popping API context when one wasn't pushed

### DIFF
--- a/src/H5private.h
+++ b/src/H5private.h
@@ -2082,6 +2082,8 @@ H5_DLL herr_t H5CX_pop(hbool_t update_dxpl_props);
     /* Push the API context */                                                                               \
     if (H5CX_push() < 0)                                                                                     \
         HGOTO_ERROR(H5E_FUNC, H5E_CANTSET, err, "can't set API context")                                     \
+    else                                                                                                     \
+        api_ctx_pushed = TRUE;                                                                               \
                                                                                                              \
     BEGIN_MPE_LOG
 
@@ -2089,6 +2091,8 @@ H5_DLL herr_t H5CX_pop(hbool_t update_dxpl_props);
 #define FUNC_ENTER_API(err)                                                                                  \
     {                                                                                                        \
         {                                                                                                    \
+            hbool_t api_ctx_pushed = FALSE;                                                                  \
+                                                                                                             \
             FUNC_ENTER_API_COMMON                                                                            \
             FUNC_ENTER_API_INIT(err);                                                                        \
             FUNC_ENTER_API_PUSH(err);                                                                        \
@@ -2103,6 +2107,8 @@ H5_DLL herr_t H5CX_pop(hbool_t update_dxpl_props);
 #define FUNC_ENTER_API_NOCLEAR(err)                                                                          \
     {                                                                                                        \
         {                                                                                                    \
+            hbool_t api_ctx_pushed = FALSE;                                                                  \
+                                                                                                             \
             FUNC_ENTER_API_COMMON                                                                            \
             FUNC_ENTER_API_INIT(err);                                                                        \
             FUNC_ENTER_API_PUSH(err);                                                                        \
@@ -2369,14 +2375,17 @@ H5_DLL herr_t H5CX_pop(hbool_t update_dxpl_props);
     H5_API_SET_CANCEL
 
 #define FUNC_LEAVE_API_COMMON(ret_value)                                                                     \
-    ;                                                                                                        \
-    } /*end scope from end of FUNC_ENTER*/                                                                   \
     FINISH_MPE_LOG                                                                                           \
     H5TRACE_RETURN(ret_value);
 
 #define FUNC_LEAVE_API(ret_value)                                                                            \
+    ;                                                                                                        \
+    } /*end scope from end of FUNC_ENTER*/                                                                   \
     FUNC_LEAVE_API_COMMON(ret_value);                                                                        \
-    (void)H5CX_pop(TRUE);                                                                                    \
+    if (api_ctx_pushed) {                                                                                    \
+        (void)H5CX_pop(TRUE);                                                                                \
+        api_ctx_pushed = FALSE;                                                                              \
+    }                                                                                                        \
     H5_POP_FUNC                                                                                              \
     if (err_occurred)                                                                                        \
         (void)H5E_dump_api_stack(TRUE);                                                                      \
@@ -2387,6 +2396,8 @@ H5_DLL herr_t H5CX_pop(hbool_t update_dxpl_props);
 
 /* Use this macro to match the FUNC_ENTER_API_NOINIT macro */
 #define FUNC_LEAVE_API_NOINIT(ret_value)                                                                     \
+    ;                                                                                                        \
+    } /*end scope from end of FUNC_ENTER*/                                                                   \
     FUNC_LEAVE_API_COMMON(ret_value);                                                                        \
     H5_POP_FUNC                                                                                              \
     if (err_occurred)                                                                                        \
@@ -2399,6 +2410,8 @@ H5_DLL herr_t H5CX_pop(hbool_t update_dxpl_props);
 
 /* Use this macro to match the FUNC_ENTER_API_NOINIT_NOERR_NOFS macro */
 #define FUNC_LEAVE_API_NOFS(ret_value)                                                                       \
+    ;                                                                                                        \
+    } /*end scope from end of FUNC_ENTER*/                                                                   \
     FUNC_LEAVE_API_COMMON(ret_value);                                                                        \
     FUNC_LEAVE_API_THREADSAFE                                                                                \
     return (ret_value);                                                                                      \


### PR DESCRIPTION
This PR avoids popping an API context when one wasn't pushed, which is usually the case when library initialization fails. If library initialization fails, the API context push will be skipped and then when H5CX_pop is hit inside the FUNC_LEAVE_ macros, an assertion will be triggered because it expects a context to have been pushed.