### PR TITLE
Implement selection I/O for contiguous datasets

### DIFF
--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -2471,6 +2471,8 @@ H5D__chunk_may_use_select_io(const H5D_io_info_t *io_info)
     else {
         htri_t page_buf_enabled;
 
+        HDassert(io_info->io_ops.single_write == H5D__select_write);
+
         /* Check if the page buffer is enabled */
         if ((page_buf_enabled = H5PB_enabled(io_info->f_sh, H5FD_MEM_DRAW)) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't check if page buffer is enabled")
@@ -2649,7 +2651,8 @@ H5D__chunk_read(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize_
          * because this is raw data) */
         if (num_chunks > 0 &&
             H5F_shared_select_read(H5F_SHARED(io_info->dset->oloc.file), H5FD_MEM_DRAW, (uint32_t)num_chunks,
-                                   chunk_mem_spaces, chunk_file_spaces, chunk_addrs, element_sizes, bufs) < 0)
+                                   (const H5S_t * const *)chunk_mem_spaces, (const H5S_t * const *)chunk_file_spaces,
+                                   chunk_addrs, element_sizes, bufs) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "chunk selection read failed")
 
         /* Clean up memory */
@@ -2988,7 +2991,8 @@ H5D__chunk_write(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize
          * because this is raw data) */
         if (num_chunks > 0 && H5F_shared_select_write(
                                   H5F_SHARED(io_info->dset->oloc.file), H5FD_MEM_DRAW, (uint32_t)num_chunks,
-                                  chunk_mem_spaces, chunk_file_spaces, chunk_addrs, element_sizes, bufs) < 0)
+                                  (const H5S_t * const *)chunk_mem_spaces, (const H5S_t * const *)chunk_file_spaces,
+                                  chunk_addrs, element_sizes, bufs) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "chunk selection read failed")
 
         /* Clean up memory */

--- a/src/H5Dcontig.c
+++ b/src/H5Dcontig.c
@@ -43,6 +43,7 @@
 #include "H5FOprivate.h" /* File objects                 */
 #include "H5Oprivate.h"  /* Object headers               */
 #include "H5Pprivate.h"  /* Property lists               */
+#include "H5PBprivate.h" /* Page Buffer	                 */
 #include "H5VMprivate.h" /* Vector and array functions   */
 
 /****************/
@@ -103,6 +104,7 @@ static herr_t  H5D__contig_flush(H5D_t *dset);
 
 /* Helper routines */
 static herr_t H5D__contig_write_one(H5D_io_info_t *io_info, hsize_t offset, size_t size);
+static htri_t H5D__contig_may_use_select_io(const H5D_io_info_t *io_info, H5D_io_op_type_t op_type);
 
 /*********************/
 /* Package Variables */
@@ -562,6 +564,59 @@ H5D__contig_io_init(const H5D_io_info_t *io_info, const H5D_type_info_t H5_ATTR_
 } /* end H5D__contig_io_init() */
 
 /*-------------------------------------------------------------------------
+ * Function:    H5D__contig_may_use_select_io
+ *
+ * Purpose:    A small internal function to if it may be possible to use
+ *             selection I/O.
+ *
+ * Return:    TRUE or FALSE
+ *
+ * Programmer:    Neil Fortner
+ *        3 August 2021
+ *
+ *-------------------------------------------------------------------------
+ */
+static htri_t
+H5D__contig_may_use_select_io(const H5D_io_info_t *io_info, H5D_io_op_type_t op_type)
+{
+    const H5D_t *dataset   = io_info->dset; /* Local pointer to dataset info */
+    htri_t       ret_value = FAIL;          /* Return value */
+
+    FUNC_ENTER_STATIC
+
+    /* Sanity check */
+    HDassert(io_info);
+    HDassert(dataset);
+    HDassert(op_type == H5D_IO_OP_READ || op_type == H5D_IO_OP_WRITE);
+
+    /* Don't use selection I/O if it's globally disabled, if there is a type
+     * conversion, or if it's not a contiguous dataset, or if the sieve buffer
+     * exists (write) or is dirty (read) */
+    if (!H5_use_selection_io_g || io_info->io_ops.single_read != H5D__select_read
+        || io_info->layout_ops.readvv != H5D__contig_readvv
+        || (op_type == H5D_IO_OP_READ && io_info->dset->shared->cache.contig.sieve_dirty)
+        || (op_type == H5D_IO_OP_WRITE && io_info->dset->shared->cache.contig.sieve_buf))
+        ret_value = FALSE;
+    else {
+        htri_t page_buf_enabled;
+
+        HDassert(io_info->io_ops.single_write == H5D__select_write);
+        HDassert(io_info->layout_ops.writevv == H5D__contig_writevv);
+
+        /* Check if the page buffer is enabled */
+        if ((page_buf_enabled = H5PB_enabled(io_info->f_sh, H5FD_MEM_DRAW)) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't check if page buffer is enabled")
+        if (page_buf_enabled)
+            ret_value = FALSE;
+        else
+            ret_value = TRUE;
+    } /* end else */
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5D__contig_may_use_select_io() */
+
+/*-------------------------------------------------------------------------
  * Function:	H5D__contig_read
  *
  * Purpose:	Read from a contiguous dataset.
@@ -577,7 +632,8 @@ herr_t
 H5D__contig_read(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize_t nelmts,
                  const H5S_t *file_space, const H5S_t *mem_space, H5D_chunk_map_t H5_ATTR_UNUSED *fm)
 {
-    herr_t ret_value = SUCCEED; /*return value		*/
+    htri_t use_selection_io = FALSE; /* Whether to use selection I/O */
+    herr_t ret_value = SUCCEED;      /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -588,9 +644,25 @@ H5D__contig_read(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize
     HDassert(mem_space);
     HDassert(file_space);
 
-    /* Read data */
-    if ((io_info->io_ops.single_read)(io_info, type_info, nelmts, file_space, mem_space) < 0)
-        HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "contiguous read failed")
+    /* Check if we're performing selection I/O */
+    if ((use_selection_io = H5D__contig_may_use_select_io(io_info, H5D_IO_OP_READ)) < 0)
+        HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't check if selection I/O is possible")
+
+    if (use_selection_io) {
+        size_t dst_type_size = type_info->dst_type_size;
+
+        /* Issue selection I/O call (we can skip the page buffer because we've
+         * already verified it won't be used, and the metadata accumulator
+         * because this is raw data) Only call funciton if nelmts > 0. */
+        if (nelmts > 0 && H5F_shared_select_read(H5F_SHARED(io_info->dset->oloc.file), H5FD_MEM_DRAW, 1,
+                                   &mem_space, &file_space, &(io_info->store->contig.dset_addr),
+                                   &dst_type_size, &(io_info->u.rbuf)) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "contiguous selection read failed")
+    } /* end if */
+    else
+        /* Read data through legacy (non-selection I/O) pathway */
+        if ((io_info->io_ops.single_read)(io_info, type_info, nelmts, file_space, mem_space) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "contiguous read failed")
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -612,7 +684,8 @@ herr_t
 H5D__contig_write(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize_t nelmts,
                   const H5S_t *file_space, const H5S_t *mem_space, H5D_chunk_map_t H5_ATTR_UNUSED *fm)
 {
-    herr_t ret_value = SUCCEED; /*return value		*/
+    htri_t use_selection_io = FALSE; /* Whether to use selection I/O */
+    herr_t ret_value = SUCCEED;      /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -623,9 +696,25 @@ H5D__contig_write(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsiz
     HDassert(mem_space);
     HDassert(file_space);
 
-    /* Write data */
-    if ((io_info->io_ops.single_write)(io_info, type_info, nelmts, file_space, mem_space) < 0)
-        HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "contiguous write failed")
+    /* Check if we're performing selection I/O */
+    if ((use_selection_io = H5D__contig_may_use_select_io(io_info, H5D_IO_OP_WRITE)) < 0)
+        HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't check if selection I/O is possible")
+
+    if (use_selection_io) {
+        size_t dst_type_size = type_info->dst_type_size;
+
+        /* Issue selection I/O call (we can skip the page buffer because we've
+         * already verified it won't be used, and the metadata accumulator
+         * because this is raw data). Only call funciton if nelmts > 0. */
+        if (nelmts > 0 && H5F_shared_select_write(H5F_SHARED(io_info->dset->oloc.file), H5FD_MEM_DRAW, 1,
+                                   &mem_space, &file_space, &(io_info->store->contig.dset_addr),
+                                   &dst_type_size, &(io_info->u.wbuf)) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "contiguous selection write failed")
+    } /* end if */
+    else
+        /* Write data through legacy (non-selection I/O) pathway */
+        if ((io_info->io_ops.single_write)(io_info, type_info, nelmts, file_space, mem_space) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "contiguous write failed")
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1561,3 +1650,4 @@ done:
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5D__contig_copy() */
+

--- a/src/H5FDint.c
+++ b/src/H5FDint.c
@@ -627,8 +627,8 @@ done:
  */
 static herr_t
 H5FD__read_selection_translate(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, uint32_t count,
-                               H5S_t *mem_spaces[], H5S_t *file_spaces[], haddr_t offsets[],
-                               size_t element_sizes[], void *bufs[] /* out */)
+                               const H5S_t * const *mem_spaces, const H5S_t * const *file_spaces,
+                               haddr_t offsets[], size_t element_sizes[], void *bufs[] /* out */)
 {
     hbool_t        extend_sizes = FALSE;
     hbool_t        extend_bufs  = FALSE;
@@ -651,7 +651,9 @@ H5FD__read_selection_translate(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, uin
     size_t         file_nseq;
     size_t         mem_nseq;
     size_t         io_len;
-    size_t         dummy_nelem;
+    size_t         nelmts;
+    hssize_t       hss_nelmts;
+    size_t         seq_nelem;
     H5S_sel_iter_t file_iter;
     H5S_sel_iter_t mem_iter;
     H5FD_mem_t     types[2]       = {type, H5FD_MEM_NOLIST};
@@ -719,20 +721,52 @@ H5FD__read_selection_translate(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, uin
         if (H5S_select_iter_init(&mem_iter, mem_spaces[i], element_size, 0) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "can't initialize sequence list for memory space")
 
-        /* Fill sequence lists */
-        if (H5S_SELECT_ITER_GET_SEQ_LIST(&file_iter, H5FD_SEQ_LIST_LEN, SIZE_MAX, &file_nseq, &dummy_nelem,
-                                         file_off, file_len) < 0)
-            HGOTO_ERROR(H5E_INTERNAL, H5E_UNSUPPORTED, FAIL, "sequence length generation failed")
-        if (H5S_SELECT_ITER_GET_SEQ_LIST(&mem_iter, H5FD_SEQ_LIST_LEN, SIZE_MAX, &mem_nseq, &dummy_nelem,
-                                         mem_off, mem_len) < 0)
-            HGOTO_ERROR(H5E_INTERNAL, H5E_UNSUPPORTED, FAIL, "sequence length generation failed")
-        if (file_nseq && !mem_nseq)
-            HGOTO_ERROR(H5E_INTERNAL, H5E_BADVALUE, FAIL,
-                        "memory selection is empty but file selection is not")
-        file_seq_i = 0;
-        mem_seq_i  = 0;
+        /* Get the number of elements in selection */
+        if ((hss_nelmts = (hssize_t)H5S_GET_SELECT_NPOINTS(file_spaces[i])) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTCOUNT, FAIL, "can't get number of elements selected")
+        H5_CHECKED_ASSIGN(nelmts, size_t, hss_nelmts, hssize_t);
 
-        while (file_seq_i < file_nseq) {
+#ifndef NDEBUG
+        /* Verify mem space has the same number of elements */
+        {
+            if ((hss_nelmts = (hssize_t)H5S_GET_SELECT_NPOINTS(mem_spaces[i])) < 0)
+                HGOTO_ERROR(H5E_VFL, H5E_CANTCOUNT, FAIL, "can't get number of elements selected")
+            HDassert((hssize_t)nelmts == hss_nelmts);
+        }
+#endif /* NDEBUG */
+
+        /* Initialize values so sequence lists are retrieved on the first
+         * iteration */
+        file_seq_i = H5FD_SEQ_LIST_LEN;
+        mem_seq_i = H5FD_SEQ_LIST_LEN;
+        file_nseq = 0;
+        mem_nseq = 0;
+
+        /* Loop until all elements are processed */
+        while (file_seq_i < file_nseq || nelmts > 0) {
+            /* Fill/refill file sequence list if necessary */
+            if (file_seq_i == H5FD_SEQ_LIST_LEN) {
+                if (H5S_SELECT_ITER_GET_SEQ_LIST(&file_iter, H5FD_SEQ_LIST_LEN, SIZE_MAX, &file_nseq,
+                                                 &seq_nelem, file_off, file_len) < 0)
+                    HGOTO_ERROR(H5E_INTERNAL, H5E_UNSUPPORTED, FAIL, "sequence length generation failed")
+                HDassert(file_nseq > 0);
+
+                nelmts -= seq_nelem;
+                file_seq_i = 0;
+            }
+            HDassert(file_seq_i < file_nseq);
+
+            /* Fill/refill memory sequence list if necessary */
+            if (mem_seq_i == H5FD_SEQ_LIST_LEN) {
+                if (H5S_SELECT_ITER_GET_SEQ_LIST(&mem_iter, H5FD_SEQ_LIST_LEN, SIZE_MAX, &mem_nseq,
+                                                 &seq_nelem, mem_off, mem_len) < 0)
+                    HGOTO_ERROR(H5E_INTERNAL, H5E_UNSUPPORTED, FAIL, "sequence length generation failed")
+                HDassert(mem_nseq > 0);
+
+                mem_seq_i = 0;
+            }
+            HDassert(mem_seq_i < mem_nseq);
+
             /* Calculate length of this IO */
             io_len = MIN(file_len[file_seq_i], mem_len[mem_seq_i]);
 
@@ -810,30 +844,6 @@ H5FD__read_selection_translate(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, uin
                 mem_off[mem_seq_i] += io_len;
                 mem_len[mem_seq_i] -= io_len;
             }
-
-            /* Refill file sequence list if necessary */
-            if (file_seq_i == H5FD_SEQ_LIST_LEN) {
-                if (H5S_SELECT_ITER_GET_SEQ_LIST(&file_iter, H5FD_SEQ_LIST_LEN, SIZE_MAX, &file_nseq,
-                                                 &dummy_nelem, file_off, file_len) < 0)
-                    HGOTO_ERROR(H5E_INTERNAL, H5E_UNSUPPORTED, FAIL, "sequence length generation failed")
-
-                file_seq_i = 0;
-            }
-            HDassert(file_seq_i <= file_nseq);
-
-            /* Refill memory sequence list if necessary */
-            if (mem_seq_i == H5FD_SEQ_LIST_LEN) {
-                if (H5S_SELECT_ITER_GET_SEQ_LIST(&mem_iter, H5FD_SEQ_LIST_LEN, SIZE_MAX, &mem_nseq,
-                                                 &dummy_nelem, mem_off, mem_len) < 0)
-                    HGOTO_ERROR(H5E_INTERNAL, H5E_UNSUPPORTED, FAIL, "sequence length generation failed")
-
-                if (!mem_nseq && file_seq_i < file_nseq)
-                    HGOTO_ERROR(H5E_INTERNAL, H5E_BADVALUE, FAIL,
-                                "memory selection terminated before file selection")
-
-                mem_seq_i = 0;
-            }
-            HDassert(mem_seq_i <= mem_nseq);
         }
 
         if (mem_seq_i < mem_nseq)
@@ -915,8 +925,9 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5FD_read_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t *mem_spaces[], H5S_t *file_spaces[],
-                    haddr_t offsets[], size_t element_sizes[], void *bufs[] /* out */)
+H5FD_read_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, const H5S_t * const *mem_spaces,
+                    const H5S_t * const *file_spaces, haddr_t offsets[], size_t element_sizes[],
+                    void *bufs[] /* out */)
 {
     hbool_t  offsets_cooked = FALSE;
     hid_t    mem_space_ids_static[8];
@@ -1188,8 +1199,8 @@ H5FD_read_selection_id(H5FD_t *file, H5FD_mem_t type, uint32_t count, hid_t mem_
         }
 
         /* Translate to vector or scalar I/O */
-        if (H5FD__read_selection_translate(file, type, dxpl_id, count, mem_spaces, file_spaces, offsets,
-                                           element_sizes, bufs) < 0)
+        if (H5FD__read_selection_translate(file, type, dxpl_id, count, (const H5S_t * const *)mem_spaces,
+                                           (const H5S_t * const *)file_spaces, offsets, element_sizes, bufs) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, "translation to vector or scalar read failed")
     }
 
@@ -1235,8 +1246,8 @@ done:
  */
 static herr_t
 H5FD__write_selection_translate(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, uint32_t count,
-                                H5S_t *mem_spaces[], H5S_t *file_spaces[], haddr_t offsets[],
-                                size_t element_sizes[], const void *bufs[])
+                                const H5S_t * const *mem_spaces, const H5S_t * const *file_spaces,
+                                haddr_t offsets[], size_t element_sizes[], const void *bufs[])
 {
     hbool_t        extend_sizes = FALSE;
     hbool_t        extend_bufs  = FALSE;
@@ -1259,7 +1270,9 @@ H5FD__write_selection_translate(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, ui
     size_t         file_nseq;
     size_t         mem_nseq;
     size_t         io_len;
-    size_t         dummy_nelem;
+    size_t         nelmts;
+    hssize_t       hss_nelmts;
+    size_t         seq_nelem;
     H5S_sel_iter_t file_iter;
     H5S_sel_iter_t mem_iter;
     H5FD_mem_t     types[2]       = {type, H5FD_MEM_NOLIST};
@@ -1327,20 +1340,52 @@ H5FD__write_selection_translate(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, ui
         if (H5S_select_iter_init(&mem_iter, mem_spaces[i], element_size, 0) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "can't initialize sequence list for memory space")
 
-        /* Fill sequence lists */
-        if (H5S_SELECT_ITER_GET_SEQ_LIST(&file_iter, H5FD_SEQ_LIST_LEN, SIZE_MAX, &file_nseq, &dummy_nelem,
-                                         file_off, file_len) < 0)
-            HGOTO_ERROR(H5E_INTERNAL, H5E_UNSUPPORTED, FAIL, "sequence length generation failed")
-        if (H5S_SELECT_ITER_GET_SEQ_LIST(&mem_iter, H5FD_SEQ_LIST_LEN, SIZE_MAX, &mem_nseq, &dummy_nelem,
-                                         mem_off, mem_len) < 0)
-            HGOTO_ERROR(H5E_INTERNAL, H5E_UNSUPPORTED, FAIL, "sequence length generation failed")
-        if (file_nseq && !mem_nseq)
-            HGOTO_ERROR(H5E_INTERNAL, H5E_BADVALUE, FAIL,
-                        "memory selection is empty but file selection is not")
-        file_seq_i = 0;
-        mem_seq_i  = 0;
+        /* Get the number of elements in selection */
+        if ((hss_nelmts = (hssize_t)H5S_GET_SELECT_NPOINTS(file_spaces[i])) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTCOUNT, FAIL, "can't get number of elements selected")
+        H5_CHECKED_ASSIGN(nelmts, size_t, hss_nelmts, hssize_t);
 
-        while (file_seq_i < file_nseq) {
+#ifndef NDEBUG
+        /* Verify mem space has the same number of elements */
+        {
+            if ((hss_nelmts = (hssize_t)H5S_GET_SELECT_NPOINTS(mem_spaces[i])) < 0)
+                HGOTO_ERROR(H5E_VFL, H5E_CANTCOUNT, FAIL, "can't get number of elements selected")
+            HDassert((hssize_t)nelmts == hss_nelmts);
+        }
+#endif /* NDEBUG */
+
+        /* Initialize values so sequence lists are retrieved on the first
+         * iteration */
+        file_seq_i = H5FD_SEQ_LIST_LEN;
+        mem_seq_i = H5FD_SEQ_LIST_LEN;
+        file_nseq = 0;
+        mem_nseq = 0;
+
+        /* Loop until all elements are processed */
+        while (file_seq_i < file_nseq || nelmts > 0) {
+            /* Fill/refill file sequence list if necessary */
+            if (file_seq_i == H5FD_SEQ_LIST_LEN) {
+                if (H5S_SELECT_ITER_GET_SEQ_LIST(&file_iter, H5FD_SEQ_LIST_LEN, SIZE_MAX, &file_nseq,
+                                                 &seq_nelem, file_off, file_len) < 0)
+                    HGOTO_ERROR(H5E_INTERNAL, H5E_UNSUPPORTED, FAIL, "sequence length generation failed")
+                HDassert(file_nseq > 0);
+
+                nelmts -= seq_nelem;
+                file_seq_i = 0;
+            }
+            HDassert(file_seq_i < file_nseq);
+
+            /* Fill/refill memory sequence list if necessary */
+            if (mem_seq_i == H5FD_SEQ_LIST_LEN) {
+                if (H5S_SELECT_ITER_GET_SEQ_LIST(&mem_iter, H5FD_SEQ_LIST_LEN, SIZE_MAX, &mem_nseq,
+                                                 &seq_nelem, mem_off, mem_len) < 0)
+                    HGOTO_ERROR(H5E_INTERNAL, H5E_UNSUPPORTED, FAIL, "sequence length generation failed")
+                HDassert(mem_nseq > 0);
+
+                mem_seq_i = 0;
+            }
+            HDassert(mem_seq_i < mem_nseq);
+
             /* Calculate length of this IO */
             io_len = MIN(file_len[file_seq_i], mem_len[mem_seq_i]);
 
@@ -1418,30 +1463,6 @@ H5FD__write_selection_translate(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, ui
                 mem_off[mem_seq_i] += io_len;
                 mem_len[mem_seq_i] -= io_len;
             }
-
-            /* Refill file sequence list if necessary */
-            if (file_seq_i == H5FD_SEQ_LIST_LEN) {
-                if (H5S_SELECT_ITER_GET_SEQ_LIST(&file_iter, H5FD_SEQ_LIST_LEN, SIZE_MAX, &file_nseq,
-                                                 &dummy_nelem, file_off, file_len) < 0)
-                    HGOTO_ERROR(H5E_INTERNAL, H5E_UNSUPPORTED, FAIL, "sequence length generation failed")
-
-                file_seq_i = 0;
-            }
-            HDassert(file_seq_i <= file_nseq);
-
-            /* Refill memory sequence list if necessary */
-            if (mem_seq_i == H5FD_SEQ_LIST_LEN) {
-                if (H5S_SELECT_ITER_GET_SEQ_LIST(&mem_iter, H5FD_SEQ_LIST_LEN, SIZE_MAX, &mem_nseq,
-                                                 &dummy_nelem, mem_off, mem_len) < 0)
-                    HGOTO_ERROR(H5E_INTERNAL, H5E_UNSUPPORTED, FAIL, "sequence length generation failed")
-
-                if (!mem_nseq && file_seq_i < file_nseq)
-                    HGOTO_ERROR(H5E_INTERNAL, H5E_BADVALUE, FAIL,
-                                "memory selection terminated before file selection")
-
-                mem_seq_i = 0;
-            }
-            HDassert(mem_seq_i <= mem_nseq);
         }
 
         if (mem_seq_i < mem_nseq)
@@ -1521,8 +1542,9 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5FD_write_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t *mem_spaces[], H5S_t *file_spaces[],
-                     haddr_t offsets[], size_t element_sizes[], const void *bufs[])
+H5FD_write_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, const H5S_t * const *mem_spaces,
+                     const H5S_t * const *file_spaces, haddr_t offsets[], size_t element_sizes[],
+                     const void *bufs[])
 {
     hbool_t  offsets_cooked = FALSE;
     hid_t    mem_space_ids_static[8];
@@ -1779,8 +1801,8 @@ H5FD_write_selection_id(H5FD_t *file, H5FD_mem_t type, uint32_t count, hid_t mem
         }
 
         /* Translate to vector or scalar I/O */
-        if (H5FD__write_selection_translate(file, type, dxpl_id, count, mem_spaces, file_spaces, offsets,
-                                            element_sizes, bufs) < 0)
+        if (H5FD__write_selection_translate(file, type, dxpl_id, count, (const H5S_t * const *)mem_spaces,
+                                            (const H5S_t * const *)file_spaces, offsets, element_sizes, bufs) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, FAIL, "translation to vector or scalar write failed")
     }
 

--- a/src/H5FDprivate.h
+++ b/src/H5FDprivate.h
@@ -136,11 +136,11 @@ H5_DLL herr_t  H5FD_read_vector(H5FD_t *file, uint32_t count, H5FD_mem_t types[]
                                 size_t sizes[], void *bufs[] /* out */);
 H5_DLL herr_t  H5FD_write_vector(H5FD_t *file, uint32_t count, H5FD_mem_t types[], haddr_t addrs[],
                                  size_t sizes[], const void *bufs[] /* out */);
-H5_DLL herr_t  H5FD_read_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t *mem_spaces[],
-                                   H5S_t *file_spaces[], haddr_t offsets[], size_t element_sizes[],
+H5_DLL herr_t  H5FD_read_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, const H5S_t * const *mem_spaces,
+                                   const H5S_t * const *file_spaces, haddr_t offsets[], size_t element_sizes[],
                                    void *bufs[] /* out */);
-H5_DLL herr_t  H5FD_write_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t *mem_spaces[],
-                                    H5S_t *file_spaces[], haddr_t offsets[], size_t element_sizes[],
+H5_DLL herr_t  H5FD_write_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, const H5S_t * const *mem_spaces,
+                                    const H5S_t * const *file_spaces, haddr_t offsets[], size_t element_sizes[],
                                     const void *bufs[]);
 H5_DLL herr_t  H5FD_read_selection_id(H5FD_t *file, H5FD_mem_t type, uint32_t count, hid_t mem_space_ids[],
                                       hid_t file_space_ids[], haddr_t offsets[], size_t element_sizes[],

--- a/src/H5Fio.c
+++ b/src/H5Fio.c
@@ -254,8 +254,8 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5F_shared_select_read(H5F_shared_t *f_sh, H5FD_mem_t type, uint32_t count, H5S_t *mem_spaces[],
-                       H5S_t *file_spaces[], haddr_t offsets[], size_t element_sizes[],
+H5F_shared_select_read(H5F_shared_t *f_sh, H5FD_mem_t type, uint32_t count, const H5S_t * const *mem_spaces,
+                       const H5S_t * const *file_spaces, haddr_t offsets[], size_t element_sizes[],
                        void *bufs[] /* out */)
 {
     H5FD_mem_t map_type;            /* Mapped memory type */
@@ -300,8 +300,8 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5F_shared_select_write(H5F_shared_t *f_sh, H5FD_mem_t type, uint32_t count, H5S_t *mem_spaces[],
-                        H5S_t *file_spaces[], haddr_t offsets[], size_t element_sizes[], const void *bufs[])
+H5F_shared_select_write(H5F_shared_t *f_sh, H5FD_mem_t type, uint32_t count, const H5S_t * const *mem_spaces,
+                        const H5S_t * const *file_spaces, haddr_t offsets[], size_t element_sizes[], const void *bufs[])
 {
     H5FD_mem_t map_type;            /* Mapped memory type */
     herr_t     ret_value = SUCCEED; /* Return value */

--- a/src/H5Fprivate.h
+++ b/src/H5Fprivate.h
@@ -924,10 +924,10 @@ H5_DLL herr_t H5F_block_write(H5F_t *f, H5FD_mem_t type, haddr_t addr, size_t si
 
 /* Functions that operate on selections of elements in the file */
 H5_DLL herr_t H5F_shared_select_read(H5F_shared_t *f_sh, H5FD_mem_t type, uint32_t count,
-                                     struct H5S_t *mem_spaces[], struct H5S_t *file_spaces[],
+                                     const struct H5S_t * const *mem_spaces, const struct H5S_t * const *file_spaces,
                                      haddr_t offsets[], size_t element_sizes[], void *bufs[] /* out */);
 H5_DLL herr_t H5F_shared_select_write(H5F_shared_t *f_sh, H5FD_mem_t type, uint32_t count,
-                                      struct H5S_t *mem_spaces[], struct H5S_t *file_spaces[],
+                                      const struct H5S_t * const *mem_spaces, const struct H5S_t * const *file_spaces,
                                       haddr_t offsets[], size_t element_sizes[], const void *bufs[]);
 
 /* Functions that flush or evict */


### PR DESCRIPTION
Also fix bug in selection I/O translation.  Add const qualifiers to some internal selection I/O
routines to maintain const-correctness while avoiding memcpys.