### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/test/tvlstr.c
+++ b/test/tvlstr.c
@@ -293,7 +293,7 @@ test_vlstrings_special(void)
     /* Check data read in */
     for (i = 0; i < SPACE1_DIM1; i++)
         if (rdata[i] != NULL)
-            TestErrPrintf("VL doesn't match!, rdata[%d]=%p\n", (int)i, rdata[i]);
+            TestErrPrintf("VL doesn't match!, rdata[%d]=%s\n", (int)i, rdata[i]);
 
     /* Write dataset to disk */
     ret = H5Dwrite(dataset, tid1, H5S_ALL, H5S_ALL, H5P_DEFAULT, wdata);
@@ -352,7 +352,7 @@ test_vlstrings_special(void)
     /* Check data read in */
     for (i = 0; i < SPACE1_DIM1; i++)
         if (rdata[i] != NULL)
-            TestErrPrintf("VL doesn't match!, rdata[%d]=%p\n", (int)i, rdata[i]);
+            TestErrPrintf("VL doesn't match!, rdata[%d]=%s\n", (int)i, rdata[i]);
 
     /* Try to write nil strings to disk. */
     ret = H5Dwrite(dataset, tid1, H5S_ALL, H5S_ALL, H5P_DEFAULT, wdata2);
@@ -365,7 +365,7 @@ test_vlstrings_special(void)
     /* Check data read in */
     for (i = 0; i < SPACE1_DIM1; i++)
         if (rdata[i] != NULL)
-            TestErrPrintf("VL doesn't match!, rdata[%d]=%p\n", (int)i, rdata[i]);
+            TestErrPrintf("VL doesn't match!, rdata[%d]=%s\n", (int)i, rdata[i]);
 
     /* Close Dataset */
     ret = H5Dclose(dataset);


### PR DESCRIPTION
This will remove the following warning:

```
tvlstr.c:296:72: warning: format specifies type 'void *' but the argument has type
      'char *' [-Wformat-pedantic]
            TestErrPrintf("VL doesn't match!, rdata[%d]=%p\n", (int)i, rdata[i]);
                                                        ~~             ^~~~~~~~
                                                        %s
```
