### PR TITLE
Guard the SKIP_MPICXX macros against redefinition.

### DIFF
--- a/src/H5public.h
+++ b/src/H5public.h
@@ -56,8 +56,12 @@
 
 #ifdef H5_HAVE_PARALLEL
 /* Don't link against MPI C++ bindings */
+#ifndef MPICH_SKIP_MPICXX
 #define MPICH_SKIP_MPICXX 1
+#endif
+#ifndef OMPI_SKIP_MPICXX
 #define OMPI_SKIP_MPICXX  1
+#endif
 #include <mpi.h>
 #ifndef MPI_FILE_NULL /* MPIO may be defined in mpi.h already */
 #include <mpio.h>


### PR DESCRIPTION
This fixes some harmless but annoying compiler warnings.