### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/tools/src/h5perf/pio_perf.c
+++ b/tools/src/h5perf/pio_perf.c
@@ -904,7 +904,7 @@ accumulate_minmax_stuff(minmax *mm, int count)
     int    i;
     minmax total_mm;
 
-    total_mm.sum = 0.0f;
+    total_mm.sum = 0.0;
     total_mm.max = -DBL_MAX;
     total_mm.min = DBL_MAX;
     total_mm.num = count;


### PR DESCRIPTION
```
warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
    total_mm.sum = 0.0f;
                 ~ ^~~~
```