### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/src/H5FDros3.c
+++ b/src/H5FDros3.c
@@ -304,8 +304,12 @@ H5FD_ros3_init(void)
     HDfprintf(stdout, "H5FD_ros3_init() called.\n");
 #endif
 
-    if (H5I_VFL != H5I_get_type(H5FD_ROS3_g))
+    if (H5I_VFL != H5I_get_type(H5FD_ROS3_g)) {
         H5FD_ROS3_g = H5FD_register(&H5FD_ros3_g, sizeof(H5FD_class_t), FALSE);
+        if (H5I_INVALID_HID == H5FD_ROS3_g) {
+            HGOTO_ERROR(H5E_ID, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to register ros3");
+        }
+    }
 
 #if ROS3_STATS
     /* pre-compute statsbin boundaries


### PR DESCRIPTION
```
H5FDros3.c:301:5: warning: unused variable 'err_occurred' [-Wunused-variable]
    FUNC_ENTER_NOAPI(H5I_INVALID_HID)
    ^
./H5private.h:2192:9: note: expanded from macro 'FUNC_ENTER_NOAPI'
        FUNC_ENTER_COMMON(!H5_IS_API(__func__));                                   \
                          \
        ^
./H5private.h:2050:13: note: expanded from macro 'FUNC_ENTER_COMMON'
    hbool_t err_occurred = FALSE;                                                  \
                          \
            ^
H5FDros3.c:323:1: warning: unused label 'done' [-Wunused-label]
done:
^~~~~

```