### PR TITLE
Fix Fortran REGEX and newlines

### DIFF
--- a/config/cmake/H5pubconf.h.in
+++ b/config/cmake/H5pubconf.h.in
@@ -71,13 +71,13 @@
 /* Define Fortran compiler ID */
 #define H5_Fortran_COMPILER_ID @CMAKE_Fortran_COMPILER_ID@
 
+/* Define number of valid Fortran INTEGER KINDs (must be defined before F_NUM_IKIND)*/
+#cmakedefine H5_H5CONFIG_F_NUM_IKIND @H5_H5CONFIG_F_NUM_IKIND@
+
 /* Define valid Fortran INTEGER KINDs */
 #cmakedefine H5_H5CONFIG_F_IKIND @H5_H5CONFIG_F_IKIND@
 
-/* Define number of valid Fortran INTEGER KINDs */
-#cmakedefine H5_H5CONFIG_F_NUM_IKIND @H5_H5CONFIG_F_NUM_IKIND@
-
-/* Define number of valid Fortran REAL KINDs */
+/* Define number of valid Fortran REAL KINDs (must be defined before F_NUM_RKIND) */
 #cmakedefine H5_H5CONFIG_F_NUM_RKIND @H5_H5CONFIG_F_NUM_RKIND@
 
 /* Define valid Fortran REAL KINDs */

--- a/config/cmake/H5pubconf.h.in
+++ b/config/cmake/H5pubconf.h.in
@@ -71,13 +71,13 @@
 /* Define Fortran compiler ID */
 #define H5_Fortran_COMPILER_ID @CMAKE_Fortran_COMPILER_ID@
 
-/* Define number of valid Fortran INTEGER KINDs (must be defined before F_NUM_IKIND)*/
+/* Define number of valid Fortran INTEGER KINDs (must be defined before F_IKIND)*/
 #cmakedefine H5_H5CONFIG_F_NUM_IKIND @H5_H5CONFIG_F_NUM_IKIND@
 
 /* Define valid Fortran INTEGER KINDs */
 #cmakedefine H5_H5CONFIG_F_IKIND @H5_H5CONFIG_F_IKIND@
 
-/* Define number of valid Fortran REAL KINDs (must be defined before F_NUM_RKIND) */
+/* Define number of valid Fortran REAL KINDs (must be defined before F_RKIND) */
 #cmakedefine H5_H5CONFIG_F_NUM_RKIND @H5_H5CONFIG_F_NUM_RKIND@
 
 /* Define valid Fortran REAL KINDs */

--- a/config/cmake/HDF5UseFortran.cmake
+++ b/config/cmake/HDF5UseFortran.cmake
@@ -141,7 +141,7 @@ FORTRAN_RUN ("REAL and INTEGER KINDs"
 # dnl    -- LINE 5 --  number of valid real kinds
 #
 # Convert the string to a list of strings by replacing the carriage return with a semicolon
-string (REGEX REPLACE "\n" ";" PROG_OUTPUT "${PROG_OUTPUT}")
+string (REGEX REPLACE "[\r\n]+" ";" PROG_OUTPUT "${PROG_OUTPUT}")
 
 list (GET PROG_OUTPUT 0 pac_validIntKinds)
 list (GET PROG_OUTPUT 1 pac_validRealKinds)
@@ -195,7 +195,7 @@ foreach (KIND ${VAR})
    "
   )
   FORTRAN_RUN("INTEGER KIND SIZEOF" ${PROG_SRC_${KIND}} XX YY VALIDINTKINDS_RESULT_${KIND} PROG_OUTPUT1)
-  string (REGEX REPLACE "\n" "" PROG_OUTPUT1 "${PROG_OUTPUT1}")
+  string (REGEX REPLACE "[\r\n]+" "" PROG_OUTPUT1 "${PROG_OUTPUT1}")
   set (pack_int_sizeof "${pack_int_sizeof} ${PROG_OUTPUT1},")
 endforeach ()
 
@@ -238,7 +238,7 @@ foreach (KIND ${VAR} )
   "
   )
   FORTRAN_RUN ("REAL KIND SIZEOF" ${PROG_SRC2_${KIND}} XX YY VALIDREALKINDS_RESULT_${KIND} PROG_OUTPUT2)
-  string (REGEX REPLACE "\n" "" PROG_OUTPUT2 "${PROG_OUTPUT2}")
+  string (REGEX REPLACE "[\r\n]+" "" PROG_OUTPUT2 "${PROG_OUTPUT2}")
   set (pack_real_sizeof "${pack_real_sizeof} ${PROG_OUTPUT2},")
 endforeach ()
 
@@ -296,7 +296,7 @@ FORTRAN_RUN ("SIZEOF NATIVE KINDs" ${PROG_SRC3} XX YY PAC_SIZEOF_NATIVE_KINDS_RE
 # dnl    -- LINE 6 --  kind of DOUBLE PRECISION
 #
 # Convert the string to a list of strings by replacing the carriage return with a semicolon
-string (REGEX REPLACE "\n" ";" PROG_OUTPUT3 "${PROG_OUTPUT3}")
+string (REGEX REPLACE "[\r\n]+" ";" PROG_OUTPUT3 "${PROG_OUTPUT3}")
 
 list (GET PROG_OUTPUT3 0 PAC_FORTRAN_NATIVE_INTEGER_SIZEOF)
 list (GET PROG_OUTPUT3 1 PAC_FORTRAN_NATIVE_INTEGER_KIND)


### PR DESCRIPTION
On windows the extra CR would cause clang and Intel compilers to fail in compiling the H5pubconf.h.
The trick is to change the regex from just "\n" to "[\r\n]+"