### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/src/H5FDcore.c
+++ b/src/H5FDcore.c
@@ -190,8 +190,8 @@ static const H5FD_class_t H5FD_core_g = {
 };
 
 /* Default configurations, if none provided */
-static const H5FD_core_fapl_t H5FD_core_default_config_g       = {(size_t)H5_MB, TRUE, H5FD_CORE_WRITE_TRACKING_FLAG,
-                                                            H5FD_CORE_WRITE_TRACKING_PAGE_SIZE};
+static const H5FD_core_fapl_t H5FD_core_default_config_g = {
+    (size_t)H5_MB, TRUE, H5FD_CORE_WRITE_TRACKING_FLAG, H5FD_CORE_WRITE_TRACKING_PAGE_SIZE};
 static const H5FD_core_fapl_t H5FD_core_default_paged_config_g = {(size_t)H5_MB, TRUE, TRUE, (size_t)4096};
 
 /* Define a free list to manage the region type */
@@ -952,8 +952,8 @@ H5FD__core_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
                             "file read failed: time = %s, filename = '%s', file descriptor = %d, errno = %d, "
                             "error message = '%s', file->mem = %p, total read size = %llu, bytes this "
                             "sub-read = %llu, bytes actually read = %llu, offset = %llu",
-                            HDctime(&mytime), file->name, file->fd, myerrno, HDstrerror(myerrno), (void *)file->mem,
-                            (unsigned long long)size, (unsigned long long)bytes_in,
+                            HDctime(&mytime), file->name, file->fd, myerrno, HDstrerror(myerrno),
+                            (void *)file->mem, (unsigned long long)size, (unsigned long long)bytes_in,
                             (unsigned long long)bytes_read, (unsigned long long)offset);
                     } /* end if */
 

--- a/src/H5FDcore.c
+++ b/src/H5FDcore.c
@@ -190,9 +190,9 @@ static const H5FD_class_t H5FD_core_g = {
 };
 
 /* Default configurations, if none provided */
-static const H5FD_core_fapl_t H5FD_core_default_config_g       = {H5_MB, TRUE, H5FD_CORE_WRITE_TRACKING_FLAG,
+static const H5FD_core_fapl_t H5FD_core_default_config_g       = {(size_t)H5_MB, TRUE, H5FD_CORE_WRITE_TRACKING_FLAG,
                                                             H5FD_CORE_WRITE_TRACKING_PAGE_SIZE};
-static const H5FD_core_fapl_t H5FD_core_default_paged_config_g = {H5_MB, TRUE, TRUE, (size_t)4096};
+static const H5FD_core_fapl_t H5FD_core_default_paged_config_g = {(size_t)H5_MB, TRUE, TRUE, (size_t)4096};
 
 /* Define a free list to manage the region type */
 H5FL_DEFINE(H5FD_core_region_t);
@@ -398,7 +398,7 @@ H5FD__core_write_to_bstore(H5FD_core_t *file, haddr_t addr, size_t size)
                         "write to backing store failed: time = %s, filename = '%s', file descriptor = %d, "
                         "errno = %d, error message = '%s', ptr = %p, total write size = %llu, bytes this "
                         "sub-write = %llu, bytes actually written = %llu, offset = %llu",
-                        HDctime(&mytime), file->name, file->fd, myerrno, HDstrerror(myerrno), ptr,
+                        HDctime(&mytime), file->name, file->fd, myerrno, HDstrerror(myerrno), (void *)ptr,
                         (unsigned long long)size, (unsigned long long)bytes_in,
                         (unsigned long long)bytes_wrote, (unsigned long long)offset);
         } /* end if */
@@ -952,7 +952,7 @@ H5FD__core_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
                             "file read failed: time = %s, filename = '%s', file descriptor = %d, errno = %d, "
                             "error message = '%s', file->mem = %p, total read size = %llu, bytes this "
                             "sub-read = %llu, bytes actually read = %llu, offset = %llu",
-                            HDctime(&mytime), file->name, file->fd, myerrno, HDstrerror(myerrno), file->mem,
+                            HDctime(&mytime), file->name, file->fd, myerrno, HDstrerror(myerrno), (void *)file->mem,
                             (unsigned long long)size, (unsigned long long)bytes_in,
                             (unsigned long long)bytes_read, (unsigned long long)offset);
                     } /* end if */


### PR DESCRIPTION
This will remove ``` warning: implicit conversion turns floating-point number into integer: 'float' to 'size_t' (aka 'unsigned long') [-Wfloat-conversion]``` warnings.