### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/test/testmeta.c
+++ b/test/testmeta.c
@@ -195,7 +195,7 @@ main(void)
 
             start[0] = 0;
             status   = H5Sselect_hyperslab(memspace_id, H5S_SELECT_SET, start, stride, count, NULL);
-            start[0] = (hssize_t)j;
+            start[0] = (hsize_t)j;
             status   = H5Sselect_hyperslab(dataspace_id, H5S_SELECT_SET, start, stride, count, NULL);
             status   = H5Dwrite(dataset_id, type_id, memspace_id, dataspace_id, H5P_DEFAULT, &floatval);
             if (status < 0) {


### PR DESCRIPTION
This will remove ```testmeta.c:198:24: warning: implicit conversion changes signedness: 'hssize_t'
      (aka 'long long') to 'hsize_t' (aka 'unsigned long long') [-Wsign-conversion]```.