### PR TITLE
unlock file before closing

### DIFF
--- a/src/H5FDsec2.c
+++ b/src/H5FDsec2.c
@@ -457,6 +457,9 @@ H5FD__sec2_close(H5FD_t *_file)
     /* Sanity check */
     HDassert(file);
 
+    /* ensure we don't keep a lock, even if the fd has been duplicated */
+    HDflock(file->fd, LOCK_UN | LOCK_NB);
+
     /* Close the underlying file */
     if(HDclose(file->fd) < 0)
         HSYS_GOTO_ERROR(H5E_IO, H5E_CANTCLOSEFILE, FAIL, "unable to close file")


### PR DESCRIPTION
Unlocking ensures that if a new thread has spawned and thus there are
still copies of the fd around, the file get's still unlocked and can be
read again.