### PR TITLE
Sync CMake java macros with cmake repo

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3574,6 +3574,7 @@
 ./config/cmake/HDF5PluginMacros.cmake
 ./config/cmake/HDF5PluginCache.cmake
 ./config/cmake/HDF5UseFortran.cmake
+./config/cmake/javaTargets.cmake.in
 ./config/cmake/jrunTest.cmake
 ./config/cmake/jvolTest.cmake
 ./config/cmake/libh5cc.in

--- a/config/cmake/UseJavaClassFilelist.cmake
+++ b/config/cmake/UseJavaClassFilelist.cmake
@@ -1,17 +1,8 @@
 # Distributed under the OSI-approved BSD 3-Clause License.  See https://cmake.org/licensing for details.
 
-#[=======================================================================[.rst:
-UseJavaClassFilelist
---------------------
-
-
-
-
-
-This script create a list of compiled Java class files to be added to
-a jar file.  This avoids including cmake files which get created in
-the binary directory.
-#]=======================================================================]
+# This script creates a list of compiled Java class files to be added to
+# a jar file.  This avoids including cmake files which get created in
+# the binary directory.
 
 if (CMAKE_JAVA_CLASS_OUTPUT_PATH)
     if (EXISTS "${CMAKE_JAVA_CLASS_OUTPUT_PATH}")
@@ -23,7 +14,7 @@ if (CMAKE_JAVA_CLASS_OUTPUT_PATH)
 
                 file(GLOB_RECURSE _JAVA_GLOBBED_TMP_FILES "${CMAKE_JAVA_CLASS_OUTPUT_PATH}/${JAR_CLASS_PREFIX}/*.class")
                 if (_JAVA_GLOBBED_TMP_FILES)
-                    list (APPEND _JAVA_GLOBBED_FILES ${_JAVA_GLOBBED_TMP_FILES})
+                    list(APPEND _JAVA_GLOBBED_FILES ${_JAVA_GLOBBED_TMP_FILES})
                 endif ()
             endforeach()
         else()

--- a/config/cmake/UseJavaSymlinks.cmake
+++ b/config/cmake/UseJavaSymlinks.cmake
@@ -1,15 +1,6 @@
 # Distributed under the OSI-approved BSD 3-Clause License.  See https://cmake.org/licensing for details.
 
-#[=======================================================================[.rst:
-UseJavaSymlinks
----------------
-
-
-
-
-
-Helper script for UseJava.cmake
-#]=======================================================================]
+# Helper script for UseJava.cmake
 
 if (UNIX AND _JAVA_TARGET_OUTPUT_LINK)
     if (_JAVA_TARGET_OUTPUT_NAME)

--- a/config/cmake/javaTargets.cmake.in
+++ b/config/cmake/javaTargets.cmake.in
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 2.8.12)
+cmake_policy(PUSH)
+cmake_policy(VERSION 2.8)
+
+#----------------------------------------------------------------
+# Generated CMake Java target import file.
+#----------------------------------------------------------------
+
+# Protect against multiple inclusion, which would fail when already imported targets are added once more.
+set(_targetsDefined)
+set(_targetsNotDefined)
+set(_expectedTargets)
+foreach(_expectedTarget @__targets__@)
+  list(APPEND _expectedTargets ${_expectedTarget})
+  if(TARGET ${_expectedTarget})
+    list(APPEND _targetsDefined ${_expectedTarget})
+  else()
+    list(APPEND _targetsNotDefined ${_expectedTarget})
+  endif()
+endforeach()
+if("%${_targetsDefined}" STREQUAL "%${_expectedTargets}")
+  unset(_targetsDefined)
+  unset(_targetsNotDefined)
+  unset(_expectedTargets)
+  cmake_policy(POP)
+  return()
+endif()
+if(NOT "${_targetsDefined}" STREQUAL "")
+  message(FATAL_ERROR
+    "Some (but not all) targets in this export set were already defined.\n"
+    "Targets Defined: ${_targetsDefined}\n"
+    "Targets not yet defined: ${_targetsNotDefined}\n")
+endif()
+unset(_targetsDefined)
+unset(_targetsNotDefined)
+unset(_expectedTargets)
+
+@__targetdefs__@
+cmake_policy(POP)


### PR DESCRIPTION
This updates the java macros with changes from the CMake repo. This is not an exact duplicate because we use the javadoc overview feature in HDF code.