### PR TITLE
Get class name null str 1 1 8

### DIFF
--- a/c++/src/H5PropList.cpp
+++ b/c++/src/H5PropList.cpp
@@ -534,7 +534,7 @@ PropList::getPropSize(const H5std_string &name) const
 // Function:    PropList::getClassName
 ///\brief       Return the name of a generic property list class.
 ///\return      A string containing the class name, if success, otherwise,
-///             a NULL string.
+///             an empty string.
 // Programmer:  Binh-Minh Ribler - April, 2004
 //--------------------------------------------------------------------------
 H5std_string
@@ -550,8 +550,9 @@ PropList::getClassName() const
         return (class_name);
     }
     else
-        return 0;
+        return "";
 }
+
 //--------------------------------------------------------------------------
 // Function:    PropList::getNumProps
 ///\brief       Returns the number of properties in this property list or class.


### PR DESCRIPTION
Error message from MSVC with C++23 enabled:

error C2440: 'return': cannot convert from 'int' to 'std::basic_string<char,std::char_traits,std::allocator>'