### PR TITLE
OESS-168: Remove clang warnings.

### DIFF
--- a/tools/src/h5diff/ph5diff_main.c
+++ b/tools/src/h5diff/ph5diff_main.c
@@ -46,7 +46,9 @@ static void ph5diff_worker(int);
 int
 main(int argc, const char *argv[])
 {
+    int         i        = 0;
     int         nID      = 0;
+    char **     args     = NULL;
     const char *fname1   = NULL;
     const char *fname2   = NULL;
     const char *objname1 = NULL;
@@ -62,7 +64,16 @@ main(int argc, const char *argv[])
     outBuffOffset = 0;
     g_Parallel    = 1;
 
-    MPI_Init(&argc, (char ***)&argv);
+    if ((args = (char **)HDcalloc((size_t)argc, sizeof(char *))) == NULL) {
+        HDfprintf(stderr, "%s: HDcalloc call failed\n", PROGRAMNAME);
+        return EXIT_FAILURE;
+    }
+    else {
+        for (i = 0; i < argc; i++) {
+            args[i] = HDstrdup(argv[i]);
+        }
+    }
+    MPI_Init(&argc, &args);
 
     MPI_Comm_rank(MPI_COMM_WORLD, &nID);
     MPI_Comm_size(MPI_COMM_WORLD, &g_nTasks);
@@ -102,7 +113,13 @@ main(int argc, const char *argv[])
     } /* end else */
 
     MPI_Finalize();
-
+    if (args) {
+        for (i = 0; i < argc; i++) {
+            if (args[i])
+                HDfree(args[i]);
+        }
+        HDfree(args);
+    }
     return 0;
 }
 


### PR DESCRIPTION
```
ph5diff_main.c  :65:31: warning: cast from 'const char *' to 'char *' drops const q\
ualifier [-Wcast-qual]
    MPI_Init(&argc, (char ***)&argv);
                              ^
```