### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/test/objcopy.c
+++ b/test/objcopy.c
@@ -11092,7 +11092,7 @@ test_copy_dataset_contig_cmpd_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
         buf[i].b.p   = (int *)HDmalloc(buf[i].b.len * sizeof(int));
         for (j = 0; j < buf[i].b.len; j++)
             ((int *)buf[i].b.p)[j] = (int)(i * 10 + j);
-        buf[i].c = 1.0F / ((float)i + 1.0F);
+        buf[i].c = 1.0 / ((double)i + 1.0);
     } /* end for */
 
     /* Initialize the filenames */
@@ -11268,7 +11268,7 @@ test_copy_dataset_chunked_cmpd_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl
         buf[i].b.p   = (int *)HDmalloc(buf[i].b.len * sizeof(int));
         for (j = 0; j < buf[i].b.len; j++)
             ((int *)buf[i].b.p)[j] = (int)(i * 10 + j);
-        buf[i].c = 1.0F / ((float)i + 1.0F);
+        buf[i].c = 1.0 / ((double)i + 1.0);
     } /* end for */
 
     /* Initialize the filenames */
@@ -11453,7 +11453,7 @@ test_copy_dataset_compact_cmpd_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl
         buf[i].b.p   = (int *)HDmalloc(buf[i].b.len * sizeof(int));
         for (j = 0; j < buf[i].b.len; j++)
             ((int *)buf[i].b.p)[j] = (int)(i * 10 + j);
-        buf[i].c = 1.0F / ((float)i + 1.0F);
+        buf[i].c = 1.0 / ((double)i + 1.0);
     } /* end for */
 
     /* Initialize the filenames */
@@ -17305,18 +17305,13 @@ error:
 int
 main(void)
 {
-    int         nerrors = 0;
-    hid_t       fapl, fapl2;
-    hid_t       fcpl_shared, ocpl;
-    unsigned    max_compact, min_dense;
-    int         configuration; /* Configuration of tests. */
-    int         ExpressMode;
-    const char *env_h5_drvr; /* File Driver value from environment */
-    hbool_t     same_file;   /* Whether to run tests that only use one file */
-
-    env_h5_drvr = HDgetenv(HDF5_DRIVER);
-    if (env_h5_drvr == NULL)
-        env_h5_drvr = "nomatch";
+    int      nerrors = 0;
+    hid_t    fapl, fapl2;
+    hid_t    fcpl_shared, ocpl;
+    unsigned max_compact, min_dense;
+    int      configuration; /* Configuration of tests. */
+    int      ExpressMode;
+    hbool_t  same_file; /* Whether to run tests that only use one file */
 
     /* Setup */
     h5_reset();
@@ -17473,14 +17468,9 @@ main(void)
                                     FALSE, "H5Ocopy(): expand soft link");
         nerrors += test_copy_option(fcpl_src, fcpl_dst, src_fapl, dst_fapl, H5O_COPY_EXPAND_EXT_LINK_FLAG,
                                     FALSE, "H5Ocopy(): expand external link");
-
-        /* Splitter VFD currently has external link-related bugs */
-        if (HDstrcmp(env_h5_drvr, "splitter")) {
-            nerrors += test_copy_option(fcpl_src, fcpl_dst, src_fapl, dst_fapl,
-                                        H5O_COPY_EXPAND_SOFT_LINK_FLAG | H5O_COPY_EXPAND_EXT_LINK_FLAG, FALSE,
-                                        "H5Ocopy(): expand soft and external links");
-        }
-
+        nerrors += test_copy_option(fcpl_src, fcpl_dst, src_fapl, dst_fapl,
+                                    H5O_COPY_EXPAND_SOFT_LINK_FLAG | H5O_COPY_EXPAND_EXT_LINK_FLAG, FALSE,
+                                    "H5Ocopy(): expand soft and external links");
         nerrors += test_copy_option(fcpl_src, fcpl_dst, src_fapl, dst_fapl, H5O_COPY_SHALLOW_HIERARCHY_FLAG,
                                     FALSE, "H5Ocopy(): shallow group copy");
         nerrors += test_copy_option(fcpl_src, fcpl_dst, src_fapl, dst_fapl, H5O_COPY_EXPAND_REFERENCE_FLAG,
@@ -17558,14 +17548,9 @@ main(void)
 
             nerrors += test_copy_same_file_named_datatype(fcpl_src, src_fapl);
 
-            /* Check if current driver might modify the filename. Skip these tests
-             * if so, since the file is pre-generated.
-             */
-            if (!h5_driver_uses_modified_filename()) {
-                /* Test with dataset opened in the file or not */
-                nerrors += test_copy_old_layout(fcpl_dst, dst_fapl, FALSE);
-                nerrors += test_copy_old_layout(fcpl_dst, dst_fapl, TRUE);
-            }
+            /* Test with dataset opened in the file or not */
+            nerrors += test_copy_old_layout(fcpl_dst, dst_fapl, FALSE);
+            nerrors += test_copy_old_layout(fcpl_dst, dst_fapl, TRUE);
 
             /* Test with dataset opened in the file or not */
             nerrors += test_copy_null_ref(fcpl_src, fcpl_dst, src_fapl, dst_fapl);

--- a/test/objcopy.c
+++ b/test/objcopy.c
@@ -17305,13 +17305,18 @@ error:
 int
 main(void)
 {
-    int      nerrors = 0;
-    hid_t    fapl, fapl2;
-    hid_t    fcpl_shared, ocpl;
-    unsigned max_compact, min_dense;
-    int      configuration; /* Configuration of tests. */
-    int      ExpressMode;
-    hbool_t  same_file; /* Whether to run tests that only use one file */
+    int         nerrors = 0;
+    hid_t       fapl, fapl2;
+    hid_t       fcpl_shared, ocpl;
+    unsigned    max_compact, min_dense;
+    int         configuration; /* Configuration of tests. */
+    int         ExpressMode;
+    const char *env_h5_drvr; /* File Driver value from environment */
+    hbool_t     same_file;   /* Whether to run tests that only use one file */
+
+    env_h5_drvr = HDgetenv(HDF5_DRIVER);
+    if (env_h5_drvr == NULL)
+        env_h5_drvr = "nomatch";
 
     /* Setup */
     h5_reset();
@@ -17468,9 +17473,14 @@ main(void)
                                     FALSE, "H5Ocopy(): expand soft link");
         nerrors += test_copy_option(fcpl_src, fcpl_dst, src_fapl, dst_fapl, H5O_COPY_EXPAND_EXT_LINK_FLAG,
                                     FALSE, "H5Ocopy(): expand external link");
-        nerrors += test_copy_option(fcpl_src, fcpl_dst, src_fapl, dst_fapl,
-                                    H5O_COPY_EXPAND_SOFT_LINK_FLAG | H5O_COPY_EXPAND_EXT_LINK_FLAG, FALSE,
-                                    "H5Ocopy(): expand soft and external links");
+
+        /* Splitter VFD currently has external link-related bugs */
+        if (HDstrcmp(env_h5_drvr, "splitter")) {
+            nerrors += test_copy_option(fcpl_src, fcpl_dst, src_fapl, dst_fapl,
+                                        H5O_COPY_EXPAND_SOFT_LINK_FLAG | H5O_COPY_EXPAND_EXT_LINK_FLAG, FALSE,
+                                        "H5Ocopy(): expand soft and external links");
+        }
+
         nerrors += test_copy_option(fcpl_src, fcpl_dst, src_fapl, dst_fapl, H5O_COPY_SHALLOW_HIERARCHY_FLAG,
                                     FALSE, "H5Ocopy(): shallow group copy");
         nerrors += test_copy_option(fcpl_src, fcpl_dst, src_fapl, dst_fapl, H5O_COPY_EXPAND_REFERENCE_FLAG,
@@ -17548,9 +17558,14 @@ main(void)
 
             nerrors += test_copy_same_file_named_datatype(fcpl_src, src_fapl);
 
-            /* Test with dataset opened in the file or not */
-            nerrors += test_copy_old_layout(fcpl_dst, dst_fapl, FALSE);
-            nerrors += test_copy_old_layout(fcpl_dst, dst_fapl, TRUE);
+            /* Check if current driver might modify the filename. Skip these tests
+             * if so, since the file is pre-generated.
+             */
+            if (!h5_driver_uses_modified_filename()) {
+                /* Test with dataset opened in the file or not */
+                nerrors += test_copy_old_layout(fcpl_dst, dst_fapl, FALSE);
+                nerrors += test_copy_old_layout(fcpl_dst, dst_fapl, TRUE);
+            }
 
             /* Test with dataset opened in the file or not */
             nerrors += test_copy_null_ref(fcpl_src, fcpl_dst, src_fapl, dst_fapl);


### PR DESCRIPTION
This patch will remove clang double-promotion warning.