### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/tools/test/perform/zip_perf.c
+++ b/tools/test/perform/zip_perf.c
@@ -396,7 +396,7 @@ do_write_test(unsigned long file_size, unsigned long min_buf_size, unsigned long
             error("out of memory");
         }
 
-        compression_time = 0.0F;
+        compression_time = 0.0;
 
         if (random_test)
             fill_with_random_data(src, src_len);


### PR DESCRIPTION
This patch will remove clang warnings on Mac:

      'float' to 'double' [-Wdouble-promotion]