### PR TITLE
Fixes a couple of warnings

### DIFF
--- a/src/H5Pdxpl.c
+++ b/src/H5Pdxpl.c
@@ -2281,7 +2281,7 @@ herr_t
 H5Pset_dataset_io_hyperslab_selection(hid_t plist_id, unsigned rank, H5S_seloper_t op, const hsize_t start[],
                                       const hsize_t stride[], const hsize_t count[], const hsize_t block[])
 {
-    H5P_genplist_t *plist;                         /* Property list pointer */
+    H5P_genplist_t *plist = NULL;                  /* Property list pointer */
     H5S_t *         space;                         /* Dataspace to hold selection */
     hbool_t         space_created       = FALSE;   /* Whether a new dataspace has been created */
     hbool_t         reset_prop_on_error = FALSE;   /* Whether to reset the property on failure */
@@ -2371,7 +2371,7 @@ H5Pset_dataset_io_hyperslab_selection(hid_t plist_id, unsigned rank, H5S_seloper
 done:
     /* Cleanup on failure */
     if (ret_value < 0) {
-        if (reset_prop_on_error && H5P_poke(plist, H5D_XFER_DSET_IO_SEL_NAME, &space) < 0)
+        if (reset_prop_on_error && plist && H5P_poke(plist, H5D_XFER_DSET_IO_SEL_NAME, &space) < 0)
             HDONE_ERROR(H5E_PLIST, H5E_CANTSET, FAIL, "error setting dataset I/O selection")
         if (space_created && H5S_close(space) < 0)
             HDONE_ERROR(H5E_PLIST, H5E_CLOSEERROR, FAIL, "unable to release dataspace")

--- a/test/null_vol_connector.c
+++ b/test/null_vol_connector.c
@@ -116,6 +116,7 @@ static const H5VL_class_t null_vol_g = {
     {
         /* introspect_cls */
         NULL, /* get_conn_cls     */
+        NULL, /* get_cap_flags    */
         NULL, /* opt_query        */
     },
     {

--- a/tools/test/h5jam/h5jamgentest.c
+++ b/tools/test/h5jam/h5jamgentest.c
@@ -83,7 +83,7 @@ UD_traverse(const char H5_ATTR_UNUSED *link_name, hid_t H5_ATTR_UNUSED cur_group
             const void H5_ATTR_UNUSED *udata, size_t H5_ATTR_UNUSED udata_size, hid_t H5_ATTR_UNUSED lapl_id,
             hid_t H5_ATTR_UNUSED dxpl_id)
 {
-    return -1;
+    return H5I_INVALID_HID;
 }
 
 #define MY_LINKCLASS 187
@@ -116,196 +116,311 @@ g2 : dset2.1  dset2.2 udlink
 
 */
 
-static void
+static herr_t
 gent_ub(const char *filename, size_t ub_size, size_t ub_fill)
 {
-    hid_t   fid, group, attr, dataset, space;
-    hid_t   create_plist;
+    hid_t   fid          = H5I_INVALID_HID;
+    hid_t   group        = H5I_INVALID_HID;
+    hid_t   attr         = H5I_INVALID_HID;
+    hid_t   dataset      = H5I_INVALID_HID;
+    hid_t   space        = H5I_INVALID_HID;
+    hid_t   create_plist = H5I_INVALID_HID;
     hsize_t dims[2];
     int     data[2][2], dset1[10][10], dset2[20];
     char    buf[BUF_SIZE];
     int     i, j;
     size_t  u;
     float   dset2_1[10], dset2_2[3][5];
-    int     fd;
-    char *  bp;
+    int     fd = -1;
 
     if (ub_size > 0) {
-        create_plist = H5Pcreate(H5P_FILE_CREATE);
-        H5Pset_userblock(create_plist, (hsize_t)ub_size);
-        fid = H5Fcreate(filename, H5F_ACC_TRUNC, create_plist, H5P_DEFAULT);
+        if ((create_plist = H5Pcreate(H5P_FILE_CREATE)) < 0)
+            goto error;
+        if (H5Pset_userblock(create_plist, (hsize_t)ub_size) < 0)
+            goto error;
+        if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, create_plist, H5P_DEFAULT)) < 0)
+            goto error;
     }
     else {
-        fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+        if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+            goto error;
     }
 
-    /* create groups */
-    group = H5Gcreate2(fid, "/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    H5Gclose(group);
+    /* Create groups */
+    if ((group = H5Gcreate2(fid, "/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto error;
+    if (H5Gclose(group) < 0)
+        goto error;
 
-    group = H5Gcreate2(fid, "/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    H5Gclose(group);
+    if ((group = H5Gcreate2(fid, "/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto error;
+    if (H5Gclose(group) < 0)
+        goto error;
 
-    group = H5Gcreate2(fid, "/g1/g1.1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    H5Gclose(group);
+    if ((group = H5Gcreate2(fid, "/g1/g1.1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto error;
+    if (H5Gclose(group) < 0)
+        goto error;
 
-    group = H5Gcreate2(fid, "/g1/g1.2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    H5Gclose(group);
+    if ((group = H5Gcreate2(fid, "/g1/g1.2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto error;
+    if (H5Gclose(group) < 0)
+        goto error;
 
-    group = H5Gcreate2(fid, "/g1/g1.2/g1.2.1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    H5Gclose(group);
+    if ((group = H5Gcreate2(fid, "/g1/g1.2/g1.2.1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto error;
+    if (H5Gclose(group) < 0)
+        goto error;
 
-    /* root attributes */
-    group = H5Gopen2(fid, "/", H5P_DEFAULT);
+    /* Root attributes */
+    if ((group = H5Gopen2(fid, "/", H5P_DEFAULT)) < 0)
+        goto error;
 
     dims[0] = 10;
-    space   = H5Screate_simple(1, dims, NULL);
-    attr    = H5Acreate2(group, "attr1", H5T_STD_I8BE, space, H5P_DEFAULT, H5P_DEFAULT);
-    HDsprintf(buf, "abcdefghi");
-    H5Awrite(attr, H5T_NATIVE_SCHAR, buf);
-    H5Sclose(space);
-    H5Aclose(attr);
+    if ((space = H5Screate_simple(1, dims, NULL)) < 0)
+        goto error;
+    if ((attr = H5Acreate2(group, "attr1", H5T_STD_I8BE, space, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto error;
+    if (HDsprintf(buf, "abcdefghi") < 0)
+        goto error;
+    if (H5Awrite(attr, H5T_NATIVE_SCHAR, buf) < 0)
+        goto error;
+    if (H5Sclose(space) < 0)
+        goto error;
+    if (H5Aclose(attr) < 0)
+        goto error;
 
-    dims[0]    = 2;
-    dims[1]    = 2;
-    space      = H5Screate_simple(2, dims, NULL);
-    attr       = H5Acreate2(group, "attr2", H5T_STD_I32BE, space, H5P_DEFAULT, H5P_DEFAULT);
+    dims[0] = 2;
+    dims[1] = 2;
+    if ((space = H5Screate_simple(2, dims, NULL)) < 0)
+        goto error;
+    if ((attr = H5Acreate2(group, "attr2", H5T_STD_I32BE, space, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto error;
     data[0][0] = 0;
     data[0][1] = 1;
     data[1][0] = 2;
     data[1][1] = 3;
-    H5Awrite(attr, H5T_NATIVE_INT, data);
-    H5Sclose(space);
-    H5Aclose(attr);
+    if (H5Awrite(attr, H5T_NATIVE_INT, data) < 0)
+        goto error;
+    if (H5Sclose(space) < 0)
+        goto error;
+    if (H5Aclose(attr) < 0)
+        goto error;
 
-    H5Gclose(group);
+    if (H5Gclose(group) < 0)
+        goto error;
 
-    group = H5Gopen2(fid, "/g1/g1.1", H5P_DEFAULT);
+    if ((group = H5Gopen2(fid, "/g1/g1.1", H5P_DEFAULT)) < 0)
+        goto error;
 
-    /* dset1.1.1 */
+    /* Dataset 1.1.1 */
     dims[0] = 10;
     dims[1] = 10;
-    space   = H5Screate_simple(2, dims, NULL);
-    dataset = H5Dcreate2(group, "dset1.1.1", H5T_STD_I32BE, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    if ((space = H5Screate_simple(2, dims, NULL)) < 0)
+        goto error;
+    if ((dataset =
+             H5Dcreate2(group, "dset1.1.1", H5T_STD_I32BE, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto error;
     for (i = 0; i < 10; i++)
         for (j = 0; j < 10; j++)
             dset1[i][j] = j * i;
-    H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, dset1);
-    H5Sclose(space);
+    if (H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, dset1) < 0)
+        goto error;
+    if (H5Sclose(space) < 0)
+        goto error;
 
-    /* attributes of dset1.1.1 */
+    /* Attributes of dset1.1.1 */
     dims[0] = 27;
-    space   = H5Screate_simple(1, dims, NULL);
-    attr    = H5Acreate2(dataset, "attr1", H5T_STD_I8BE, space, H5P_DEFAULT, H5P_DEFAULT);
-    HDsprintf(buf, "1st attribute of dset1.1.1");
-    H5Awrite(attr, H5T_NATIVE_SCHAR, buf);
-    H5Sclose(space);
-    H5Aclose(attr);
+    if ((space = H5Screate_simple(1, dims, NULL)) < 0)
+        goto error;
+    if ((attr = H5Acreate2(dataset, "attr1", H5T_STD_I8BE, space, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto error;
+    if (HDsprintf(buf, "1st attribute of dset1.1.1") < 0)
+        goto error;
+    if (H5Awrite(attr, H5T_NATIVE_SCHAR, buf) < 0)
+        goto error;
+    if (H5Sclose(space) < 0)
+        goto error;
+    if (H5Aclose(attr) < 0)
+        goto error;
 
     dims[0] = 27;
-    space   = H5Screate_simple(1, dims, NULL);
-    attr    = H5Acreate2(dataset, "attr2", H5T_STD_I8BE, space, H5P_DEFAULT, H5P_DEFAULT);
-    HDsprintf(buf, "2nd attribute of dset1.1.1");
-    H5Awrite(attr, H5T_NATIVE_SCHAR, buf);
-    H5Sclose(space);
-    H5Aclose(attr);
+    if ((space = H5Screate_simple(1, dims, NULL)) < 0)
+        goto error;
+    if ((attr = H5Acreate2(dataset, "attr2", H5T_STD_I8BE, space, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto error;
+    if (HDsprintf(buf, "2nd attribute of dset1.1.1") < 0)
+        goto error;
+    if (H5Awrite(attr, H5T_NATIVE_SCHAR, buf) < 0)
+        goto error;
+    if (H5Sclose(space) < 0)
+        goto error;
+    if (H5Aclose(attr) < 0)
+        goto error;
 
-    H5Dclose(dataset);
+    if (H5Dclose(dataset) < 0)
+        goto error;
 
-    /* dset1.1.2 */
+    /* Dataset 1.1.2 */
     dims[0] = 20;
-    space   = H5Screate_simple(1, dims, NULL);
-    dataset = H5Dcreate2(group, "dset1.1.2", H5T_STD_I32BE, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    if ((space = H5Screate_simple(1, dims, NULL)) < 0)
+        goto error;
+    if ((dataset =
+             H5Dcreate2(group, "dset1.1.2", H5T_STD_I32BE, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto error;
     for (i = 0; i < 20; i++)
         dset2[i] = i;
-    H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, dset2);
-    H5Sclose(space);
-    H5Dclose(dataset);
+    if (H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, dset2) < 0)
+        goto error;
+    if (H5Sclose(space) < 0)
+        goto error;
+    if (H5Dclose(dataset) < 0)
+        goto error;
 
-    H5Gclose(group);
+    if (H5Gclose(group) < 0)
+        goto error;
 
-    /* external link */
-    H5Lcreate_external("somefile", "somepath", fid, "/g1/g1.2/extlink", H5P_DEFAULT, H5P_DEFAULT);
+    /* External link */
+    if (H5Lcreate_external("somefile", "somepath", fid, "/g1/g1.2/extlink", H5P_DEFAULT, H5P_DEFAULT) < 0)
+        goto error;
 
-    /* soft link */
-    group = H5Gopen2(fid, "/g1/g1.2/g1.2.1", H5P_DEFAULT);
-    H5Lcreate_soft("somevalue", group, "slink", H5P_DEFAULT, H5P_DEFAULT);
-    H5Gclose(group);
+    /* Soft link */
+    if ((group = H5Gopen2(fid, "/g1/g1.2/g1.2.1", H5P_DEFAULT)) < 0)
+        goto error;
+    if (H5Lcreate_soft("somevalue", group, "slink", H5P_DEFAULT, H5P_DEFAULT) < 0)
+        goto error;
+    if (H5Gclose(group) < 0)
+        goto error;
 
-    group = H5Gopen2(fid, "/g2", H5P_DEFAULT);
+    if ((group = H5Gopen2(fid, "/g2", H5P_DEFAULT)) < 0)
+        goto error;
 
-    /* dset2.1 */
+    /* Dataset 2.1 */
     dims[0] = 10;
-    space   = H5Screate_simple(1, dims, NULL);
-    dataset = H5Dcreate2(group, "dset2.1", H5T_IEEE_F32BE, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    if ((space = H5Screate_simple(1, dims, NULL)) < 0)
+        goto error;
+    if ((dataset =
+             H5Dcreate2(group, "dset2.1", H5T_IEEE_F32BE, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto error;
     for (i = 0; i < 10; i++)
         dset2_1[i] = (float)((float)i * 0.1F + 1.0F);
-    H5Dwrite(dataset, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, dset2_1);
-    H5Sclose(space);
-    H5Dclose(dataset);
+    if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, dset2_1) < 0)
+        goto error;
+    if (H5Sclose(space) < 0)
+        goto error;
+    if (H5Dclose(dataset) < 0)
+        goto error;
 
-    /* dset2.2 */
+    /* Dataset 2.2 */
     dims[0] = 3;
     dims[1] = 5;
-    space   = H5Screate_simple(2, dims, NULL);
-    dataset = H5Dcreate2(group, "dset2.2", H5T_IEEE_F32BE, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    if ((space = H5Screate_simple(2, dims, NULL)) < 0)
+        goto error;
+    if ((dataset =
+             H5Dcreate2(group, "dset2.2", H5T_IEEE_F32BE, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto error;
     for (i = 0; i < 3; i++)
         for (j = 0; j < 5; j++)
             dset2_2[i][j] = (float)(((float)i + 1.0F) * (float)j * 0.1F);
-    H5Dwrite(dataset, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, dset2_2);
-    H5Sclose(space);
-    H5Dclose(dataset);
+    if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, dset2_2) < 0)
+        goto error;
+    if (H5Sclose(space) < 0)
+        goto error;
+    if (H5Dclose(dataset) < 0)
+        goto error;
 
-    H5Gclose(group);
+    if (H5Gclose(group) < 0)
+        goto error;
 
-    /* user-defined link */
-    H5Lregister(UD_link_class);
-    H5Lcreate_ud(fid, "/g2/udlink", (H5L_type_t)MY_LINKCLASS, NULL, (size_t)0, H5P_DEFAULT, H5P_DEFAULT);
+    /* User-defined link */
+    if (H5Lregister(UD_link_class) < 0)
+        goto error;
+    if (H5Lcreate_ud(fid, "/g2/udlink", (H5L_type_t)MY_LINKCLASS, NULL, (size_t)0, H5P_DEFAULT, H5P_DEFAULT) <
+        0)
+        goto error;
 
-    H5Fclose(fid);
+    /* MUST close the file ID before the user block code or you risk tripping
+     * over file locking issues.
+     */
+    if (H5Fclose(fid) < 0)
+        goto error;
 
     /* If a user block is being used, write to it here */
     if (ub_size > 0) {
-        HDassert(ub_size <= BUF_SIZE);
+        char *bp;
 
-        fd = HDopen(filename, O_RDWR);
-        HDassert(fd >= 0);
+        if (ub_size > BUF_SIZE)
+            goto error;
 
-        /* fill buf with pattern */
+        if ((fd = HDopen(filename, O_RDWR)) < 0)
+            goto error;
+
+        /* Fill buf with pattern */
         HDmemset(buf, '\0', ub_size);
         bp = buf;
         for (u = 0; u < ub_fill; u++)
             *bp++ = pattern[u % 10];
 
-        (void)HDwrite(fd, buf, ub_size);
+        if (HDwrite(fd, buf, ub_size) < 0)
+            goto error;
 
-        HDclose(fd);
+        if (HDclose(fd) < 0)
+            goto error;
     }
+
+    return SUCCEED;
+
+error:
+    if (fd >= 0)
+        HDclose(fd);
+
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(fid);
+        H5Gclose(group);
+        H5Aclose(attr);
+        H5Dclose(dataset);
+        H5Sclose(space);
+        H5Pclose(create_plist);
+    }
+    H5E_END_TRY;
+
+    return FAIL;
 }
 
-static void
+/* Creates a simple (i.e., not HDF5) text file and fills it with a pattern */
+static herr_t
 create_textfile(const char *name, size_t size)
 {
-    char * buf;
-    int    fd;
+    char * buf = NULL;
+    int    fd  = -1;
     size_t i;
-    char * bp;
+    char * bp = NULL;
 
-    fd = HDcreat(name, 0777);
-    HDassert(fd >= 0);
-    buf = (char *)HDcalloc(size, (size_t)1);
-    HDassert(buf);
+    if ((fd = HDcreat(name, 0777)) < 0)
+        goto error;
+    if (NULL == (buf = (char *)HDcalloc(size, 1)))
+        goto error;
 
-    /* fill buf with pattern */
+    /* Fill buf with pattern */
     bp = buf;
     for (i = 0; i < size; i++)
         *bp++ = pattern[i % 10];
 
-    (void)HDwrite(fd, buf, size);
+    if (HDwrite(fd, buf, size) < 0)
+        goto error;
 
     HDfree(buf);
-
     HDclose(fd);
+
+    return SUCCEED;
+
+error:
+    HDfree(buf);
+    if (fd >= 0)
+        HDclose(fd);
+
+    return FAIL;
 }
 
 #ifdef notdef
@@ -318,19 +433,20 @@ create_binfile(char *name, off_t size)
     int   i;
     char *bp;
 
-    fd = creat(name, 0777);
+    fd = HDcreat(name, 0777);
     HDassert(fd >= 0);
 
     buf = HDcalloc(size, 1);
     HDassert(buf);
 
-    /* fill buf with pattern */
+    /* Fill buf with pattern */
     bp = buf;
     for (i = 0; i < size; i++)
         *bp++ = (char)i & 0xff;
 
     (void)HDwrite(fd, buf, size);
 
+    HDfree(buf);
     HDclose(fd);
 }
 #endif
@@ -344,14 +460,19 @@ create_binfile(char *name, off_t size)
 int
 main(void)
 {
-
     /*
     create_textfile(UBTXT1, (size_t)0);
     */
-    create_textfile(UBTXT2, (size_t)10);
-    create_textfile(UBTXT3, (size_t)511);
-    create_textfile(UBTXT4, (size_t)512);
-    create_textfile(UBTXT5, (size_t)513);
+
+    if (create_textfile(UBTXT2, 10) < 0)
+        goto error;
+    if (create_textfile(UBTXT3, 511) < 0)
+        goto error;
+    if (create_textfile(UBTXT4, 512) < 0)
+        goto error;
+    if (create_textfile(UBTXT5, 513) < 0)
+        goto error;
+
     /*
     create_textfile(UBTXT6, (size_t)1023);
     create_textfile(UBTXT7, (size_t)1024);
@@ -365,11 +486,18 @@ main(void)
     create_binfile(UBBIN3, (off_t)511);
     create_binfile(UBBIN4, (off_t)512);
     create_binfile(UBBIN5, (off_t)513);
-
     */
-    gent_ub(FILE7, (size_t)0, (size_t)0);
-    gent_ub(FILE8, (size_t)512, HDstrlen(pattern));
-    gent_ub(FILE9, (size_t)1024, (size_t)513);
 
-    return 0;
+    if (gent_ub(FILE7, 0, 0) < 0)
+        goto error;
+    if (gent_ub(FILE8, 512, HDstrlen(pattern)) < 0)
+        goto error;
+    if (gent_ub(FILE9, 1024, 513) < 0)
+        goto error;
+
+    return EXIT_SUCCESS;
+
+error:
+    HDfprintf(stderr, "h5jam test generator FAILED\n");
+    return EXIT_FAILURE;
 }


### PR DESCRIPTION
 - warn_unused_result warnings from h5jamgentest and h5stat_gentest
   that were triggered by write(2) calls where we didn't check the
   return value
 - A missing callback in the NULL VOL connector
 - A possibly uninitialized property list pointer (error case only)