### PR TITLE
Convert integer<->pointer conversions to errors

### DIFF
--- a/config/gnu-warnings/error-general
+++ b/config/gnu-warnings/error-general
@@ -11,6 +11,8 @@
 -Werror=packed
 -Werror=pointer-sign
 -Werror=pointer-to-int-cast
+-Werror=int-to-pointer-cast
+-Werror=int-conversion
 -Werror=redundant-decls
 -Werror=strict-prototypes
 -Werror=switch


### PR DESCRIPTION
Make it an error if the library implicitly converts from integer to  pointer or from pointer to integer (-Werror=int-conversion).  Also, make it an error if the library explicitly converts to pointer from an integer of a different size (-Werror=int-to-pointer-cast).