### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/src/H5FDdirect.c
+++ b/src/H5FDdirect.c
@@ -213,8 +213,11 @@ H5FD_direct_init(void)
     else
         ignore_disabled_file_locks_s = FAIL; /* Environment variable not set, or not set correctly */
 
-    if (H5I_VFL != H5I_get_type(H5FD_DIRECT_g))
+    if (H5I_VFL != H5I_get_type(H5FD_DIRECT_g)) {
         H5FD_DIRECT_g = H5FD_register(&H5FD_direct_g, sizeof(H5FD_class_t), FALSE);
+        if (H5I_INVALID_HID == H5FD_DIRECT_g)
+            HGOTO_ERROR(H5E_ID, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to register direct");
+    }
 
     /* Set return value */
     ret_value = H5FD_DIRECT_g;


### PR DESCRIPTION
```
warning: unknown warning option '-Wdouble-promotion'; did you mean
      '-Wdocumentation'? [-Wunknown-warning-option]
H5FDdirect.c:205:5: warning: unused variable 'err_occurred' [-Wunused-variable]
    FUNC_ENTER_NOAPI(H5I_INVALID_HID)
    ^
./H5private.h:2192:9: note: expanded from macro 'FUNC_ENTER_NOAPI'
        FUNC_ENTER_COMMON(!H5_IS_API(__func__))...
        ^
./H5private.h:2050:13: note: expanded from macro 'FUNC_ENTER_COMMON'
    hbool_t err_occurred = FALSE...
            ^
H5FDdirect.c:222:1: warning: unused label 'done' [-Wunused-label]
done:
^~~~~
```