### PR TITLE
Update copyright headers with reproduction notice in 5 files 

### DIFF
--- a/java/src/hdf/hdf5lib/structs/H5FD_hdfs_fapl_t.java
+++ b/java/src/hdf/hdf5lib/structs/H5FD_hdfs_fapl_t.java
@@ -1,15 +1,14 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- * Read-Only HDFS Virtual File Driver (VFD)                                  *
- * Copyright (c) 2018, The HDF Group.                                        *
+ * Copyright by The HDF Group.                                               *
  *                                                                           *
  * All rights reserved.                                                      *
  *                                                                           *
- * NOTICE:                                                                   *
- * All information contained herein is, and remains, the property of The HDF *
- * Group. The intellectual and technical concepts contained herein are       *
- * proprietary to The HDF Group. Dissemination of this information or        *
- * reproduction of this material is strictly forbidden unless prior written  *
- * permission is obtained from The HDF Group.                                *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the root of the source code       *
+ * distribution tree, or in https://www.hdfgroup.org/licenses.               *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 package hdf.hdf5lib.structs;

--- a/java/src/hdf/hdf5lib/structs/H5FD_ros3_fapl_t.java
+++ b/java/src/hdf/hdf5lib/structs/H5FD_ros3_fapl_t.java
@@ -1,15 +1,14 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- * Read-Only S3 Virtual File Driver (VFD)                                    *
- * Copyright (c) 2017-2018, The HDF Group.                                   *
+ * Copyright by The HDF Group.                                               *
  *                                                                           *
  * All rights reserved.                                                      *
  *                                                                           *
- * NOTICE:                                                                   *
- * All information contained herein is, and remains, the property of The HDF *
- * Group. The intellectual and technical concepts contained herein are       *
- * proprietary to The HDF Group. Dissemination of this information or        *
- * reproduction of this material is strictly forbidden unless prior written  *
- * permission is obtained from The HDF Group.                                *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the root of the source code       *
+ * distribution tree, or in https://www.hdfgroup.org/licenses.               *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 package hdf.hdf5lib.structs;

--- a/src/H5FDhdfs.c
+++ b/src/H5FDhdfs.c
@@ -1,15 +1,13 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- * Read-Only HDFS Virtual File Driver (VFD)                                  *
- * Copyright (c) 2018, The HDF Group.                                        *
- *                                                                           *
+ * Copyright by The HDF Group.                                               *
  * All rights reserved.                                                      *
  *                                                                           *
- * NOTICE:                                                                   *
- * All information contained herein is, and remains, the property of The HDF *
- * Group. The intellectual and technical concepts contained herein are       *
- * proprietary to The HDF Group. Dissemination of this information or        *
- * reproduction of this material is strictly forbidden unless prior written  *
- * permission is obtained from The HDF Group.                                *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the root of the source code       *
+ * distribution tree, or in https://www.hdfgroup.org/licenses.               *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        * 
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*

--- a/src/H5FDhdfs.c
+++ b/src/H5FDhdfs.c
@@ -7,7 +7,7 @@
  * the COPYING file, which can be found at the root of the source code       *
  * distribution tree, or in https://www.hdfgroup.org/licenses.               *
  * If you do not have access to either file, you may request a copy from     *
- * help@hdfgroup.org.                                                        * 
+ * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*

--- a/src/H5FDhdfs.h
+++ b/src/H5FDhdfs.h
@@ -1,15 +1,14 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- * Read-Only HDFS Virtual File Driver (VFD)                                  *
- * Copyright (c) 2018, The HDF Group.                                        *
+ * Copyright by The HDF Group.                                               *
  *                                                                           *
  * All rights reserved.                                                      *
  *                                                                           *
- * NOTICE:                                                                   *
- * All information contained herein is, and remains, the property of The HDF *
- * Group. The intellectual and technical concepts contained herein are       *
- * proprietary to The HDF Group. Dissemination of this information or        *
- * reproduction of this material is strictly forbidden unless prior written  *
- * permission is obtained from The HDF Group.                                *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the root of the source code       *
+ * distribution tree, or in https://www.hdfgroup.org/licenses.               *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*

--- a/tools/libtest/Makefile.am
+++ b/tools/libtest/Makefile.am
@@ -1,16 +1,16 @@
 #
-# Read-Only S3 Virtual File Driver (VFD)
-# Copyright (c) 2017-2018, The HDF Group.
-#
+# Copyright by The HDF Group.
 # All rights reserved.
 #
 # NOTICE:
-# All information contained herein is, and remains, the property of The HDF
-# Group. The intellectual and technical concepts contained herein are
-# proprietary to The HDF Group. Dissemination of this information or
-# reproduction of this material is strictly forbidden unless prior written
-# permission is obtained from The HDF Group.
-##
+#
+# This file is part of HDF5.  The full HDF5 copyright notice, including
+# terms governing use, modification, and redistribution, is contained in
+# the COPYING file, which can be found at the root of the source code
+# distribution tree, or in https://www.hdfgroup.org/licenses.
+# If you do not have access to either file, you may request a copy from
+# help@hdfgroup.org.
+#
 ## Makefile.am
 ## Run automake to generate a Makefile.in from this file.
 #


### PR DESCRIPTION
that did not match terms in COPYING file.

Fix #990.