### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/testpar/t_file.c
+++ b/testpar/t_file.c
@@ -106,9 +106,7 @@ test_split_comm_access(void)
 
         /* delete the test file */
         if (sub_mpi_rank == 0) {
-            char fname[NAME_MAX];
-            strncpy(fname, filename, strlen(filename));
-            mrc = MPI_File_delete(fname, info);
+            mrc = MPI_File_delete(filename, info);
             /*VRFY((mrc==MPI_SUCCESS), ""); */
         }
     }

--- a/testpar/t_file.c
+++ b/testpar/t_file.c
@@ -108,7 +108,6 @@ test_split_comm_access(void)
         if (sub_mpi_rank == 0) {
             char fname[NAME_MAX];
             strncpy(fname, filename, strlen(filename));
-            // mrc = MPI_File_delete((char *)filename, info);
             mrc = MPI_File_delete(fname, info);
             /*VRFY((mrc==MPI_SUCCESS), ""); */
         }

--- a/testpar/t_file.c
+++ b/testpar/t_file.c
@@ -106,7 +106,10 @@ test_split_comm_access(void)
 
         /* delete the test file */
         if (sub_mpi_rank == 0) {
-            mrc = MPI_File_delete((char *)filename, info);
+            char fname[NAME_MAX];
+            strncpy(fname, filename, strlen(filename));
+            // mrc = MPI_File_delete((char *)filename, info);
+            mrc = MPI_File_delete(fname, info);
             /*VRFY((mrc==MPI_SUCCESS), ""); */
         }
     }


### PR DESCRIPTION
```
t_file.c:109:43: warning: cast from 'const char *' to 'char *' drops const qualifier [-Wcast-qual]
            mrc = MPI_File_delete((char *)filename, info);
```