### PR TITLE
Fix ASAN issue in h5dump error path

### DIFF
--- a/tools/lib/h5tools_utils.c
+++ b/tools/lib/h5tools_utils.c
@@ -450,6 +450,7 @@ free_table(table_t *table)
             HDfree(table->objs[u].objname);
 
     HDfree(table->objs);
+    HDfree(table);
 }
 
 #ifdef H5DUMP_DEBUG

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -1471,6 +1471,10 @@ main(int argc, const char *argv[])
         if (table_list_add(fid, oi.fileno) < 0) {
             error_msg("internal error (file %s:line %d)\n", __FILE__, __LINE__);
             h5tools_setstatus(EXIT_FAILURE);
+            /* table_list.nused will be zero and the added containers needs to be cleaned up */
+            HDfree(table_list.tables[0].group_table);
+            HDfree(table_list.tables[0].dset_table);
+            HDfree(table_list.tables[0].type_table);
             goto done;
         }
         group_table = table_list.tables[0].group_table;

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -453,11 +453,8 @@ table_list_free(void)
 
         /* Free each table */
         free_table(table_list.tables[u].group_table);
-        HDfree(table_list.tables[u].group_table);
         free_table(table_list.tables[u].dset_table);
-        HDfree(table_list.tables[u].dset_table);
         free_table(table_list.tables[u].type_table);
-        HDfree(table_list.tables[u].type_table);
     }
 
     /* Free the table list */
@@ -1471,10 +1468,6 @@ main(int argc, const char *argv[])
         if (table_list_add(fid, oi.fileno) < 0) {
             error_msg("internal error (file %s:line %d)\n", __FILE__, __LINE__);
             h5tools_setstatus(EXIT_FAILURE);
-            /* table_list.nused will be zero and the added containers needs to be cleaned up */
-            HDfree(table_list.tables[0].group_table);
-            HDfree(table_list.tables[0].dset_table);
-            HDfree(table_list.tables[0].type_table);
             goto done;
         }
         group_table = table_list.tables[0].group_table;


### PR DESCRIPTION
Dynamic Analysis indicated an error when there was an error in the table add function, created tables need to be freed in the error block because otherwise there is no indication they were created. The count is only updated after there is an addition to the tables.

==1031476==ERROR: LeakSanitizer: detected memory leaks

Direct leak Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x498bdd in malloc (/home/hdf-winadmin/autotest/hdf5trunk-StdClang-code-ubuntu2010/build/ctest/clang/Address/bin/h5dump-shared+0x498bdd)
    #1 0x7f2dad24b2c5 in init_objs (/home/hdf-winadmin/autotest/hdf5trunk-StdClang-code-ubuntu2010/build/ctest/clang/Address/bin/libhdf5_tools.so.1000+0x912c5)
    #2 0x4c897f in table_list_add (/home/hdf-winadmin/autotest/hdf5trunk-StdClang-code-ubuntu2010/build/ctest/clang/Address/bin/h5dump-shared+0x4c897f)
    #3 0x4ca790 in main (/home/hdf-winadmin/autotest/hdf5trunk-StdClang-code-ubuntu2010/build/ctest/clang/Address/bin/h5dump-shared+0x4ca790)
    #4 0x7f2dac025cb1 in __libc_start_main csu/../csu/libc-start.c:314:16
