### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/test/tunicode.c
+++ b/test/tunicode.c
@@ -34,7 +34,7 @@
 #define RANK            1
 #define COMP_INT_VAL    7
 #define COMP_FLOAT_VAL  (-42.0F)
-#define COMP_DOUBLE_VAL 42.0F
+#define COMP_DOUBLE_VAL 42.0
 
 /* Test function prototypes */
 void test_fl_string(hid_t fid, const char *string);


### PR DESCRIPTION
This patch will remove clang double-promotion warning.