### PR TITLE
Fix issue #924, ${HDF5_CXXLINKER} does not work in h5c++.

### DIFF
--- a/c++/src/h5c++.in
+++ b/c++/src/h5c++.in
@@ -35,10 +35,10 @@ HL="@HL@"
 ## (Advanced usage - know what you're doing - you're on your own here.)   ##
 ## The four variables below can be used to insert paths and flags in      ##
 ## CPPFLAGS, CXXFLAGS, LDFLAGS, or LIBS in the h5cc compile line:         ##
-##    $CLINKER $H5BLD_CPPFLAGS $CPPFLAGS $H5BLD_CXXFLAGS $CXXFLAGS        ##
+##    $CXXLINKER $H5BLD_CPPFLAGS $CPPFLAGS $H5BLD_CXXFLAGS $CXXFLAGS      ##
 ##    $LDFLAGS $LIBS $clibpath $link_objs $link_args $shared_link         ##
 ##                                                                        ##
-## These settings can be overridden by setting HDF5_CXXFLAGS,              ##
+## These settings can be overridden by setting HDF5_CXXFLAGS,             ##
 ## HDF5_CPPFLAGS, HDF5_LDFLAGS, or HDF5_LIBS in the environment.          ##
 ##                                                                        ##
 ############################################################################
@@ -93,7 +93,7 @@ H5BLD_LDFLAGS="@AM_LDFLAGS@ @LDFLAGS@"
 H5BLD_LIBS="@LIBS@"
 
 CXX="${HDF5_CXX:-$CXXBASE}"
-CXXLINKER="${HDF5_CLINKER:-$CXXLINKERBASE}"
+CXXLINKER="${HDF5_CXXLINKER:-$CXXLINKERBASE}"
 CXXFLAGS="${HDF5_CXXFLAGS:-$CXXFLAGSBASE}"
 CPPFLAGS="${HDF5_CPPFLAGS:-$CPPFLAGSBASE}"
 LDFLAGS="${HDF5_LDFLAGS:-$LDFLAGSBASE}"


### PR DESCRIPTION
2 instances of CLINKER corrected to CXXLINKER
comment border aligned