### PR TITLE
CMake should use the output dir programs for shell scripts

### DIFF
--- a/test/ShellTests.cmake
+++ b/test/ShellTests.cmake
@@ -19,7 +19,8 @@ if (UNIX)
 
   find_program (SH_PROGRAM bash)
   if (SH_PROGRAM)
-
+    set (srcdir ${HDF5_TEST_SOURCE_DIR})
+    set (bindir ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
     ##############################################################################
     #  configure scripts to test dir
     ##############################################################################
@@ -33,13 +34,8 @@ if (UNIX)
     ##############################################################################
     #  copy test programs to test dir
     ##############################################################################
-    add_custom_command (
-        TARGET     swmr_check_compat_vfd
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:swmr_check_compat_vfd>" "${HDF5_TEST_BINARY_DIR}/H5TEST/swmr_check_compat_vfd"
-    )
-
+    #shell script creates dir
+    #file (MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/H5TEST/swmr_test")
     add_custom_command (
         TARGET     swmr_check_compat_vfd
         POST_BUILD
@@ -47,118 +43,12 @@ if (UNIX)
         ARGS       -E copy_if_different "${HDF5_SOURCE_DIR}/bin/output_filter.sh" "${HDF5_TEST_BINARY_DIR}/H5TEST/bin/output_filter.sh"
     )
 
-    file (MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/H5TEST/flushrefresh_test")
-    add_custom_command (
-        TARGET     flushrefresh
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:flushrefresh>" "${HDF5_TEST_BINARY_DIR}/H5TEST/flushrefresh"
-    )
-
     #shell script creates dir
     #file (MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/H5TEST/usecases_test")
-    add_custom_command (
-        TARGET     use_append_mchunks
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:use_append_mchunks>" "${HDF5_TEST_BINARY_DIR}/H5TEST/use_append_mchunks"
-    )
-    add_custom_command (
-        TARGET     use_disable_mdc_flushes
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:use_disable_mdc_flushes>" "${HDF5_TEST_BINARY_DIR}/H5TEST/use_disable_mdc_flushes"
-    )
-    add_custom_command (
-        TARGET     twriteorder
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:twriteorder>" "${HDF5_TEST_BINARY_DIR}/H5TEST/twriteorder"
-    )
-    add_custom_command (
-        TARGET     use_append_chunk
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:use_append_chunk>" "${HDF5_TEST_BINARY_DIR}/H5TEST/use_append_chunk"
-    )
 
     file (MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/H5TEST/swmr_test")
-    add_custom_command (
-        TARGET     swmr_generator
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:swmr_generator>" "${HDF5_TEST_BINARY_DIR}/H5TEST/swmr_test/swmr_generator"
-    )
-    add_custom_command (
-        TARGET     swmr_start_write
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:swmr_start_write>" "${HDF5_TEST_BINARY_DIR}/H5TEST/swmr_test/swmr_start_write"
-    )
-    add_custom_command (
-        TARGET     swmr_reader
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:swmr_reader>" "${HDF5_TEST_BINARY_DIR}/H5TEST/swmr_test/swmr_reader"
-    )
-    add_custom_command (
-        TARGET     swmr_writer
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:swmr_writer>" "${HDF5_TEST_BINARY_DIR}/H5TEST/swmr_test/swmr_writer"
-    )
-    add_custom_command (
-        TARGET     swmr_remove_reader
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:swmr_remove_reader>" "${HDF5_TEST_BINARY_DIR}/H5TEST/swmr_test/swmr_remove_reader"
-    )
-    add_custom_command (
-        TARGET     swmr_remove_writer
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:swmr_remove_writer>" "${HDF5_TEST_BINARY_DIR}/H5TEST/swmr_test/swmr_remove_writer"
-    )
-    add_custom_command (
-        TARGET     swmr_addrem_writer
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:swmr_addrem_writer>" "${HDF5_TEST_BINARY_DIR}/H5TEST/swmr_test/swmr_addrem_writer"
-    )
-    add_custom_command (
-        TARGET     swmr_sparse_reader
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:swmr_sparse_reader>" "${HDF5_TEST_BINARY_DIR}/H5TEST/swmr_test/swmr_sparse_reader"
-    )
-    add_custom_command (
-        TARGET     swmr_sparse_writer
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:swmr_sparse_writer>" "${HDF5_TEST_BINARY_DIR}/H5TEST/swmr_test/swmr_sparse_writer"
-    )
 
     file (MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/H5TEST/vds_swmr_test")
-    add_custom_command (
-        TARGET     vds_swmr_gen
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:vds_swmr_gen>" "${HDF5_TEST_BINARY_DIR}/H5TEST/vds_swmr_gen"
-    )
-    add_custom_command (
-        TARGET     vds_swmr_writer
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:vds_swmr_writer>" "${HDF5_TEST_BINARY_DIR}/H5TEST/vds_swmr_writer"
-    )
-    add_custom_command (
-        TARGET     vds_swmr_reader
-        POST_BUILD
-        COMMAND    ${CMAKE_COMMAND}
-        ARGS       -E copy_if_different "$<TARGET_FILE:vds_swmr_reader>" "${HDF5_TEST_BINARY_DIR}/H5TEST/vds_swmr_reader"
-    )
-
-
 
     ##############################################################################
     ##############################################################################

--- a/test/test_usecases.sh.in
+++ b/test/test_usecases.sh.in
@@ -22,10 +22,16 @@
 # exit codes are okay (0).
 
 srcdir=@srcdir@
+bindir=@bindir@
+
+# If the bindir directory is not set just use current (.).
+if test -z "$bindir"; then
+   bindir=.
+fi
 
 # Check to see if the VFD specified by the HDF5_DRIVER environment variable
 # supports SWMR.
-./swmr_check_compat_vfd
+$bindir/swmr_check_compat_vfd
 rc=$?
 if [[ $rc != 0 ]] ; then
     echo
@@ -85,7 +91,7 @@ TOOLTEST() {
     # Run test.
     TESTING $program $@
     (
-      $RUNSERIAL ./$program "$@"
+      $RUNSERIAL $bindir/$program "$@"
     ) >$actual 2>$actual_err
     exit_code=$?
 
@@ -178,14 +184,14 @@ fi
 
 # main body
 for p in $USECASES_PROGRAMS; do
-    TOOLTEST ./$p
-    TOOLTEST ./$p -z 256
+    TOOLTEST $p
+    TOOLTEST $p -z 256
     tmpfile=/tmp/datatfile.$$
-    TOOLTEST ./$p -f $tmpfile; rm -f $tmpfile
-    TOOLTEST ./$p -l w
-    TOOLTEST ./$p -l r
+    TOOLTEST $p -f $tmpfile; rm -f $tmpfile
+    TOOLTEST $p -l w
+    TOOLTEST $p -l r
     # use case 1.9, testing with multi-planes chunks
-    TOOLTEST ./$p -z 256 -y 5    # 5 planes chunks
+    TOOLTEST $p -z 256 -y 5    # 5 planes chunks
     # cleanup temp datafile
     if test -z "$HDF5_NOCLEANUP"; then
     rm -f $p.h5

--- a/test/testswmr.sh.in
+++ b/test/testswmr.sh.in
@@ -17,6 +17,7 @@
 #   Albert Cheng, 2009/07/22
 
 srcdir=@srcdir@
+bindir=@bindir@
 
 ###############################################################################
 ## test parameters
@@ -97,9 +98,14 @@ if test -z "$srcdir"; then
    srcdir=.
 fi
 
+# If the bindir directory is not set just use current (.).
+if test -z "$bindir"; then
+   bindir=.
+fi
+
 # Check to see if the VFD specified by the HDF5_DRIVER environment variable
 # supports SWMR.
-./swmr_check_compat_vfd
+$bindir/swmr_check_compat_vfd
 rc=$?
 if [ $rc -ne 0 ] ; then
     echo
@@ -172,7 +178,7 @@ do
         echo "###############################################################################"
         # Launch the Generator without SWMR_WRITE
         echo launch the swmr_generator
-        ./swmr_generator $compress $index_type
+        $bindir/swmr_generator $compress $index_type
         if test $? -ne 0; then
             echo generator had error
             nerrors=`expr $nerrors + 1`
@@ -180,7 +186,7 @@ do
 
         # Launch the Generator with SWMR_WRITE
         echo launch the swmr_generator with SWMR_WRITE
-        ./swmr_generator -s $compress $index_type
+        $bindir/swmr_generator -s $compress $index_type
         if test $? -ne 0; then
             echo generator had error
             nerrors=`expr $nerrors + 1`
@@ -204,7 +210,7 @@ do
         # Launch the Writer
         echo launch the swmr_start_writer
         seed="" # Put -r <random seed> command here
-        ./swmr_start_write $compress $index_type $Nrecords $seed 2>&1 |tee swmr_writer.out &
+        $bindir/swmr_start_write $compress $index_type $Nrecords $seed 2>&1 |tee swmr_writer.out &
         pid_writer=$!
         $DPRINT pid_writer=$pid_writer
 
@@ -220,7 +226,7 @@ do
         while [ $n -lt $Nreaders ]; do
             #seed="-r ${seeds[$n]}"
             seed=""
-            ./swmr_reader $Nsecs_add $seed 2>&1 |tee swmr_reader.out.$n &
+            $bindir/swmr_reader $Nsecs_add $seed 2>&1 |tee swmr_reader.out.$n &
             pid_readers="$pid_readers $!"
             n=`expr $n + 1`
         done
@@ -265,7 +271,7 @@ do
 
         # Launch the Generator
         echo launch the swmr_generator
-        ./swmr_generator -s $compress $index_type
+        $bindir/swmr_generator -s $compress $index_type
         if test $? -ne 0; then
             echo generator had error
             nerrors=`expr $nerrors + 1`
@@ -277,7 +283,7 @@ do
         # Launch the Writer
         echo launch the swmr_writer
         seed="" # Put -r <random seed> command here
-        ./swmr_writer -o $Nrecords $seed 2>&1 |tee swmr_writer.out &
+        $bindir/swmr_writer -o $Nrecords $seed 2>&1 |tee swmr_writer.out &
         pid_writer=$!
         $DPRINT pid_writer=$pid_writer
 
@@ -292,7 +298,7 @@ do
         while [ $n -lt $Nreaders ]; do
             #seed="-r ${seeds[$n]}"
             seed=""
-            ./swmr_reader $Nsecs_add $seed 2>&1 |tee swmr_reader.out.$n &
+            $bindir/swmr_reader $Nsecs_add $seed 2>&1 |tee swmr_reader.out.$n &
             pid_readers="$pid_readers $!"
             n=`expr $n + 1`
         done
@@ -340,7 +346,7 @@ do
         # Launch the Remove Writer
         echo launch the swmr_remove_writer
         seed="" # Put -r <random seed> command here
-        ./swmr_remove_writer -o $Nrecs_rem $seed 2>&1 |tee swmr_writer.out &
+        $bindir/swmr_remove_writer -o $Nrecs_rem $seed 2>&1 |tee swmr_writer.out &
         pid_writer=$!
         $DPRINT pid_writer=$pid_writer
 
@@ -355,7 +361,7 @@ do
         while [ $n -lt $Nreaders ]; do
             #seed="-r ${seeds[$n]}"
             seed=""
-            ./swmr_remove_reader $Nsecs_rem $seed 2>&1 |tee swmr_reader.out.$n &
+            $bindir/swmr_remove_reader $Nsecs_rem $seed 2>&1 |tee swmr_reader.out.$n &
             pid_readers="$pid_readers $!"
             n=`expr $n + 1`
         done
@@ -400,7 +406,7 @@ do
 
         # Launch the Generator
         echo launch the swmr_generator
-        ./swmr_generator $compress $index_type
+        $bindir/swmr_generator $compress $index_type
         if test $? -ne 0; then
             echo generator had error
             nerrors=`expr $nerrors + 1`
@@ -409,7 +415,7 @@ do
         # Launch the Writer (not in parallel - just to rebuild the datasets)
         echo launch the swmr_writer
         seed="" # Put -r <random seed> command here
-        ./swmr_writer $Nrecords $seed
+        $bindir/swmr_writer $Nrecords $seed
         if test $? -ne 0; then
             echo writer had error
             nerrors=`expr $nerrors + 1`
@@ -421,7 +427,7 @@ do
         # Launch the Add/Remove Writer
         echo launch the swmr_addrem_writer
         seed="" # Put -r <random seed> command here
-        ./swmr_addrem_writer $Nrecords $seed 2>&1 |tee swmr_writer.out &
+        $bindir/swmr_addrem_writer $Nrecords $seed 2>&1 |tee swmr_writer.out &
         pid_writer=$!
         $DPRINT pid_writer=$pid_writer
 
@@ -436,7 +442,7 @@ do
         while [ $n -lt $Nreaders ]; do
             #seed="-r ${seeds[$n]}"
             seed=""
-            ./swmr_remove_reader $Nsecs_addrem $seed 2>&1 |tee swmr_reader.out.$n &
+            $bindir/swmr_remove_reader $Nsecs_addrem $seed 2>&1 |tee swmr_reader.out.$n &
             pid_readers="$pid_readers $!"
             n=`expr $n + 1`
         done
@@ -484,7 +490,7 @@ do
         #       created by the generator.
         echo launch the swmr_generator
         seed="" # Put -r <random seed> command here
-        ./swmr_generator $compress $index_type $seed
+        $bindir/swmr_generator $compress $index_type $seed
         if test $? -ne 0; then
             echo generator had error
             nerrors=`expr $nerrors + 1`
@@ -494,7 +500,7 @@ do
         rm -f $WRITER_MESSAGE
         # Launch the Sparse writer
         echo launch the swmr_sparse_writer
-        nice -n 20 ./swmr_sparse_writer $Nrecs_spa 2>&1 |tee swmr_writer.out &
+        nice -n 20 $bindir/swmr_sparse_writer $Nrecs_spa 2>&1 |tee swmr_writer.out &
         pid_writer=$!
         $DPRINT pid_writer=$pid_writer
 
@@ -507,7 +513,7 @@ do
         echo launch $Nrdrs_spa swmr_sparse_readers
         while [ $n -lt $Nrdrs_spa ]; do
             # The sparse reader spits out a LOT of data so it's set to 'quiet'
-            ./swmr_sparse_reader -q $Nrecs_spa 2>&1 |tee swmr_reader.out.$n &
+            $bindir/swmr_sparse_reader -q $Nrecs_spa 2>&1 |tee swmr_reader.out.$n &
             pid_readers="$pid_readers $!"
             n=`expr $n + 1`
         done

--- a/test/testvdsswmr.sh.in
+++ b/test/testvdsswmr.sh.in
@@ -17,6 +17,7 @@
 #   Dana Robinson, November 2015
 
 srcdir=@srcdir@
+bindir=@bindir@
 
 ###############################################################################
 ## test parameters
@@ -30,7 +31,7 @@ nerrors=0
 ## definitions for message file to coordinate test runs
 ###############################################################################
 WRITER_MESSAGE=SWMR_WRITER_MESSAGE      # The message file created by writer that the open is complete
-                                        # This should be the same as the define in "./swmr_common.h"
+                                        # This should be the same as the define in "$bindir/swmr_common.h"
 MESSAGE_TIMEOUT=300                     # Message timeout length in secs
                                         # This should be the same as the define in "./h5test.h"
 
@@ -83,9 +84,14 @@ if test -z "$srcdir"; then
    srcdir=.
 fi
 
+# If the bindir directory is not set just use current (.).
+if test -z "$bindir"; then
+   bindir=.
+fi
+
 # Check to see if the VFD specified by the HDF5_DRIVER environment variable
 # supports SWMR.
-./swmr_check_compat_vfd
+$bindir/swmr_check_compat_vfd
 rc=$?
 if [ $rc -ne 0 ] ; then
     echo
@@ -148,7 +154,7 @@ echo "##########################################################################
 
 # Launch the file generator
 echo launch the generator
-./vds_swmr_gen
+$bindir/vds_swmr_gen
 if test $? -ne 0; then
     echo generator had error
     nerrors=`expr $nerrors + 1`
@@ -166,7 +172,7 @@ echo "launch the $Nwriters SWMR VDS writers (1 per source)"
 pid_writers=""
 n=0
 while [ $n -lt $Nwriters ]; do
-    ./vds_swmr_writer $n &
+    $bindir/vds_swmr_writer $n &
     pid_writers="$pid_writers $!"
     n=`expr $n + 1`
 done
@@ -181,7 +187,7 @@ echo launch $Nreaders SWMR readers
 pid_readers=""
 n=0
 while [ $n -lt $Nreaders ]; do
-    ./vds_swmr_reader &
+    $bindir/vds_swmr_reader &
     pid_readers="$pid_readers $!"
     n=`expr $n + 1`
 done


### PR DESCRIPTION
The shell scripts need to use the program/library files from the CMake output dir instead of copying like autotools.
Change the scripts to use a bindir var instead of a hardcoded "."