### PR TITLE
Stop lying about H5S_t const-ness

### DIFF
--- a/src/H5Dcompact.c
+++ b/src/H5Dcompact.c
@@ -64,8 +64,7 @@ typedef struct H5D_compact_iovv_memmanage_ud_t {
 static herr_t  H5D__compact_construct(H5F_t *f, H5D_t *dset);
 static hbool_t H5D__compact_is_space_alloc(const H5O_storage_t *storage);
 static herr_t  H5D__compact_io_init(const H5D_io_info_t *io_info, const H5D_type_info_t *type_info,
-                                    hsize_t nelmts, const H5S_t *file_space, const H5S_t *mem_space,
-                                    H5D_chunk_map_t *cm);
+                                    hsize_t nelmts, H5S_t *file_space, H5S_t *mem_space, H5D_chunk_map_t *cm);
 static herr_t  H5D__compact_iovv_memmanage_cb(hsize_t dst_off, hsize_t src_off, size_t len, void *_udata);
 static ssize_t H5D__compact_readvv(const H5D_io_info_t *io_info, size_t dset_max_nseq, size_t *dset_curr_seq,
                                    size_t dset_size_arr[], hsize_t dset_offset_arr[], size_t mem_max_nseq,
@@ -81,13 +80,24 @@ static herr_t  H5D__compact_dest(H5D_t *dset);
 /*********************/
 
 /* Compact storage layout I/O ops */
-const H5D_layout_ops_t H5D_LOPS_COMPACT[1] = {
-    {H5D__compact_construct, NULL, H5D__compact_is_space_alloc, NULL, H5D__compact_io_init, H5D__contig_read,
-     H5D__contig_write,
+const H5D_layout_ops_t H5D_LOPS_COMPACT[1] = {{
+    H5D__compact_construct,      /* construct */
+    NULL,                        /* init */
+    H5D__compact_is_space_alloc, /* is_space_alloc */
+    NULL,                        /* is_data_cached */
+    H5D__compact_io_init,        /* io_init */
+    H5D__contig_read,            /* ser_read */
+    H5D__contig_write,           /* ser_write */
 #ifdef H5_HAVE_PARALLEL
-     NULL, NULL,
-#endif /* H5_HAVE_PARALLEL */
-     H5D__compact_readvv, H5D__compact_writevv, H5D__compact_flush, NULL, H5D__compact_dest}};
+    NULL, /* par_read */
+    NULL, /* par_write */
+#endif
+    H5D__compact_readvv,  /* readvv */
+    H5D__compact_writevv, /* writevv */
+    H5D__compact_flush,   /* flush */
+    NULL,                 /* io_term */
+    H5D__compact_dest     /* dest */
+}};
 
 /*******************/
 /* Local Variables */
@@ -238,8 +248,8 @@ H5D__compact_is_space_alloc(const H5O_storage_t H5_ATTR_UNUSED *storage)
  */
 static herr_t
 H5D__compact_io_init(const H5D_io_info_t *io_info, const H5D_type_info_t H5_ATTR_UNUSED *type_info,
-                     hsize_t H5_ATTR_UNUSED nelmts, const H5S_t H5_ATTR_UNUSED *file_space,
-                     const H5S_t H5_ATTR_UNUSED *mem_space, H5D_chunk_map_t H5_ATTR_UNUSED *cm)
+                     hsize_t H5_ATTR_UNUSED nelmts, H5S_t H5_ATTR_UNUSED *file_space,
+                     H5S_t H5_ATTR_UNUSED *mem_space, H5D_chunk_map_t H5_ATTR_UNUSED *cm)
 {
     FUNC_ENTER_STATIC_NOERR
 

--- a/src/H5Dcontig.c
+++ b/src/H5Dcontig.c
@@ -91,8 +91,7 @@ typedef struct H5D_contig_writevv_ud_t {
 static herr_t  H5D__contig_construct(H5F_t *f, H5D_t *dset);
 static herr_t  H5D__contig_init(H5F_t *f, const H5D_t *dset, hid_t dapl_id);
 static herr_t  H5D__contig_io_init(const H5D_io_info_t *io_info, const H5D_type_info_t *type_info,
-                                   hsize_t nelmts, const H5S_t *file_space, const H5S_t *mem_space,
-                                   H5D_chunk_map_t *cm);
+                                   hsize_t nelmts, H5S_t *file_space, H5S_t *mem_space, H5D_chunk_map_t *cm);
 static ssize_t H5D__contig_readvv(const H5D_io_info_t *io_info, size_t dset_max_nseq, size_t *dset_curr_seq,
                                   size_t dset_len_arr[], hsize_t dset_offset_arr[], size_t mem_max_nseq,
                                   size_t *mem_curr_seq, size_t mem_len_arr[], hsize_t mem_offset_arr[]);
@@ -109,13 +108,24 @@ static herr_t H5D__contig_write_one(H5D_io_info_t *io_info, hsize_t offset, size
 /*********************/
 
 /* Contiguous storage layout I/O ops */
-const H5D_layout_ops_t H5D_LOPS_CONTIG[1] = {
-    {H5D__contig_construct, H5D__contig_init, H5D__contig_is_space_alloc, H5D__contig_is_data_cached,
-     H5D__contig_io_init, H5D__contig_read, H5D__contig_write,
+const H5D_layout_ops_t H5D_LOPS_CONTIG[1] = {{
+    H5D__contig_construct,      /* construct */
+    H5D__contig_init,           /* init */
+    H5D__contig_is_space_alloc, /* is_space_alloc */
+    H5D__contig_is_data_cached, /* is_data_cached */
+    H5D__contig_io_init,        /* io_init */
+    H5D__contig_read,           /* ser_read */
+    H5D__contig_write,          /* ser_write */
 #ifdef H5_HAVE_PARALLEL
-     H5D__contig_collective_read, H5D__contig_collective_write,
-#endif /* H5_HAVE_PARALLEL */
-     H5D__contig_readvv, H5D__contig_writevv, H5D__contig_flush, NULL, NULL}};
+    H5D__contig_collective_read,  /* par_read */
+    H5D__contig_collective_write, /* par_write */
+#endif
+    H5D__contig_readvv,  /* readvv */
+    H5D__contig_writevv, /* writevv */
+    H5D__contig_flush,   /* flush */
+    NULL,                /* io_term */
+    NULL                 /* dest */
+}};
 
 /*******************/
 /* Local Variables */
@@ -550,8 +560,8 @@ H5D__contig_is_data_cached(const H5D_shared_t *shared_dset)
  */
 static herr_t
 H5D__contig_io_init(const H5D_io_info_t *io_info, const H5D_type_info_t H5_ATTR_UNUSED *type_info,
-                    hsize_t H5_ATTR_UNUSED nelmts, const H5S_t H5_ATTR_UNUSED *file_space,
-                    const H5S_t H5_ATTR_UNUSED *mem_space, H5D_chunk_map_t H5_ATTR_UNUSED *cm)
+                    hsize_t H5_ATTR_UNUSED nelmts, H5S_t H5_ATTR_UNUSED *file_space,
+                    H5S_t H5_ATTR_UNUSED *mem_space, H5D_chunk_map_t H5_ATTR_UNUSED *cm)
 {
     FUNC_ENTER_STATIC_NOERR
 
@@ -574,8 +584,8 @@ H5D__contig_io_init(const H5D_io_info_t *io_info, const H5D_type_info_t H5_ATTR_
  *-------------------------------------------------------------------------
  */
 herr_t
-H5D__contig_read(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize_t nelmts,
-                 const H5S_t *file_space, const H5S_t *mem_space, H5D_chunk_map_t H5_ATTR_UNUSED *fm)
+H5D__contig_read(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize_t nelmts, H5S_t *file_space,
+                 H5S_t *mem_space, H5D_chunk_map_t H5_ATTR_UNUSED *fm)
 {
     herr_t ret_value = SUCCEED; /*return value		*/
 
@@ -609,8 +619,8 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5D__contig_write(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize_t nelmts,
-                  const H5S_t *file_space, const H5S_t *mem_space, H5D_chunk_map_t H5_ATTR_UNUSED *fm)
+H5D__contig_write(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize_t nelmts, H5S_t *file_space,
+                  H5S_t *mem_space, H5D_chunk_map_t H5_ATTR_UNUSED *fm)
 {
     herr_t ret_value = SUCCEED; /*return value		*/
 

--- a/src/H5Defl.c
+++ b/src/H5Defl.c
@@ -62,7 +62,7 @@ typedef struct H5D_efl_writevv_ud_t {
 /* Layout operation callbacks */
 static herr_t H5D__efl_construct(H5F_t *f, H5D_t *dset);
 static herr_t H5D__efl_io_init(const H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize_t nelmts,
-                               const H5S_t *file_space, const H5S_t *mem_space, H5D_chunk_map_t *cm);
+                               H5S_t *file_space, H5S_t *mem_space, H5D_chunk_map_t *cm);
 static ssize_t H5D__efl_readvv(const H5D_io_info_t *io_info, size_t dset_max_nseq, size_t *dset_curr_seq,
                                size_t dset_len_arr[], hsize_t dset_offset_arr[], size_t mem_max_nseq,
                                size_t *mem_curr_seq, size_t mem_len_arr[], hsize_t mem_offset_arr[]);
@@ -80,12 +80,24 @@ static herr_t H5D__efl_write(const H5O_efl_t *efl, const H5D_t *dset, haddr_t ad
 /*********************/
 
 /* External File List (EFL) storage layout I/O ops */
-const H5D_layout_ops_t H5D_LOPS_EFL[1] = {{H5D__efl_construct, NULL, H5D__efl_is_space_alloc, NULL,
-                                           H5D__efl_io_init, H5D__contig_read, H5D__contig_write,
+const H5D_layout_ops_t H5D_LOPS_EFL[1] = {{
+    H5D__efl_construct,      /* construct */
+    NULL,                    /* init */
+    H5D__efl_is_space_alloc, /* is_space_alloc */
+    NULL,                    /* is_data_cached */
+    H5D__efl_io_init,        /* io_init */
+    H5D__contig_read,        /* ser_read */
+    H5D__contig_write,       /* ser_write */
 #ifdef H5_HAVE_PARALLEL
-                                           NULL, NULL,
-#endif /* H5_HAVE_PARALLEL */
-                                           H5D__efl_readvv, H5D__efl_writevv, NULL, NULL, NULL}};
+    NULL, /* par_read */
+    NULL, /* par_write */
+#endif
+    H5D__efl_readvv,  /* readvv */
+    H5D__efl_writevv, /* writevv */
+    NULL,             /* flush */
+    NULL,             /* io_term */
+    NULL              /* dest */
+}};
 
 /*******************/
 /* Local Variables */
@@ -198,8 +210,8 @@ H5D__efl_is_space_alloc(const H5O_storage_t H5_ATTR_UNUSED *storage)
  */
 static herr_t
 H5D__efl_io_init(const H5D_io_info_t *io_info, const H5D_type_info_t H5_ATTR_UNUSED *type_info,
-                 hsize_t H5_ATTR_UNUSED nelmts, const H5S_t H5_ATTR_UNUSED *file_space,
-                 const H5S_t H5_ATTR_UNUSED *mem_space, H5D_chunk_map_t H5_ATTR_UNUSED *cm)
+                 hsize_t H5_ATTR_UNUSED nelmts, H5S_t H5_ATTR_UNUSED *file_space,
+                 H5S_t H5_ATTR_UNUSED *mem_space, H5D_chunk_map_t H5_ATTR_UNUSED *cm)
 {
     FUNC_ENTER_STATIC_NOERR
 

--- a/src/H5Dfill.c
+++ b/src/H5Dfill.c
@@ -112,7 +112,7 @@ H5FL_EXTERN(H5S_sel_iter_t);
     on each element so that each of them has a copy of the VL data.
 --------------------------------------------------------------------------*/
 herr_t
-H5D__fill(const void *fill, const H5T_t *fill_type, void *buf, const H5T_t *buf_type, const H5S_t *space)
+H5D__fill(const void *fill, const H5T_t *fill_type, void *buf, const H5T_t *buf_type, H5S_t *space)
 {
     H5S_sel_iter_t *mem_iter      = NULL;  /* Memory selection iteration info */
     hbool_t         mem_iter_init = FALSE; /* Whether the memory selection iterator has been initialized */

--- a/src/H5Dio.c
+++ b/src/H5Dio.c
@@ -82,8 +82,7 @@ H5FL_DEFINE(H5D_chunk_map_t);
  *-------------------------------------------------------------------------
  */
 herr_t
-H5D__read(H5D_t *dataset, hid_t mem_type_id, const H5S_t *mem_space, const H5S_t *file_space,
-          void *buf /*out*/)
+H5D__read(H5D_t *dataset, hid_t mem_type_id, H5S_t *mem_space, H5S_t *file_space, void *buf /*out*/)
 {
     H5D_chunk_map_t *fm = NULL;                   /* Chunk file<->memory mapping */
     H5D_io_info_t    io_info;                     /* Dataset I/O info     */
@@ -295,8 +294,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5D__write(H5D_t *dataset, hid_t mem_type_id, const H5S_t *mem_space, const H5S_t *file_space,
-           const void *buf)
+H5D__write(H5D_t *dataset, hid_t mem_type_id, H5S_t *mem_space, H5S_t *file_space, const void *buf)
 {
     H5D_chunk_map_t *fm = NULL;                   /* Chunk file<->memory mapping */
     H5D_io_info_t    io_info;                     /* Dataset I/O info     */

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -123,13 +123,12 @@ typedef hbool_t (*H5D_layout_is_space_alloc_func_t)(const H5O_storage_t *storage
 typedef hbool_t (*H5D_layout_is_data_cached_func_t)(const H5D_shared_t *shared_dset);
 typedef herr_t (*H5D_layout_io_init_func_t)(const struct H5D_io_info_t *io_info,
                                             const H5D_type_info_t *type_info, hsize_t nelmts,
-                                            const H5S_t *file_space, const H5S_t *mem_space,
-                                            struct H5D_chunk_map_t *cm);
+                                            H5S_t *file_space, H5S_t *mem_space, struct H5D_chunk_map_t *cm);
 typedef herr_t (*H5D_layout_read_func_t)(struct H5D_io_info_t *io_info, const H5D_type_info_t *type_info,
-                                         hsize_t nelmts, const H5S_t *file_space, const H5S_t *mem_space,
+                                         hsize_t nelmts, H5S_t *file_space, H5S_t *mem_space,
                                          struct H5D_chunk_map_t *fm);
 typedef herr_t (*H5D_layout_write_func_t)(struct H5D_io_info_t *io_info, const H5D_type_info_t *type_info,
-                                          hsize_t nelmts, const H5S_t *file_space, const H5S_t *mem_space,
+                                          hsize_t nelmts, H5S_t *file_space, H5S_t *mem_space,
                                           struct H5D_chunk_map_t *fm);
 typedef ssize_t (*H5D_layout_readvv_func_t)(const struct H5D_io_info_t *io_info, size_t dset_max_nseq,
                                             size_t *dset_curr_seq, size_t dset_len_arr[],
@@ -170,10 +169,10 @@ typedef struct H5D_layout_ops_t {
 /* Function pointers for either multiple or single block I/O access */
 typedef herr_t (*H5D_io_single_read_func_t)(const struct H5D_io_info_t *io_info,
                                             const H5D_type_info_t *type_info, hsize_t nelmts,
-                                            const H5S_t *file_space, const H5S_t *mem_space);
+                                            H5S_t *file_space, H5S_t *mem_space);
 typedef herr_t (*H5D_io_single_write_func_t)(const struct H5D_io_info_t *io_info,
                                              const H5D_type_info_t *type_info, hsize_t nelmts,
-                                             const H5S_t *file_space, const H5S_t *mem_space);
+                                             H5S_t *file_space, H5S_t *mem_space);
 
 /* Typedef for raw data I/O framework info */
 typedef struct H5D_io_ops_t {
@@ -346,10 +345,10 @@ typedef struct H5D_chunk_map_t {
     H5O_layout_t *layout; /* Dataset layout information*/
     hsize_t       nelmts; /* Number of elements selected in file & memory dataspaces */
 
-    const H5S_t *file_space; /* Pointer to the file dataspace */
-    unsigned     f_ndims;    /* Number of dimensions for file dataspace */
+    H5S_t *  file_space; /* Pointer to the file dataspace */
+    unsigned f_ndims;    /* Number of dimensions for file dataspace */
 
-    const H5S_t *  mem_space;   /* Pointer to the memory dataspace */
+    H5S_t *        mem_space;   /* Pointer to the memory dataspace */
     H5S_t *        mchunk_tmpl; /* Dataspace template for new memory chunks */
     H5S_sel_iter_t mem_iter;    /* Iterator for elements in memory selection */
     unsigned       m_ndims;     /* Number of dimensions for memory dataspace */
@@ -581,25 +580,25 @@ H5_DLL herr_t  H5D__refresh(H5D_t *dataset, hid_t dset_id);
 H5_DLL herr_t H5D__format_convert(H5D_t *dataset);
 
 /* Internal I/O routines */
-H5_DLL herr_t H5D__read(H5D_t *dataset, hid_t mem_type_id, const H5S_t *mem_space, const H5S_t *file_space,
+H5_DLL herr_t H5D__read(H5D_t *dataset, hid_t mem_type_id, H5S_t *mem_space, H5S_t *file_space,
                         void *buf /*out*/);
-H5_DLL herr_t H5D__write(H5D_t *dataset, hid_t mem_type_id, const H5S_t *mem_space, const H5S_t *file_space,
+H5_DLL herr_t H5D__write(H5D_t *dataset, hid_t mem_type_id, H5S_t *mem_space, H5S_t *file_space,
                          const void *buf);
 
 /* Functions that perform direct serial I/O operations */
 H5_DLL herr_t H5D__select_read(const H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize_t nelmts,
-                               const H5S_t *file_space, const H5S_t *mem_space);
+                               H5S_t *file_space, H5S_t *mem_space);
 H5_DLL herr_t H5D__select_write(const H5D_io_info_t *io_info, const H5D_type_info_t *type_info,
-                                hsize_t nelmts, const H5S_t *file_space, const H5S_t *mem_space);
+                                hsize_t nelmts, H5S_t *file_space, H5S_t *mem_space);
 
 /* Functions that perform scatter-gather serial I/O operations */
 H5_DLL herr_t H5D__scatter_mem(const void *_tscat_buf, H5S_sel_iter_t *iter, size_t nelmts, void *_buf);
 H5_DLL size_t H5D__gather_mem(const void *_buf, H5S_sel_iter_t *iter, size_t nelmts,
                               void *_tgath_buf /*out*/);
 H5_DLL herr_t H5D__scatgath_read(const H5D_io_info_t *io_info, const H5D_type_info_t *type_info,
-                                 hsize_t nelmts, const H5S_t *file_space, const H5S_t *mem_space);
+                                 hsize_t nelmts, H5S_t *file_space, H5S_t *mem_space);
 H5_DLL herr_t H5D__scatgath_write(const H5D_io_info_t *io_info, const H5D_type_info_t *type_info,
-                                  hsize_t nelmts, const H5S_t *file_space, const H5S_t *mem_space);
+                                  hsize_t nelmts, H5S_t *file_space, H5S_t *mem_space);
 
 /* Functions that operate on dataset's layout information */
 H5_DLL herr_t H5D__layout_set_io_ops(const H5D_t *dataset);
@@ -617,9 +616,9 @@ H5_DLL hbool_t H5D__contig_is_space_alloc(const H5O_storage_t *storage);
 H5_DLL hbool_t H5D__contig_is_data_cached(const H5D_shared_t *shared_dset);
 H5_DLL herr_t  H5D__contig_fill(const H5D_io_info_t *io_info);
 H5_DLL herr_t  H5D__contig_read(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize_t nelmts,
-                                const H5S_t *file_space, const H5S_t *mem_space, H5D_chunk_map_t *fm);
+                                H5S_t *file_space, H5S_t *mem_space, H5D_chunk_map_t *fm);
 H5_DLL herr_t  H5D__contig_write(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize_t nelmts,
-                                 const H5S_t *file_space, const H5S_t *mem_space, H5D_chunk_map_t *fm);
+                                 H5S_t *file_space, H5S_t *mem_space, H5D_chunk_map_t *fm);
 H5_DLL herr_t  H5D__contig_copy(H5F_t *f_src, const H5O_storage_contig_t *storage_src, H5F_t *f_dst,
                                 H5O_storage_contig_t *storage_dst, H5T_t *src_dtype, H5O_copy_t *cpy_info);
 H5_DLL herr_t  H5D__contig_delete(H5F_t *f, const H5O_storage_t *store);
@@ -686,7 +685,7 @@ H5_DLL herr_t  H5D__efl_bh_info(H5F_t *f, H5O_efl_t *efl, hsize_t *heap_size);
 
 /* Functions that perform fill value operations on datasets */
 H5_DLL herr_t H5D__fill(const void *fill, const H5T_t *fill_type, void *buf, const H5T_t *buf_type,
-                        const H5S_t *space);
+                        H5S_t *space);
 H5_DLL herr_t H5D__fill_init(H5D_fill_buf_info_t *fb_info, void *caller_fill_buf, H5MM_allocate_t alloc_func,
                              void *alloc_info, H5MM_free_t free_func, void *free_info, const H5O_fill_t *fill,
                              const H5T_t *dset_type, hid_t dset_type_id, size_t nelmts, size_t min_buf_size);

--- a/src/H5Dscatgath.c
+++ b/src/H5Dscatgath.c
@@ -437,7 +437,7 @@ done:
  */
 herr_t
 H5D__scatgath_read(const H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize_t nelmts,
-                   const H5S_t *file_space, const H5S_t *mem_space)
+                   H5S_t *file_space, H5S_t *mem_space)
 {
     void *          buf            = io_info->u.rbuf; /* Local pointer to application buffer */
     H5S_sel_iter_t *mem_iter       = NULL;            /* Memory selection iteration info*/
@@ -577,7 +577,7 @@ done:
  */
 herr_t
 H5D__scatgath_write(const H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize_t nelmts,
-                    const H5S_t *file_space, const H5S_t *mem_space)
+                    H5S_t *file_space, H5S_t *mem_space)
 {
     const void *    buf            = io_info->u.wbuf; /* Local pointer to application buffer */
     H5S_sel_iter_t *mem_iter       = NULL;            /* Memory selection iteration info*/

--- a/src/H5Dselect.c
+++ b/src/H5Dselect.c
@@ -44,8 +44,8 @@
 /* Local Prototypes */
 /********************/
 
-static herr_t H5D__select_io(const H5D_io_info_t *io_info, size_t elmt_size, size_t nelmts,
-                             const H5S_t *file_space, const H5S_t *mem_space);
+static herr_t H5D__select_io(const H5D_io_info_t *io_info, size_t elmt_size, size_t nelmts, H5S_t *file_space,
+                             H5S_t *mem_space);
 
 /*********************/
 /* Package Variables */
@@ -77,8 +77,8 @@ H5FL_EXTERN(H5S_sel_iter_t);
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__select_io(const H5D_io_info_t *io_info, size_t elmt_size, size_t nelmts, const H5S_t *file_space,
-               const H5S_t *mem_space)
+H5D__select_io(const H5D_io_info_t *io_info, size_t elmt_size, size_t nelmts, H5S_t *file_space,
+               H5S_t *mem_space)
 {
     H5S_sel_iter_t *mem_iter       = NULL;  /* Memory selection iteration info */
     hbool_t         mem_iter_init  = FALSE; /* Memory selection iteration info has been initialized */
@@ -270,7 +270,7 @@ done:
  */
 herr_t
 H5D__select_read(const H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize_t nelmts,
-                 const H5S_t *file_space, const H5S_t *mem_space)
+                 H5S_t *file_space, H5S_t *mem_space)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
@@ -299,7 +299,7 @@ done:
  */
 herr_t
 H5D__select_write(const H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize_t nelmts,
-                  const H5S_t *file_space, const H5S_t *mem_space)
+                  H5S_t *file_space, H5S_t *mem_space)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 

--- a/src/H5Pdxpl.c
+++ b/src/H5Pdxpl.c
@@ -2213,10 +2213,18 @@ H5P__dxfr_dset_io_hyp_sel_cmp(const void *_space1, const void *_space2, size_t H
         if (TRUE != H5S_extent_equal(*space1, *space2))
             HGOTO_DONE(-1);
 
-        /* Compare the selection "shape" of the dataspaces */
-        /* (Error & not-equal count the same) */
-        if (TRUE != H5S_select_shape_same(*space1, *space2))
+        /* Compare the selection "shape" of the dataspaces
+         * (Error & not-equal count the same)
+         *
+         * Since H5S_select_shape_same() can result in the dataspaces being
+         * rebuilt, the parameters are not const which makes it impossible
+         * to match the cmp prototype. Since we need to compare them,
+         * we quiet the const warning.
+         */
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
+        if (TRUE != H5S_select_shape_same((H5S_t *)*space1, (H5S_t *)*space2))
             HGOTO_DONE(-1);
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
     } /* end if */
 
 done:

--- a/src/H5Sall.c
+++ b/src/H5Sall.c
@@ -49,22 +49,22 @@
 static herr_t   H5S__all_copy(H5S_t *dst, const H5S_t *src, hbool_t share_selection);
 static herr_t   H5S__all_release(H5S_t *space);
 static htri_t   H5S__all_is_valid(const H5S_t *space);
-static hssize_t H5S__all_serial_size(const H5S_t *space);
-static herr_t   H5S__all_serialize(const H5S_t *space, uint8_t **p);
+static hssize_t H5S__all_serial_size(H5S_t *space);
+static herr_t   H5S__all_serialize(H5S_t *space, uint8_t **p);
 static herr_t   H5S__all_deserialize(H5S_t **space, const uint8_t **p);
 static herr_t   H5S__all_bounds(const H5S_t *space, hsize_t *start, hsize_t *end);
 static herr_t   H5S__all_offset(const H5S_t *space, hsize_t *off);
 static int      H5S__all_unlim_dim(const H5S_t *space);
 static htri_t   H5S__all_is_contiguous(const H5S_t *space);
 static htri_t   H5S__all_is_single(const H5S_t *space);
-static htri_t   H5S__all_is_regular(const H5S_t *space);
-static htri_t   H5S__all_shape_same(const H5S_t *space1, const H5S_t *space2);
-static htri_t   H5S__all_intersect_block(const H5S_t *space, const hsize_t *start, const hsize_t *end);
+static htri_t   H5S__all_is_regular(H5S_t *space);
+static htri_t   H5S__all_shape_same(H5S_t *space1, H5S_t *space2);
+static htri_t   H5S__all_intersect_block(H5S_t *space, const hsize_t *start, const hsize_t *end);
 static herr_t   H5S__all_adjust_u(H5S_t *space, const hsize_t *offset);
 static herr_t   H5S__all_adjust_s(H5S_t *space, const hssize_t *offset);
 static herr_t   H5S__all_project_scalar(const H5S_t *space, hsize_t *offset);
 static herr_t   H5S__all_project_simple(const H5S_t *space, H5S_t *new_space, hsize_t *offset);
-static herr_t   H5S__all_iter_init(const H5S_t *space, H5S_sel_iter_t *iter);
+static herr_t   H5S__all_iter_init(H5S_t *space, H5S_sel_iter_t *iter);
 
 /* Selection iteration callbacks */
 static herr_t  H5S__all_iter_coords(const H5S_sel_iter_t *iter, hsize_t *coords);
@@ -144,7 +144,7 @@ static const H5S_sel_iter_class_t H5S_sel_iter_all[1] = {{
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5S__all_iter_init(const H5S_t H5_ATTR_UNUSED *space, H5S_sel_iter_t *iter)
+H5S__all_iter_init(H5S_t H5_ATTR_UNUSED *space, H5S_sel_iter_t *iter)
 {
     FUNC_ENTER_STATIC_NOERR
 
@@ -557,7 +557,7 @@ H5S__all_is_valid(const H5S_t H5_ATTR_UNUSED *space)
  REVISION LOG
 --------------------------------------------------------------------------*/
 static hssize_t
-H5S__all_serial_size(const H5S_t H5_ATTR_UNUSED *space)
+H5S__all_serial_size(H5S_t H5_ATTR_UNUSED *space)
 {
     FUNC_ENTER_STATIC_NOERR
 
@@ -577,7 +577,7 @@ H5S__all_serial_size(const H5S_t H5_ATTR_UNUSED *space)
     Serialize the current selection into a user-provided buffer.
  USAGE
     herr_t H5S__all_serialize(space, p)
-        const H5S_t *space;     IN: Dataspace with selection to serialize
+        H5S_t *space;           IN: Dataspace with selection to serialize
         uint8_t **p;            OUT: Pointer to buffer to put serialized
                                 selection.  Will be advanced to end of
                                 serialized selection.
@@ -592,7 +592,7 @@ H5S__all_serial_size(const H5S_t H5_ATTR_UNUSED *space)
  REVISION LOG
 --------------------------------------------------------------------------*/
 static herr_t
-H5S__all_serialize(const H5S_t *space, uint8_t **p)
+H5S__all_serialize(H5S_t *space, uint8_t **p)
 {
     uint8_t *pp = (*p); /* Local pointer for decoding */
 
@@ -864,7 +864,7 @@ H5S__all_is_single(const H5S_t H5_ATTR_UNUSED *space)
     Check if a "all" selection is "regular"
  USAGE
     htri_t H5S__all_is_regular(space)
-        const H5S_t *space;     IN: Dataspace pointer to check
+        H5S_t *space;     IN: Dataspace pointer to check
  RETURNS
     TRUE/FALSE/FAIL
  DESCRIPTION
@@ -877,7 +877,7 @@ H5S__all_is_single(const H5S_t H5_ATTR_UNUSED *space)
  REVISION LOG
 --------------------------------------------------------------------------*/
 static htri_t
-H5S__all_is_regular(const H5S_t H5_ATTR_UNUSED *space)
+H5S__all_is_regular(H5S_t H5_ATTR_UNUSED *space)
 {
     FUNC_ENTER_STATIC_NOERR
 
@@ -894,8 +894,8 @@ H5S__all_is_regular(const H5S_t H5_ATTR_UNUSED *space)
     Check if a two "all" selections are the same shape
  USAGE
     htri_t H5S__all_shape_same(space1, space2)
-        const H5S_t *space1;     IN: First dataspace to check
-        const H5S_t *space2;     IN: Second dataspace to check
+        H5S_t *space1;           IN: First dataspace to check
+        H5S_t *space2;           IN: Second dataspace to check
  RETURNS
     TRUE / FALSE / FAIL
  DESCRIPTION
@@ -907,7 +907,7 @@ H5S__all_is_regular(const H5S_t H5_ATTR_UNUSED *space)
  REVISION LOG
 --------------------------------------------------------------------------*/
 static htri_t
-H5S__all_shape_same(const H5S_t *space1, const H5S_t *space2)
+H5S__all_shape_same(H5S_t *space1, H5S_t *space2)
 {
     int    space1_dim;       /* Current dimension in first dataspace */
     int    space2_dim;       /* Current dimension in second dataspace */
@@ -957,7 +957,7 @@ done:
     Detect intersections of selection with block
  USAGE
     htri_t H5S__all_intersect_block(space, start, end)
-        const H5S_t *space;     IN: Dataspace with selection to use
+        H5S_t *space;           IN: Dataspace with selection to use
         const hsize_t *start;   IN: Starting coordinate for block
         const hsize_t *end;     IN: Ending coordinate for block
  RETURNS
@@ -970,7 +970,7 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 htri_t
-H5S__all_intersect_block(const H5S_t H5_ATTR_UNUSED *space, const hsize_t H5_ATTR_UNUSED *start,
+H5S__all_intersect_block(H5S_t H5_ATTR_UNUSED *space, const hsize_t H5_ATTR_UNUSED *start,
                          const hsize_t H5_ATTR_UNUSED *end)
 {
     FUNC_ENTER_STATIC_NOERR

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -173,8 +173,8 @@ static herr_t   H5S__hyper_copy(H5S_t *dst, const H5S_t *src, hbool_t share_sele
 static herr_t   H5S__hyper_release(H5S_t *space);
 static htri_t   H5S__hyper_is_valid(const H5S_t *space);
 static hsize_t  H5S__hyper_span_nblocks(H5S_hyper_span_info_t *spans);
-static hssize_t H5S__hyper_serial_size(const H5S_t *space);
-static herr_t   H5S__hyper_serialize(const H5S_t *space, uint8_t **p);
+static hssize_t H5S__hyper_serial_size(H5S_t *space);
+static herr_t   H5S__hyper_serialize(H5S_t *space, uint8_t **p);
 static herr_t   H5S__hyper_deserialize(H5S_t **space, const uint8_t **p);
 static herr_t   H5S__hyper_bounds(const H5S_t *space, hsize_t *start, hsize_t *end);
 static herr_t   H5S__hyper_offset(const H5S_t *space, hsize_t *offset);
@@ -182,14 +182,14 @@ static int      H5S__hyper_unlim_dim(const H5S_t *space);
 static herr_t   H5S__hyper_num_elem_non_unlim(const H5S_t *space, hsize_t *num_elem_non_unlim);
 static htri_t   H5S__hyper_is_contiguous(const H5S_t *space);
 static htri_t   H5S__hyper_is_single(const H5S_t *space);
-static htri_t   H5S__hyper_is_regular(const H5S_t *space);
-static htri_t   H5S__hyper_shape_same(const H5S_t *space1, const H5S_t *space2);
-static htri_t   H5S__hyper_intersect_block(const H5S_t *space, const hsize_t *start, const hsize_t *end);
+static htri_t   H5S__hyper_is_regular(H5S_t *space);
+static htri_t   H5S__hyper_shape_same(H5S_t *space1, H5S_t *space2);
+static htri_t   H5S__hyper_intersect_block(H5S_t *space, const hsize_t *start, const hsize_t *end);
 static herr_t   H5S__hyper_adjust_u(H5S_t *space, const hsize_t *offset);
 static herr_t   H5S__hyper_adjust_s(H5S_t *space, const hssize_t *offset);
 static herr_t   H5S__hyper_project_scalar(const H5S_t *space, hsize_t *offset);
 static herr_t   H5S__hyper_project_simple(const H5S_t *space, H5S_t *new_space, hsize_t *offset);
-static herr_t   H5S__hyper_iter_init(const H5S_t *space, H5S_sel_iter_t *iter);
+static herr_t   H5S__hyper_iter_init(H5S_t *space, H5S_sel_iter_t *iter);
 
 /* Selection iteration callbacks */
 static herr_t  H5S__hyper_iter_coords(const H5S_sel_iter_t *iter, hsize_t *coords);
@@ -559,7 +559,7 @@ H5S__hyper_get_op_gen(void)
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5S__hyper_iter_init(const H5S_t *space, H5S_sel_iter_t *iter)
+H5S__hyper_iter_init(H5S_t *space, H5S_sel_iter_t *iter)
 {
     hsize_t *slab_size;           /* Pointer to the dataspace dimensions to use for calc. slab */
     hsize_t  acc;                 /* Accumulator for computing cumulative sizes */
@@ -586,7 +586,7 @@ H5S__hyper_iter_init(const H5S_t *space, H5S_sel_iter_t *iter)
      * to be impossible.
      */
     if (space->select.sel_info.hslab->diminfo_valid == H5S_DIMINFO_VALID_NO)
-        H5S__hyper_rebuild((H5S_t *)space); /* Casting away const OK -NAF */
+        H5S__hyper_rebuild(space);
 
     /* Check for the special case of just one H5Sselect_hyperslab call made */
     if (space->select.sel_info.hslab->diminfo_valid == H5S_DIMINFO_VALID_YES) {
@@ -3575,7 +3575,7 @@ H5S__hyper_get_enc_size_real(hsize_t max_size)
  REVISION LOG
 --------------------------------------------------------------------------*/
 static herr_t
-H5S__hyper_get_version_enc_size(const H5S_t *space, hsize_t block_count, uint32_t *version, uint8_t *enc_size)
+H5S__hyper_get_version_enc_size(H5S_t *space, hsize_t block_count, uint32_t *version, uint8_t *enc_size)
 {
     hsize_t      bounds_start[H5S_MAX_RANK]; /* Starting coordinate of bounding box */
     hsize_t      bounds_end[H5S_MAX_RANK];   /* Opposite coordinate of bounding box */
@@ -3728,7 +3728,7 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 static hssize_t
-H5S__hyper_serial_size(const H5S_t *space)
+H5S__hyper_serial_size(H5S_t *space)
 {
     hsize_t  block_count = 0; /* block counter for regular hyperslabs */
     uint32_t version;         /* Version number */
@@ -3928,7 +3928,7 @@ H5S__hyper_serialize_helper(const H5S_hyper_span_info_t *spans, hsize_t *start, 
     Serialize the current selection into a user-provided buffer.
  USAGE
     herr_t H5S__hyper_serialize(space, p)
-        const H5S_t *space;     IN: Dataspace with selection to serialize
+        H5S_t *space;           IN: Dataspace with selection to serialize
         uint8_t **p;            OUT: Pointer to buffer to put serialized
                                 selection.  Will be advanced to end of
                                 serialized selection.
@@ -3943,7 +3943,7 @@ H5S__hyper_serialize_helper(const H5S_hyper_span_info_t *spans, hsize_t *start, 
  REVISION LOG
 --------------------------------------------------------------------------*/
 static herr_t
-H5S__hyper_serialize(const H5S_t *space, uint8_t **p)
+H5S__hyper_serialize(H5S_t *space, uint8_t **p)
 {
     const H5S_hyper_dim_t *diminfo;                 /* Alias for dataspace's diminfo information */
     hsize_t                tmp_count[H5S_MAX_RANK]; /* Temporary hyperslab counts */
@@ -5326,7 +5326,7 @@ done:
     Check if a hyperslab selection is "regular"
  USAGE
     htri_t H5S__hyper_is_regular(space)
-        const H5S_t *space;     IN: Dataspace pointer to check
+        H5S_t *space;     IN: Dataspace pointer to check
  RETURNS
     TRUE/FALSE/FAIL
  DESCRIPTION
@@ -5339,7 +5339,7 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 static htri_t
-H5S__hyper_is_regular(const H5S_t *space)
+H5S__hyper_is_regular(H5S_t *space)
 {
     htri_t ret_value = FAIL; /* return value */
 
@@ -5352,7 +5352,7 @@ H5S__hyper_is_regular(const H5S_t *space)
      * to be impossible.
      */
     if (space->select.sel_info.hslab->diminfo_valid == H5S_DIMINFO_VALID_NO)
-        H5S__hyper_rebuild((H5S_t *)space); /* Casting away const OK -NAF */
+        H5S__hyper_rebuild(space);
 
     /* Only simple check for regular hyperslabs for now... */
     if (space->select.sel_info.hslab->diminfo_valid == H5S_DIMINFO_VALID_YES)
@@ -5576,8 +5576,8 @@ H5S__hyper_spans_shape_same(const H5S_hyper_span_info_t *span_info1, const H5S_h
     Check if a two hyperslab selections are the same shape
  USAGE
     htri_t H5S__hyper_shape_same(space1, space2)
-        const H5S_t *space1;     IN: First dataspace to check
-        const H5S_t *space2;     IN: Second dataspace to check
+        H5S_t *space1;           IN: First dataspace to check
+        H5S_t *space2;           IN: Second dataspace to check
  RETURNS
     TRUE / FALSE / FAIL
  DESCRIPTION
@@ -5594,7 +5594,7 @@ H5S__hyper_spans_shape_same(const H5S_hyper_span_info_t *span_info1, const H5S_h
  REVISION LOG
 --------------------------------------------------------------------------*/
 static htri_t
-H5S__hyper_shape_same(const H5S_t *space1, const H5S_t *space2)
+H5S__hyper_shape_same(H5S_t *space1, H5S_t *space2)
 {
     unsigned space1_rank;      /* Number of dimensions of first dataspace */
     unsigned space2_rank;      /* Number of dimensions of second dataspace */
@@ -5617,9 +5617,9 @@ H5S__hyper_shape_same(const H5S_t *space1, const H5S_t *space2)
     /* Rebuild diminfo if it is invalid and has not been confirmed to be
      * impossible */
     if (space1->select.sel_info.hslab->diminfo_valid == H5S_DIMINFO_VALID_NO)
-        H5S__hyper_rebuild((H5S_t *)space1); /* Casting away const OK -QAK */
+        H5S__hyper_rebuild(space1);
     if (space2->select.sel_info.hslab->diminfo_valid == H5S_DIMINFO_VALID_NO)
-        H5S__hyper_rebuild((H5S_t *)space2); /* Casting away const OK -QAK */
+        H5S__hyper_rebuild(space2);
 
     /* If both are regular hyperslabs, compare their diminfo values */
     if (space1->select.sel_info.hslab->diminfo_valid == H5S_DIMINFO_VALID_YES &&
@@ -5664,11 +5664,11 @@ H5S__hyper_shape_same(const H5S_t *space1, const H5S_t *space2)
 
         /* Make certain that both selections have span trees */
         if (NULL == space1->select.sel_info.hslab->span_lst)
-            if (H5S__hyper_generate_spans((H5S_t *)space1) < 0) /* Casting away const OK -QAK */
+            if (H5S__hyper_generate_spans(space1) < 0)
                 HGOTO_ERROR(H5E_DATASPACE, H5E_UNINITIALIZED, FAIL,
                             "can't construct span tree for hyperslab selection")
         if (NULL == space2->select.sel_info.hslab->span_lst)
-            if (H5S__hyper_generate_spans((H5S_t *)space2) < 0) /* Casting away const OK -QAK */
+            if (H5S__hyper_generate_spans(space2) < 0)
                 HGOTO_ERROR(H5E_DATASPACE, H5E_UNINITIALIZED, FAIL,
                             "can't construct span tree for hyperslab selection")
 
@@ -6255,7 +6255,7 @@ done:
     Detect intersections of selection with block
  USAGE
     htri_t H5S__hyper_intersect_block(space, start, end)
-        const H5S_t *space;     IN: Dataspace with selection to use
+        H5S_t *space;           IN: Dataspace with selection to use
         const hsize_t *start;   IN: Starting coordinate for block
         const hsize_t *end;     IN: Ending coordinate for block
  RETURNS
@@ -6270,7 +6270,7 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 static htri_t
-H5S__hyper_intersect_block(const H5S_t *space, const hsize_t *start, const hsize_t *end)
+H5S__hyper_intersect_block(H5S_t *space, const hsize_t *start, const hsize_t *end)
 {
     htri_t ret_value = FAIL; /* Return value */
 
@@ -6286,7 +6286,7 @@ H5S__hyper_intersect_block(const H5S_t *space, const hsize_t *start, const hsize
      * to be impossible.
      */
     if (space->select.sel_info.hslab->diminfo_valid == H5S_DIMINFO_VALID_NO)
-        H5S__hyper_rebuild((H5S_t *)space); /* Casting away const OK -QAK */
+        H5S__hyper_rebuild(space);
 
     /* Check for regular hyperslab intersection */
     if (space->select.sel_info.hslab->diminfo_valid == H5S_DIMINFO_VALID_YES) {
@@ -11592,8 +11592,8 @@ also that proj_space can share some span trees with dst_space, so proj_space mus
 if dst_space must be preserved. GLOBAL VARIABLES COMMENTS, BUGS, ASSUMPTIONS EXAMPLES REVISION LOG
 --------------------------------------------------------------------------*/
 herr_t
-H5S__hyper_project_intersection(const H5S_t *src_space, const H5S_t *dst_space,
-                                const H5S_t *src_intersect_space, H5S_t *proj_space, hbool_t share_selection)
+H5S__hyper_project_intersection(H5S_t *src_space, H5S_t *dst_space, H5S_t *src_intersect_space,
+                                H5S_t *proj_space, hbool_t share_selection)
 {
     H5S_hyper_project_intersect_ud_t udata; /* User data for subroutines */
     const H5S_hyper_span_info_t *    ss_span_info;
@@ -11622,7 +11622,7 @@ H5S__hyper_project_intersection(const H5S_t *src_space, const H5S_t *dst_space,
     if (H5S_GET_SELECT_TYPE(src_space) == H5S_SEL_HYPERSLABS) {
         /* Make certain the selection has a span tree */
         if (NULL == src_space->select.sel_info.hslab->span_lst)
-            if (H5S__hyper_generate_spans((H5S_t *)src_space) < 0) /* Casting away const OK -NAF */
+            if (H5S__hyper_generate_spans(src_space) < 0)
                 HGOTO_ERROR(H5E_DATASPACE, H5E_UNINITIALIZED, FAIL,
                             "can't construct span tree for source hyperslab selection")
 
@@ -11644,7 +11644,7 @@ H5S__hyper_project_intersection(const H5S_t *src_space, const H5S_t *dst_space,
     if (H5S_GET_SELECT_TYPE(dst_space) == H5S_SEL_HYPERSLABS) {
         /* Make certain the selection has a span tree */
         if (NULL == dst_space->select.sel_info.hslab->span_lst)
-            if (H5S__hyper_generate_spans((H5S_t *)dst_space) < 0) /* Casting away const OK -NAF */
+            if (H5S__hyper_generate_spans(dst_space) < 0)
                 HGOTO_ERROR(H5E_DATASPACE, H5E_UNINITIALIZED, FAIL,
                             "can't construct span tree for dsetination hyperslab selection")
 
@@ -11664,7 +11664,7 @@ H5S__hyper_project_intersection(const H5S_t *src_space, const H5S_t *dst_space,
 
     /* Make certain the source intersect selection has a span tree */
     if (NULL == src_intersect_space->select.sel_info.hslab->span_lst)
-        if (H5S__hyper_generate_spans((H5S_t *)src_intersect_space) < 0) /* Casting away const OK -NAF */
+        if (H5S__hyper_generate_spans(src_intersect_space) < 0)
             HGOTO_ERROR(H5E_DATASPACE, H5E_UNINITIALIZED, FAIL,
                         "can't construct span tree for source intersect hyperslab selection")
 

--- a/src/H5Snone.c
+++ b/src/H5Snone.c
@@ -49,22 +49,22 @@
 static herr_t   H5S__none_copy(H5S_t *dst, const H5S_t *src, hbool_t share_selection);
 static herr_t   H5S__none_release(H5S_t *space);
 static htri_t   H5S__none_is_valid(const H5S_t *space);
-static hssize_t H5S__none_serial_size(const H5S_t *space);
-static herr_t   H5S__none_serialize(const H5S_t *space, uint8_t **p);
+static hssize_t H5S__none_serial_size(H5S_t *space);
+static herr_t   H5S__none_serialize(H5S_t *space, uint8_t **p);
 static herr_t   H5S__none_deserialize(H5S_t **space, const uint8_t **p);
 static herr_t   H5S__none_bounds(const H5S_t *space, hsize_t *start, hsize_t *end);
 static herr_t   H5S__none_offset(const H5S_t *space, hsize_t *off);
 static int      H5S__none_unlim_dim(const H5S_t *space);
 static htri_t   H5S__none_is_contiguous(const H5S_t *space);
 static htri_t   H5S__none_is_single(const H5S_t *space);
-static htri_t   H5S__none_is_regular(const H5S_t *space);
-static htri_t   H5S__none_shape_same(const H5S_t *space1, const H5S_t *space2);
-static htri_t   H5S__none_intersect_block(const H5S_t *space, const hsize_t *start, const hsize_t *end);
+static htri_t   H5S__none_is_regular(H5S_t *space);
+static htri_t   H5S__none_shape_same(H5S_t *space1, H5S_t *space2);
+static htri_t   H5S__none_intersect_block(H5S_t *space, const hsize_t *start, const hsize_t *end);
 static herr_t   H5S__none_adjust_u(H5S_t *space, const hsize_t *offset);
 static herr_t   H5S__none_adjust_s(H5S_t *space, const hssize_t *offset);
 static herr_t   H5S__none_project_scalar(const H5S_t *space, hsize_t *offset);
 static herr_t   H5S__none_project_simple(const H5S_t *space, H5S_t *new_space, hsize_t *offset);
-static herr_t   H5S__none_iter_init(const H5S_t *space, H5S_sel_iter_t *iter);
+static herr_t   H5S__none_iter_init(H5S_t *space, H5S_sel_iter_t *iter);
 
 /* Selection iteration callbacks */
 static herr_t  H5S__none_iter_coords(const H5S_sel_iter_t *iter, hsize_t *coords);
@@ -144,7 +144,7 @@ static const H5S_sel_iter_class_t H5S_sel_iter_none[1] = {{
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5S__none_iter_init(const H5S_t H5_ATTR_UNUSED *space, H5S_sel_iter_t *iter)
+H5S__none_iter_init(H5S_t H5_ATTR_UNUSED *space, H5S_sel_iter_t *iter)
 {
     FUNC_ENTER_STATIC_NOERR
 
@@ -513,7 +513,7 @@ H5S__none_is_valid(const H5S_t H5_ATTR_UNUSED *space)
  REVISION LOG
 --------------------------------------------------------------------------*/
 static hssize_t
-H5S__none_serial_size(const H5S_t H5_ATTR_UNUSED *space)
+H5S__none_serial_size(H5S_t H5_ATTR_UNUSED *space)
 {
     FUNC_ENTER_STATIC_NOERR
 
@@ -533,7 +533,7 @@ H5S__none_serial_size(const H5S_t H5_ATTR_UNUSED *space)
     Serialize the current selection into a user-provided buffer.
  USAGE
     herr_t H5S__none_serialize(space, p)
-        const H5S_t *space;     IN: Dataspace with selection to serialize
+        H5S_t *space;           IN: Dataspace with selection to serialize
         uint8_t **p;            OUT: Pointer to buffer to put serialized
                                 selection.  Will be advanced to end of
                                 serialized selection.
@@ -548,7 +548,7 @@ H5S__none_serial_size(const H5S_t H5_ATTR_UNUSED *space)
  REVISION LOG
 --------------------------------------------------------------------------*/
 static herr_t
-H5S__none_serialize(const H5S_t *space, uint8_t **p)
+H5S__none_serialize(H5S_t *space, uint8_t **p)
 {
     uint8_t *pp = (*p); /* Local pointer for decoding */
 
@@ -803,7 +803,7 @@ H5S__none_is_single(const H5S_t H5_ATTR_UNUSED *space)
     Check if a "none" selection is "regular"
  USAGE
     htri_t H5S__none_is_regular(space)
-        const H5S_t *space;     IN: Dataspace pointer to check
+        H5S_t *space;     IN: Dataspace pointer to check
  RETURNS
     TRUE/FALSE/FAIL
  DESCRIPTION
@@ -816,7 +816,7 @@ H5S__none_is_single(const H5S_t H5_ATTR_UNUSED *space)
  REVISION LOG
 --------------------------------------------------------------------------*/
 static htri_t
-H5S__none_is_regular(const H5S_t H5_ATTR_UNUSED *space)
+H5S__none_is_regular(H5S_t H5_ATTR_UNUSED *space)
 {
     FUNC_ENTER_STATIC_NOERR
 
@@ -833,8 +833,8 @@ H5S__none_is_regular(const H5S_t H5_ATTR_UNUSED *space)
     Check if a two "none" selections are the same shape
  USAGE
     htri_t H5S__none_shape_same(space1, space2)
-        const H5S_t *space1;     IN: First dataspace to check
-        const H5S_t *space2;     IN: Second dataspace to check
+        H5S_t *space1;           IN: First dataspace to check
+        H5S_t *space2;           IN: Second dataspace to check
  RETURNS
     TRUE / FALSE / FAIL
  DESCRIPTION
@@ -846,7 +846,7 @@ H5S__none_is_regular(const H5S_t H5_ATTR_UNUSED *space)
  REVISION LOG
 --------------------------------------------------------------------------*/
 static htri_t
-H5S__none_shape_same(const H5S_t H5_ATTR_UNUSED *space1, const H5S_t H5_ATTR_UNUSED *space2)
+H5S__none_shape_same(H5S_t H5_ATTR_UNUSED *space1, H5S_t H5_ATTR_UNUSED *space2)
 {
     FUNC_ENTER_STATIC_NOERR
 
@@ -864,7 +864,7 @@ H5S__none_shape_same(const H5S_t H5_ATTR_UNUSED *space1, const H5S_t H5_ATTR_UNU
     Detect intersections of selection with block
  USAGE
     htri_t H5S__none_intersect_block(space, start, end)
-        const H5S_t *space;     IN: Dataspace with selection to use
+        H5S_t *space;           IN: Dataspace with selection to use
         const hsize_t *start;   IN: Starting coordinate for block
         const hsize_t *end;     IN: Ending coordinate for block
  RETURNS
@@ -877,7 +877,7 @@ H5S__none_shape_same(const H5S_t H5_ATTR_UNUSED *space1, const H5S_t H5_ATTR_UNU
  REVISION LOG
 --------------------------------------------------------------------------*/
 htri_t
-H5S__none_intersect_block(const H5S_t H5_ATTR_UNUSED *space, const hsize_t H5_ATTR_UNUSED *start,
+H5S__none_intersect_block(H5S_t H5_ATTR_UNUSED *space, const hsize_t H5_ATTR_UNUSED *start,
                           const hsize_t H5_ATTR_UNUSED *end)
 {
     FUNC_ENTER_STATIC_NOERR

--- a/src/H5Spkg.h
+++ b/src/H5Spkg.h
@@ -242,9 +242,9 @@ typedef herr_t (*H5S_sel_release_func_t)(H5S_t *space);
 /* Method to determine if current selection is valid for dataspace */
 typedef htri_t (*H5S_sel_is_valid_func_t)(const H5S_t *space);
 /* Method to determine number of bytes required to store current selection */
-typedef hssize_t (*H5S_sel_serial_size_func_t)(const H5S_t *space);
+typedef hssize_t (*H5S_sel_serial_size_func_t)(H5S_t *space);
 /* Method to store current selection in "serialized" form (a byte sequence suitable for storing on disk) */
-typedef herr_t (*H5S_sel_serialize_func_t)(const H5S_t *space, uint8_t **p);
+typedef herr_t (*H5S_sel_serialize_func_t)(H5S_t *space, uint8_t **p);
 /* Method to create selection from "serialized" form (a byte sequence suitable for storing on disk) */
 typedef herr_t (*H5S_sel_deserialize_func_t)(H5S_t **space, const uint8_t **p);
 /* Method to determine smallest n-D bounding box containing the current selection */
@@ -260,12 +260,11 @@ typedef htri_t (*H5S_sel_is_contiguous_func_t)(const H5S_t *space);
 /* Method to determine if current selection is a single block */
 typedef htri_t (*H5S_sel_is_single_func_t)(const H5S_t *space);
 /* Method to determine if current selection is "regular" */
-typedef htri_t (*H5S_sel_is_regular_func_t)(const H5S_t *space);
+typedef htri_t (*H5S_sel_is_regular_func_t)(H5S_t *space);
 /* Method to determine if two dataspaces' selections are the same shape */
-typedef htri_t (*H5S_sel_shape_same_func_t)(const H5S_t *space1, const H5S_t *space2);
+typedef htri_t (*H5S_sel_shape_same_func_t)(H5S_t *space1, H5S_t *space2);
 /* Method to determine if selection intersects a block */
-typedef htri_t (*H5S_sel_intersect_block_func_t)(const H5S_t *space, const hsize_t *start,
-                                                 const hsize_t *end);
+typedef htri_t (*H5S_sel_intersect_block_func_t)(H5S_t *space, const hsize_t *start, const hsize_t *end);
 /* Method to adjust a selection by an offset */
 typedef herr_t (*H5S_sel_adjust_u_func_t)(H5S_t *space, const hsize_t *offset);
 /* Method to adjust a selection by an offset (signed) */
@@ -275,7 +274,7 @@ typedef herr_t (*H5S_sel_project_scalar)(const H5S_t *space, hsize_t *offset);
 /* Method to construct selection projection onto/into simple dataspace */
 typedef herr_t (*H5S_sel_project_simple)(const H5S_t *space, H5S_t *new_space, hsize_t *offset);
 /* Method to initialize iterator for current selection */
-typedef herr_t (*H5S_sel_iter_init_func_t)(const H5S_t *space, H5S_sel_iter_t *sel_iter);
+typedef herr_t (*H5S_sel_iter_init_func_t)(H5S_t *space, H5S_sel_iter_t *sel_iter);
 
 /* Selection class information */
 typedef struct {
@@ -405,9 +404,8 @@ H5_DLL herr_t H5S__extent_copy_real(H5S_extent_t *dst, const H5S_extent_t *src, 
 H5_DLL uint64_t H5S__hyper_get_op_gen(void);
 H5_DLL void     H5S__hyper_rebuild(H5S_t *space);
 H5_DLL herr_t   H5S__modify_select(H5S_t *space1, H5S_seloper_t op, H5S_t *space2);
-H5_DLL herr_t   H5S__hyper_project_intersection(const H5S_t *src_space, const H5S_t *dst_space,
-                                                const H5S_t *src_intersect_space, H5S_t *proj_space,
-                                                hbool_t share_space);
+H5_DLL herr_t H5S__hyper_project_intersection(H5S_t *src_space, H5S_t *dst_space, H5S_t *src_intersect_space,
+                                              H5S_t *proj_space, hbool_t share_space);
 
 /* Operations on selection iterators */
 H5_DLL herr_t H5S__sel_iter_close_cb(H5S_sel_iter_t *_sel_iter, void **request);

--- a/src/H5Spoint.c
+++ b/src/H5Spoint.c
@@ -59,22 +59,22 @@ static void            H5S__free_pnt_list(H5S_pnt_list_t *pnt_lst);
 static herr_t   H5S__point_copy(H5S_t *dst, const H5S_t *src, hbool_t share_selection);
 static herr_t   H5S__point_release(H5S_t *space);
 static htri_t   H5S__point_is_valid(const H5S_t *space);
-static hssize_t H5S__point_serial_size(const H5S_t *space);
-static herr_t   H5S__point_serialize(const H5S_t *space, uint8_t **p);
+static hssize_t H5S__point_serial_size(H5S_t *space);
+static herr_t   H5S__point_serialize(H5S_t *space, uint8_t **p);
 static herr_t   H5S__point_deserialize(H5S_t **space, const uint8_t **p);
 static herr_t   H5S__point_bounds(const H5S_t *space, hsize_t *start, hsize_t *end);
 static herr_t   H5S__point_offset(const H5S_t *space, hsize_t *off);
 static int      H5S__point_unlim_dim(const H5S_t *space);
 static htri_t   H5S__point_is_contiguous(const H5S_t *space);
 static htri_t   H5S__point_is_single(const H5S_t *space);
-static htri_t   H5S__point_is_regular(const H5S_t *space);
-static htri_t   H5S__point_shape_same(const H5S_t *space1, const H5S_t *space2);
-static htri_t   H5S__point_intersect_block(const H5S_t *space, const hsize_t *start, const hsize_t *end);
+static htri_t   H5S__point_is_regular(H5S_t *space);
+static htri_t   H5S__point_shape_same(H5S_t *space1, H5S_t *space2);
+static htri_t   H5S__point_intersect_block(H5S_t *space, const hsize_t *start, const hsize_t *end);
 static herr_t   H5S__point_adjust_u(H5S_t *space, const hsize_t *offset);
 static herr_t   H5S__point_adjust_s(H5S_t *space, const hssize_t *offset);
 static herr_t   H5S__point_project_scalar(const H5S_t *space, hsize_t *offset);
 static herr_t   H5S__point_project_simple(const H5S_t *space, H5S_t *new_space, hsize_t *offset);
-static herr_t   H5S__point_iter_init(const H5S_t *space, H5S_sel_iter_t *iter);
+static herr_t   H5S__point_iter_init(H5S_t *space, H5S_sel_iter_t *iter);
 static herr_t   H5S__point_get_version_enc_size(const H5S_t *space, uint32_t *version, uint8_t *enc_size);
 
 /* Selection iteration callbacks */
@@ -170,7 +170,7 @@ H5FL_DEFINE_STATIC(H5S_pnt_list_t);
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5S__point_iter_init(const H5S_t *space, H5S_sel_iter_t *iter)
+H5S__point_iter_init(H5S_t *space, H5S_sel_iter_t *iter)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
@@ -1159,7 +1159,7 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 static hssize_t
-H5S__point_serial_size(const H5S_t *space)
+H5S__point_serial_size(H5S_t *space)
 {
     uint32_t version;        /* Version number */
     uint8_t  enc_size;       /* Encoded size of point selection info */
@@ -1204,7 +1204,7 @@ done:
     Serialize the current selection into a user-provided buffer.
  USAGE
     herr_t H5S__point_serialize(space, p)
-        const H5S_t *space;     IN: Dataspace with selection to serialize
+        H5S_t *space;           IN: Dataspace with selection to serialize
         uint8_t **p;            OUT: Pointer to buffer to put serialized
                                 selection.  Will be advanced to end of
                                 serialized selection.
@@ -1219,7 +1219,7 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 static herr_t
-H5S__point_serialize(const H5S_t *space, uint8_t **p)
+H5S__point_serialize(H5S_t *space, uint8_t **p)
 {
     H5S_pnt_node_t *curr;                /* Point information nodes */
     uint8_t *       pp;                  /* Local pointer for encoding */
@@ -1844,7 +1844,7 @@ H5S__point_is_single(const H5S_t *space)
     Check if a point selection is "regular"
  USAGE
     htri_t H5S__point_is_regular(space)
-        const H5S_t *space;     IN: Dataspace pointer to check
+        H5S_t *space;     IN: Dataspace pointer to check
  RETURNS
     TRUE/FALSE/FAIL
  DESCRIPTION
@@ -1859,7 +1859,7 @@ H5S__point_is_single(const H5S_t *space)
  REVISION LOG
 --------------------------------------------------------------------------*/
 static htri_t
-H5S__point_is_regular(const H5S_t *space)
+H5S__point_is_regular(H5S_t *space)
 {
     htri_t ret_value = FAIL; /* Return value */
 
@@ -1884,8 +1884,8 @@ H5S__point_is_regular(const H5S_t *space)
     Check if a two "point" selections are the same shape
  USAGE
     htri_t H5S__point_shape_same(space1, space2)
-        const H5S_t *space1;     IN: First dataspace to check
-        const H5S_t *space2;     IN: Second dataspace to check
+        H5S_t *space1;           IN: First dataspace to check
+        H5S_t *space2;           IN: Second dataspace to check
  RETURNS
     TRUE / FALSE / FAIL
  DESCRIPTION
@@ -1897,7 +1897,7 @@ H5S__point_is_regular(const H5S_t *space)
  REVISION LOG
 --------------------------------------------------------------------------*/
 static htri_t
-H5S__point_shape_same(const H5S_t *space1, const H5S_t *space2)
+H5S__point_shape_same(H5S_t *space1, H5S_t *space2)
 {
     H5S_pnt_node_t *pnt1, *pnt2;          /* Point information nodes */
     hssize_t        offset[H5S_MAX_RANK]; /* Offset between the selections */
@@ -1990,7 +1990,7 @@ done:
     Detect intersections of selection with block
  USAGE
     htri_t H5S__point_intersect_block(space, start, end)
-        const H5S_t *space;     IN: Dataspace with selection to use
+        H5S_t *space;           IN: Dataspace with selection to use
         const hsize_t *start;   IN: Starting coordinate for block
         const hsize_t *end;     IN: Ending coordinate for block
  RETURNS
@@ -2003,7 +2003,7 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 htri_t
-H5S__point_intersect_block(const H5S_t *space, const hsize_t *start, const hsize_t *end)
+H5S__point_intersect_block(H5S_t *space, const hsize_t *start, const hsize_t *end)
 {
     H5S_pnt_node_t *pnt;               /* Point information node */
     htri_t          ret_value = FALSE; /* Return value */

--- a/src/H5Sprivate.h
+++ b/src/H5Sprivate.h
@@ -232,36 +232,35 @@ H5_DLL herr_t  H5S_extent_copy(H5S_t *dst, const H5S_t *src);
 /* Operations on selections */
 H5_DLL herr_t       H5S_select_deserialize(H5S_t **space, const uint8_t **p);
 H5_DLL H5S_sel_type H5S_get_select_type(const H5S_t *space);
-H5_DLL herr_t       H5S_select_iterate(void *buf, const H5T_t *type, const H5S_t *space,
-                                       const H5S_sel_iter_op_t *op, void *op_data);
-H5_DLL herr_t       H5S_select_fill(const void *fill, size_t fill_size, const H5S_t *space, void *buf);
-H5_DLL htri_t       H5S_select_valid(const H5S_t *space);
-H5_DLL hsize_t      H5S_get_select_npoints(const H5S_t *space);
-H5_DLL herr_t       H5S_get_select_bounds(const H5S_t *space, hsize_t *start, hsize_t *end);
-H5_DLL herr_t       H5S_get_select_offset(const H5S_t *space, hsize_t *offset);
-H5_DLL int          H5S_get_select_unlim_dim(const H5S_t *space);
-H5_DLL herr_t       H5S_get_select_num_elem_non_unlim(const H5S_t *space, hsize_t *num_elem_non_unlim);
-H5_DLL herr_t       H5S_select_offset(H5S_t *space, const hssize_t *offset);
-H5_DLL herr_t       H5S_select_copy(H5S_t *dst, const H5S_t *src, hbool_t share_selection);
-H5_DLL htri_t       H5S_select_shape_same(const H5S_t *space1, const H5S_t *space2);
-H5_DLL htri_t       H5S_select_intersect_block(const H5S_t *space, const hsize_t *start, const hsize_t *end);
-H5_DLL herr_t       H5S_select_construct_projection(const H5S_t *base_space, H5S_t **new_space_ptr,
-                                                    unsigned new_space_rank, const void *buf,
-                                                    void const **adj_buf_ptr, hsize_t element_size);
-H5_DLL herr_t       H5S_select_release(H5S_t *ds);
-H5_DLL hssize_t     H5S_select_serial_size(const H5S_t *space);
-H5_DLL herr_t       H5S_select_serialize(const H5S_t *space, uint8_t **p);
-H5_DLL htri_t       H5S_select_is_contiguous(const H5S_t *space);
-H5_DLL htri_t       H5S_select_is_single(const H5S_t *space);
-H5_DLL htri_t       H5S_select_is_regular(const H5S_t *space);
-H5_DLL herr_t       H5S_select_adjust_u(H5S_t *space, const hsize_t *offset);
-H5_DLL herr_t       H5S_select_adjust_s(H5S_t *space, const hssize_t *offset);
-H5_DLL herr_t       H5S_select_project_scalar(const H5S_t *space, hsize_t *offset);
-H5_DLL herr_t       H5S_select_project_simple(const H5S_t *space, H5S_t *new_space, hsize_t *offset);
-H5_DLL herr_t       H5S_select_project_intersection(const H5S_t *src_space, const H5S_t *dst_space,
-                                                    const H5S_t *src_intersect_space, H5S_t **new_space_ptr,
-                                                    hbool_t share_space);
-H5_DLL herr_t       H5S_select_subtract(H5S_t *space, H5S_t *subtract_space);
+H5_DLL herr_t   H5S_select_iterate(void *buf, const H5T_t *type, H5S_t *space, const H5S_sel_iter_op_t *op,
+                                   void *op_data);
+H5_DLL herr_t   H5S_select_fill(const void *fill, size_t fill_size, H5S_t *space, void *buf);
+H5_DLL htri_t   H5S_select_valid(const H5S_t *space);
+H5_DLL hsize_t  H5S_get_select_npoints(const H5S_t *space);
+H5_DLL herr_t   H5S_get_select_bounds(const H5S_t *space, hsize_t *start, hsize_t *end);
+H5_DLL herr_t   H5S_get_select_offset(const H5S_t *space, hsize_t *offset);
+H5_DLL int      H5S_get_select_unlim_dim(const H5S_t *space);
+H5_DLL herr_t   H5S_get_select_num_elem_non_unlim(const H5S_t *space, hsize_t *num_elem_non_unlim);
+H5_DLL herr_t   H5S_select_offset(H5S_t *space, const hssize_t *offset);
+H5_DLL herr_t   H5S_select_copy(H5S_t *dst, const H5S_t *src, hbool_t share_selection);
+H5_DLL htri_t   H5S_select_shape_same(H5S_t *space1, H5S_t *space2);
+H5_DLL htri_t   H5S_select_intersect_block(H5S_t *space, const hsize_t *start, const hsize_t *end);
+H5_DLL herr_t   H5S_select_construct_projection(H5S_t *base_space, H5S_t **new_space_ptr,
+                                                unsigned new_space_rank, const void *buf,
+                                                void const **adj_buf_ptr, hsize_t element_size);
+H5_DLL herr_t   H5S_select_release(H5S_t *ds);
+H5_DLL hssize_t H5S_select_serial_size(H5S_t *space);
+H5_DLL herr_t   H5S_select_serialize(H5S_t *space, uint8_t **p);
+H5_DLL htri_t   H5S_select_is_contiguous(const H5S_t *space);
+H5_DLL htri_t   H5S_select_is_single(const H5S_t *space);
+H5_DLL htri_t   H5S_select_is_regular(H5S_t *space);
+H5_DLL herr_t   H5S_select_adjust_u(H5S_t *space, const hsize_t *offset);
+H5_DLL herr_t   H5S_select_adjust_s(H5S_t *space, const hssize_t *offset);
+H5_DLL herr_t   H5S_select_project_scalar(const H5S_t *space, hsize_t *offset);
+H5_DLL herr_t   H5S_select_project_simple(const H5S_t *space, H5S_t *new_space, hsize_t *offset);
+H5_DLL herr_t H5S_select_project_intersection(H5S_t *src_space, H5S_t *dst_space, H5S_t *src_intersect_space,
+                                              H5S_t **new_space_ptr, hbool_t share_space);
+H5_DLL herr_t H5S_select_subtract(H5S_t *space, H5S_t *subtract_space);
 
 /* Operations on all selections */
 H5_DLL herr_t H5S_select_all(H5S_t *space, hbool_t rel_prev);
@@ -290,8 +289,7 @@ H5_DLL H5S_t * H5S_hyper_get_unlim_block(const H5S_t *space, hsize_t block_index
 H5_DLL hsize_t H5S_hyper_get_first_inc_block(const H5S_t *space, hsize_t clip_size, hbool_t *partial);
 
 /* Operations on selection iterators */
-H5_DLL herr_t  H5S_select_iter_init(H5S_sel_iter_t *iter, const H5S_t *space, size_t elmt_size,
-                                    unsigned flags);
+H5_DLL herr_t  H5S_select_iter_init(H5S_sel_iter_t *iter, H5S_t *space, size_t elmt_size, unsigned flags);
 H5_DLL herr_t  H5S_select_iter_coords(const H5S_sel_iter_t *sel_iter, hsize_t *coords);
 H5_DLL hsize_t H5S_select_iter_nelmts(const H5S_sel_iter_t *sel_iter);
 H5_DLL herr_t  H5S_select_iter_next(H5S_sel_iter_t *sel_iter, size_t nelem);

--- a/src/H5Sselect.c
+++ b/src/H5Sselect.c
@@ -304,7 +304,7 @@ done:
  *-------------------------------------------------------------------------
  */
 hssize_t
-H5S_select_serial_size(const H5S_t *space)
+H5S_select_serial_size(H5S_t *space)
 {
     hssize_t ret_value = -1; /* Return value */
 
@@ -343,7 +343,7 @@ H5S_select_serial_size(const H5S_t *space)
  REVISION LOG
 --------------------------------------------------------------------------*/
 herr_t
-H5S_select_serialize(const H5S_t *space, uint8_t **p)
+H5S_select_serialize(H5S_t *space, uint8_t **p)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
@@ -880,7 +880,7 @@ H5S_select_is_single(const H5S_t *space)
  REVISION LOG
 --------------------------------------------------------------------------*/
 htri_t
-H5S_select_is_regular(const H5S_t *space)
+H5S_select_is_regular(H5S_t *space)
 {
     herr_t ret_value = FAIL; /* Return value */
 
@@ -1116,7 +1116,7 @@ H5S_select_project_simple(const H5S_t *space, H5S_t *new_space, hsize_t *offset)
     in the dataspace's selection.
 --------------------------------------------------------------------------*/
 herr_t
-H5S_select_iter_init(H5S_sel_iter_t *sel_iter, const H5S_t *space, size_t elmt_size, unsigned flags)
+H5S_select_iter_init(H5S_sel_iter_t *sel_iter, H5S_t *space, size_t elmt_size, unsigned flags)
 {
     herr_t ret_value = FAIL; /* Return value */
 
@@ -1497,8 +1497,7 @@ H5S_select_iter_release(H5S_sel_iter_t *sel_iter)
         the selection is not modified.
 --------------------------------------------------------------------------*/
 herr_t
-H5S_select_iterate(void *buf, const H5T_t *type, const H5S_t *space, const H5S_sel_iter_op_t *op,
-                   void *op_data)
+H5S_select_iterate(void *buf, const H5T_t *type, H5S_t *space, const H5S_sel_iter_op_t *op, void *op_data)
 {
     H5S_sel_iter_t *iter      = NULL;         /* Selection iteration info */
     hbool_t         iter_init = FALSE;        /* Selection iteration info has been initialized */
@@ -1739,7 +1738,7 @@ H5S_get_select_type(const H5S_t *space)
  REVISION LOG
 --------------------------------------------------------------------------*/
 htri_t
-H5S_select_shape_same(const H5S_t *space1, const H5S_t *space2)
+H5S_select_shape_same(H5S_t *space1, H5S_t *space2)
 {
     H5S_sel_iter_t *iter_a      = NULL;  /* Selection a iteration info */
     H5S_sel_iter_t *iter_b      = NULL;  /* Selection b iteration info */
@@ -1760,8 +1759,8 @@ H5S_select_shape_same(const H5S_t *space1, const H5S_t *space2)
     /* Check special cases if both dataspaces aren't scalar */
     /* (If only one is, the number of selected points check is sufficient) */
     if (space1->extent.rank > 0 && space2->extent.rank > 0) {
-        const H5S_t *space_a;      /* Dataspace with larger rank */
-        const H5S_t *space_b;      /* Dataspace with smaller rank */
+        H5S_t *      space_a;      /* Dataspace with larger rank */
+        H5S_t *      space_b;      /* Dataspace with smaller rank */
         unsigned     space_a_rank; /* Number of dimensions of dataspace A */
         unsigned     space_b_rank; /* Number of dimensions of dataspace B */
         int          space_a_dim;  /* Current dimension in dataspace A */
@@ -2063,7 +2062,7 @@ done:
     don't call it directly, use the appropriate macro defined in H5Sprivate.h.
 --------------------------------------------------------------------------*/
 htri_t
-H5S_select_intersect_block(const H5S_t *space, const hsize_t *start, const hsize_t *end)
+H5S_select_intersect_block(H5S_t *space, const hsize_t *start, const hsize_t *end)
 {
     htri_t ret_value = TRUE; /* Return value */
 
@@ -2214,7 +2213,7 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 herr_t
-H5S_select_construct_projection(const H5S_t *base_space, H5S_t **new_space_ptr, unsigned new_space_rank,
+H5S_select_construct_projection(H5S_t *base_space, H5S_t **new_space_ptr, unsigned new_space_rank,
                                 const void *buf, void const **adj_buf_ptr, hsize_t element_size)
 {
     H5S_t *  new_space = NULL;                         /* New dataspace constructed */
@@ -2452,7 +2451,7 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 herr_t
-H5S_select_fill(const void *fill, size_t fill_size, const H5S_t *space, void *_buf)
+H5S_select_fill(const void *fill, size_t fill_size, H5S_t *space, void *_buf)
 {
     H5S_sel_iter_t *iter      = NULL;    /* Selection iteration info */
     hbool_t         iter_init = FALSE;   /* Selection iteration info has been initialized */
@@ -2568,9 +2567,8 @@ to share structures inside dst_space with proj_space
  REVISION LOG
 --------------------------------------------------------------------------*/
 herr_t
-H5S_select_project_intersection(const H5S_t *src_space, const H5S_t *dst_space,
-                                const H5S_t *src_intersect_space, H5S_t **new_space_ptr,
-                                hbool_t share_selection)
+H5S_select_project_intersection(H5S_t *src_space, H5S_t *dst_space, H5S_t *src_intersect_space,
+                                H5S_t **new_space_ptr, hbool_t share_selection)
 {
     H5S_t *         new_space               = NULL;    /* New dataspace constructed */
     H5S_t *         tmp_src_intersect_space = NULL;    /* Temporary SIS converted from points->hyperslabs */


### PR DESCRIPTION
Hyperslabs can be reworked inside several H5S callbacks, making H5S_t
non-const in some places where it is marked const. This change switches
these incorrectly const H5S_t pointer parameters and variables to
non-const where appropriate.