### PR TITLE
Fix H5DS warnings

### DIFF
--- a/hl/src/H5DS.c
+++ b/hl/src/H5DS.c
@@ -22,31 +22,35 @@ static herr_t H5DS_is_reserved(hid_t did);
 /*-------------------------------------------------------------------------
  * Function: H5DSwith_new_ref
  *
- * Purpose: Detremines if new references are used with dimension scales.
+ * Purpose: Determines if new references are used with dimension scales.
  *   The function H5DSwith_new_ref takes any object identifier and checks
- *   if new references are used for dimenison scales. Currently,
+ *   if new references are used for dimension scales. Currently,
  *   new references are used when non-native VOL connector is used or when
  *   H5_DIMENSION_SCALES_WITH_NEW_REF is set up via configure option.
  *
- * Return: Success: TRUE/FALSE, Failure: FAIL
+ * Return: Non-negative on success/Negative on failure
  *
  *-------------------------------------------------------------------------
  */
-hbool_t
-H5DSwith_new_ref(hid_t obj_id)
+herr_t
+H5DSwith_new_ref(hid_t obj_id, hbool_t *with_new_ref)
 {
-    hbool_t ret_value   = FALSE;
     hbool_t config_flag = FALSE;
     hbool_t native      = FALSE;
 
-    native = H5VLobject_is_native(obj_id);
-    if (native < 0)
+    if (!with_new_ref)
         return FAIL;
+
+    if (H5VLobject_is_native(obj_id, &native) < 0)
+        return FAIL;
+
 #ifdef H5_DIMENSION_SCALES_WITH_NEW_REF
     config_flag = TRUE;
 #endif
-    ret_value = (config_flag || !native);
-    return ret_value;
+
+    *with_new_ref = (config_flag || !native);
+
+    return SUCCEED;
 }
 
 /*-------------------------------------------------------------------------
@@ -205,8 +209,7 @@ H5DSattach_scale(hid_t did, hid_t dsid, unsigned int idx)
      *-------------------------------------------------------------------------
      */
 
-    is_new_ref = H5DSwith_new_ref(did);
-    if (is_new_ref < 0)
+    if (H5DSwith_new_ref(did, &is_new_ref) < 0)
         return FAIL;
 
     /* get ID type */
@@ -793,8 +796,7 @@ H5DSdetach_scale(hid_t did, hid_t dsid, unsigned int idx)
      * determine if old or new references should be used
      *-------------------------------------------------------------------------
      */
-    is_new_ref = H5DSwith_new_ref(did);
-    if (is_new_ref < 0)
+    if (H5DSwith_new_ref(did, &is_new_ref) < 0)
         return FAIL;
 
     /*-------------------------------------------------------------------------
@@ -1283,8 +1285,7 @@ H5DSis_attached(hid_t did, hid_t dsid, unsigned int idx)
      *-------------------------------------------------------------------------
      */
 
-    is_new_ref = H5DSwith_new_ref(did);
-    if (is_new_ref < 0)
+    if (H5DSwith_new_ref(did, &is_new_ref) < 0)
         return FAIL;
 
     /* get ID type */
@@ -1629,8 +1630,7 @@ H5DSiterate_scales(hid_t did, unsigned int dim, int *ds_idx, H5DS_iterate_t visi
      *-------------------------------------------------------------------------
      */
 
-    is_new_ref = H5DSwith_new_ref(did);
-    if (is_new_ref < 0)
+    if (H5DSwith_new_ref(did, &is_new_ref) < 0)
         return FAIL;
 
     /* get the number of scales assotiated with this DIM */

--- a/hl/src/H5DSpublic.h
+++ b/hl/src/H5DSpublic.h
@@ -25,7 +25,7 @@ typedef herr_t (*H5DS_iterate_t)(hid_t dset, unsigned dim, hid_t scale, void *vi
 extern "C" {
 #endif
 
-H5_HLDLL hbool_t H5DSwith_new_ref(hid_t obj_id);
+H5_HLDLL herr_t H5DSwith_new_ref(hid_t obj_id, hbool_t *with_new_ref);
 
 H5_HLDLL herr_t H5DSattach_scale(hid_t did, hid_t dsid, unsigned int idx);
 

--- a/src/H5VL.c
+++ b/src/H5VL.c
@@ -661,25 +661,27 @@ done:
  * Purpose:     Determines whether an object ID represents a native VOL
  *              connector object.
  *
- * Return:      Success:    TRUE/FALSE
- *              Failure:    FAIL
+ * Return:      Non-negative on success/Negative on failure
  *
  *---------------------------------------------------------------------------
  */
-hbool_t
-H5VLobject_is_native(hid_t obj_id)
+herr_t
+H5VLobject_is_native(hid_t obj_id, hbool_t *is_native)
 {
     H5VL_object_t *vol_obj   = NULL;
-    hbool_t        ret_value = FALSE;
+    herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_API(FALSE)
-    H5TRACE1("b", "i", obj_id);
+    FUNC_ENTER_API(FAIL)
+    H5TRACE2("e", "i*b", obj_id, is_native);
+
+    if (!is_native)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "`is_native` argument is NULL")
 
     /* Get the location object for the ID */
     if (NULL == (vol_obj = H5VL_vol_object(obj_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid object identifier")
 
-    if (H5VL_object_is_native(vol_obj, &ret_value) < 0)
+    if (H5VL_object_is_native(vol_obj, is_native) < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTGET, FAIL, "can't determine if object is a native connector object")
 
 done:

--- a/src/H5VLpublic.h
+++ b/src/H5VLpublic.h
@@ -362,11 +362,13 @@ H5_DLL herr_t H5VLquery_optional(hid_t obj_id, H5VL_subclass_t subcls, int opt_t
  *        VOL connector object.
  *
  * \param[in] obj_id Object identifier
- * \return \hbool_t
+ * \param[in] is_native Boolean determining whether object is a native
+ *            VOL connector object
+ * \return \herr_t
  *
- * \since 1.12.1
+ * \since 1.13.0
  */
-H5_DLL hbool_t H5VLobject_is_native(hid_t obj_id);
+H5_DLL herr_t H5VLobject_is_native(hid_t obj_id, hbool_t *is_native);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes "comparison of constant 0 to boolean expression is always false" caused by trying to check for errors from H5DSwith_new_ref and H5VLobject_is_native that both previously returned hbool_t. Both of these APIs are new for 1.13, so changing their signatures shouldn't be a problem.