### PR TITLE
Add tools/src/h5perf/Makefile.in

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3824,6 +3824,7 @@
 ./tools/src/h5import/Makefile.in
 ./tools/src/h5jam/Makefile.in
 ./tools/src/h5ls/Makefile.in
+./tools/src/h5perf/Makefile.in
 ./tools/src/h5repack/Makefile.in
 ./tools/src/h5stat/Makefile.in
 ./tools/src/misc/Makefile.in


### PR DESCRIPTION
tools/src/h5perf/Makefile.am was added in PR #884.  tools/src/h5perf/Makefile.in is also needed in MANIFEST for releases and also for bin/chkmanifest to pass in release branches when files generated by autogen.sh are added to source control.