### PR TITLE
Move -Werror=int-conversion from error-general to error-5

### DIFF
--- a/config/gnu-warnings/error-5
+++ b/config/gnu-warnings/error-5
@@ -1,4 +1,5 @@
 -Werror=incompatible-pointer-types
+-Werror=int-conversion
 #
 # In GCC 4.4.7, the compiler gripes about shadowed global
 # declarations when a local variable uses the name of a

--- a/config/gnu-warnings/error-general
+++ b/config/gnu-warnings/error-general
@@ -12,7 +12,6 @@
 -Werror=pointer-sign
 -Werror=pointer-to-int-cast
 -Werror=int-to-pointer-cast
--Werror=int-conversion
 -Werror=redundant-decls
 -Werror=strict-prototypes
 -Werror=switch


### PR DESCRIPTION
 in gnu-warnings (unrecognized command line option for gcc 4.85/4.93).