### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/testpar/t_prop.c
+++ b/testpar/t_prop.c
@@ -215,7 +215,7 @@ test_plist_ed(void)
     dxpl = H5Pcreate(H5P_DATASET_XFER);
     VRFY((dxpl >= 0), "H5Pcreate succeeded");
 
-    ret = H5Pset_btree_ratios(dxpl, 0.2f, 0.6f, 0.2f);
+    ret = H5Pset_btree_ratios(dxpl, 0.2, 0.6, 0.2);
     VRFY((ret >= 0), "H5Pset_btree_ratios succeeded");
 
     ret = H5Pset_hyper_vector_size(dxpl, 5);
@@ -354,7 +354,7 @@ test_plist_ed(void)
     ret = H5Pset_alignment(fapl, 2, 1024);
     VRFY((ret >= 0), "H5Pset_alignment succeeded");
 
-    ret = H5Pset_cache(fapl, 1024, 128, 10485760, 0.3f);
+    ret = H5Pset_cache(fapl, 1024, 128, 10485760, 0.3);
     VRFY((ret >= 0), "H5Pset_cache succeeded");
 
     ret = H5Pset_elink_file_cache_size(fapl, 10485760);


### PR DESCRIPTION
```
t_prop.c:218:49: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
    ret = H5Pset_btree_ratios(dxpl, 0.2f, 0.6f, 0.2f);
          ~~~~~~~~~~~~~~~~~~~                   ^~~~
t_prop.c:218:43: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
    ret = H5Pset_btree_ratios(dxpl, 0.2f, 0.6f, 0.2f);
          ~~~~~~~~~~~~~~~~~~~             ^~~~
t_prop.c:218:37: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
    ret = H5Pset_btree_ratios(dxpl, 0.2f, 0.6f, 0.2f);
          ~~~~~~~~~~~~~~~~~~~       ^~~~
t_prop.c:357:51: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
    ret = H5Pset_cache(fapl, 1024, 128, 10485760, 0.3f);
          ~~~~~~~~~~~~                            ^~~~
4 warnings generated.
```