### PR TITLE
Make default to build high-level tools the same as default for

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -849,7 +849,7 @@ if test "X-$BUILD_MODE" = "X-clean" ; then
   HDF5_HL_TOOLS=no
 else
   HDF5_HL=yes
-  HDF5_HL_TOOLS=no
+  HDF5_HL_TOOLS=yes
 fi
 
 ## high-level library directories (set when needed, blank until then)

--- a/configure.ac
+++ b/configure.ac
@@ -846,8 +846,10 @@ AC_SUBST([HDF5_HL_TOOLS])
 ## The high-level library is enabled unless the build mode is clean.
 if test "X-$BUILD_MODE" = "X-clean" ; then
   HDF5_HL=no
+  HDF5_HL_TOOLS=no
 else
   HDF5_HL=yes
+  HDF5_HL_TOOLS=no
 fi
 
 ## high-level library directories (set when needed, blank until then)


### PR DESCRIPTION
high-level library.