### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/src/H5ACprivate.h
+++ b/src/H5ACprivate.h
@@ -234,27 +234,27 @@ typedef struct H5AC_proxy_entry_t {
   /* hbool_t     evictions_enabled      = */ TRUE,                            \
   /* hbool_t     set_initial_size       = */ TRUE,                            \
   /* size_t      initial_size           = */ ( 2 * 1024 * 1024),              \
-  /* double      min_clean_fraction     = */ 0.3f,                            \
+  /* double      min_clean_fraction     = */ 0.3,                            \
   /* size_t      max_size               = */ (32 * 1024 * 1024),              \
   /* size_t      min_size               = */ (1 * 1024 * 1024),               \
   /* long int    epoch_length           = */ 50000,                           \
   /* enum H5C_cache_incr_mode incr_mode = */ H5C_incr__threshold,             \
-  /* double      lower_hr_threshold     = */ 0.9f,                            \
-  /* double      increment              = */ 2.0f,                            \
+  /* double      lower_hr_threshold     = */ 0.9,                            \
+  /* double      increment              = */ 2.0,                            \
   /* hbool_t     apply_max_increment    = */ TRUE,                            \
   /* size_t      max_increment          = */ (4 * 1024 * 1024),               \
   /* enum H5C_cache_flash_incr_mode       */                                  \
   /*                    flash_incr_mode = */ H5C_flash_incr__add_space,       \
-  /* double      flash_multiple         = */ 1.0f,                            \
-  /* double      flash_threshold        = */ 0.25f,                           \
+  /* double      flash_multiple         = */ 1.0,                            \
+  /* double      flash_threshold        = */ 0.25,                           \
   /* enum H5C_cache_decr_mode decr_mode = */ H5C_decr__age_out_with_threshold, \
-  /* double      upper_hr_threshold     = */ 0.999f,                          \
-  /* double      decrement              = */ 0.9f,                            \
+  /* double      upper_hr_threshold     = */ 0.999,                          \
+  /* double      decrement              = */ 0.9,                           \
   /* hbool_t     apply_max_decrement    = */ TRUE,                            \
   /* size_t      max_decrement          = */ (1 * 1024 * 1024),               \
   /* int         epochs_before_eviction = */ 3,                               \
   /* hbool_t     apply_empty_reserve    = */ TRUE,                            \
-  /* double      empty_reserve          = */ 0.1f,                            \
+  /* double      empty_reserve          = */ 0.1,                            \
   /* size_t      dirty_bytes_threshold  = */ (256 * 1024),                    \
   /* int         metadata_write_strategy = */                                  \
                     H5AC__DEFAULT_METADATA_WRITE_STRATEGY  \
@@ -270,7 +270,7 @@ typedef struct H5AC_proxy_entry_t {
   /* hbool_t     evictions_enabled      = */ TRUE,                            \
   /* hbool_t     set_initial_size       = */ TRUE,                            \
   /* size_t      initial_size           = */ ( 2 * 1024 * 1024),              \
-  /* double      min_clean_fraction     = */ 0.01f,                           \
+  /* double      min_clean_fraction     = */ 0.01,                           \
   /* size_t      max_size               = */ (32 * 1024 * 1024),              \
   /* size_t      min_size               = */ ( 1 * 1024 * 1024),              \
   /* long int    epoch_length           = */ 50000,                           \

--- a/test/cache_api.c
+++ b/test/cache_api.c
@@ -546,7 +546,7 @@ check_file_mdc_api_calls(unsigned paged, hid_t fcpl_id)
         /* size_t      max_decrement          = */ (1 * 1024 * 1024 - 1),
         /* int         epochs_before_eviction = */ 4,
         /* hbool_t     apply_empty_reserve    = */ TRUE,
-        /* double      empty_reserve          = */ 0.05f,
+        /* double      empty_reserve          = */ 0.05,
         /* int         dirty_bytes_threshold  = */ (256 * 1024),
         /* int        metadata_write_strategy = */
         H5AC__DEFAULT_METADATA_WRITE_STRATEGY};


### PR DESCRIPTION
This patch will remove clang double-promotion warning.