### PR TITLE
 Revert references to SIZE_MAX to ((size_t)(-1)) in C header defines …

### DIFF
--- a/src/H5Dpublic.h
+++ b/src/H5Dpublic.h
@@ -28,8 +28,8 @@
 /*****************/
 
 /* Macros used to "unset" chunk cache configuration parameters */
-#define H5D_CHUNK_CACHE_NSLOTS_DEFAULT SIZE_MAX
-#define H5D_CHUNK_CACHE_NBYTES_DEFAULT SIZE_MAX
+#define H5D_CHUNK_CACHE_NSLOTS_DEFAULT ((size_t)-1)
+#define H5D_CHUNK_CACHE_NBYTES_DEFAULT ((size_t)-1)
 #define H5D_CHUNK_CACHE_W0_DEFAULT     (-1.0)
 
 /* Bit flags for the H5Pset_chunk_opts() and H5Pget_chunk_opts() */

--- a/src/H5Tpublic.h
+++ b/src/H5Tpublic.h
@@ -245,7 +245,7 @@ typedef struct {
  * Indicate that a string is variable length (null-terminated in C, instead of
  * fixed length)
  */
-#define H5T_VARIABLE SIZE_MAX
+#define H5T_VARIABLE ((size_t)-1)
 
 /* Opaque information */
 /**


### PR DESCRIPTION
…used by c++ code that fails on centos7 when -std=c++11 is not set. (#847)

