### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/src/H5private.h
+++ b/src/H5private.h
@@ -255,7 +255,7 @@
 #if defined(__clang__) || defined(__GNUC__) && __GNUC__ >= 7 && !defined(__INTEL_COMPILER)
 #define H5_ATTR_FALLTHROUGH __attribute__((fallthrough));
 #else
-#define H5_ATTR_FALLTHROUGH /*void*/
+#define H5_ATTR_FALLTHROUGH /* FALLTHROUGH */
 #endif
 #else
 #define H5_ATTR_FORMAT(X, Y, Z) /*void*/

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -252,7 +252,7 @@
 #define H5_ATTR_NORETURN __attribute__((noreturn))
 #define H5_ATTR_CONST    __attribute__((const))
 #define H5_ATTR_PURE     __attribute__((pure))
-#if defined(__GNUC__) && __GNUC__ >= 7 && !defined(__INTEL_COMPILER)
+#if defined(__clang__) || defined(__GNUC__) && __GNUC__ >= 7 && !defined(__INTEL_COMPILER)
 #define H5_ATTR_FALLTHROUGH __attribute__((fallthrough));
 #else
 #define H5_ATTR_FALLTHROUGH /*void*/

--- a/src/uthash.h
+++ b/src/uthash.h
@@ -30,6 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stddef.h> /* ptrdiff_t */
 #include <stdlib.h> /* exit */
 
+
 /* These macros use decltype or the earlier __typeof GNU extension.
    As decltype is only available in newer compilers (VS2010 or gcc 4.3+
    when compiling c++ source) this code uses whatever method is needed
@@ -714,25 +715,25 @@ typedef unsigned char uint8_t;
         hashv += (unsigned)(keylen);                                                                         \
         switch (_hj_k) {                                                                                     \
             case 11:                                                                                         \
-                hashv += ((unsigned)_hj_key[10] << 24); /* FALLTHROUGH */                                    \
+                hashv += ((unsigned)_hj_key[10] << 24); H5_ATTR_FALLTHROUGH                                    \
             case 10:                                                                                         \
-                hashv += ((unsigned)_hj_key[9] << 16); /* FALLTHROUGH */                                     \
+                hashv += ((unsigned)_hj_key[9] << 16); H5_ATTR_FALLTHROUGH                                     \
             case 9:                                                                                          \
-                hashv += ((unsigned)_hj_key[8] << 8); /* FALLTHROUGH */                                      \
+                hashv += ((unsigned)_hj_key[8] << 8); H5_ATTR_FALLTHROUGH                                      \
             case 8:                                                                                          \
-                _hj_j += ((unsigned)_hj_key[7] << 24); /* FALLTHROUGH */                                     \
+                _hj_j += ((unsigned)_hj_key[7] << 24); H5_ATTR_FALLTHROUGH                                     \
             case 7:                                                                                          \
-                _hj_j += ((unsigned)_hj_key[6] << 16); /* FALLTHROUGH */                                     \
+                _hj_j += ((unsigned)_hj_key[6] << 16); H5_ATTR_FALLTHROUGH                                     \
             case 6:                                                                                          \
-                _hj_j += ((unsigned)_hj_key[5] << 8); /* FALLTHROUGH */                                      \
+                _hj_j += ((unsigned)_hj_key[5] << 8); H5_ATTR_FALLTHROUGH                                      \
             case 5:                                                                                          \
-                _hj_j += _hj_key[4]; /* FALLTHROUGH */                                                       \
+                _hj_j += _hj_key[4]; H5_ATTR_FALLTHROUGH                                                       \
             case 4:                                                                                          \
-                _hj_i += ((unsigned)_hj_key[3] << 24); /* FALLTHROUGH */                                     \
+                _hj_i += ((unsigned)_hj_key[3] << 24); H5_ATTR_FALLTHROUGH                                     \
             case 3:                                                                                          \
-                _hj_i += ((unsigned)_hj_key[2] << 16); /* FALLTHROUGH */                                     \
+                _hj_i += ((unsigned)_hj_key[2] << 16); H5_ATTR_FALLTHROUGH                                     \
             case 2:                                                                                          \
-                _hj_i += ((unsigned)_hj_key[1] << 8); /* FALLTHROUGH */                                      \
+                _hj_i += ((unsigned)_hj_key[1] << 8); H5_ATTR_FALLTHROUGH                                      \
             case 1:                                                                                          \
                 _hj_i += _hj_key[0];                                                                         \
         }                                                                                                    \

--- a/src/uthash.h
+++ b/src/uthash.h
@@ -30,7 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stddef.h> /* ptrdiff_t */
 #include <stdlib.h> /* exit */
 
-
 /* These macros use decltype or the earlier __typeof GNU extension.
    As decltype is only available in newer compilers (VS2010 or gcc 4.3+
    when compiling c++ source) this code uses whatever method is needed
@@ -715,25 +714,35 @@ typedef unsigned char uint8_t;
         hashv += (unsigned)(keylen);                                                                         \
         switch (_hj_k) {                                                                                     \
             case 11:                                                                                         \
-                hashv += ((unsigned)_hj_key[10] << 24); H5_ATTR_FALLTHROUGH                                    \
+                hashv += ((unsigned)_hj_key[10] << 24);                                                      \
+                H5_ATTR_FALLTHROUGH                                                                          \
             case 10:                                                                                         \
-                hashv += ((unsigned)_hj_key[9] << 16); H5_ATTR_FALLTHROUGH                                     \
+                hashv += ((unsigned)_hj_key[9] << 16);                                                       \
+                H5_ATTR_FALLTHROUGH                                                                          \
             case 9:                                                                                          \
-                hashv += ((unsigned)_hj_key[8] << 8); H5_ATTR_FALLTHROUGH                                      \
+                hashv += ((unsigned)_hj_key[8] << 8);                                                        \
+                H5_ATTR_FALLTHROUGH                                                                          \
             case 8:                                                                                          \
-                _hj_j += ((unsigned)_hj_key[7] << 24); H5_ATTR_FALLTHROUGH                                     \
+                _hj_j += ((unsigned)_hj_key[7] << 24);                                                       \
+                H5_ATTR_FALLTHROUGH                                                                          \
             case 7:                                                                                          \
-                _hj_j += ((unsigned)_hj_key[6] << 16); H5_ATTR_FALLTHROUGH                                     \
+                _hj_j += ((unsigned)_hj_key[6] << 16);                                                       \
+                H5_ATTR_FALLTHROUGH                                                                          \
             case 6:                                                                                          \
-                _hj_j += ((unsigned)_hj_key[5] << 8); H5_ATTR_FALLTHROUGH                                      \
+                _hj_j += ((unsigned)_hj_key[5] << 8);                                                        \
+                H5_ATTR_FALLTHROUGH                                                                          \
             case 5:                                                                                          \
-                _hj_j += _hj_key[4]; H5_ATTR_FALLTHROUGH                                                       \
+                _hj_j += _hj_key[4];                                                                         \
+                H5_ATTR_FALLTHROUGH                                                                          \
             case 4:                                                                                          \
-                _hj_i += ((unsigned)_hj_key[3] << 24); H5_ATTR_FALLTHROUGH                                     \
+                _hj_i += ((unsigned)_hj_key[3] << 24);                                                       \
+                H5_ATTR_FALLTHROUGH                                                                          \
             case 3:                                                                                          \
-                _hj_i += ((unsigned)_hj_key[2] << 16); H5_ATTR_FALLTHROUGH                                     \
+                _hj_i += ((unsigned)_hj_key[2] << 16);                                                       \
+                H5_ATTR_FALLTHROUGH                                                                          \
             case 2:                                                                                          \
-                _hj_i += ((unsigned)_hj_key[1] << 8); H5_ATTR_FALLTHROUGH                                      \
+                _hj_i += ((unsigned)_hj_key[1] << 8);                                                        \
+                H5_ATTR_FALLTHROUGH                                                                          \
             case 1:                                                                                          \
                 _hj_i += _hj_key[0];                                                                         \
         }                                                                                                    \


### PR DESCRIPTION
 Remove ```warning: unannotated fall-through between switch labels [-Wimplicit-fallthrough]``` from 

- H5checksum.c  
- H5Zshuffle.c  
- H5Shyper.c  
- H5Tref.c
- H5Iint.c