### PR TITLE
1.8 Rework of PR #826 (#972)

### DIFF
--- a/fortran/src/H5Fff.f90
+++ b/fortran/src/H5Fff.f90
@@ -765,7 +765,7 @@ CONTAINS
   SUBROUTINE h5fget_name_f(obj_id, buf, size, hdferr)
     IMPLICIT NONE
     INTEGER(HID_T), INTENT(IN) :: obj_id   ! Object identifier
-    CHARACTER(LEN=*), INTENT(INOUT) :: buf
+    CHARACTER(LEN=*), INTENT(OUT) :: buf
                                            ! Buffer to hold file name
     INTEGER(SIZE_T), INTENT(OUT) :: size   ! Size of the file name
     INTEGER, INTENT(OUT) :: hdferr         ! Error code: 0 on success,
@@ -786,7 +786,7 @@ CONTAINS
          CHARACTER(LEN=*), INTENT(OUT) :: buf
        END FUNCTION h5fget_name_c
     END INTERFACE
-    buflen = LEN_TRIM(buf)
+    buflen = LEN(buf)
     hdferr = h5fget_name_c(obj_id, size, buf, buflen)
   END SUBROUTINE h5fget_name_f
 !****s* H5F/h5fget_filesize_f

--- a/fortran/test/fortranlib_test.f90
+++ b/fortran/test/fortranlib_test.f90
@@ -72,6 +72,10 @@ PROGRAM fortranlibtest
   CALL write_test_status(ret_total_error, ' Reopen test', total_error)
 
   ret_total_error = 0
+  CALL get_name_test(cleanup, ret_total_error)
+  CALL write_test_status(ret_total_error, ' Get name test', total_error)
+
+  ret_total_error = 0
   CALL file_close(cleanup, ret_total_error)
   CALL write_test_status(ret_total_error, ' File open/close test', total_error)
 

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -156,7 +156,11 @@ New Features
 
     Fortran Library:
     ----------------
-    -
+    - H5Fget_name_f fixed to handle correctly trailing whitespaces and
+      newly allocated buffers.
+
+      (MSB - 2021/08/30, github-826,972)
+
 
     C++ Library:
     ------------


### PR DESCRIPTION
*    H5Fget_name_f fixed to handle correctly trailing whitespaces and newly allocated buffers.

Co-authored-by: github-actions <41898282+github-actions[bot]@users.noreply.github.com>