### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/test/swmr.c
+++ b/test/swmr.c
@@ -5220,7 +5220,7 @@ test_file_lock_swmr_concur(hid_t H5_ATTR_UNUSED in_fapl)
 static int
 test_file_lock_swmr_concur(hid_t in_fapl)
 {
-    hid_t fid;                     /* File ID */
+    hid_t fid = -1;                /* File ID */
     hid_t fapl;                    /* File access property list */
     char  filename[NAME_BUF_SIZE]; /* file name */
     pid_t childpid = 0;            /* Child process ID */
@@ -6721,7 +6721,7 @@ test_refresh_concur(hid_t H5_ATTR_UNUSED in_fapl, hbool_t new_format)
 static int
 test_refresh_concur(hid_t in_fapl, hbool_t new_format)
 {
-    hid_t fid;                     /* File ID */
+    hid_t fid = -1;                /* File ID */
     hid_t fapl;                    /* File access property list */
     pid_t childpid = 0;            /* Child process ID */
     pid_t tmppid;                  /* Child process ID returned by waitpid */

--- a/test/swmr.c
+++ b/test/swmr.c
@@ -5220,7 +5220,7 @@ test_file_lock_swmr_concur(hid_t H5_ATTR_UNUSED in_fapl)
 static int
 test_file_lock_swmr_concur(hid_t in_fapl)
 {
-    hid_t fid = -1;                /* File ID */
+    hid_t fid = H5I_INVALID_HID;   /* File ID */
     hid_t fapl;                    /* File access property list */
     char  filename[NAME_BUF_SIZE]; /* file name */
     pid_t childpid = 0;            /* Child process ID */
@@ -6721,7 +6721,7 @@ test_refresh_concur(hid_t H5_ATTR_UNUSED in_fapl, hbool_t new_format)
 static int
 test_refresh_concur(hid_t in_fapl, hbool_t new_format)
 {
-    hid_t fid = -1;                /* File ID */
+    hid_t fid = H5I_INVALID_HID;   /* File ID */
     hid_t fapl;                    /* File access property list */
     pid_t childpid = 0;            /* Child process ID */
     pid_t tmppid;                  /* Child process ID returned by waitpid */


### PR DESCRIPTION
This will remove ```warning: variable 'fid' is used uninitialized whenever 'if' condition is true [-Wsometimes-uninitialized]```.
