### PR TITLE
Quiets most const warnings in the fractal heap code

### DIFF
--- a/src/H5HF.c
+++ b/src/H5HF.c
@@ -114,8 +114,14 @@ H5HF__op_write(const void *obj, size_t obj_len, void *op_data)
 {
     FUNC_ENTER_PACKAGE_NOERR
 
-    /* Perform "write", using memcpy() */
-    H5MM_memcpy((void *)obj, op_data, obj_len); /* Casting away const OK -QAK */
+    /* Perform "write", using memcpy()
+     *
+     * We cast away const here because no obj pointer that was originally
+     * const should ever arrive here.
+     */
+    H5_GCC_CLANG_DIAG_OFF("cast-qual")
+    H5MM_memcpy((void *)obj, op_data, obj_len);
+    H5_GCC_CLANG_DIAG_ON("cast-qual")
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5HF__op_write() */
@@ -347,10 +353,15 @@ H5HF_insert(H5HF_t *fh, size_t size, const void *obj, void *id /*out*/)
 
     /* Check for 'huge' object */
     if (size > hdr->max_man_size) {
-        /* Store 'huge' object in heap */
-        /* (Casting away const OK - QAK) */
+        /* Store 'huge' object in heap
+         *
+         * Although not ideal, we can quiet the const warning here becuase no
+         * obj pointer that was originally const should ever arrive here.
+         */
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
         if (H5HF__huge_insert(hdr, size, (void *)obj, id) < 0)
             HGOTO_ERROR(H5E_HEAP, H5E_CANTINSERT, FAIL, "can't store 'huge' object in fractal heap")
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
     } /* end if */
     /* Check for 'tiny' object */
     else if (size <= hdr->tiny_max_len) {

--- a/src/H5HFcache.c
+++ b/src/H5HFcache.c
@@ -1655,9 +1655,15 @@ H5HF__cache_dblock_verify_chksum(const void *_image, size_t len, void *_udata)
         /* Update info about direct block */
         udata->decompressed = TRUE;
         len                 = nbytes;
-    } /* end if */
-    else
-        read_buf = (void *)image; /* Casting away const OK - QAK */
+    }
+    else {
+        /* If the data are unfiltered, we just point to the image, which we
+         * never modify. Casting away const is okay here.
+         */
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
+        read_buf = (void *)image;
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
+    }
 
     /* Decode checksum */
     chk_size = (size_t)(H5HF_MAN_ABS_DIRECT_OVERHEAD(hdr) - H5HF_SIZEOF_CHKSUM);

--- a/src/H5HFman.c
+++ b/src/H5HFman.c
@@ -487,10 +487,16 @@ H5HF__man_write(H5HF_hdr_t *hdr, const uint8_t *id, const void *obj)
     HDassert(id);
     HDassert(obj);
 
-    /* Call the internal 'op' routine routine */
-    /* (Casting away const OK - QAK) */
+    /* Call the internal 'op' routine routine
+     *
+     * In this case, the callback operation needs to modify the obj buffer that
+     * was passed in as const. We quiet the warning here because an obj pointer
+     * that was originally const should *never* arrive here.
+     */
+    H5_GCC_CLANG_DIAG_OFF("cast-qual")
     if (H5HF__man_op_real(hdr, id, H5HF__op_write, (void *)obj, H5HF_OP_MODIFY) < 0)
         HGOTO_ERROR(H5E_HEAP, H5E_CANTOPERATE, FAIL, "unable to operate on heap object")
+    H5_GCC_CLANG_DIAG_ON("cast-qual")
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)


### PR DESCRIPTION
The biggest problem here is the 'generic operation' scheme that combines a const void pointer to arbitrary data + a callback that can sometimes modify said arbitrary data, thus undermining the const-ness in certain cases. Since nobody is going to rearchitect this scheme anytime soon, I've at least quieted the warnings that we know are not a problem since the "sometimes const" pointers won't be modified when they point to const data given the existing code.

In case anyone is wondering, making the operation callbacks simply take a non-const pointer is a bit like pulling on the loose yarn in a sweater. I started going down this road, but I think this is a more minimalist and cleaner solution for now.

I left the file pointer const warnings in the cache client code alone. That's a can of worms I'm unwilling to touch at this time and I also don't want to just glibly turn off the cast warnings.