### PR TITLE
Disable fortran warning

### DIFF
--- a/config/cmake/HDFFortranCompilerFlags.cmake
+++ b/config/cmake/HDFFortranCompilerFlags.cmake
@@ -91,9 +91,10 @@ if (NOT MSVC AND NOT MINGW)
     #endif ()
 
     # Append more extra warning flags that only gcc 5.x+ knows about
-    if (NOT CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 5.0)
-      ADD_H5_FLAGS (HDF5_CMAKE_Fortran_FLAGS "${HDF5_SOURCE_DIR}/config/gnu-warnings/gfort-5")
-    endif ()
+    # do not include -Wuse-without-only
+    #if (NOT CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 5.0)
+    #  ADD_H5_FLAGS (HDF5_CMAKE_Fortran_FLAGS "${HDF5_SOURCE_DIR}/config/gnu-warnings/gfort-5")
+    #endif ()
 
     # Append more extra warning flags that only gcc 6.x+ knows about
     if (NOT CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 6.0)

--- a/config/gnu-fflags
+++ b/config/gnu-fflags
@@ -161,10 +161,10 @@ if test "X-gfortran" = "X-$f9x_vendor"; then
 
     # gfortran 4.9 (nothing new)
 
-    # gfortran >= 5
-    if test $f9x_vers_major -ge 5; then
-        H5_FCFLAGS="$H5_FCFLAGS $(load_gnu_arguments gfort-5)"
-    fi
+    # gfortran >= 5 (do not include -Wuse-without-only)
+    #if test $f9x_vers_major -ge 5; then
+    #    H5_FCFLAGS="$H5_FCFLAGS $(load_gnu_arguments gfort-5)"
+    #fi
 
     # gfortran >= 6
     if test $f9x_vers_major -ge 6; then


### PR DESCRIPTION
The -Wuse-without-only warning was the only warning in the gfort-5 file