### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/src/H5FDmirror.c
+++ b/src/H5FDmirror.c
@@ -225,9 +225,11 @@ H5FD_mirror_init(void)
 
     LOG_OP_CALL(__func__);
 
-    if (H5I_VFL != H5I_get_type(H5FD_MIRROR_g))
+    if (H5I_VFL != H5I_get_type(H5FD_MIRROR_g)) {
         H5FD_MIRROR_g = H5FD_register(&H5FD_mirror_g, sizeof(H5FD_class_t), FALSE);
-
+        if (H5I_INVALID_HID == H5FD_MIRROR_g)
+            HGOTO_ERROR(H5E_ID, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to register mirror");
+    }
     ret_value = H5FD_MIRROR_g;
 
 done:


### PR DESCRIPTION
```
H5FDmirror.c:224:5: warning: unused variable 'err_occurred' [-Wunused-variable]
    FUNC_ENTER_NOAPI(H5I_INVALID_HID)
    ^
H5FDmirror.c:233:1: warning: unused label 'done' [-Wunused-label]
done:
^~~~~
```