### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/test/h5test.h
+++ b/test/h5test.h
@@ -210,7 +210,7 @@ H5TEST_DLLVAR MPI_Info h5_io_info_g; /* MPI INFO object for IO */
                                                                                                              \
         ARR = (TYPE **)HDmalloc(h5taa_pointers_size + h5taa_data_size);                                      \
                                                                                                              \
-        ARR[0] = (TYPE *)(ARR + (DIMS_I));                                                                   \
+        ARR[0] = (void *)(ARR + (DIMS_I));                                                                   \
                                                                                                              \
         for (h5taa_i = 1; h5taa_i < (DIMS_I); h5taa_i++)                                                     \
             ARR[h5taa_i] = ARR[h5taa_i - 1] + (DIMS_J);                                                      \


### PR DESCRIPTION
This will fix the following warning:

```h5dumpgentest.c:10258:5: warning: cast from 'long double **' to 'long double *'  increases required alignment from 8 to 16 [-Wcast-align]```