### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/test/mirror_vfd.c
+++ b/test/mirror_vfd.c
@@ -2610,7 +2610,6 @@ main(void)
     if (nerrors == 0) {
         nerrors -= test_fapl_configuration();
         nerrors -= test_xmit_encode_decode();
-        nerrors -= test_on_disk_zoo();
         nerrors -= test_create_and_close();
         nerrors -= test_basic_dataset_write();
         nerrors -= test_chunked_dataset_write();

--- a/test/mirror_vfd.c
+++ b/test/mirror_vfd.c
@@ -2183,8 +2183,9 @@ test_on_disk_zoo(void)
     if (pass) {
         validate_zoo(file_id, grp_name, 0); /* sanity-check */
     }
+
     if (!pass) {
-        HDprintf(failure_mssg);
+        HDprintf("%s", failure_mssg);
         TEST_ERROR;
     }
 
@@ -2609,6 +2610,7 @@ main(void)
     if (nerrors == 0) {
         nerrors -= test_fapl_configuration();
         nerrors -= test_xmit_encode_decode();
+        nerrors -= test_on_disk_zoo();
         nerrors -= test_create_and_close();
         nerrors -= test_basic_dataset_write();
         nerrors -= test_chunked_dataset_write();


### PR DESCRIPTION
```
 mirror_vfd.c:2188:18: warning: format string is not a string literal
      (potentially insecure) [-Wformat-security]
        HDprintf(failure_mssg);
                 ^~~~~~~~~~~~
```