### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/tools/lib/h5diff_array.c
+++ b/tools/lib/h5diff_array.c
@@ -2163,8 +2163,7 @@ diff_ldouble_element(unsigned char *mem1, unsigned char *mem2, hsize_t elem_idx,
                 }
                 nfound++;
             }
-            else if (per > opts->percent &&
-                     (double) ABS(temp1_double - temp2_double) > opts->delta) {
+            else if (per > opts->percent && (double)ABS(temp1_double - temp2_double) > opts->delta) {
                 opts->print_percentage = 1;
                 print_pos(opts, elem_idx, 0);
                 if (print_data(opts)) {

--- a/tools/lib/h5diff_array.c
+++ b/tools/lib/h5diff_array.c
@@ -2070,7 +2070,7 @@ diff_ldouble_element(unsigned char *mem1, unsigned char *mem2, hsize_t elem_idx,
 
         /* both not NaN, do the comparison */
         if (!isnan1 && !isnan2) {
-            if (ABS(temp1_double - temp2_double) > opts->delta) {
+            if ((double)ABS(temp1_double - temp2_double) > opts->delta) {
                 opts->print_percentage = 0;
                 print_pos(opts, elem_idx, 0);
                 if (print_data(opts)) {
@@ -2163,7 +2163,8 @@ diff_ldouble_element(unsigned char *mem1, unsigned char *mem2, hsize_t elem_idx,
                 }
                 nfound++;
             }
-            else if (per > opts->percent && ABS(temp1_double - temp2_double) > opts->delta) {
+            else if (per > opts->percent &&
+                     (double) ABS(temp1_double - temp2_double) > opts->delta) {
                 opts->print_percentage = 1;
                 print_pos(opts, elem_idx, 0);
                 if (print_data(opts)) {


### PR DESCRIPTION
This patch will remove clang double-promotion warning.