### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/src/H5FDmirror_priv.h
+++ b/src/H5FDmirror_priv.h
@@ -28,10 +28,10 @@ extern "C" {
  * = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
  */
 
-/* The maximum allowed size for a receiving buffer when accepting bytes to
+/* Define the maximum allowed size for a receiving buffer when accepting bytes to
  * write. Writes larger than this size are performed by multiple accept-write
  * steps by the Writer. */
-#define H5FD_MIRROR_DATA_BUFFER_MAX H5_GB /* 1 Gigabyte */
+#define H5FD_MIRROR_DATA_BUFFER_MAX (1024 * 1024 * 1024) /* 1 Gigabyte */
 
 #define H5FD_MIRROR_XMIT_CURR_VERSION 1
 #define H5FD_MIRROR_XMIT_MAGIC        0x87F8005B

--- a/src/H5Lint.c
+++ b/src/H5Lint.c
@@ -596,8 +596,10 @@ H5L__link_cb(H5G_loc_t *grp_loc /*in*/, const char *name, const H5O_link_t H5_AT
 
     /* Set the link's name correctly */
     /* Casting away const OK -QAK */
-    udata->lnk->name = (char *)name;
-
+    udata->lnk->name = strdup(name);
+    if (NULL == udata->lnk->name) {
+        HGOTO_ERROR(H5E_LINK, H5E_CANTINIT, FAIL, "out of memory")
+    }
     /* Insert link into group */
     if (H5G_obj_insert(grp_loc->oloc, name, udata->lnk, TRUE,
                        udata->ocrt_info ? udata->ocrt_info->obj_type : H5O_TYPE_UNKNOWN,
@@ -646,8 +648,13 @@ H5L__link_cb(H5G_loc_t *grp_loc /*in*/, const char *name, const H5O_link_t H5_AT
     }     /* end if */
 
 done:
+
     /* Check if an object was created */
     if (obj_created) {
+        if (NULL != udata->lnk->name) {
+            HDfree(udata->lnk->name);
+        }
+
         H5O_loc_t oloc; /* Object location for created object */
 
         /* Set up object location */
@@ -675,7 +682,6 @@ done:
     /* Indicate that this callback didn't take ownership of the group *
      * location for the object */
     *own_loc = H5G_OWN_NONE;
-
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5L__link_cb() */
 
@@ -1376,7 +1382,10 @@ H5L__move_dest_cb(H5G_loc_t *grp_loc /*in*/, const char *name, const H5O_link_t 
     /* Give the object its new name */
     /* Casting away const okay -JML */
     HDassert(udata->lnk->name == NULL);
-    udata->lnk->name = (char *)name;
+    udata->lnk->name = strdup(name);
+    if (NULL == udata->lnk->name) {
+        HGOTO_ERROR(H5E_LINK, H5E_CANTINIT, FAIL, "out of memory")
+    }
 
     /* Insert the link into the group */
     if (H5G_obj_insert(grp_loc->oloc, name, udata->lnk, TRUE, H5O_TYPE_UNKNOWN, NULL) < 0)
@@ -1443,8 +1452,10 @@ done:
 
     /* Reset the "name" field in udata->lnk because it is owned by traverse()
      * and must not be manipulated after traverse closes */
+    if (NULL != udata->lnk->name) {
+        HDfree(udata->lnk->name);
+    }
     udata->lnk->name = NULL;
-
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5L__move_dest_cb() */
 

--- a/src/H5Lint.c
+++ b/src/H5Lint.c
@@ -596,7 +596,7 @@ H5L__link_cb(H5G_loc_t *grp_loc /*in*/, const char *name, const H5O_link_t H5_AT
 
     /* Set the link's name correctly */
     /* Casting away const OK -QAK */
-    udata->lnk->name = strdup(name);
+    udata->lnk->name = HDstrdup(name);
     if (NULL == udata->lnk->name) {
         HGOTO_ERROR(H5E_LINK, H5E_CANTINIT, FAIL, "out of memory")
     }

--- a/utils/mirror_vfd/mirror_writer.c
+++ b/utils/mirror_vfd/mirror_writer.c
@@ -868,7 +868,7 @@ receive_communique(struct mirror_session *session, struct sock_comm *comm)
     mirror_log(session->loginfo, V_INFO, "received %zd bytes", read_ret);
     if (HEXDUMP_XMITS) {
         mirror_log(session->loginfo, V_ALL, "```", read_ret);
-        mirror_log_bytes(session->loginfo, V_ALL, (size_t)read_ret, (const unsigned char *)comm->raw);
+        mirror_log_bytes(session->loginfo, V_ALL, read_ret, (const unsigned char *)comm->raw);
         mirror_log(session->loginfo, V_ALL, "```");
     } /* end if hexdump transmissions received */
 


### PR DESCRIPTION
```
H5Lint.c:599:32: warning: cast from 'const char *' to 'char *' drops const qualifie\
r [-Wcast-qual]
    udata->lnk->name = (char *)name;
                               ^
H5Lint.c:1379:32: warning: cast from 'const char *' to 'char *' drops const qualifi\
er [-Wcast-qual]
    udata->lnk->name = (char *)name;
```