### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/src/H5FDmirror_priv.h
+++ b/src/H5FDmirror_priv.h
@@ -28,10 +28,10 @@ extern "C" {
  * = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
  */
 
-/* The maximum allowed size for a receiving buffer when accepting bytes to
+/* Define the maximum allowed size for a receiving buffer when accepting bytes to
  * write. Writes larger than this size are performed by multiple accept-write
  * steps by the Writer. */
-#define H5FD_MIRROR_DATA_BUFFER_MAX H5_GB /* 1 Gigabyte */
+#define H5FD_MIRROR_DATA_BUFFER_MAX (1024 * 1024 * 1024) /* 1 Gigabyte */
 
 #define H5FD_MIRROR_XMIT_CURR_VERSION 1
 #define H5FD_MIRROR_XMIT_MAGIC        0x87F8005B

--- a/utils/mirror_vfd/mirror_remote.c
+++ b/utils/mirror_vfd/mirror_remote.c
@@ -78,7 +78,7 @@ mirror_log(struct mirror_log_info *info, unsigned int level, const char *format,
  * ----------------------------------------------------------------------------
  */
 void
-mirror_log_bytes(struct mirror_log_info *info, unsigned int level, size_t n_bytes, const unsigned char *buf)
+mirror_log_bytes(struct mirror_log_info *info, unsigned int level, ssize_t n_bytes, const unsigned char *buf)
 {
     FILE *       stream    = MIRROR_LOG_DEFAULT_STREAM;
     unsigned int verbosity = MIRROR_LOG_DEFAULT_VERBOSITY;
@@ -93,7 +93,7 @@ mirror_log_bytes(struct mirror_log_info *info, unsigned int level, size_t n_byte
     }
 
     if (level <= verbosity) {
-        size_t               bytes_written = 0;
+        ssize_t              bytes_written = 0;
         const unsigned char *b             = NULL;
 
         /* print whole lines */
@@ -147,7 +147,7 @@ mirror_log_bytes(struct mirror_log_info *info, unsigned int level, size_t n_byte
  * ----------------------------------------------------------------------------
  */
 loginfo_t *
-mirror_log_init(char *path, char *prefix, unsigned int verbosity)
+mirror_log_init(char *path, const char *prefix, unsigned int verbosity)
 {
     loginfo_t *info = NULL;
 

--- a/utils/mirror_vfd/mirror_remote.h
+++ b/utils/mirror_vfd/mirror_remote.h
@@ -41,8 +41,8 @@ typedef struct mirror_log_info {
 } loginfo_t;
 
 void       mirror_log(loginfo_t *info, unsigned int level, const char *format, ...);
-void       mirror_log_bytes(loginfo_t *info, unsigned int level, size_t n_bytes, const unsigned char *buf);
-loginfo_t *mirror_log_init(char *path, char *prefix, unsigned int verbosity);
+void       mirror_log_bytes(loginfo_t *info, unsigned int level, ssize_t n_bytes, const unsigned char *buf);
+loginfo_t *mirror_log_init(char *path, const char *prefix, unsigned int verbosity);
 int        mirror_log_term(loginfo_t *loginfo);
 
 herr_t run_writer(int socketfd, H5FD_mirror_xmit_open_t *xmit_open);

--- a/utils/mirror_vfd/mirror_server.c
+++ b/utils/mirror_vfd/mirror_server.c
@@ -94,14 +94,14 @@
  * ---------------------------------------------------------------------------
  */
 struct op_args {
-    uint32_t magic;
-    int      help;
-    int      main_port;
-    int      verbosity;
-    int      log_prepend_serv;
-    int      log_prepend_type;
-    char     log_path[PATH_MAX + 1];
-    char     writer_log_path[PATH_MAX + 1];
+    uint32_t     magic;
+    int          help;
+    int          main_port;
+    unsigned int verbosity;
+    int          log_prepend_serv;
+    int          log_prepend_type;
+    char         log_path[PATH_MAX + 1];
+    char         writer_log_path[PATH_MAX + 1];
 };
 
 /* ---------------------------------------------------------------------------
@@ -224,7 +224,7 @@ parse_args(int argc, char **argv, struct op_args *args_out)
         } /* end if port */
         else if (!HDstrncmp(argv[i], "--verbosity=", 12)) {
             mirror_log(NULL, V_INFO, "parsing 'verbosity' (%s)", argv[i] + 12);
-            args_out->verbosity = HDatoi(argv[i] + 12);
+            args_out->verbosity = (unsigned int)HDatoi(argv[i] + 12);
         } /* end if verbosity */
         else if (!HDstrncmp(argv[i], "--logpath=", 10)) {
             mirror_log(NULL, V_INFO, "parsing 'logpath' (%s)", argv[i] + 10);
@@ -456,7 +456,7 @@ error:
  * ---------------------------------------------------------------------------
  */
 static void
-wait_for_child(int sig)
+wait_for_child()
 {
     while (HDwaitpid(-1, NULL, WNOHANG) > 0)
         ;
@@ -476,7 +476,7 @@ handle_requests(struct server_run *run)
 {
     int              connfd = -1;                       /**/
     char             mybuf[H5FD_MIRROR_XMIT_OPEN_SIZE]; /**/
-    int              ret;                               /* general-purpose error-checking */
+    ssize_t          ret;                               /* general-purpose error-checking */
     int              pid;                               /* process ID of fork */
     struct sigaction sa;
     int              ret_value = 0;
@@ -521,7 +521,7 @@ handle_requests(struct server_run *run)
         /* Read handshake from port connection.
          */
 
-        ret = (int)HDread(connfd, &mybuf, H5FD_MIRROR_XMIT_OPEN_SIZE);
+        ret = HDread(connfd, &mybuf, H5FD_MIRROR_XMIT_OPEN_SIZE);
         if (-1 == ret) {
             mirror_log(run->loginfo, V_ERR, "read:%d", ret);
             goto error;

--- a/utils/mirror_vfd/mirror_writer.c
+++ b/utils/mirror_vfd/mirror_writer.c
@@ -763,7 +763,7 @@ do_write(struct mirror_session *session, const unsigned char *xmit_buf)
 
     /* Allocate the buffer once -- re-use between loops.
      */
-    buf = (char *)HDmalloc(sizeof(char) * (unsigned long)H5FD_MIRROR_DATA_BUFFER_MAX);
+    buf = (char *)HDmalloc(sizeof(char) * H5FD_MIRROR_DATA_BUFFER_MAX);
     if (NULL == buf) {
         mirror_log(session->loginfo, V_ERR, "can't allocate databuffer");
         reply_error(session, "can't allocate buffer for receiving data");
@@ -788,7 +788,7 @@ do_write(struct mirror_session *session, const unsigned char *xmit_buf)
      */
     sum_bytes_written = 0;
     do {
-        nbytes_in_packet = HDread(session->sockfd, buf, (unsigned long)H5FD_MIRROR_DATA_BUFFER_MAX);
+        nbytes_in_packet = HDread(session->sockfd, buf, H5FD_MIRROR_DATA_BUFFER_MAX);
         if (-1 == nbytes_in_packet) {
             mirror_log(session->loginfo, V_ERR, "can't read into databuffer");
             reply_error(session, "can't read data buffer");

--- a/utils/mirror_vfd/mirror_writer.c
+++ b/utils/mirror_vfd/mirror_writer.c
@@ -763,7 +763,7 @@ do_write(struct mirror_session *session, const unsigned char *xmit_buf)
 
     /* Allocate the buffer once -- re-use between loops.
      */
-    buf = (char *)HDmalloc(sizeof(char) * H5FD_MIRROR_DATA_BUFFER_MAX);
+    buf = (char *)HDmalloc(sizeof(char) * (unsigned long)H5FD_MIRROR_DATA_BUFFER_MAX);
     if (NULL == buf) {
         mirror_log(session->loginfo, V_ERR, "can't allocate databuffer");
         reply_error(session, "can't allocate buffer for receiving data");
@@ -788,7 +788,7 @@ do_write(struct mirror_session *session, const unsigned char *xmit_buf)
      */
     sum_bytes_written = 0;
     do {
-        nbytes_in_packet = HDread(session->sockfd, buf, H5FD_MIRROR_DATA_BUFFER_MAX);
+        nbytes_in_packet = HDread(session->sockfd, buf, (unsigned long)H5FD_MIRROR_DATA_BUFFER_MAX);
         if (-1 == nbytes_in_packet) {
             mirror_log(session->loginfo, V_ERR, "can't read into databuffer");
             reply_error(session, "can't read data buffer");
@@ -868,7 +868,7 @@ receive_communique(struct mirror_session *session, struct sock_comm *comm)
     mirror_log(session->loginfo, V_INFO, "received %zd bytes", read_ret);
     if (HEXDUMP_XMITS) {
         mirror_log(session->loginfo, V_ALL, "```", read_ret);
-        mirror_log_bytes(session->loginfo, V_ALL, (size_t)read_ret, (const unsigned char *)comm->raw);
+        mirror_log_bytes(session->loginfo, V_ALL, read_ret, (const unsigned char *)comm->raw);
         mirror_log(session->loginfo, V_ALL, "```");
     } /* end if hexdump transmissions received */
 


### PR DESCRIPTION
```
mirror_writer.c:225:55: warning: passing 'const char [4]' to parameter of type 'cha\
r *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
    session->loginfo = mirror_log_init(opts->logpath, "W- ", MIRROR_LOG_DEFAULT_VER\
BOSITY);
                                                      ^~~~~
./mirror_remote.h:45:46: note: passing argument to parameter 'prefix' here
loginfo_t *mirror_log_init(char *path, char *prefix, unsigned int verbosity);
                                             ^
mirror_writer.c:766:41: warning: implicit conversion turns floating-point number in\
to integer: 'float' to 'unsigned long' [-Wfloat-conversion]
    buf = (char *)HDmalloc(sizeof(char) * H5FD_MIRROR_DATA_BUFFER_MAX);
                  ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../src/H5private.h:1053:28: note: expanded from macro 'HDmalloc'
#define HDmalloc(Z) malloc(Z)
                    ~~~~~~ ^
mirror_writer.c:791:57: warning: implicit conversion turns floating-point number in\
to integer: 'float' to 'size_t' (aka 'unsigned long') [-Wfloat-conversion]
        nbytes_in_packet = HDread(session->sockfd, buf, H5FD_MIRROR_DATA_BUFFER_MAX\
);

                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~\
~
../../src/H5FDmirror_priv.h:34:37: note: expanded from macro 'H5FD_MIRROR_DATA_BUFF\
ER_MAX'
#define H5FD_MIRROR_DATA_BUFFER_MAX H5_GB /* 1 Gigabyte */
                                    ^~~~~
../../src/H5private.h:443:34: note: expanded from macro 'H5_GB'
#define H5_GB (1024.0F * 1024.0F * 1024.0F)
               ~~~~~~~~~~~~~~~~~~^~~~~~~~~
../../src/H5private.h:1243:36: note: expanded from macro 'HDread'
#define HDread(F, M, Z) read(F, M, Z)
                        ~~~~       ^
mirror_writer.c:801:55: warning: implicit conversion changes signedness: 'ssize_t' \
(aka 'long') to 'size_t' (aka 'unsigned long') [-Wsign-conversion]
            mirror_log_bytes(session->loginfo, V_ALL, nbytes_in_packet, (const unsi\
gned char *)buf);
            ~~~~~~~~~~~~~~~~                          ^~~~~~~~~~~~~~~~
mirror_server.c:341:56: warning: passing 'const char [4]' to parameter of type 'cha\
r *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
    run->loginfo = mirror_log_init(run->opts.log_path, "s- ", run->opts.verbosity);
                                                       ^~~~~
./mirror_remote.h:45:46: note: passing argument to parameter 'prefix' here
loginfo_t *mirror_log_init(char *path, char *prefix, unsigned int verbosity);
                                             ^
mirror_server.c:341:73: warning: implicit conversion changes signedness: 'int' to '\
unsigned int' [-Wsign-conversion]
    run->loginfo = mirror_log_init(run->opts.log_path, "s- ", run->opts.verbosity);
                   ~~~~~~~~~~~~~~~                            ~~~~~~~~~~^~~~~~~~~
mirror_server.c:459:20: warning: unused parameter 'sig' [-Wunused-parameter]
wait_for_child(int sig)
                   ^
mirror_server.c:531:47: warning: implicit conversion changes signedness: 'int' to '\
size_t' (aka 'unsigned long') [-Wsign-conversion]
        mirror_log_bytes(run->loginfo, V_ALL, ret, (const unsigned char *)mybuf);
        ~~~~~~~~~~~~~~~~                      ^~~
```