### PR TITLE
OESS-168: Remove clang warnings

### DIFF
--- a/tools/test/perform/overhead.c
+++ b/tools/test/perform/overhead.c
@@ -187,7 +187,7 @@ test(fill_t fill_style, const double splits[], hbool_t verbose, hbool_t use_rdcc
     if (!use_rdcc) {
         if (H5Pget_cache(fapl, &mdc_nelmts, NULL, NULL, NULL) < 0)
             goto error;
-        if (H5Pset_cache(fapl, mdc_nelmts, 0, 0, 0.0F) < 0)
+        if (H5Pset_cache(fapl, mdc_nelmts, 0, 0, 0.0) < 0)
             goto error;
     }
     if ((file = H5Fcreate(FILE_NAME_1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)


### PR DESCRIPTION
This patch will remove clang double-promotion warning.