### PR TITLE
fixed off-by-one error in h5fget_name_f, HDFFV-11290

### DIFF
--- a/fortran/src/H5Ff.c
+++ b/fortran/src/H5Ff.c
@@ -583,7 +583,7 @@ h5fget_name_c(hid_t_f *obj_id, size_t_f *size, _fcd buf, size_t_f *buflen)
     int_f   ret_value = 0; /* Return value */
 
     /*
-     * Allocate buffer to hold name of an attribute
+     * Allocate buffer to hold name of file
      */
     if (NULL == (c_buf = (char *)HDmalloc((size_t)*buflen + 1)))
         HGOTO_DONE(FAIL);

--- a/fortran/src/H5Ff.c
+++ b/fortran/src/H5Ff.c
@@ -591,7 +591,7 @@ h5fget_name_c(hid_t_f *obj_id, size_t_f *size, _fcd buf, size_t_f *buflen)
     /*
      * Call H5Fget_name function
      */
-    if ((size_c = H5Fget_name((hid_t)*obj_id, c_buf, (size_t)*buflen)) < 0)
+    if ((size_c = H5Fget_name((hid_t)*obj_id, c_buf, (size_t)*buflen + 1)) < 0)
         HGOTO_DONE(FAIL);
 
     /*

--- a/fortran/test/tH5F.F90
+++ b/fortran/test/tH5F.F90
@@ -584,17 +584,23 @@ CONTAINS
 !    The following subroutine checks that h5fget_name_f produces
 !    correct output for a given obj_id and filename.
 !
-        SUBROUTINE check_get_name(obj_id, fix_filename, total_error)
+        SUBROUTINE check_get_name(obj_id, fix_filename, len_filename, total_error)
           USE HDF5  ! This module contains all necessary modules
           USE TH5_MISC
           IMPLICIT NONE
           INTEGER(HID_T) :: obj_id                          ! Object identifier
           CHARACTER(LEN=80), INTENT(IN) :: fix_filename     ! Expected filename
+          INTEGER, INTENT(IN) :: len_filename               ! The length of the filename
           INTEGER, INTENT(INOUT) :: total_error             ! Error count
 
           CHARACTER(LEN=80):: file_name  ! Filename buffer
           INTEGER:: error                ! HDF5 error code
           INTEGER(SIZE_T):: name_size    ! Filename length
+
+          INTEGER, PARAMETER :: sm_len = 2
+          CHARACTER(LEN=len_filename) :: filename_exact
+          CHARACTER(LEN=len_filename-sm_len) :: filename_sm
+
           !
           !Get file name from the dataset identifier
           !
@@ -637,6 +643,30 @@ CONTAINS
             total_error = total_error + 1
          END IF
 
+         ! Use a buffer which is the exact size needed to hold the filename
+         CALL h5fget_name_f(obj_id, filename_exact, name_size, error)
+         CALL check("h5fget_name_f",error,total_error)
+         IF(name_size .NE. len_filename)THEN
+            WRITE(*,*) "  file name size obtained from the object id is incorrect"
+            total_error = total_error + 1
+         ENDIF
+         IF(filename_exact .NE. TRIM(fix_filename)) THEN
+            WRITE(*,*) "  file name obtained from the object id is incorrect"
+            total_error = total_error + 1
+         END IF
+
+         ! Use a buffer which is smaller than needed to hold the filename
+         CALL h5fget_name_f(obj_id, filename_sm, name_size, error)
+         CALL check("h5fget_name_f",error,total_error)
+         IF(name_size .NE. len_filename)THEN
+            WRITE(*,*) "  file name size obtained from the object id is incorrect"
+            total_error = total_error + 1
+         ENDIF
+         IF(filename_sm(1:len_filename-sm_len) .NE. fix_filename(1:len_filename-sm_len)) THEN
+            WRITE(*,*) "  file name obtained from the object id is incorrect"
+            total_error = total_error + 1
+         END IF
+
         END SUBROUTINE check_get_name
 
 !    The following subroutine tests h5fget_name_f.
@@ -653,6 +683,7 @@ CONTAINS
 
           CHARACTER(LEN=*), PARAMETER :: filename = "filename"
           CHARACTER(LEN=80)  :: fix_filename
+          INTEGER :: len_filename
 
           INTEGER(HID_T) :: file_id          ! File identifier
           INTEGER(HID_T) :: g_id             ! Group identifier
@@ -679,8 +710,9 @@ CONTAINS
           CALL h5gopen_f(file_id,"/",g_id, error)
           CALL check("h5gopen_f",error,total_error)
 
-          CALL check_get_name(file_id, fix_filename, total_error)
-          CALL check_get_name(g_id, fix_filename, total_error)
+          len_filename = LEN_TRIM(fix_filename)
+          CALL check_get_name(file_id, fix_filename, len_filename, total_error)
+          CALL check_get_name(g_id, fix_filename, len_filename, total_error)
 
           ! Close the group.
           !


### PR DESCRIPTION
If an exact size buffer is passed to h5fget_name_f, then the returned filename will be truncated by one due to an error in the C wrapper. This fixes the issue and adds a test.