### PR TITLE
Initialize filter mask and chunk nbytes for 'Single' chunk index

### DIFF
--- a/src/H5Dsingle.c
+++ b/src/H5Dsingle.c
@@ -125,8 +125,14 @@ H5D__single_idx_init(const H5D_chk_idx_info_t *idx_info, const H5S_t H5_ATTR_UNU
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
 
-    if (idx_info->pline->nused)
+    if (idx_info->pline->nused) {
         idx_info->layout->flags |= H5O_LAYOUT_CHUNK_SINGLE_INDEX_WITH_FILTER;
+
+        if (!H5F_addr_defined(idx_info->storage->idx_addr)) {
+            idx_info->storage->u.single.nbytes      = 0;
+            idx_info->storage->u.single.filter_mask = 0;
+        }
+    }
     else
         idx_info->layout->flags = 0;
 


### PR DESCRIPTION
While experimenting with parallel compression and early file space allocation, I noticed that in the case of one-chunk datasets, the chunk was being written out without a filter applied. Then I noticed that the filter mask for the chunk upon chunk lookup was UINT_MAX, which causes the H5Z_pipeline call to ignore all filters and therefore the chunk gets inserted into the chunk index with all filters disabled.

Turns out, at dataset creation time we copy the default chunked layout into the dataset's shared structure. This default layout uses HADDR_UNDEF for the 'dset_ohdr_addr' field in the H5O_storage_chunk_t's 'btree' union field. Since the 'single' index exists in the same union, that HADDR_UNDEF value sets the 'single' field's 'nbytes' and 'filter_mask' fields both to UINT_MAX (the fields are both uint32_ts). Initializing them both to 0 on index initialization fixes this.