### PR TITLE
Fixed HDFFV-11052 (CVE-2020-10812)

### DIFF
--- a/src/H5Fquery.c
+++ b/src/H5Fquery.c
@@ -575,7 +575,7 @@ H5F_get_nrefs(const H5F_t *f)
     HDassert(f);
     HDassert(f->shared);
 
-    if(f->shared != NULL)
+    if (f->shared != NULL)
         ret_value = f->shared->nrefs;
 
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Fquery.c
+++ b/src/H5Fquery.c
@@ -555,18 +555,30 @@ H5F_Kvalue(const H5F_t *f, const H5B_class_t *type)
  * Purpose:  Retrieve the file's 'nrefs' value
  *
  * Return:   'nrefs' on success/abort on failure (shouldn't fail)
+ *
+ * Modifications:
+ *
+ *              BMR -- 9/15/21
+ *              Temporary solution for CVE-2020-10812:
+ *                  Returning UINT_MAX when null pointer is encountered to
+ *                  avoid core dump in production mode.
  *-------------------------------------------------------------------------
  */
 unsigned
 H5F_get_nrefs(const H5F_t *f)
 {
+    unsigned ret_value = UINT_MAX;
+
     /* Use FUNC_ENTER_NOAPI_NOINIT_NOERR here to avoid performance issues */
     FUNC_ENTER_NOAPI_NOINIT_NOERR
 
     HDassert(f);
     HDassert(f->shared);
 
-    FUNC_LEAVE_NOAPI(f->shared->nrefs)
+    if(f->shared != NULL)
+        ret_value = f->shared->nrefs;
+
+    FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5F_get_nrefs() */
 
 /*-------------------------------------------------------------------------

--- a/src/H5VLnative_file.c
+++ b/src/H5VLnative_file.c
@@ -754,7 +754,7 @@ herr_t
 H5VL__native_file_close(void *file, hid_t H5_ATTR_UNUSED dxpl_id, void H5_ATTR_UNUSED **req)
 {
     int      nref;
-    H5F_t   *f         = (H5F_t *)file;
+    H5F_t *  f         = (H5F_t *)file;
     hid_t    file_id   = H5I_INVALID_HID;
     unsigned f_nrefs   = UINT_MAX;
     herr_t   ret_value = SUCCEED; /* Return value */


### PR DESCRIPTION
Description
    The tool h5debug on a corrupted file produced a core dump.   The
    issue occurred during failure recovery when a null shared file pointer
    was being accessed.

    A permanent solution to handle corrupted file during failure recovery
    will require more careful consideration to avoid bad side-effects to
    other parts of the library.  In the meantime, a workaround is used to
    catch the attempt of accessing the null shared file pointer.  The tool
    will then return error instead of segfault.
Platforms tested:
    Linux/64 (jelly)