### PR TITLE
Fixed HDFFV-11150 (#356)

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -209,6 +209,14 @@ Bug Fixes since HDF5-1.12.1 release
 ===================================
     Library
     -------
+    - Fixed a segmentation fault
+
+      A segmentation fault occurred with a Mathworks corrupted file.
+
+      A detection of accessing a null pointer was added to prevent the problem.
+
+      (BMR - 2021/10/14, HDFFV-11150)
+
     - Detection of simple data transform function "x"
 
         In the case of the simple data transform function "x" the (parallel)

--- a/src/H5Ochunk.c
+++ b/src/H5Ochunk.c
@@ -412,12 +412,12 @@ H5O__chunk_dest(H5O_chunk_proxy_t *chk_proxy)
     HDassert(chk_proxy);
 
     /* Decrement reference count of object header */
-    if (chk_proxy->oh && H5O__dec_rc(chk_proxy->oh) < 0)
+    if (H5O__dec_rc(chk_proxy->oh) < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTDEC, FAIL, "can't decrement reference count on object header")
 
+done:
     /* Release the chunk proxy object */
     chk_proxy = H5FL_FREE(H5O_chunk_proxy_t, chk_proxy);
 
-done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* H5O__chunk_dest() */

--- a/src/H5Oint.c
+++ b/src/H5Oint.c
@@ -2925,7 +2925,8 @@ H5O__dec_rc(H5O_t *oh)
     FUNC_ENTER_PACKAGE
 
     /* check args */
-    HDassert(oh);
+    if (!oh)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid object header")
 
     /* Decrement reference count */
     oh->rc--;


### PR DESCRIPTION
Description
    Replaced an HDassert with a check for null pointer in H5O_dec_rc() to
    catch null pointer in corrupted data situation.
    As a result, removed the null check prior to H5O_dec_rc() calls.
Platforms tested:
    Linux/64 (jelly)