### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/testpar/t_2Gio.c
+++ b/testpar/t_2Gio.c
@@ -3347,12 +3347,12 @@ none_selection_chunk(void)
 static void
 test_actual_io_mode(int selection_mode)
 {
-    H5D_mpio_actual_chunk_opt_mode_t actual_chunk_opt_mode_write    = -1;
-    H5D_mpio_actual_chunk_opt_mode_t actual_chunk_opt_mode_read     = -1;
-    H5D_mpio_actual_chunk_opt_mode_t actual_chunk_opt_mode_expected = -1;
-    H5D_mpio_actual_io_mode_t        actual_io_mode_write           = -1;
-    H5D_mpio_actual_io_mode_t        actual_io_mode_read            = -1;
-    H5D_mpio_actual_io_mode_t        actual_io_mode_expected        = -1;
+    H5D_mpio_actual_chunk_opt_mode_t actual_chunk_opt_mode_write    = H5D_MPIO_NO_CHUNK_OPTIMIZATION;
+    H5D_mpio_actual_chunk_opt_mode_t actual_chunk_opt_mode_read     = H5D_MPIO_NO_CHUNK_OPTIMIZATION;
+    H5D_mpio_actual_chunk_opt_mode_t actual_chunk_opt_mode_expected = H5D_MPIO_NO_CHUNK_OPTIMIZATION;
+    H5D_mpio_actual_io_mode_t        actual_io_mode_write           = H5D_MPIO_NO_COLLECTIVE;
+    H5D_mpio_actual_io_mode_t        actual_io_mode_read            = H5D_MPIO_NO_COLLECTIVE;
+    H5D_mpio_actual_io_mode_t        actual_io_mode_expected        = H5D_MPIO_NO_COLLECTIVE;
     const char *                     filename;
     const char *                     test_name;
     hbool_t                          direct_multi_chunk_io;
@@ -3605,8 +3605,8 @@ test_actual_io_mode(int selection_mode)
 
         default:
             test_name                      = "Undefined Selection Mode";
-            actual_chunk_opt_mode_expected = -1;
-            actual_io_mode_expected        = -1;
+            actual_chunk_opt_mode_expected = H5D_MPIO_NO_CHUNK_OPTIMIZATION;
+            actual_io_mode_expected        = H5D_MPIO_NO_COLLECTIVE;
             break;
     }
 


### PR DESCRIPTION
```
t_2Gio.c:3350:71: warning: implicit conversion changes signedness: 'int' to
      'H5D_mpio_actual_chunk_opt_mode_t' (aka 'enum
      H5D_mpio_actual_chunk_opt_mode_t') [-Wsign-conversion]
    H5D_mpio_actual_chunk_opt_mode_t actual_chunk_opt_mode_write    = -1;
                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~      ^~
t_2Gio.c:3351:71: warning: implicit conversion changes signedness: 'int' to
      'H5D_mpio_actual_chunk_opt_mode_t' (aka 'enum
      H5D_mpio_actual_chunk_opt_mode_t') [-Wsign-conversion]
    H5D_mpio_actual_chunk_opt_mode_t actual_chunk_opt_mode_read     = -1;
                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~       ^~
t_2Gio.c:3352:71: warning: implicit conversion changes signedness: 'int' to
      'H5D_mpio_actual_chunk_opt_mode_t' (aka 'enum
      H5D_mpio_actual_chunk_opt_mode_t') [-Wsign-conversion]
    H5D_mpio_actual_chunk_opt_mode_t actual_chunk_opt_mode_expected = -1;
                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   ^~
t_2Gio.c:3353:71: warning: implicit conversion changes signedness: 'int' to
      'H5D_mpio_actual_io_mode_t' (aka 'enum H5D_mpio_actual_io_mode_t')
      [-Wsign-conversion]
    H5D_mpio_actual_io_mode_t        actual_io_mode_write           = -1;
                                     ~~~~~~~~~~~~~~~~~~~~             ^~
t_2Gio.c:3354:71: warning: implicit conversion changes signedness: 'int' to
      'H5D_mpio_actual_io_mode_t' (aka 'enum H5D_mpio_actual_io_mode_t')
      [-Wsign-conversion]
    H5D_mpio_actual_io_mode_t        actual_io_mode_read            = -1;
                                     ~~~~~~~~~~~~~~~~~~~              ^~
t_2Gio.c:3355:71: warning: implicit conversion changes signedness: 'int' to
      'H5D_mpio_actual_io_mode_t' (aka 'enum H5D_mpio_actual_io_mode_t')
      [-Wsign-conversion]
    H5D_mpio_actual_io_mode_t        actual_io_mode_expected        = -1;
                                     ~~~~~~~~~~~~~~~~~~~~~~~          ^~
t_2Gio.c:3608:46: warning: implicit conversion changes signedness: 'int' to
      'H5D_mpio_actual_chunk_opt_mode_t' (aka 'enum
      H5D_mpio_actual_chunk_opt_mode_t') [-Wsign-conversion]
            actual_chunk_opt_mode_expected = -1;
                                           ~ ^~
t_2Gio.c:3609:46: warning: implicit conversion changes signedness: 'int' to
      'H5D_mpio_actual_io_mode_t' (aka 'enum H5D_mpio_actual_io_mode_t')
      [-Wsign-conversion]
            actual_io_mode_expected        = -1;
                                           ~ ^~
```