### PR TITLE
Fix compilation issues with Mingw

### DIFF
--- a/src/H5private.h
+++ b/src/H5private.h
@@ -44,10 +44,12 @@
 #include <sys/time.h>
 #endif
 #ifdef H5_HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 #ifdef H5_HAVE_PWD_H
 #include <pwd.h>
 #endif
-#include <unistd.h>
+#ifdef H5_HAVE_WAITPID
 #include <sys/wait.h>
 #endif
 

--- a/test/dt_arith.c
+++ b/test/dt_arith.c
@@ -79,7 +79,7 @@ typedef enum dtype_t {
  * be allowed to continue (cf. Posix signals) so in order to recover from a
  * SIGFPE we run tests that might generate one in a child process.
  */
-#ifdef H5_HAVE_UNISTD_H
+#if defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID)
 #define HANDLE_SIGFPE
 #endif
 

--- a/test/swmr.c
+++ b/test/swmr.c
@@ -2395,7 +2395,7 @@ error:
  *  (5) Parent: open a file with write access; enable SWMR writing mode
  *      Child: concurrent open of the file with write and SWMR write access (fail)
  */
-#ifndef H5_HAVE_UNISTD_H
+#if !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID))
 
 static int
 test_start_swmr_write_concur(hid_t H5_ATTR_UNUSED in_fapl, hbool_t new_format)
@@ -2408,11 +2408,11 @@ test_start_swmr_write_concur(hid_t H5_ATTR_UNUSED in_fapl, hbool_t new_format)
     }
 
     SKIPPED();
-    HDputs("    Test skipped due to a lack of unistd.h functionality.");
+    HDputs("    Test skipped due to fork or waitpid not defined.");
     return 0;
 } /* test_start_swmr_write_concur() */
 
-#else  /* H5_HAVE_UNISTD_H */
+#else  /* !defined(H5_HAVE_FORK && defined(H5_HAVE_WAITPID) */
 
 static int
 test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
@@ -3014,7 +3014,7 @@ error:
     return -1;
 
 } /* test_start_swmr_write_concur() */
-#endif /* H5_HAVE_UNISTD_H */
+#endif /* !defined(H5_HAVE_FORK && defined(H5_HAVE_WAITPID) */
 
 /*
  * test_start_swmr_write_stress_ohdr():
@@ -4809,7 +4809,7 @@ error:
 **    This is for concurrent access.
 **
 *****************************************************************/
-#ifndef H5_HAVE_UNISTD_H
+#if !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID) && defined(H5_HAVE_FLOCK))
 
 static int
 test_file_lock_concur(hid_t H5_ATTR_UNUSED in_fapl)
@@ -4817,12 +4817,12 @@ test_file_lock_concur(hid_t H5_ATTR_UNUSED in_fapl)
     /* Output message about test being performed */
     TESTING("File open with different combinations of flags--concurrent access");
     SKIPPED();
-    HDputs("    Test skipped due to a lack of unistd.h functionality.");
+    HDputs("    Test skipped due to fork or waitpid not defined.");
     return 0;
 
 } /* end test_file_lock_concur() */
 
-#else /* H5_HAVE_UNISTD_H */
+#else /* !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID) && defined(H5_HAVE_FLOCK)) */
 
 static int
 test_file_lock_concur(hid_t in_fapl)
@@ -5192,7 +5192,7 @@ error:
 
 } /* end test_file_lock_concur() */
 
-#endif /* H5_HAVE_UNISTD_H */
+#endif /* #if !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID) && defined(H5_HAVE_FLOCK)) */
 
 /****************************************************************
 **
@@ -5202,7 +5202,7 @@ error:
 **    This is for concurrent access.
 **
 *****************************************************************/
-#ifndef H5_HAVE_UNISTD_H
+#if !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID))
 
 static int
 test_file_lock_swmr_concur(hid_t H5_ATTR_UNUSED in_fapl)
@@ -5210,12 +5210,12 @@ test_file_lock_swmr_concur(hid_t H5_ATTR_UNUSED in_fapl)
     /* Output message about test being performed */
     TESTING("File open with different combintations of flags + SWMR flags--concurrent access");
     SKIPPED();
-    HDputs("    Test skipped due to a lack of unistd.h functionality.");
+    HDputs("    Test skipped due to fork or waitpid not defined.");
     return 0;
 
 } /* end test_file_lock_swmr_concur() */
 
-#else /* H5_HAVE_UNISTD_H */
+#else /* !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID)) */
 
 static int
 test_file_lock_swmr_concur(hid_t in_fapl)
@@ -6215,7 +6215,7 @@ error:
 
 } /* end test_file_lock_swmr_concur() */
 
-#endif /* H5_HAVE_UNISTD_H */
+#endif /* !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID)) */
 
 /****************************************************************
 **
@@ -6227,7 +6227,7 @@ error:
 static int
 test_file_locking(hid_t in_fapl, hbool_t turn_locking_on, hbool_t env_var_override)
 {
-#ifndef H5_HAVE_UNISTD_H
+#if !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID))
     if (turn_locking_on && env_var_override)
         TESTING("File locking: ON w/ env var override")
     else if (turn_locking_on && !env_var_override)
@@ -6237,9 +6237,9 @@ test_file_locking(hid_t in_fapl, hbool_t turn_locking_on, hbool_t env_var_overri
     else
         TESTING("File locking: OFF")
     SKIPPED();
-    HDputs("    Test skipped due to a lack of unistd.h functionality.");
+    HDputs("    Test skipped due to fork or waitpid not defined.");
     return 0;
-#else /* H5_HAVE_UNISTD_H */
+#else /* !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID)) */
     hid_t  fid  = -1;               /* File ID */
     hid_t  fapl = -1;               /* File access property list */
     char   filename[NAME_BUF_SIZE]; /* file name */
@@ -6405,7 +6405,7 @@ error:
 
     return -1;
 
-#endif /* H5_HAVE_UNISTD_H */
+#endif /* !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID)) */
 
 } /* end test_file_locking() */
 
@@ -6699,7 +6699,7 @@ error:
  *              (7) Refresh the dataset
  *              (8) Verify the dataset's dimension and data are correct
  */
-#ifndef H5_HAVE_UNISTD_H
+#if !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID))
 
 static int
 test_refresh_concur(hid_t H5_ATTR_UNUSED in_fapl, hbool_t new_format)
@@ -6712,11 +6712,11 @@ test_refresh_concur(hid_t H5_ATTR_UNUSED in_fapl, hbool_t new_format)
     }
 
     SKIPPED();
-    HDputs("    Test skipped due to a lack of unistd.h functionality.");
+    HDputs("    Test skipped due to fork or waitpid not defined.");
     return 0;
 } /* test_refresh_concur() */
 
-#else  /* H5_HAVE_UNISTD_H */
+#else  /* !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID)) */
 
 static int
 test_refresh_concur(hid_t in_fapl, hbool_t new_format)
@@ -7016,7 +7016,7 @@ error:
     return -1;
 
 } /* test_refresh_concur() */
-#endif /* H5_HAVE_UNISTD_H */
+#endif /* !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID)) */
 
 /*
  * test_multiple_same():

--- a/test/twriteorder.c
+++ b/test/twriteorder.c
@@ -63,7 +63,7 @@
 /* This test uses many POSIX things that are not available on
  * Windows.
  */
-#ifdef H5_HAVE_UNISTD_H
+#if defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID)
 
 #define DATAFILE "twriteorder.dat"
 /* #define READERS_MAX      10 */ /* max number of readers */
@@ -466,7 +466,7 @@ done:
     return ret_value;
 }
 
-#else /* H5_HAVE_UNISTD_H */
+#else /* defined(H5_HAVE_FORK && defined(H5_HAVE_WAITPID) */
 
 int
 main(void)
@@ -475,4 +475,4 @@ main(void)
     return EXIT_SUCCESS;
 } /* end main() */
 
-#endif /* H5_HAVE_UNISTD_H */
+#endif /* defined(H5_HAVE_FORK && defined(H5_HAVE_WAITPID) */

--- a/test/use_append_chunk.c
+++ b/test/use_append_chunk.c
@@ -63,7 +63,7 @@
 /* This test uses many POSIX things that are not available on
  * Windows.
  */
-#ifdef H5_HAVE_UNISTD_H
+#if defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID)
 
 #include "use.h"
 
@@ -270,7 +270,7 @@ done:
     return (ret_value);
 }
 
-#else /* H5_HAVE_UNISTD_H */
+#else /* defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID) */
 
 int
 main(void)
@@ -279,4 +279,4 @@ main(void)
     return EXIT_SUCCESS;
 } /* end main() */
 
-#endif /* H5_HAVE_UNISTD_H */
+#endif /* defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID) */

--- a/test/use_append_mchunks.c
+++ b/test/use_append_mchunks.c
@@ -55,7 +55,7 @@
 /* This test uses many POSIX things that are not available on
  * Windows.
  */
-#ifdef H5_HAVE_UNISTD_H
+#if defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID)
 
 #include "use.h"
 
@@ -265,7 +265,7 @@ done:
     return (ret_value);
 } /* end main() */
 
-#else /* H5_HAVE_UNISTD_H */
+#else /* defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID) */
 
 int
 main(void)
@@ -274,4 +274,4 @@ main(void)
     return EXIT_SUCCESS;
 } /* end main() */
 
-#endif /* H5_HAVE_UNISTD_H */
+#endif /* defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID) */


### PR DESCRIPTION
Currently, building HDF5 with Mingw only works on MSYS.

This restores compilation with the standalone version of Mingw, which has been broken since PRs #457 and #783.

This should be backported to branch `hdf5_1_10`.
