### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/tools/test/perform/chunk_cache.c
+++ b/tools/test/perform/chunk_cache.c
@@ -39,7 +39,7 @@
 
 #define RDCC_NSLOTS 5
 #define RDCC_NBYTES (1024 * 1024 * 10)
-#define RDCC_W0     0.75F
+#define RDCC_W0     0.75
 
 #define FILTER_COUNTER 306
 static size_t nbytes_global;


### PR DESCRIPTION
This patch will remove clang double-promotion warning.