### PR TITLE
Add high-level set/get for `unsigned long long` attributes.

### DIFF
--- a/hl/src/H5LT.c
+++ b/hl/src/H5LT.c
@@ -1791,8 +1791,8 @@ H5LTset_attribute_ulong(hid_t loc_id, const char *obj_name, const char *attr_nam
  *-------------------------------------------------------------------------
  */
 herr_t
-H5LTset_attribute_ullong(hid_t loc_id, const char *obj_name, const char *attr_name, const unsigned long long *data,
-                        size_t size)
+H5LTset_attribute_ullong(hid_t loc_id, const char *obj_name, const char *attr_name,
+                         const unsigned long long *data, size_t size)
 {
 
     if (H5LT_set_attribute_numerical(loc_id, obj_name, attr_name, size, H5T_NATIVE_ULLONG, data) < 0)

--- a/hl/src/H5LT.c
+++ b/hl/src/H5LT.c
@@ -1776,6 +1776,32 @@ H5LTset_attribute_ulong(hid_t loc_id, const char *obj_name, const char *attr_nam
 }
 
 /*-------------------------------------------------------------------------
+ * Function: H5LTset_attribute_ullong
+ *
+ * Purpose: Create and write an attribute.
+ *
+ * Return: Success: 0, Failure: -1
+ *
+ * Programmer: Alessandro Felder
+ *
+ * Date: August 27, 2021
+ *
+ * Comments:
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5LTset_attribute_ullong(hid_t loc_id, const char *obj_name, const char *attr_name, const unsigned long long *data,
+                        size_t size)
+{
+
+    if (H5LT_set_attribute_numerical(loc_id, obj_name, attr_name, size, H5T_NATIVE_ULLONG, data) < 0)
+        return -1;
+
+    return 0;
+}
+
+/*-------------------------------------------------------------------------
  * Function: H5LTset_attribute_float
  *
  * Purpose: Create and write an attribute.
@@ -3311,6 +3337,33 @@ H5LTget_attribute_ulong(hid_t loc_id, const char *obj_name, const char *attr_nam
 {
     /* Get the attribute */
     if (H5LT_get_attribute_mem(loc_id, obj_name, attr_name, H5T_NATIVE_ULONG, data) < 0)
+        return -1;
+
+    return 0;
+}
+
+/*-------------------------------------------------------------------------
+ * Function: H5LTget_attribute_ullong
+ *
+ * Purpose: Reads an attribute named attr_name
+ *
+ * Return: Success: 0, Failure: -1
+ *
+ * Programmer: Alessandro Felder
+ *
+ * Date: August 27, 2021
+ *
+ * Comments:
+ *
+ * Modifications:
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5LTget_attribute_ullong(hid_t loc_id, const char *obj_name, const char *attr_name, unsigned long long *data)
+{
+    /* Get the attribute */
+    if (H5LT_get_attribute_mem(loc_id, obj_name, attr_name, H5T_NATIVE_ULLONG, data) < 0)
         return -1;
 
     return 0;

--- a/hl/src/H5LTpublic.h
+++ b/hl/src/H5LTpublic.h
@@ -140,7 +140,7 @@ H5_HLDLL herr_t H5LTset_attribute_ulong(hid_t loc_id, const char *obj_name, cons
                                         const unsigned long *buffer, size_t size);
 
 H5_HLDLL herr_t H5LTset_attribute_ullong(hid_t loc_id, const char *obj_name, const char *attr_name,
-                                        const unsigned long long *buffer, size_t size);
+                                         const unsigned long long *buffer, size_t size);
 
 H5_HLDLL herr_t H5LTset_attribute_float(hid_t loc_id, const char *obj_name, const char *attr_name,
                                         const float *buffer, size_t size);
@@ -186,7 +186,7 @@ H5_HLDLL herr_t H5LTget_attribute_ulong(hid_t loc_id, const char *obj_name, cons
                                         unsigned long *data);
 
 H5_HLDLL herr_t H5LTget_attribute_ullong(hid_t loc_id, const char *obj_name, const char *attr_name,
-                                        unsigned long long *data);
+                                         unsigned long long *data);
 
 H5_HLDLL herr_t H5LTget_attribute_float(hid_t loc_id, const char *obj_name, const char *attr_name,
                                         float *data);

--- a/hl/src/H5LTpublic.h
+++ b/hl/src/H5LTpublic.h
@@ -139,6 +139,9 @@ H5_HLDLL herr_t H5LTset_attribute_long_long(hid_t loc_id, const char *obj_name, 
 H5_HLDLL herr_t H5LTset_attribute_ulong(hid_t loc_id, const char *obj_name, const char *attr_name,
                                         const unsigned long *buffer, size_t size);
 
+H5_HLDLL herr_t H5LTset_attribute_ullong(hid_t loc_id, const char *obj_name, const char *attr_name,
+                                        const unsigned long long *buffer, size_t size);
+
 H5_HLDLL herr_t H5LTset_attribute_float(hid_t loc_id, const char *obj_name, const char *attr_name,
                                         const float *buffer, size_t size);
 
@@ -181,6 +184,9 @@ H5_HLDLL herr_t H5LTget_attribute_long_long(hid_t loc_id, const char *obj_name, 
 
 H5_HLDLL herr_t H5LTget_attribute_ulong(hid_t loc_id, const char *obj_name, const char *attr_name,
                                         unsigned long *data);
+
+H5_HLDLL herr_t H5LTget_attribute_ullong(hid_t loc_id, const char *obj_name, const char *attr_name,
+                                        unsigned long long *data);
 
 H5_HLDLL herr_t H5LTget_attribute_float(hid_t loc_id, const char *obj_name, const char *attr_name,
                                         float *data);

--- a/hl/test/test_lite.c
+++ b/hl/test/test_lite.c
@@ -509,7 +509,7 @@ make_attributes(hid_t loc_id, const char *obj_name)
     PASSED();
 
     /*-------------------------------------------------------------------------
-     * H5LTset_attribute_string test
+     * H5LTget_attribute_string test
      *-------------------------------------------------------------------------
      */
 

--- a/hl/test/test_lite.c
+++ b/hl/test/test_lite.c
@@ -472,28 +472,30 @@ make_attributes(hid_t loc_id, const char *obj_name)
     size_t      type_size;
     int         i;
 
-    char           attr_str_in[] = {"My attribute"};
-    char           attr_str_out[20];
-    char           attr_char_in[5] = {1, 2, 3, 4, 5};
-    char           attr_char_out[5];
-    short          attr_short_in[5] = {1, 2, 3, 4, 5};
-    short          attr_short_out[5];
-    int            attr_int_in[5] = {1, 2, 3, 4, 5};
-    int            attr_int_out[5];
-    long           attr_long_in[5] = {1, 2, 3, 4, 5};
-    long           attr_long_out[5];
-    float          attr_float_in[5] = {1, 2, 3, 4, 5};
-    float          attr_float_out[5];
-    double         attr_double_in[5] = {1, 2, 3, 4, 5};
-    double         attr_double_out[5];
-    unsigned char  attr_uchar_in[5] = {1, 2, 3, 4, 5};
-    unsigned char  attr_uchar_out[5];
-    unsigned short attr_ushort_in[5] = {1, 2, 3, 4, 5};
-    unsigned short attr_ushort_out[5];
-    unsigned int   attr_uint_in[5] = {1, 2, 3, 4, 5};
-    unsigned int   attr_uint_out[5];
-    unsigned long  attr_ulong_in[5] = {1, 2, 3, 4, 5};
-    unsigned long  attr_ulong_out[5];
+    char               attr_str_in[] = {"My attribute"};
+    char               attr_str_out[20];
+    char               attr_char_in[5] = {1, 2, 3, 4, 5};
+    char               attr_char_out[5];
+    short              attr_short_in[5] = {1, 2, 3, 4, 5};
+    short              attr_short_out[5];
+    int                attr_int_in[5] = {1, 2, 3, 4, 5};
+    int                attr_int_out[5];
+    long               attr_long_in[5] = {1, 2, 3, 4, 5};
+    long               attr_long_out[5];
+    float              attr_float_in[5] = {1, 2, 3, 4, 5};
+    float              attr_float_out[5];
+    double             attr_double_in[5] = {1, 2, 3, 4, 5};
+    double             attr_double_out[5];
+    unsigned char      attr_uchar_in[5] = {1, 2, 3, 4, 5};
+    unsigned char      attr_uchar_out[5];
+    unsigned short     attr_ushort_in[5] = {1, 2, 3, 4, 5};
+    unsigned short     attr_ushort_out[5];
+    unsigned int       attr_uint_in[5] = {1, 2, 3, 4, 5};
+    unsigned int       attr_uint_out[5];
+    unsigned long      attr_ulong_in[5] = {1, 2, 3, 4, 5};
+    unsigned long      attr_ulong_out[5];
+    unsigned long long attr_ullong_in[5] = {1, 2, 3, 4, 5};
+    unsigned long long attr_ullong_out[5];
 
     /*-------------------------------------------------------------------------
      * H5LTset_attribute_string test

--- a/hl/test/test_lite.c
+++ b/hl/test/test_lite.c
@@ -43,8 +43,9 @@
 #define ATTR7_NAME    "attr ushort"
 #define ATTR8_NAME    "attr uint"
 #define ATTR9_NAME    "attr ulong"
-#define ATTR10_NAME   "attr float"
-#define ATTR11_NAME   "attr double"
+#define ATTR10_NAME   "attr ullong"
+#define ATTR11_NAME   "attr float"
+#define ATTR12_NAME   "attr double"
 
 static herr_t make_attributes(hid_t loc_id, const char *obj_name);
 
@@ -897,7 +898,7 @@ make_attributes(hid_t loc_id, const char *obj_name)
     HL_TESTING2("H5LTset_attribute_float");
 
     /* Set the attribute */
-    if (H5LTset_attribute_float(loc_id, obj_name, ATTR10_NAME, attr_float_in, (size_t)5) < 0)
+    if (H5LTset_attribute_float(loc_id, obj_name, ATTR11_NAME, attr_float_in, (size_t)5) < 0)
         return -1;
 
     PASSED();
@@ -910,7 +911,7 @@ make_attributes(hid_t loc_id, const char *obj_name)
     HL_TESTING2("H5LTget_attribute_float");
 
     /* Get the attribute */
-    if (H5LTget_attribute_float(loc_id, obj_name, ATTR10_NAME, attr_float_out) < 0)
+    if (H5LTget_attribute_float(loc_id, obj_name, ATTR11_NAME, attr_float_out) < 0)
         return -1;
 
     for (i = 0; i < 5; i++) {
@@ -920,7 +921,7 @@ make_attributes(hid_t loc_id, const char *obj_name)
     }
 
     /* Get the attribute */
-    if (H5LTget_attribute(loc_id, obj_name, ATTR10_NAME, H5T_NATIVE_FLOAT, attr_float_out) < 0)
+    if (H5LTget_attribute(loc_id, obj_name, ATTR11_NAME, H5T_NATIVE_FLOAT, attr_float_out) < 0)
         return -1;
 
     for (i = 0; i < 5; i++) {
@@ -939,7 +940,7 @@ make_attributes(hid_t loc_id, const char *obj_name)
     HL_TESTING2("H5LTset_attribute_double");
 
     /* Set the attribute */
-    if (H5LTset_attribute_double(loc_id, obj_name, ATTR11_NAME, attr_double_in, (size_t)5) < 0)
+    if (H5LTset_attribute_double(loc_id, obj_name, ATTR12_NAME, attr_double_in, (size_t)5) < 0)
         return -1;
 
     PASSED();
@@ -952,7 +953,7 @@ make_attributes(hid_t loc_id, const char *obj_name)
     HL_TESTING2("H5LTget_attribute_double");
 
     /* Get the attribute */
-    if (H5LTget_attribute_double(loc_id, obj_name, ATTR11_NAME, attr_double_out) < 0)
+    if (H5LTget_attribute_double(loc_id, obj_name, ATTR12_NAME, attr_double_out) < 0)
         return -1;
 
     for (i = 0; i < 5; i++) {
@@ -962,7 +963,7 @@ make_attributes(hid_t loc_id, const char *obj_name)
     }
 
     /* Get the attribute */
-    if (H5LTget_attribute(loc_id, obj_name, ATTR11_NAME, H5T_NATIVE_DOUBLE, attr_double_out) < 0)
+    if (H5LTget_attribute(loc_id, obj_name, ATTR12_NAME, H5T_NATIVE_DOUBLE, attr_double_out) < 0)
         return -1;
 
     for (i = 0; i < 5; i++) {

--- a/hl/test/test_lite.c
+++ b/hl/test/test_lite.c
@@ -862,7 +862,7 @@ make_attributes(hid_t loc_id, const char *obj_name)
     PASSED();
 
     /*-------------------------------------------------------------------------
-     * H5LTget_attribute_long test
+     * H5LTget_attribute_ulong test
      *-------------------------------------------------------------------------
      */
 
@@ -884,6 +884,48 @@ make_attributes(hid_t loc_id, const char *obj_name)
 
     for (i = 0; i < 5; i++) {
         if (attr_ulong_in[i] != attr_ulong_out[i]) {
+            return -1;
+        }
+    }
+
+    PASSED();
+
+    /*-------------------------------------------------------------------------
+     * H5LTset_attribute_ullong test
+     *-------------------------------------------------------------------------
+     */
+
+    HL_TESTING2("H5LTset_attribute_ullong");
+
+    /* Set the attribute */
+    if (H5LTset_attribute_ullong(loc_id, obj_name, ATTR10_NAME, attr_ullong_in, (size_t)5) < 0)
+        return -1;
+
+    PASSED();
+
+    /*-------------------------------------------------------------------------
+     * H5LTget_attribute_ullong test
+     *-------------------------------------------------------------------------
+     */
+
+    HL_TESTING2("H5LTget_attribute_ullong");
+
+    /* Get the attribute */
+    if (H5LTget_attribute_ullong(loc_id, obj_name, ATTR10_NAME, attr_ullong_out) < 0)
+        return -1;
+
+    for (i = 0; i < 5; i++) {
+        if (attr_ullong_in[i] != attr_ullong_out[i]) {
+            return -1;
+        }
+    }
+
+    /* Get the attribute */
+    if (H5LTget_attribute(loc_id, obj_name, ATTR10_NAME, H5T_NATIVE_ULONG, attr_ullong_out) < 0)
+        return -1;
+
+    for (i = 0; i < 5; i++) {
+        if (attr_ullong_in[i] != attr_ullong_out[i]) {
             return -1;
         }
     }

--- a/hl/test/test_lite.c
+++ b/hl/test/test_lite.c
@@ -921,7 +921,7 @@ make_attributes(hid_t loc_id, const char *obj_name)
     }
 
     /* Get the attribute */
-    if (H5LTget_attribute(loc_id, obj_name, ATTR10_NAME, H5T_NATIVE_ULONG, attr_ullong_out) < 0)
+    if (H5LTget_attribute(loc_id, obj_name, ATTR10_NAME, H5T_NATIVE_ULLONG, attr_ullong_out) < 0)
         return -1;
 
     for (i = 0; i < 5; i++) {

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -902,7 +902,13 @@ New Features
 
     High-Level APIs:
     ----------------
-    -
+    - added set/get for unsigned long long attributes
+
+        the attribute writing high-level API has been expanded to include 
+        public set/get functions for ULL attributes, analogously to the 
+        existing set/get for other types.
+
+        (AF - 2021/09/08)
 
     C Packet Table API:
     -------------------


### PR DESCRIPTION
This PR adds
* setter and getter for `unsigned long long` attributes to the high-level c library
* tests for the new setter and getter functions

It also fixes two small typos in the test comments.

Motivated by @gheber's answer to [my question](https://forum.hdfgroup.org/t/why-is-there-no-h5ltset-attribute-unsigned-long-long/8863/2) on the HDF5 forum.