### PR TITLE
Fix usage of several HDfprintf format specifiers after HDfprintf removal

### DIFF
--- a/src/H5FAdblkpage.c
+++ b/src/H5FAdblkpage.c
@@ -147,7 +147,7 @@ H5FA__dblk_page_create(H5FA_hdr_t *hdr, haddr_t addr, size_t nelmts)
     FUNC_ENTER_PACKAGE
 
 #ifdef H5FA_DEBUG
-    HDfprintf(stderr, "%s: Called, addr = %a\n", __func__, addr);
+    HDfprintf(stderr, "%s: Called, addr = " H5_PRINTF_HADDR_FMT "\n", __func__, addr);
 #endif /* H5FA_DEBUG */
 
     /* Sanity check */

--- a/src/H5FAprivate.h
+++ b/src/H5FAprivate.h
@@ -134,7 +134,7 @@ H5_DLL herr_t  H5FA_patch_file(H5FA_t *fa, H5F_t *f);
 H5_DLL herr_t H5FA_get_stats(const H5FA_t *ea, H5FA_stat_t *stats);
 
 /* Debugging routines */
-#ifdef H5FA_DEBUGGING
-#endif /* H5FA_DEBUGGING */
+#ifdef H5FA_DEBUG
+#endif /* H5FA_DEBUG */
 
 #endif /* H5FAprivate_H */

--- a/src/H5FDspace.c
+++ b/src/H5FDspace.c
@@ -148,7 +148,7 @@ H5FD__alloc_real(H5FD_t *file, H5FD_mem_t type, hsize_t size, haddr_t *frag_addr
 
     FUNC_ENTER_PACKAGE
 #ifdef H5FD_ALLOC_DEBUG
-    HDfprintf(stderr, "%s: type = %u, size = %Hu\n", __func__, (unsigned)type, size);
+    HDfprintf(stderr, "%s: type = %u, size = " H5_PRINTF_HSIZE_FMT "\n", __func__, (unsigned)type, size);
 #endif /* H5FD_ALLOC_DEBUG */
 
     /* check args */
@@ -211,7 +211,7 @@ H5FD__alloc_real(H5FD_t *file, H5FD_mem_t type, hsize_t size, haddr_t *frag_addr
 
 done:
 #ifdef H5FD_ALLOC_DEBUG
-    HDfprintf(stderr, "%s: ret_value = %a\n", __func__, ret_value);
+    HDfprintf(stderr, "%s: ret_value = " H5_PRINTF_HADDR_FMT "\n", __func__, ret_value);
 #endif /* H5FD_ALLOC_DEBUG */
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5FD__alloc_real() */
@@ -287,7 +287,8 @@ H5FD__free_real(H5FD_t *file, H5FD_mem_t type, haddr_t addr, hsize_t size)
     HDassert(size > 0);
 
 #ifdef H5FD_ALLOC_DEBUG
-    HDfprintf(stderr, "%s: type = %u, addr = %a, size = %Hu\n", __func__, (unsigned)type, addr, size);
+    HDfprintf(stderr, "%s: type = %u, addr = " H5_PRINTF_HADDR_FMT ", size = " H5_PRINTF_HSIZE_FMT "\n",
+              __func__, (unsigned)type, addr, size);
 #endif /* H5FD_ALLOC_DEBUG */
 
     /* Sanity checking */
@@ -317,11 +318,11 @@ H5FD__free_real(H5FD_t *file, H5FD_mem_t type, haddr_t addr, hsize_t size)
 
         eoa = file->cls->get_eoa(file, type);
 #ifdef H5FD_ALLOC_DEBUG
-        HDfprintf(stderr, "%s: eoa = %a\n", __func__, eoa);
+        HDfprintf(stderr, "%s: eoa = " H5_PRINTF_HADDR_FMT "\n", __func__, eoa);
 #endif /* H5FD_ALLOC_DEBUG */
         if (eoa == (addr + size)) {
 #ifdef H5FD_ALLOC_DEBUG
-            HDfprintf(stderr, "%s: Reducing file size to = %a\n", __func__, addr);
+            HDfprintf(stderr, "%s: Reducing file size to = " H5_PRINTF_HADDR_FMT "\n", __func__, addr);
 #endif /* H5FD_ALLOC_DEBUG */
             if (file->cls->set_eoa(file, type, addr) < 0)
                 HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, "set end of space allocation request failed")
@@ -330,8 +331,10 @@ H5FD__free_real(H5FD_t *file, H5FD_mem_t type, haddr_t addr, hsize_t size)
     else {
         /* leak memory */
 #ifdef H5FD_ALLOC_DEBUG
-        HDfprintf(stderr, "%s: LEAKED MEMORY!!! type = %u, addr = %a, size = %Hu\n", __func__, (unsigned)type,
-                  addr, size);
+        HDfprintf(stderr,
+                  "%s: LEAKED MEMORY!!! type = %u, addr = " H5_PRINTF_HADDR_FMT
+                  ", size = " H5_PRINTF_HSIZE_FMT "\n",
+                  __func__, (unsigned)type, addr, size);
 #endif /* H5FD_ALLOC_DEBUG */
     }  /* end else */
 

--- a/src/H5FS.c
+++ b/src/H5FS.c
@@ -143,7 +143,8 @@ H5FS_create(H5F_t *f, haddr_t *fs_addr, const H5FS_create_t *fs_create, uint16_t
     /* Set the return value */
     ret_value = fspace;
 #ifdef H5FS_DEBUG
-    HDfprintf(stderr, "%s: fspace = %p, fspace->addr = %a\n", __func__, fspace, fspace->addr);
+    HDfprintf(stderr, "%s: fspace = %p, fspace->addr = " H5_PRINTF_HADDR_FMT "\n", __func__, (void *)fspace,
+              fspace->addr);
 #endif /* H5FS_DEBUG */
 
 done:
@@ -152,7 +153,7 @@ done:
             HDONE_ERROR(H5E_FSPACE, H5E_CANTFREE, NULL, "unable to destroy free space header")
 
 #ifdef H5FS_DEBUG
-    HDfprintf(stderr, "%s: Leaving, ret_value = %d\n", __func__, ret_value);
+    HDfprintf(stderr, "%s: Leaving, ret_value = %p\n", __func__, (void *)ret_value);
 #endif /* H5FS_DEBUG */
     FUNC_LEAVE_NOAPI(ret_value)
 } /* H5FS_create() */
@@ -180,8 +181,8 @@ H5FS_open(H5F_t *f, haddr_t fs_addr, uint16_t nclasses, const H5FS_section_class
 
     FUNC_ENTER_NOAPI(NULL)
 #ifdef H5FS_DEBUG
-    HDfprintf(stderr, "%s: Opening free space manager, fs_addr = %a, nclasses = %Zu\n", __func__, fs_addr,
-              nclasses);
+    HDfprintf(stderr, "%s: Opening free space manager, fs_addr = " H5_PRINTF_HADDR_FMT ", nclasses = %Zu\n",
+              __func__, fs_addr, nclasses);
 #endif /* H5FS_DEBUG */
 
     /* Check arguments. */
@@ -201,10 +202,11 @@ H5FS_open(H5F_t *f, haddr_t fs_addr, uint16_t nclasses, const H5FS_section_class
         (fspace = (H5FS_t *)H5AC_protect(f, H5AC_FSPACE_HDR, fs_addr, &cache_udata, H5AC__READ_ONLY_FLAG)))
         HGOTO_ERROR(H5E_FSPACE, H5E_CANTPROTECT, NULL, "unable to load free space header")
 #ifdef H5FS_DEBUG
-    HDfprintf(stderr, "%s: fspace->sect_addr = %a\n", __func__, fspace->sect_addr);
-    HDfprintf(stderr, "%s: fspace->sect_size = %Hu\n", __func__, fspace->sect_size);
-    HDfprintf(stderr, "%s: fspace->alloc_sect_size = %Hu\n", __func__, fspace->alloc_sect_size);
-    HDfprintf(stderr, "%s: fspace->sinfo = %p\n", __func__, fspace->sinfo);
+    HDfprintf(stderr, "%s: fspace->sect_addr = " H5_PRINTF_HADDR_FMT "\n", __func__, fspace->sect_addr);
+    HDfprintf(stderr, "%s: fspace->sect_size = " H5_PRINTF_HSIZE_FMT "\n", __func__, fspace->sect_size);
+    HDfprintf(stderr, "%s: fspace->alloc_sect_size = " H5_PRINTF_HSIZE_FMT "\n", __func__,
+              fspace->alloc_sect_size);
+    HDfprintf(stderr, "%s: fspace->sinfo = %p\n", __func__, (void *)fspace->sinfo);
     HDfprintf(stderr, "%s: fspace->rc = %u\n", __func__, fspace->rc);
 #endif /* H5FS_DEBUG */
 
@@ -248,7 +250,8 @@ H5FS_delete(H5F_t *f, haddr_t fs_addr)
 
     FUNC_ENTER_NOAPI(FAIL)
 #ifdef H5FS_DEBUG
-    HDfprintf(stderr, "%s: Deleting free space manager, fs_addr = %a\n", __func__, fs_addr);
+    HDfprintf(stderr, "%s: Deleting free space manager, fs_addr = " H5_PRINTF_HADDR_FMT "\n", __func__,
+              fs_addr);
 #endif /* H5FS_DEBUG */
 
     /* Check arguments. */
@@ -318,7 +321,7 @@ H5FS_delete(H5F_t *f, haddr_t fs_addr)
 
     /* Delete serialized section storage, if there are any */
 #ifdef H5FS_DEBUG
-    HDfprintf(stderr, "%s: fspace->sect_addr = %a\n", __func__, fspace->sect_addr);
+    HDfprintf(stderr, "%s: fspace->sect_addr = " H5_PRINTF_HADDR_FMT "\n", __func__, fspace->sect_addr);
 #endif /* H5FS_DEBUG */
     if (fspace->serial_sect_count > 0) {
         unsigned sinfo_status = 0; /* Free space section info's status in the metadata cache */
@@ -404,8 +407,9 @@ H5FS_close(H5F_t *f, H5FS_t *fspace)
     HDassert(f);
     HDassert(fspace);
 #ifdef H5FS_DEBUG
-    HDfprintf(stderr, "%s: Entering, fspace = %p, fspace->addr = %a, fspace->sinfo = %p\n", __func__, fspace,
-              fspace->addr, fspace->sinfo);
+    HDfprintf(stderr,
+              "%s: Entering, fspace = %p, fspace->addr = " H5_PRINTF_HADDR_FMT ", fspace->sinfo = %p\n",
+              __func__, (void *)fspace, fspace->addr, (void *)fspace->sinfo);
 #endif /* H5FS_DEBUG */
 
     /* Check if section info is valid */
@@ -413,11 +417,14 @@ H5FS_close(H5F_t *f, H5FS_t *fspace)
     if (fspace->sinfo) {
 #ifdef H5FS_DEBUG
         HDfprintf(stderr,
-                  "%s: fspace->tot_sect_count = %Hu, fspace->serial_sect_count = %Hu, fspace->sect_addr = "
-                  "%a, fspace->rc = %u\n",
+                  "%s: fspace->tot_sect_count = " H5_PRINTF_HSIZE_FMT
+                  ", fspace->serial_sect_count = " H5_PRINTF_HSIZE_FMT
+                  ", fspace->sect_addr = " H5_PRINTF_HADDR_FMT ", fspace->rc = %u\n",
                   __func__, fspace->tot_sect_count, fspace->serial_sect_count, fspace->sect_addr, fspace->rc);
-        HDfprintf(stderr, "%s: fspace->alloc_sect_size = %Hu, fspace->sect_size = %Hu\n", __func__,
-                  fspace->alloc_sect_size, fspace->sect_size);
+        HDfprintf(stderr,
+                  "%s: fspace->alloc_sect_size = " H5_PRINTF_HSIZE_FMT
+                  ", fspace->sect_size = " H5_PRINTF_HSIZE_FMT "\n",
+                  __func__, fspace->alloc_sect_size, fspace->sect_size);
 #endif /* H5FS_DEBUG */
         /* If there are sections to serialize, update them */
         /* (if the free space manager is persistent) */
@@ -708,8 +715,8 @@ H5FS__incr(H5FS_t *fspace)
 
     FUNC_ENTER_PACKAGE
 #ifdef H5FS_DEBUG
-    HDfprintf(stderr, "%s: Entering, fpace->addr = %a, fspace->rc = %u\n", __func__, fspace->addr,
-              fspace->rc);
+    HDfprintf(stderr, "%s: Entering, fpace->addr = " H5_PRINTF_HADDR_FMT ", fspace->rc = %u\n", __func__,
+              fspace->addr, fspace->rc);
 #endif /* H5FS_DEBUG */
 
     /*
@@ -748,8 +755,8 @@ H5FS__decr(H5FS_t *fspace)
 
     FUNC_ENTER_PACKAGE
 #ifdef H5FS_DEBUG
-    HDfprintf(stderr, "%s: Entering, fpace->addr = %a, fspace->rc = %u\n", __func__, fspace->addr,
-              fspace->rc);
+    HDfprintf(stderr, "%s: Entering, fpace->addr = " H5_PRINTF_HADDR_FMT ", fspace->rc = %u\n", __func__,
+              fspace->addr, fspace->rc);
 #endif /* H5FS_DEBUG */
 
     /*

--- a/src/H5FSsection.c
+++ b/src/H5FSsection.c
@@ -123,7 +123,7 @@ H5FS__sinfo_new(H5F_t *f, H5FS_t *fspace)
     HDassert(f);
     HDassert(fspace);
 #ifdef H5FS_SINFO_DEBUG
-    HDfprintf(stderr, "%s: fspace->addr = %a\n", __func__, fspace->addr);
+    HDfprintf(stderr, "%s: fspace->addr = " H5_PRINTF_HADDR_FMT "\n", __func__, fspace->addr);
 #endif /* H5FS_SINFO_DEBUG */
 
     /* Allocate the free space header */
@@ -136,7 +136,8 @@ H5FS__sinfo_new(H5F_t *f, H5FS_t *fspace)
     sinfo->sect_off_size    = (fspace->max_sect_addr + 7) / 8;
     sinfo->sect_len_size    = H5VM_limit_enc_size((uint64_t)fspace->max_sect_size);
 #ifdef H5FS_SINFO_DEBUG
-    HDfprintf(stderr, "%s: fspace->max_sect_size = %Hu\n", __func__, fspace->max_sect_size);
+    HDfprintf(stderr, "%s: fspace->max_sect_size = " H5_PRINTF_HSIZE_FMT "\n", __func__,
+              fspace->max_sect_size);
     HDfprintf(stderr, "%s: fspace->max_sect_addr = %u\n", __func__, fspace->max_sect_addr);
     HDfprintf(stderr, "%s: sinfo->nbins = %u\n", __func__, sinfo->nbins);
     HDfprintf(stderr, "%s: sinfo->sect_off_size = %u, sinfo->sect_len_size = %u\n", __func__,
@@ -200,10 +201,14 @@ H5FS__sinfo_lock(H5F_t *f, H5FS_t *fspace, unsigned accmode)
     FUNC_ENTER_STATIC
 
 #ifdef H5FS_SINFO_DEBUG
-    HDfprintf(stderr, "%s: Called, fspace->addr = %a, fspace->sinfo = %p, fspace->sect_addr = %a\n", __func__,
-              fspace->addr, fspace->sinfo, fspace->sect_addr);
-    HDfprintf(stderr, "%s: fspace->alloc_sect_size = %Hu, fspace->sect_size = %Hu\n", __func__,
-              fspace->alloc_sect_size, fspace->sect_size);
+    HDfprintf(stderr,
+              "%s: Called, fspace->addr = " H5_PRINTF_HADDR_FMT
+              ", fspace->sinfo = %p, fspace->sect_addr = " H5_PRINTF_HADDR_FMT "\n",
+              __func__, fspace->addr, (void *)fspace->sinfo, fspace->sect_addr);
+    HDfprintf(stderr,
+              "%s: fspace->alloc_sect_size = " H5_PRINTF_HSIZE_FMT
+              ", fspace->sect_size = " H5_PRINTF_HSIZE_FMT "\n",
+              __func__, fspace->alloc_sect_size, fspace->sect_size);
 #endif /* H5FS_SINFO_DEBUG */
 
     /* Check arguments. */
@@ -251,8 +256,9 @@ H5FS__sinfo_lock(H5F_t *f, H5FS_t *fspace, unsigned accmode)
             HDassert(H5F_addr_defined(fspace->addr));
 
 #ifdef H5FS_SINFO_DEBUG
-            HDfprintf(stderr, "%s: Reading in existing sections, fspace->sect_addr = %a\n", __func__,
-                      fspace->sect_addr);
+            HDfprintf(stderr,
+                      "%s: Reading in existing sections, fspace->sect_addr = " H5_PRINTF_HADDR_FMT "\n",
+                      __func__, fspace->sect_addr);
 #endif /* H5FS_SINFO_DEBUG */
             /* Protect the free space sections */
             cache_udata.f      = f;
@@ -289,10 +295,14 @@ H5FS__sinfo_lock(H5F_t *f, H5FS_t *fspace, unsigned accmode)
 
 done:
 #ifdef H5FS_SINFO_DEBUG
-    HDfprintf(stderr, "%s: Leaving, fspace->addr = %a, fspace->sinfo = %p, fspace->sect_addr = %a\n",
-              __func__, fspace->addr, fspace->sinfo, fspace->sect_addr);
-    HDfprintf(stderr, "%s: fspace->alloc_sect_size = %Hu, fspace->sect_size = %Hu\n", __func__,
-              fspace->alloc_sect_size, fspace->sect_size);
+    HDfprintf(stderr,
+              "%s: Leaving, fspace->addr = " H5_PRINTF_HADDR_FMT
+              ", fspace->sinfo = %p, fspace->sect_addr = " H5_PRINTF_HADDR_FMT "\n",
+              __func__, fspace->addr, (void *)fspace->sinfo, fspace->sect_addr);
+    HDfprintf(stderr,
+              "%s: fspace->alloc_sect_size = " H5_PRINTF_HSIZE_FMT
+              ", fspace->sect_size = " H5_PRINTF_HSIZE_FMT "\n",
+              __func__, fspace->alloc_sect_size, fspace->sect_size);
 #endif /* H5FS_SINFO_DEBUG */
     FUNC_LEAVE_NOAPI(ret_value)
 } /* H5FS__sinfo_lock() */
@@ -331,14 +341,18 @@ H5FS__sinfo_unlock(H5F_t *f, H5FS_t *fspace, hbool_t modified)
 
     FUNC_ENTER_STATIC
 #ifdef H5FS_SINFO_DEBUG
-    HDfprintf(stderr, "%s: Called, modified = %t, fspace->addr = %a, fspace->sect_addr = %a\n", __func__,
-              modified, fspace->addr, fspace->sect_addr);
+    HDfprintf(stderr,
+              "%s: Called, modified = %d, fspace->addr = " H5_PRINTF_HADDR_FMT
+              ", fspace->sect_addr = " H5_PRINTF_HADDR_FMT "\n",
+              __func__, modified, fspace->addr, fspace->sect_addr);
     HDfprintf(
         stderr,
-        "%s: fspace->sinfo_lock_count = %u, fspace->sinfo_modified = %t, fspace->sinfo_protected = %t\n",
+        "%s: fspace->sinfo_lock_count = %u, fspace->sinfo_modified = %d, fspace->sinfo_protected = %d\n",
         __func__, fspace->sinfo_lock_count, fspace->sinfo_modified, fspace->sinfo_protected);
-    HDfprintf(stderr, "%s: fspace->alloc_sect_size = %Hu, fspace->sect_size = %Hu\n", __func__,
-              fspace->alloc_sect_size, fspace->sect_size);
+    HDfprintf(stderr,
+              "%s: fspace->alloc_sect_size = " H5_PRINTF_HSIZE_FMT
+              ", fspace->sect_size = " H5_PRINTF_HSIZE_FMT "\n",
+              __func__, fspace->alloc_sect_size, fspace->sect_size);
 #endif /* H5FS_SINFO_DEBUG */
 
     /* Check arguments. */
@@ -490,7 +504,8 @@ H5FS__sinfo_unlock(H5F_t *f, H5FS_t *fspace, hbool_t modified)
 
 #ifdef H5FS_SINFO_DEBUG
             HDfprintf(stderr,
-                      "%s: Freeing section info on disk, old_sect_addr = %a, old_alloc_sect_size = %Hu\n",
+                      "%s: Freeing section info on disk, old_sect_addr = " H5_PRINTF_HADDR_FMT
+                      ", old_alloc_sect_size = " H5_PRINTF_HSIZE_FMT "\n",
                       __func__, old_sect_addr, old_alloc_sect_size);
 #endif /* H5FS_SINFO_DEBUG */
             /* Release space for section info in file */
@@ -1343,7 +1358,8 @@ H5FS_sect_add(H5F_t *f, H5FS_t *fspace, H5FS_section_info_t *sect, unsigned flag
     FUNC_ENTER_NOAPI(FAIL)
 
 #ifdef H5FS_SINFO_DEBUG
-    HDfprintf(stderr, "%s: *sect = {%a, %Hu, %u, %s}\n", __func__, sect->addr, sect->size, sect->type,
+    HDfprintf(stderr, "%s: *sect = {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT ", %u, %s}\n", __func__,
+              sect->addr, sect->size, sect->type,
               (sect->state == H5FS_SECT_LIVE ? "H5FS_SECT_LIVE" : "H5FS_SECT_SERIALIZED"));
 #endif /* H5FS_SINFO_DEBUG */
 
@@ -1384,7 +1400,7 @@ H5FS_sect_add(H5F_t *f, H5FS_t *fspace, H5FS_section_info_t *sect, unsigned flag
             HGOTO_ERROR(H5E_FSPACE, H5E_CANTINSERT, FAIL, "can't insert free space section into skip list")
 
 #ifdef H5FS_SINFO_DEBUG
-    HDfprintf(stderr, "%s: fspace->tot_space = %Hu\n", __func__, fspace->tot_space);
+    HDfprintf(stderr, "%s: fspace->tot_space = " H5_PRINTF_HSIZE_FMT "\n", __func__, fspace->tot_space);
 #endif /* H5FS_SINFO_DEBUG */
     /* Mark free space sections as changed */
     /* (if adding sections while deserializing sections, don't set the flag) */
@@ -1429,8 +1445,10 @@ H5FS_sect_try_extend(H5F_t *f, H5FS_t *fspace, haddr_t addr, hsize_t size, hsize
     FUNC_ENTER_NOAPI(FAIL)
 
 #ifdef H5FS_SINFO_DEBUG
-    HDfprintf(stderr, "%s: addr = %a, size = %Hu, extra_requested = %hu\n", __func__, addr, size,
-              extra_requested);
+    HDfprintf(stderr,
+              "%s: addr = " H5_PRINTF_HADDR_FMT ", size = " H5_PRINTF_HSIZE_FMT
+              ", extra_requested = " H5_PRINTF_HSIZE_FMT "\n",
+              __func__, addr, size, extra_requested);
 #endif /* H5FS_SINFO_DEBUG */
 
     /* Check arguments. */
@@ -1442,9 +1460,12 @@ H5FS_sect_try_extend(H5F_t *f, H5FS_t *fspace, haddr_t addr, hsize_t size, hsize
 
     /* Check for any sections on free space list */
 #ifdef H5FS_SINFO_DEBUG
-    HDfprintf(stderr, "%s: fspace->tot_sect_count = %Hu\n", __func__, fspace->tot_sect_count);
-    HDfprintf(stderr, "%s: fspace->serial_sect_count = %Hu\n", __func__, fspace->serial_sect_count);
-    HDfprintf(stderr, "%s: fspace->ghost_sect_count = %Hu\n", __func__, fspace->ghost_sect_count);
+    HDfprintf(stderr, "%s: fspace->tot_sect_count = " H5_PRINTF_HSIZE_FMT "\n", __func__,
+              fspace->tot_sect_count);
+    HDfprintf(stderr, "%s: fspace->serial_sect_count = " H5_PRINTF_HSIZE_FMT "\n", __func__,
+              fspace->serial_sect_count);
+    HDfprintf(stderr, "%s: fspace->ghost_sect_count = " H5_PRINTF_HSIZE_FMT "\n", __func__,
+              fspace->ghost_sect_count);
 #endif /* H5FS_SINFO_DEBUG */
     if (fspace->tot_sect_count > 0) {
         H5FS_section_info_t *sect; /* Temporary free space section */

--- a/src/H5MF.c
+++ b/src/H5MF.c
@@ -650,8 +650,10 @@ H5MF__add_sect(H5F_t *f, H5FD_mem_t alloc_type, H5FS_t *fspace, H5MF_free_sectio
     H5AC_set_ring(fsm_ring, &orig_ring);
 
 #ifdef H5MF_ALLOC_DEBUG_MORE
-    HDfprintf(stderr, "%s: adding node, node->sect_info.addr = %a, node->sect_info.size = %Hu\n", __func__,
-              node->sect_info.addr, node->sect_info.size);
+    HDfprintf(stderr,
+              "%s: adding node, node->sect_info.addr = " H5_PRINTF_HADDR_FMT
+              ", node->sect_info.size = " H5_PRINTF_HSIZE_FMT "\n",
+              __func__, node->sect_info.addr, node->sect_info.size);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
     /* Add the section */
     if (H5FS_sect_add(f, fspace, (H5FS_section_info_t *)node, H5FS_ADD_RETURNED_SPACE, &udata) < 0)
@@ -703,7 +705,7 @@ H5MF__find_sect(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size, H5FS_t *fspace, h
         HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL, "error locating free space in file")
 
 #ifdef H5MF_ALLOC_DEBUG_MORE
-    HDfprintf(stderr, "%s: section found = %t\n", __func__, ret_value);
+    HDfprintf(stderr, "%s: section found = %d\n", __func__, ret_value);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
 
     /* Check for actually finding section */
@@ -731,8 +733,8 @@ H5MF__find_sect(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size, H5FS_t *fspace, h
             node->sect_info.size -= size;
 
 #ifdef H5MF_ALLOC_DEBUG_MORE
-            HDfprintf(stderr, "%s: re-adding node, node->sect_info.size = %Hu\n", __func__,
-                      node->sect_info.size);
+            HDfprintf(stderr, "%s: re-adding node, node->sect_info.size = " H5_PRINTF_HSIZE_FMT "\n",
+                      __func__, node->sect_info.size);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
 
             /* Re-add the section to the free-space manager */
@@ -775,7 +777,8 @@ H5MF_alloc(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size)
 
     FUNC_ENTER_NOAPI_TAG(H5AC__FREESPACE_TAG, HADDR_UNDEF)
 #ifdef H5MF_ALLOC_DEBUG
-    HDfprintf(stderr, "%s: alloc_type = %u, size = %Hu\n", __func__, (unsigned)alloc_type, size);
+    HDfprintf(stderr, "%s: alloc_type = %u, size = " H5_PRINTF_HSIZE_FMT "\n", __func__, (unsigned)alloc_type,
+              size);
 #endif /* H5MF_ALLOC_DEBUG */
 
     /* check arguments */
@@ -848,7 +851,8 @@ done:
         H5AC_set_ring(orig_ring, NULL);
 
 #ifdef H5MF_ALLOC_DEBUG
-    HDfprintf(stderr, "%s: Leaving: ret_value = %a, size = %Hu\n", __func__, ret_value, size);
+    HDfprintf(stderr, "%s: Leaving: ret_value = " H5_PRINTF_HADDR_FMT ", size = " H5_PRINTF_HSIZE_FMT "\n",
+              __func__, ret_value, size);
 #endif /* H5MF_ALLOC_DEBUG */
 #ifdef H5MF_ALLOC_DEBUG_DUMP
     H5MF__sects_dump(f, stderr);
@@ -888,7 +892,8 @@ H5MF__alloc_pagefs(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size)
     FUNC_ENTER_STATIC
 
 #ifdef H5MF_ALLOC_DEBUG
-    HDfprintf(stderr, "%s: alloc_type = %u, size = %Hu\n", __func__, (unsigned)alloc_type, size);
+    HDfprintf(stderr, "%s: alloc_type = %u, size = " H5_PRINTF_HSIZE_FMT "\n", __func__, (unsigned)alloc_type,
+              size);
 #endif /* H5MF_ALLOC_DEBUG */
 
     H5MF__alloc_to_fs_type(f->shared, alloc_type, size, &ptype);
@@ -985,7 +990,8 @@ H5MF__alloc_pagefs(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size)
 
 done:
 #ifdef H5MF_ALLOC_DEBUG
-    HDfprintf(stderr, "%s: Leaving: ret_value = %a, size = %Hu\n", __func__, ret_value, size);
+    HDfprintf(stderr, "%s: Leaving: ret_value = " H5_PRINTF_HADDR_FMT ", size = " H5_PRINTF_HSIZE_FMT "\n",
+              __func__, ret_value, size);
 #endif /* H5MF_ALLOC_DEBUG */
 #ifdef H5MF_ALLOC_DEBUG_DUMP
     H5MF__sects_dump(f, stderr);
@@ -1031,7 +1037,7 @@ H5MF_alloc_tmp(H5F_t *f, hsize_t size)
 
     FUNC_ENTER_NOAPI(HADDR_UNDEF)
 #ifdef H5MF_ALLOC_DEBUG
-    HDfprintf(stderr, "%s: size = %Hu\n", __func__, size);
+    HDfprintf(stderr, "%s: size = " H5_PRINTF_HSIZE_FMT "\n", __func__, size);
 #endif /* H5MF_ALLOC_DEBUG */
 
     /* check args */
@@ -1083,8 +1089,10 @@ H5MF_xfree(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size)
 
     FUNC_ENTER_NOAPI_TAG(H5AC__FREESPACE_TAG, FAIL)
 #ifdef H5MF_ALLOC_DEBUG
-    HDfprintf(stderr, "%s: Entering - alloc_type = %u, addr = %a, size = %Hu\n", __func__,
-              (unsigned)alloc_type, addr, size);
+    HDfprintf(stderr,
+              "%s: Entering - alloc_type = %u, addr = " H5_PRINTF_HADDR_FMT ", size = " H5_PRINTF_HSIZE_FMT
+              "\n",
+              __func__, (unsigned)alloc_type, addr, size);
 #endif /* H5MF_ALLOC_DEBUG */
 
     /* check arguments */
@@ -1133,7 +1141,7 @@ H5MF_xfree(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size)
          *  space is at the end of the file
          */
 #ifdef H5MF_ALLOC_DEBUG_MORE
-        HDfprintf(stderr, "%s: fs_addr = %a\n", __func__, f->shared->fs_addr[fs_type]);
+        HDfprintf(stderr, "%s: fs_addr = " H5_PRINTF_HADDR_FMT "\n", __func__, f->shared->fs_addr[fs_type]);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
         if (!H5F_addr_defined(f->shared->fs_addr[fs_type])) {
             htri_t status; /* "can absorb" status for section into */
@@ -1149,8 +1157,10 @@ H5MF_xfree(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size)
                 HGOTO_DONE(SUCCEED)
             else if (size < f->shared->fs_threshold) {
 #ifdef H5MF_ALLOC_DEBUG_MORE
-                HDfprintf(stderr, "%s: dropping addr = %a, size = %Hu, on the floor!\n", __func__, addr,
-                          size);
+                HDfprintf(stderr,
+                          "%s: dropping addr = " H5_PRINTF_HADDR_FMT ", size = " H5_PRINTF_HSIZE_FMT
+                          ", on the floor!\n",
+                          __func__, addr, size);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
                 HGOTO_DONE(SUCCEED)
             } /* end else-if */
@@ -1167,7 +1177,10 @@ H5MF_xfree(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size)
          */
         if (f->shared->fs_state[fs_type] == H5F_FS_STATE_DELETING || !H5F_HAVE_FREE_SPACE_MANAGER(f)) {
 #ifdef H5MF_ALLOC_DEBUG_MORE
-            HDfprintf(stderr, "%s: dropping addr = %a, size = %Hu, on the floor!\n", __func__, addr, size);
+            HDfprintf(stderr,
+                      "%s: dropping addr = " H5_PRINTF_HADDR_FMT ", size = " H5_PRINTF_HSIZE_FMT
+                      ", on the floor!\n",
+                      __func__, addr, size);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
             HGOTO_DONE(SUCCEED)
         } /* end if */
@@ -1276,7 +1289,9 @@ H5MF_try_extend(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size, hsi
 
     FUNC_ENTER_NOAPI_TAG(H5AC__FREESPACE_TAG, FAIL)
 #ifdef H5MF_ALLOC_DEBUG
-    HDfprintf(stderr, "%s: Entering: alloc_type = %u, addr = %a, size = %Hu, extra_requested = %Hu\n",
+    HDfprintf(stderr,
+              "%s: Entering: alloc_type = %u, addr = " H5_PRINTF_HADDR_FMT ", size = " H5_PRINTF_HSIZE_FMT
+              ", extra_requested = " H5_PRINTF_HSIZE_FMT "\n",
               __func__, (unsigned)alloc_type, addr, size, extra_requested);
 #endif /* H5MF_ALLOC_DEBUG */
 
@@ -1329,7 +1344,7 @@ H5MF_try_extend(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size, hsi
         if ((ret_value = H5F__try_extend(f, map_type, end, extra_requested + frag_size)) < 0)
             HGOTO_ERROR(H5E_RESOURCE, H5E_CANTEXTEND, FAIL, "error extending file")
 #ifdef H5MF_ALLOC_DEBUG_MORE
-        HDfprintf(stderr, "%s: extended = %t\n", __func__, ret_value);
+        HDfprintf(stderr, "%s: extended = %d\n", __func__, ret_value);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
 
         /* If extending at EOA succeeds: */
@@ -1367,7 +1382,7 @@ H5MF_try_extend(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size, hsi
                 HGOTO_ERROR(H5E_RESOURCE, H5E_CANTEXTEND, FAIL, "error extending aggregation block")
 
 #ifdef H5MF_ALLOC_DEBUG_MORE
-            HDfprintf(stderr, "%s: H5MF__aggr_try_extend = %t\n", __func__, ret_value);
+            HDfprintf(stderr, "%s: H5MF__aggr_try_extend = %d\n", __func__, ret_value);
 #endif    /* H5MF_ALLOC_DEBUG_MORE */
         } /* end if */
 
@@ -1393,7 +1408,7 @@ H5MF_try_extend(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size, hsi
                     HGOTO_ERROR(H5E_RESOURCE, H5E_CANTEXTEND, FAIL,
                                 "error extending block in free space manager")
 #ifdef H5MF_ALLOC_DEBUG_MORE
-                HDfprintf(stderr, "%s: Try to H5FS_sect_try_extend = %t\n", __func__, ret_value);
+                HDfprintf(stderr, "%s: Try to H5FS_sect_try_extend = %d\n", __func__, ret_value);
 #endif        /* H5MF_ALLOC_DEBUG_MORE */
             } /* end if */
 
@@ -1404,7 +1419,7 @@ H5MF_try_extend(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size, hsi
                 if (frag_size <= H5F_PGEND_META_THRES(f) && extra_requested <= frag_size)
                     ret_value = TRUE;
 #ifdef H5MF_ALLOC_DEBUG_MORE
-                HDfprintf(stderr, "%s: Try to extend into the page end threshold = %t\n", __func__,
+                HDfprintf(stderr, "%s: Try to extend into the page end threshold = %d\n", __func__,
                           ret_value);
 #endif        /* H5MF_ALLOC_DEBUG_MORE */
             } /* end if */
@@ -1417,7 +1432,7 @@ done:
         H5AC_set_ring(orig_ring, NULL);
 
 #ifdef H5MF_ALLOC_DEBUG
-    HDfprintf(stderr, "%s: Leaving: ret_value = %t\n", __func__, ret_value);
+    HDfprintf(stderr, "%s: Leaving: ret_value = %d\n", __func__, ret_value);
 #endif /* H5MF_ALLOC_DEBUG */
 #ifdef H5MF_ALLOC_DEBUG_DUMP
     H5MF__sects_dump(f, stderr);
@@ -1452,8 +1467,10 @@ H5MF_try_shrink(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size)
 
     FUNC_ENTER_NOAPI_TAG(H5AC__FREESPACE_TAG, FAIL)
 #ifdef H5MF_ALLOC_DEBUG
-    HDfprintf(stderr, "%s: Entering - alloc_type = %u, addr = %a, size = %Hu\n", __func__,
-              (unsigned)alloc_type, addr, size);
+    HDfprintf(stderr,
+              "%s: Entering - alloc_type = %u, addr = " H5_PRINTF_HADDR_FMT ", size = " H5_PRINTF_HSIZE_FMT
+              "\n",
+              __func__, (unsigned)alloc_type, addr, size);
 #endif /* H5MF_ALLOC_DEBUG */
 
     /* check arguments */
@@ -1589,8 +1606,10 @@ H5MF__close_delete_fstype(H5F_t *f, H5F_mem_page_t type)
         HDassert((H5FD_mem_t)type < H5FD_MEM_NTYPES);
 
 #ifdef H5MF_ALLOC_DEBUG_MORE
-    HDfprintf(stderr, "%s: Check 1.0 - f->shared->fs_man[%u] = %p, f->shared->fs_addr[%u] = %a\n", __func__,
-              (unsigned)type, f->shared->fs_man[type], (unsigned)type, f->shared->fs_addr[type]);
+    HDfprintf(
+        stderr,
+        "%s: Check 1.0 - f->shared->fs_man[%u] = %p, f->shared->fs_addr[%u] = " H5_PRINTF_HADDR_FMT "\n",
+        __func__, (unsigned)type, (void *)f->shared->fs_man[type], (unsigned)type, f->shared->fs_addr[type]);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
 
     /* If the free space manager for this type is open, close it */
@@ -1599,8 +1618,10 @@ H5MF__close_delete_fstype(H5F_t *f, H5F_mem_page_t type)
             HGOTO_ERROR(H5E_RESOURCE, H5E_CANTRELEASE, FAIL, "can't close the free space manager")
 
 #ifdef H5MF_ALLOC_DEBUG_MORE
-    HDfprintf(stderr, "%s: Check 2.0 - f->shared->fs_man[%u] = %p, f->shared->fs_addr[%u] = %a\n", __func__,
-              (unsigned)type, f->shared->fs_man[type], (unsigned)type, f->shared->fs_addr[type]);
+    HDfprintf(
+        stderr,
+        "%s: Check 2.0 - f->shared->fs_man[%u] = %p, f->shared->fs_addr[%u] = " H5_PRINTF_HADDR_FMT "\n",
+        __func__, (unsigned)type, (void *)f->shared->fs_man[type], (unsigned)type, f->shared->fs_addr[type]);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
 
     /* If there is free space manager info for this type, delete it */

--- a/src/H5MFaggr.c
+++ b/src/H5MFaggr.c
@@ -92,7 +92,8 @@ H5MF_aggr_vfd_alloc(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size)
 
     FUNC_ENTER_NOAPI(HADDR_UNDEF)
 #ifdef H5MF_AGGR_DEBUG
-    HDfprintf(stderr, "%s: alloc_type = %u, size = %Hu\n", __func__, (unsigned)alloc_type, size);
+    HDfprintf(stderr, "%s: alloc_type = %u, size = " H5_PRINTF_HSIZE_FMT "\n", __func__, (unsigned)alloc_type,
+              size);
 #endif /* H5MF_AGGR_DEBUG */
 
     /* check arguments */
@@ -120,7 +121,8 @@ H5MF_aggr_vfd_alloc(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size)
 
 done:
 #ifdef H5MF_AGGR_DEBUG
-    HDfprintf(stderr, "%s: Leaving: ret_value = %a, size = %Hu\n", __func__, ret_value, size);
+    HDfprintf(stderr, "%s: Leaving: ret_value = " H5_PRINTF_HADDR_FMT ", size = " H5_PRINTF_HSIZE_FMT "\n",
+              __func__, ret_value, size);
 #endif /* H5MF_AGGR_DEBUG */
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -150,7 +152,7 @@ H5MF__aggr_alloc(H5F_t *f, H5F_blk_aggr_t *aggr, H5F_blk_aggr_t *other_aggr, H5F
 
     FUNC_ENTER_STATIC
 #ifdef H5MF_AGGR_DEBUG
-    HDfprintf(stderr, "%s: type = %u, size = %Hu\n", __func__, (unsigned)type, size);
+    HDfprintf(stderr, "%s: type = %u, size = " H5_PRINTF_HSIZE_FMT "\n", __func__, (unsigned)type, size);
 #endif /* H5MF_AGGR_DEBUG */
 
     /* check args */
@@ -199,8 +201,10 @@ H5MF__aggr_alloc(H5F_t *f, H5F_blk_aggr_t *aggr, H5F_blk_aggr_t *other_aggr, H5F
             H5FD_mem_t alloc_type, other_alloc_type; /* Current aggregator & 'other' aggregator types */
 
 #ifdef H5MF_AGGR_DEBUG
-            HDfprintf(stderr, "%s: aggr = {%a, %Hu, %Hu}\n", __func__, aggr->addr, aggr->tot_size,
-                      aggr->size);
+            HDfprintf(stderr,
+                      "%s: aggr = {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT ", " H5_PRINTF_HSIZE_FMT
+                      "}\n",
+                      __func__, aggr->addr, aggr->tot_size, aggr->size);
 #endif /* H5MF_AGGR_DEBUG */
 
             /* Turn off alignment if allocation < threshold */
@@ -388,7 +392,7 @@ H5MF__aggr_alloc(H5F_t *f, H5F_blk_aggr_t *aggr, H5F_blk_aggr_t *other_aggr, H5F
 
 done:
 #ifdef H5MF_AGGR_DEBUG
-        HDfprintf(stderr, "%s: ret_value = %a\n", __func__, ret_value);
+        HDfprintf(stderr, "%s: ret_value = " H5_PRINTF_HADDR_FMT "\n", __func__, ret_value);
 #endif /* H5MF_AGGR_DEBUG */
         FUNC_LEAVE_NOAPI(ret_value)
     } /* end H5MF__aggr_alloc() */
@@ -537,8 +541,11 @@ done:
             if (H5F_addr_eq((sect->sect_info.addr + sect->sect_info.size), aggr->addr) ||
                 H5F_addr_eq((aggr->addr + aggr->size), sect->sect_info.addr)) {
 #ifdef H5MF_AGGR_DEBUG
-                HDfprintf(stderr, "%s: section {%a, %Hu} adjoins aggr = {%a, %Hu}\n", "H5MF__aggr_can_absorb",
-                          sect->sect_info.addr, sect->sect_info.size, aggr->addr, aggr->size);
+                HDfprintf(stderr,
+                          "%s: section {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT
+                          "} adjoins aggr = {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT "}\n",
+                          "H5MF__aggr_can_absorb", sect->sect_info.addr, sect->sect_info.size, aggr->addr,
+                          aggr->size);
 #endif /* H5MF_AGGR_DEBUG */
                 /* Check if aggregator would get too large and should be absorbed into section */
                 if ((aggr->size + sect->sect_info.size) >= aggr->alloc_size)
@@ -587,7 +594,9 @@ done:
             /* Check if the section adjoins the beginning or end of the aggregator */
             if (H5F_addr_eq((sect->sect_info.addr + sect->sect_info.size), aggr->addr)) {
 #ifdef H5MF_AGGR_DEBUG
-                HDfprintf(stderr, "%s: aggr {%a, %Hu} adjoins front of section = {%a, %Hu}\n",
+                HDfprintf(stderr,
+                          "%s: aggr {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT
+                          "} adjoins front of section = {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT "}\n",
                           "H5MF__aggr_absorb", aggr->addr, aggr->size, sect->sect_info.addr,
                           sect->sect_info.size);
 #endif /* H5MF_AGGR_DEBUG */
@@ -599,7 +608,9 @@ done:
                 HDassert(H5F_addr_eq((aggr->addr + aggr->size), sect->sect_info.addr));
 
 #ifdef H5MF_AGGR_DEBUG
-                HDfprintf(stderr, "%s: aggr {%a, %Hu} adjoins end of section = {%a, %Hu}\n",
+                HDfprintf(stderr,
+                          "%s: aggr {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT
+                          "} adjoins end of section = {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT "}\n",
                           "H5MF__aggr_absorb", aggr->addr, aggr->size, sect->sect_info.addr,
                           sect->sect_info.size);
 #endif /* H5MF_AGGR_DEBUG */
@@ -617,7 +628,9 @@ done:
             /* Check if the section adjoins the beginning or end of the aggregator */
             if (H5F_addr_eq((sect->sect_info.addr + sect->sect_info.size), aggr->addr)) {
 #ifdef H5MF_AGGR_DEBUG
-                HDfprintf(stderr, "%s: section {%a, %Hu} adjoins front of aggr = {%a, %Hu}\n",
+                HDfprintf(stderr,
+                          "%s: section {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT
+                          "} adjoins front of aggr = {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT "}\n",
                           "H5MF__aggr_absorb", sect->sect_info.addr, sect->sect_info.size, aggr->addr,
                           aggr->size);
 #endif /* H5MF_AGGR_DEBUG */
@@ -635,7 +648,9 @@ done:
                 HDassert(H5F_addr_eq((aggr->addr + aggr->size), sect->sect_info.addr));
 
 #ifdef H5MF_AGGR_DEBUG
-                HDfprintf(stderr, "%s: section {%a, %Hu} adjoins end of aggr = {%a, %Hu}\n",
+                HDfprintf(stderr,
+                          "%s: section {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT
+                          "} adjoins end of aggr = {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT "}\n",
                           "H5MF__aggr_absorb", sect->sect_info.addr, sect->sect_info.size, aggr->addr,
                           aggr->size);
 #endif /* H5MF_AGGR_DEBUG */
@@ -723,7 +738,8 @@ done:
             tmp_addr = aggr->addr;
             tmp_size = aggr->size;
 #ifdef H5MF_AGGR_DEBUG
-            HDfprintf(stderr, "%s: tmp_addr = %a, tmp_size = %Hu\n", __func__, tmp_addr, tmp_size);
+            HDfprintf(stderr, "%s: tmp_addr = " H5_PRINTF_HADDR_FMT ", tmp_size = " H5_PRINTF_HSIZE_FMT "\n",
+                      __func__, tmp_addr, tmp_size);
 #endif /* H5MF_AGGR_DEBUG */
 
             /* Reset aggregator block information */

--- a/src/H5MFsection.c
+++ b/src/H5MFsection.c
@@ -472,8 +472,10 @@ H5MF__sect_simple_can_shrink(const H5FS_section_info_t *_sect, void *_udata)
         /* Set the shrinking type */
         udata->shrink = H5MF_SHRINK_EOA;
 #ifdef H5MF_ALLOC_DEBUG_MORE
-        HDfprintf(stderr, "%s: section {%a, %Hu}, shrinks file, eoa = %a\n", __func__, sect->sect_info.addr,
-                  sect->sect_info.size, eoa);
+        HDfprintf(stderr,
+                  "%s: section {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT
+                  "}, shrinks file, eoa = " H5_PRINTF_HADDR_FMT "\n",
+                  __func__, sect->sect_info.addr, sect->sect_info.size, eoa);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
 
         /* Indicate shrinking can occur */
@@ -496,8 +498,10 @@ H5MF__sect_simple_can_shrink(const H5FS_section_info_t *_sect, void *_udata)
                 /* Set the aggregator to operate on */
                 udata->aggr = &(udata->f->shared->meta_aggr);
 #ifdef H5MF_ALLOC_DEBUG_MORE
-                HDfprintf(stderr, "%s: section {%a, %Hu}, adjoins metadata aggregator\n", __func__,
-                          sect->sect_info.addr, sect->sect_info.size);
+                HDfprintf(stderr,
+                          "%s: section {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT
+                          "}, adjoins metadata aggregator\n",
+                          __func__, sect->sect_info.addr, sect->sect_info.size);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
 
                 /* Indicate shrinking can occur */
@@ -517,8 +521,10 @@ H5MF__sect_simple_can_shrink(const H5FS_section_info_t *_sect, void *_udata)
                 /* Set the aggregator to operate on */
                 udata->aggr = &(udata->f->shared->sdata_aggr);
 #ifdef H5MF_ALLOC_DEBUG_MORE
-                HDfprintf(stderr, "%s: section {%a, %Hu}, adjoins small data aggregator\n", __func__,
-                          sect->sect_info.addr, sect->sect_info.size);
+                HDfprintf(stderr,
+                          "%s: section {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT
+                          "}, adjoins small data aggregator\n",
+                          __func__, sect->sect_info.addr, sect->sect_info.size);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
 
                 /* Indicate shrinking can occur */
@@ -625,8 +631,8 @@ H5MF__sect_small_add(H5FS_section_info_t **_sect, unsigned *flags, void *_udata)
     FUNC_ENTER_STATIC
 
 #ifdef H5MF_ALLOC_DEBUG_MORE
-    HDfprintf(stderr, "%s: Entering, section {%a, %Hu}\n", __func__, (*sect)->sect_info.addr,
-              (*sect)->sect_info.size);
+    HDfprintf(stderr, "%s: Entering, section {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT "}\n", __func__,
+              (*sect)->sect_info.addr, (*sect)->sect_info.size);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
 
     /* Do not adjust the section raw data or global heap data */
@@ -653,8 +659,8 @@ H5MF__sect_small_add(H5FS_section_info_t **_sect, unsigned *flags, void *_udata)
     else if (prem <= H5F_PGEND_META_THRES(udata->f)) {
         (*sect)->sect_info.size += prem;
 #ifdef H5MF_ALLOC_DEBUG_MORE
-        HDfprintf(stderr, "%s: section is adjusted {%a, %Hu}\n", __func__, (*sect)->sect_info.addr,
-                  (*sect)->sect_info.size);
+        HDfprintf(stderr, "%s: section is adjusted {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT "}\n",
+                  __func__, (*sect)->sect_info.addr, (*sect)->sect_info.size);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
     }  /* end if */
 
@@ -702,7 +708,7 @@ H5MF__sect_small_can_merge(const H5FS_section_info_t *_sect1, const H5FS_section
             ret_value = FALSE;
 
 #ifdef H5MF_ALLOC_DEBUG_MORE
-    HDfprintf(stderr, "%s: Leaving: ret_value = %t\n", __func__, ret_value);
+    HDfprintf(stderr, "%s: Leaving: ret_value = %d\n", __func__, ret_value);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -806,7 +812,7 @@ H5MF__sect_large_can_merge(const H5FS_section_info_t *_sect1, const H5FS_section
     ret_value = H5F_addr_eq(sect1->sect_info.addr + sect1->sect_info.size, sect2->sect_info.addr);
 
 #ifdef H5MF_ALLOC_DEBUG_MORE
-    HDfprintf(stderr, "%s: Leaving: ret_value = %t\n", __func__, ret_value);
+    HDfprintf(stderr, "%s: Leaving: ret_value = %d\n", __func__, ret_value);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -894,8 +900,10 @@ H5MF__sect_large_can_shrink(const H5FS_section_info_t *_sect, void *_udata)
         /* Set the shrinking type */
         udata->shrink = H5MF_SHRINK_EOA;
 #ifdef H5MF_ALLOC_DEBUG_MORE
-        HDfprintf(stderr, "%s: section {%a, %Hu}, shrinks file, eoa = %a\n", __func__, sect->sect_info.addr,
-                  sect->sect_info.size, eoa);
+        HDfprintf(stderr,
+                  "%s: section {" H5_PRINTF_HADDR_FMT ", " H5_PRINTF_HSIZE_FMT
+                  "}, shrinks file, eoa = " H5_PRINTF_HADDR_FMT "\n",
+                  __func__, sect->sect_info.addr, sect->sect_info.size, eoa);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
 
         /* Indicate shrinking can occur */

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -296,12 +296,15 @@ H5S__hyper_print_spans_helper(FILE *f, const H5S_hyper_span_t *span, unsigned de
     FUNC_ENTER_STATIC_NOERR
 
     while (span) {
-        HDfprintf(f, "%s: %*sdepth=%u, span=%p, (%Hu, %Hu), next=%p\n", __func__, depth * 2, "", depth, span,
-                  span->low, span->high, span->next);
+        HDfprintf(f,
+                  "%s: %*sdepth=%u, span=%p, (" H5_PRINTF_HSIZE_FMT ", " H5_PRINTF_HSIZE_FMT "), next=%p\n",
+                  __func__, depth * 2, "", depth, (void *)span, span->low, span->high, (void *)span->next);
         if (span->down) {
-            HDfprintf(f, "%s: %*sspans=%p, count=%u, bounds[0]={%Hu, %Hu}, head=%p\n", __func__,
-                      (depth + 1) * 2, "", span->down, span->down->count, span->down->low_bounds[0],
-                      span->down->high_bounds[0], span->down->head);
+            HDfprintf(f,
+                      "%s: %*sspans=%p, count=%u, bounds[0]={" H5_PRINTF_HSIZE_FMT ", " H5_PRINTF_HSIZE_FMT
+                      "}, head=%p\n",
+                      __func__, (depth + 1) * 2, "", (void *)span->down, span->down->count,
+                      span->down->low_bounds[0], span->down->high_bounds[0], (void *)span->down->head);
             H5S__hyper_print_spans_helper(f, span->down->head, depth + 1);
         } /* end if */
         span = span->next;
@@ -316,8 +319,11 @@ H5S__hyper_print_spans(FILE *f, const H5S_hyper_span_info_t *span_lst)
     FUNC_ENTER_STATIC_NOERR
 
     if (span_lst != NULL) {
-        HDfprintf(f, "%s: spans=%p, count=%u, bounds[0]={%Hu, %Hu}, head=%p\n", __func__, span_lst,
-                  span_lst->count, span_lst->low_bounds[0], span_lst->high_bounds[0], span_lst->head);
+        HDfprintf(f,
+                  "%s: spans=%p, count=%u, bounds[0]={" H5_PRINTF_HSIZE_FMT ", " H5_PRINTF_HSIZE_FMT
+                  "}, head=%p\n",
+                  __func__, (void *)span_lst, span_lst->count, span_lst->low_bounds[0],
+                  span_lst->high_bounds[0], (void *)span_lst->head);
         H5S__hyper_print_spans_helper(f, span_lst->head, 0);
     } /* end if */
 
@@ -344,16 +350,16 @@ H5S__hyper_print_diminfo_helper(FILE *f, const char *field, unsigned ndims, cons
     if (dinfo != NULL) {
         HDfprintf(f, "%s: %s: start=[", __func__, field);
         for (u = 0; u < ndims; u++)
-            HDfprintf(f, "%Hd%s", dinfo[u].start, (u < (ndims - 1) ? ", " : "]\n"));
+            HDfprintf(f, H5_PRINTF_HSIZE_FMT "%s", dinfo[u].start, (u < (ndims - 1) ? ", " : "]\n"));
         HDfprintf(f, "%s: %s: stride=[", __func__, field);
         for (u = 0; u < ndims; u++)
-            HDfprintf(f, "%Hu%s", dinfo[u].stride, (u < (ndims - 1) ? ", " : "]\n"));
+            HDfprintf(f, H5_PRINTF_HSIZE_FMT "%s", dinfo[u].stride, (u < (ndims - 1) ? ", " : "]\n"));
         HDfprintf(f, "%s: %s: count=[", __func__, field);
         for (u = 0; u < ndims; u++)
-            HDfprintf(f, "%Hu%s", dinfo[u].count, (u < (ndims - 1) ? ", " : "]\n"));
+            HDfprintf(f, H5_PRINTF_HSIZE_FMT "%s", dinfo[u].count, (u < (ndims - 1) ? ", " : "]\n"));
         HDfprintf(f, "%s: %s: block=[", __func__, field);
         for (u = 0; u < ndims; u++)
-            HDfprintf(f, "%Hu%s", dinfo[u].block, (u < (ndims - 1) ? ", " : "]\n"));
+            HDfprintf(f, H5_PRINTF_HSIZE_FMT "%s", dinfo[u].block, (u < (ndims - 1) ? ", " : "]\n"));
     } /* end if */
     else
         HDfprintf(f, "%s: %s==NULL\n", __func__, field);
@@ -412,31 +418,31 @@ H5S__hyper_print_spans_dfs(FILE *f, const H5S_hyper_span_info_t *span_lst, unsig
 
     for (u = 0; u < depth; u++)
         HDfprintf(f, "\t");
-    HDfprintf(f, "DIM[%u]: ref_count=%u, #elems=%u, head=%p, tail=%p, actual_tail=%p, matched=%t\n", depth,
-              span_lst->count, num_elems, span_lst->head, span_lst->tail, actual_tail,
+    HDfprintf(f, "DIM[%u]: ref_count=%u, #elems=%u, head=%p, tail=%p, actual_tail=%p, matched=%d\n", depth,
+              span_lst->count, num_elems, (void *)span_lst->head, (void *)span_lst->tail, (void *)actual_tail,
               (span_lst->tail == actual_tail));
 
     for (u = 0; u < depth; u++)
         HDfprintf(f, "\t");
     HDfprintf(f, "low_bounds=[");
     for (u = 0; u < dims - 1; u++)
-        HDfprintf(f, "%llu,", span_lst->low_bounds[u]);
-    HDfprintf(f, "%llu]\n", span_lst->low_bounds[dims - 1]);
+        HDfprintf(f, H5_PRINTF_HSIZE_FMT ",", span_lst->low_bounds[u]);
+    HDfprintf(f, H5_PRINTF_HSIZE_FMT "]\n", span_lst->low_bounds[dims - 1]);
 
     for (u = 0; u < depth; u++)
         HDfprintf(f, "\t");
     HDfprintf(f, "high_bounds=[");
     for (u = 0; u < dims - 1; u++)
-        HDfprintf(f, "%llu,", span_lst->high_bounds[u]);
-    HDfprintf(f, "%llu]\n", span_lst->high_bounds[dims - 1]);
+        HDfprintf(f, H5_PRINTF_HSIZE_FMT ",", span_lst->high_bounds[u]);
+    HDfprintf(f, H5_PRINTF_HSIZE_FMT "]\n", span_lst->high_bounds[dims - 1]);
 
     cur_elem = span_lst->head;
     elem_idx = 0;
     while (cur_elem) {
         for (u = 0; u < depth; u++)
             HDfprintf(f, "\t");
-        HDfprintf(f, "ELEM[%u]: ptr=%p, low=%Hu, high=%Hu, down=%p\n", elem_idx++, cur_elem, cur_elem->low,
-                  cur_elem->high, cur_elem->down);
+        HDfprintf(f, "ELEM[%u]: ptr=%p, low=" H5_PRINTF_HSIZE_FMT ", high=" H5_PRINTF_HSIZE_FMT ", down=%p\n",
+                  elem_idx++, (void *)cur_elem, cur_elem->low, cur_elem->high, (void *)cur_elem->down);
         if (cur_elem->down)
             H5S__hyper_print_spans_dfs(f, cur_elem->down, depth + 1, dims);
         cur_elem = cur_elem->next;
@@ -473,7 +479,7 @@ H5S__hyper_print_space_dfs(FILE *f, const H5S_t *space)
     HDassert(hslab);
 
     HDfprintf(f, "=======================\n");
-    HDfprintf(f, "SPACE: span_lst=%p, #dims=%u, offset_changed=%d\n", hslab->span_lst, dims,
+    HDfprintf(f, "SPACE: span_lst=%p, #dims=%u, offset_changed=%d\n", (void *)hslab->span_lst, dims,
               space->select.offset_changed);
 
     HDfprintf(f, "       offset=[");
@@ -484,25 +490,26 @@ H5S__hyper_print_space_dfs(FILE *f, const H5S_t *space)
     HDfprintf(f, "       low_bounds=[");
     if (space->select.sel_info.hslab->diminfo_valid == H5S_DIMINFO_VALID_YES) {
         for (u = 0; u < dims - 1; u++)
-            HDfprintf(f, "%llu,", space->select.sel_info.hslab->diminfo.low_bounds[u]);
-        HDfprintf(f, "%llu]\n", space->select.sel_info.hslab->diminfo.low_bounds[dims - 1]);
+            HDfprintf(f, H5_PRINTF_HSIZE_FMT ",", space->select.sel_info.hslab->diminfo.low_bounds[u]);
+        HDfprintf(f, H5_PRINTF_HSIZE_FMT "]\n", space->select.sel_info.hslab->diminfo.low_bounds[dims - 1]);
     } /* end if */
     else {
         for (u = 0; u < dims - 1; u++)
-            HDfprintf(f, "%llu,", space->select.sel_info.hslab->span_lst->low_bounds[u]);
-        HDfprintf(f, "%llu]\n", space->select.sel_info.hslab->span_lst->low_bounds[dims - 1]);
+            HDfprintf(f, H5_PRINTF_HSIZE_FMT ",", space->select.sel_info.hslab->span_lst->low_bounds[u]);
+        HDfprintf(f, H5_PRINTF_HSIZE_FMT "]\n", space->select.sel_info.hslab->span_lst->low_bounds[dims - 1]);
     } /* end else */
 
     HDfprintf(f, "       high_bounds=[");
     if (space->select.sel_info.hslab->diminfo_valid == H5S_DIMINFO_VALID_YES) {
         for (u = 0; u < dims - 1; u++)
-            HDfprintf(f, "%llu,", space->select.sel_info.hslab->diminfo.high_bounds[u]);
-        HDfprintf(f, "%llu]\n", space->select.sel_info.hslab->diminfo.high_bounds[dims - 1]);
+            HDfprintf(f, H5_PRINTF_HSIZE_FMT ",", space->select.sel_info.hslab->diminfo.high_bounds[u]);
+        HDfprintf(f, H5_PRINTF_HSIZE_FMT "]\n", space->select.sel_info.hslab->diminfo.high_bounds[dims - 1]);
     } /* end if */
     else {
         for (u = 0; u < dims - 1; u++)
-            HDfprintf(f, "%llu,", space->select.sel_info.hslab->span_lst->high_bounds[u]);
-        HDfprintf(f, "%llu]\n", space->select.sel_info.hslab->span_lst->high_bounds[dims - 1]);
+            HDfprintf(f, H5_PRINTF_HSIZE_FMT ",", space->select.sel_info.hslab->span_lst->high_bounds[u]);
+        HDfprintf(f, H5_PRINTF_HSIZE_FMT "]\n",
+                  space->select.sel_info.hslab->span_lst->high_bounds[dims - 1]);
     } /* end else */
 
     /* Print out diminfo, if it's valid */

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -296,15 +296,16 @@ typedef uint64_t hsize_t;
  * should be discouraged in new code.
  */
 typedef int64_t hssize_t;
-#define PRIdHSIZE          PRId64
-#define PRIiHSIZE          PRIi64
-#define PRIoHSIZE          PRIo64
-#define PRIuHSIZE          PRIu64
-#define PRIxHSIZE          PRIx64
-#define PRIXHSIZE          PRIX64
-#define H5_SIZEOF_HSIZE_T  8
-#define H5_SIZEOF_HSSIZE_T 8
-#define HSIZE_UNDEF        UINT64_MAX
+#define PRIdHSIZE           PRId64
+#define PRIiHSIZE           PRIi64
+#define PRIoHSIZE           PRIo64
+#define PRIuHSIZE           PRIu64
+#define PRIxHSIZE           PRIx64
+#define PRIXHSIZE           PRIX64
+#define H5_SIZEOF_HSIZE_T   8
+#define H5_SIZEOF_HSSIZE_T  8
+#define H5_PRINTF_HSIZE_FMT "%" PRIuHSIZE
+#define HSIZE_UNDEF         UINT64_MAX
 
 /**
  * The address of an object in the file.


### PR DESCRIPTION
This PR fixes usage of old HDfprintf format specifiers like %a, %t and %Hu after the internal HDfprintf implementation was removed.