### PR TITLE
refactor H5T_cmp and reintroduce Tony Horrobin's cache of the member-name sort order

### DIFF
--- a/src/H5T.c
+++ b/src/H5T.c
@@ -3331,7 +3331,7 @@ H5T__create(H5T_class_t type, size_t size)
             if (type == H5T_COMPOUND) {
                 dt->shared->u.compnd.packed    = FALSE; /* Start out unpacked */
                 dt->shared->u.compnd.memb_size = 0;
-                dt->shared->u.compnd.idx_name = NULL;
+                dt->shared->u.compnd.idx_name  = NULL;
             } /* end if */
             else if (type == H5T_OPAQUE)
                 /* Initialize the tag in case it's not set later.  A null tag will
@@ -3524,11 +3524,11 @@ static herr_t
 H5T__complete_copy(H5T_t *new_dt, const H5T_t *old_dt, H5T_shared_t *reopened_fo, hbool_t set_memory_type,
                    H5T_copy_func_t copyfn)
 {
-    H5T_t *  tmp = NULL;          /* Temporary copy of compound field's datatype */
-    char *   s;                   /* Temporary copy of compound field name / enum value name */
-    unsigned i;                   /* Local index variable */
-    herr_t   ret_value = SUCCEED; /* Return value */
-    H5T_shared_t * const nsh = new_dt->shared, * const osh = old_dt->shared;
+    H5T_t *             tmp = NULL;          /* Temporary copy of compound field's datatype */
+    char *              s;                   /* Temporary copy of compound field name / enum value name */
+    unsigned            i;                   /* Local index variable */
+    herr_t              ret_value = SUCCEED; /* Return value */
+    H5T_shared_t *const nsh = new_dt->shared, *const osh = old_dt->shared;
 
     FUNC_ENTER_STATIC
 
@@ -3542,8 +3542,8 @@ H5T__complete_copy(H5T_t *new_dt, const H5T_t *old_dt, H5T_shared_t *reopened_fo
 
         switch (nsh->type) {
             case H5T_COMPOUND: {
-                H5T_compnd_t * const ncmpd = &nsh->u.compnd, *ocmpd = &osh->u.compnd;
-                ssize_t accum_change = 0; /* Amount of change in the offset of the fields */
+                H5T_compnd_t *const ncmpd = &nsh->u.compnd, *ocmpd = &osh->u.compnd;
+                ssize_t             accum_change = 0; /* Amount of change in the offset of the fields */
 
                 /*
                  * Copy all member fields to new type, then overwrite the
@@ -3552,13 +3552,11 @@ H5T__complete_copy(H5T_t *new_dt, const H5T_t *old_dt, H5T_shared_t *reopened_fo
                  */
                 /* Only malloc if space has been allocated for members - NAF */
                 if (ncmpd->nalloc > 0) {
-                    ncmpd->memb =
-                        H5MM_malloc(ncmpd->nalloc * sizeof(H5T_cmemb_t));
+                    ncmpd->memb = H5MM_malloc(ncmpd->nalloc * sizeof(H5T_cmemb_t));
                     if (NULL == ncmpd->memb)
                         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL, "memory allocation failed")
 
-                    H5MM_memcpy(ncmpd->memb, ocmpd->memb,
-                                ncmpd->nmembs * sizeof(H5T_cmemb_t));
+                    H5MM_memcpy(ncmpd->memb, ocmpd->memb, ncmpd->nmembs * sizeof(H5T_cmemb_t));
                 } /* end if */
 
                 for (i = 0; i < ncmpd->nmembs; i++) {
@@ -3575,8 +3573,7 @@ H5T__complete_copy(H5T_t *new_dt, const H5T_t *old_dt, H5T_shared_t *reopened_fo
                     HDassert(tmp != NULL);
 
                     /* Range check against compound member's offset */
-                    if ((accum_change < 0) &&
-                        ((ssize_t)ncmpd->memb[i].offset < accum_change))
+                    if ((accum_change < 0) && ((ssize_t)ncmpd->memb[i].offset < accum_change))
                         HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "invalid field size in datatype")
 
                     /* Apply the accumulated size change to the offset of the field */
@@ -3584,8 +3581,7 @@ H5T__complete_copy(H5T_t *new_dt, const H5T_t *old_dt, H5T_shared_t *reopened_fo
 
                     if (ocmpd->sorted != H5T_SORT_VALUE) {
                         for (old_match = -1, j = 0; j < ocmpd->nmembs; j++) {
-                            if (!HDstrcmp(ncmpd->memb[i].name,
-                                          ocmpd->memb[j].name)) {
+                            if (!HDstrcmp(ncmpd->memb[i].name, ocmpd->memb[j].name)) {
                                 old_match = (int)j;
                                 break;
                             } /* end if */
@@ -3599,16 +3595,13 @@ H5T__complete_copy(H5T_t *new_dt, const H5T_t *old_dt, H5T_shared_t *reopened_fo
                         old_match = (int)i;
 
                     /* If the field changed size, add that change to the accumulated size change */
-                    if (ncmpd->memb[i].type->shared->size !=
-                        ocmpd->memb[old_match].type->shared->size) {
+                    if (ncmpd->memb[i].type->shared->size != ocmpd->memb[old_match].type->shared->size) {
                         /* Adjust the size of the member */
-                        ncmpd->memb[i].size =
-                            (ocmpd->memb[old_match].size * tmp->shared->size) /
-                            ocmpd->memb[old_match].type->shared->size;
+                        ncmpd->memb[i].size = (ocmpd->memb[old_match].size * tmp->shared->size) /
+                                              ocmpd->memb[old_match].type->shared->size;
 
-                        accum_change +=
-                            (ssize_t)(ncmpd->memb[i].type->shared->size -
-                                      ocmpd->memb[old_match].type->shared->size);
+                        accum_change += (ssize_t)(ncmpd->memb[i].type->shared->size -
+                                                  ocmpd->memb[old_match].type->shared->size);
                     } /* end if */
                 }     /* end for */
 
@@ -3621,16 +3614,13 @@ H5T__complete_copy(H5T_t *new_dt, const H5T_t *old_dt, H5T_shared_t *reopened_fo
 
                 /* Copy sorting index */
                 if (ncmpd->idx_name != NULL) {
-                    ncmpd->idx_name =
-                        H5MM_malloc(ncmpd->nalloc * sizeof(ncmpd->idx_name[0]));
+                    ncmpd->idx_name = H5MM_malloc(ncmpd->nalloc * sizeof(ncmpd->idx_name[0]));
                     if (NULL == ncmpd->idx_name)
                         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL, "memory allocation failed")
 
-                    H5MM_memcpy(ncmpd->idx_name, ocmpd->idx_name,
-                        ncmpd->nmembs * sizeof(ncmpd->idx_name[0]));
+                    H5MM_memcpy(ncmpd->idx_name, ocmpd->idx_name, ncmpd->nmembs * sizeof(ncmpd->idx_name[0]));
                 }
-            }
-            break;
+            } break;
 
             case H5T_ENUM:
                 /*
@@ -3638,15 +3628,12 @@ H5T__complete_copy(H5T_t *new_dt, const H5T_t *old_dt, H5T_shared_t *reopened_fo
                  * of each new member with copied values. That is, H5T_copy() is a
                  * deep copy.
                  */
-                if (NULL == (nsh->u.enumer.name =
-                                 H5MM_malloc(nsh->u.enumer.nalloc * sizeof(char *))))
+                if (NULL == (nsh->u.enumer.name = H5MM_malloc(nsh->u.enumer.nalloc * sizeof(char *))))
                     HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL, "enam name array memory allocation failed")
-                if (NULL == (nsh->u.enumer.value =
-                                 H5MM_malloc(nsh->u.enumer.nalloc * nsh->size)))
+                if (NULL == (nsh->u.enumer.value = H5MM_malloc(nsh->u.enumer.nalloc * nsh->size)))
                     HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL,
                                 "enam value array memory allocation failed")
-                H5MM_memcpy(nsh->u.enumer.value, osh->u.enumer.value,
-                            nsh->u.enumer.nmembs * nsh->size);
+                H5MM_memcpy(nsh->u.enumer.value, osh->u.enumer.value, nsh->u.enumer.nmembs * nsh->size);
                 for (i = 0; i < nsh->u.enumer.nmembs; i++) {
                     if (NULL == (s = H5MM_xstrdup(osh->u.enumer.name[i])))
                         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL,
@@ -4012,9 +3999,9 @@ done:
 herr_t
 H5T__free(H5T_t *dt)
 {
-    unsigned i;
-    herr_t   ret_value = SUCCEED; /* Return value */
-    H5T_shared_t *sh = dt->shared;
+    unsigned      i;
+    herr_t        ret_value = SUCCEED; /* Return value */
+    H5T_shared_t *sh        = dt->shared;
 
     FUNC_ENTER_PACKAGE
 
@@ -4035,8 +4022,7 @@ H5T__free(H5T_t *dt)
             sh->u.compnd.memb   = H5MM_xfree(sh->u.compnd.memb);
             sh->u.compnd.nmembs = 0;
             if (sh->u.compnd.idx_name != NULL) {
-                sh->u.compnd.idx_name =
-                    H5MM_xfree(sh->u.compnd.idx_name);
+                sh->u.compnd.idx_name = H5MM_xfree(sh->u.compnd.idx_name);
             }
             break;
 
@@ -4469,20 +4455,19 @@ H5T_get_force_conv(const H5T_t *dt)
 static void
 bubblesort_indices_by_name(H5T_compnd_t *cmpd, size_t *idx)
 {
-    hbool_t   swapped;
-    size_t i, j;
+    hbool_t swapped;
+    size_t  i, j;
 
     if (cmpd->nmembs < 2)
         return;
 
     for (i = cmpd->nmembs - 1, swapped = TRUE; swapped && i > 0; --i) {
         for (j = 0, swapped = FALSE; j < i; j++) {
-            if (HDstrcmp(cmpd->memb[idx[j]].name,
-                         cmpd->memb[idx[j + 1]].name) > 0) {
+            if (HDstrcmp(cmpd->memb[idx[j]].name, cmpd->memb[idx[j + 1]].name) > 0) {
                 size_t tmp = idx[j];
-                idx[j]          = idx[j + 1];
-                idx[j + 1]      = tmp;
-                swapped          = TRUE;
+                idx[j]     = idx[j + 1];
+                idx[j + 1] = tmp;
+                swapped    = TRUE;
             }
         }
     }
@@ -4490,13 +4475,13 @@ bubblesort_indices_by_name(H5T_compnd_t *cmpd, size_t *idx)
 
 /* Compare two compound datatypes. */
 static int
-compound_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
+compound_cmp(H5T_shared_t *const sh1, H5T_shared_t *const sh2, bool superset)
 {
-    int       ret_value = 0;
-    int       tmp;
-    size_t *idx1, *idx2;
-    size_t  u;
-    H5T_compnd_t * const cmpd1 = &sh1->u.compnd, *cmpd2 = &sh2->u.compnd;
+    int                 ret_value = 0;
+    int                 tmp;
+    size_t *            idx1, *idx2;
+    size_t              u;
+    H5T_compnd_t *const cmpd1 = &sh1->u.compnd, *cmpd2 = &sh2->u.compnd;
 
     FUNC_ENTER_NOAPI(0)
 
@@ -4521,7 +4506,7 @@ compound_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
         idx2 = H5MM_malloc(cmpd2->nmembs * sizeof(cmpd2->idx_name[0]));
         if (NULL == idx2)
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, 0, "memory allocation failed")
-        for(u = 0; u < cmpd2->nmembs; u++)
+        for (u = 0; u < cmpd2->nmembs; u++)
             idx2[u] = u;
 
         bubblesort_indices_by_name(cmpd2, idx2);
@@ -4531,17 +4516,14 @@ compound_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
 #ifdef H5T_DEBUG
     /* I don't quite trust the code above yet :-)  --RPM */
     for (u = 1; u < cmpd1->nmembs; u++) {
-        HDassert(HDstrcmp(cmpd1->memb[idx1[u - 1]].name,
-                          cmpd1->memb[idx1[u]].name) < 0);
-        HDassert(HDstrcmp(cmpd2->memb[idx2[u - 1]].name,
-                          cmpd2->memb[idx2[u]].name) < 0);
+        HDassert(HDstrcmp(cmpd1->memb[idx1[u - 1]].name, cmpd1->memb[idx1[u]].name) < 0);
+        HDassert(HDstrcmp(cmpd2->memb[idx2[u - 1]].name, cmpd2->memb[idx2[u]].name) < 0);
     }
 #endif
 
     /* Compare the members */
     for (u = 0; u < cmpd1->nmembs; u++) {
-        const H5T_cmemb_t * const m1 = &cmpd1->memb[idx1[u]],
-                          * const m2 = &cmpd2->memb[idx2[u]];
+        const H5T_cmemb_t *const m1 = &cmpd1->memb[idx1[u]], *const m2 = &cmpd2->memb[idx2[u]];
 
         if ((tmp = HDstrcmp(m1->name, m2->name)) != 0)
             HGOTO_DONE(tmp);
@@ -4567,15 +4549,15 @@ done:
 
 /* Compare two enumeration datatypes. */
 static int
-enum_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
+enum_cmp(H5T_shared_t *const sh1, H5T_shared_t *const sh2, bool superset)
 {
-    hbool_t   swapped;
-    int       ret_value = 0;
-    int       tmp;
-    unsigned *idx1 = NULL, *idx2 = NULL;
-    unsigned  u;
-    size_t    base_size;
-    H5T_enum_t * const en1 = &sh1->u.enumer, *en2 = &sh2->u.enumer;
+    hbool_t           swapped;
+    int               ret_value = 0;
+    int               tmp;
+    unsigned *        idx1 = NULL, *idx2 = NULL;
+    unsigned          u;
+    size_t            base_size;
+    H5T_enum_t *const en1 = &sh1->u.enumer, *en2 = &sh2->u.enumer;
 
     FUNC_ENTER_NOAPI(0)
 
@@ -4585,7 +4567,8 @@ enum_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
     if (superset) {
         if (en1->nmembs > en2->nmembs)
             HGOTO_DONE(1);
-    } else {
+    }
+    else {
         if (en1->nmembs < en2->nmembs)
             HGOTO_DONE(-1);
         if (en1->nmembs > en2->nmembs)
@@ -4602,8 +4585,7 @@ enum_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
         size_t i, j;
         for (i = en1->nmembs - 1, swapped = TRUE; swapped && i > 0; --i) {
             for (j = 0, swapped = FALSE; j < i; j++)
-                if (HDstrcmp(en1->name[idx1[j]],
-                             en1->name[idx1[j + 1]]) > 0) {
+                if (HDstrcmp(en1->name[idx1[j]], en1->name[idx1[j + 1]]) > 0) {
                     unsigned tmp_idx = idx1[j];
                     idx1[j]          = idx1[j + 1];
                     idx1[j + 1]      = tmp_idx;
@@ -4618,8 +4600,7 @@ enum_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
 
         for (i = en2->nmembs - 1, swapped = TRUE; swapped && i > 0; --i) {
             for (j = 0, swapped = FALSE; j < i; j++)
-                if (HDstrcmp(en2->name[idx2[j]],
-                             en2->name[idx2[j + 1]]) > 0) {
+                if (HDstrcmp(en2->name[idx2[j]], en2->name[idx2[j + 1]]) > 0) {
                     unsigned tmp_idx = idx2[j];
                     idx2[j]          = idx2[j + 1];
                     idx2[j + 1]      = tmp_idx;
@@ -4631,10 +4612,8 @@ enum_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
 #ifdef H5T_DEBUG
     /* I don't quite trust the code above yet :-)  --RPM */
     for (u = 1; u < en1->nmembs; u++) {
-        HDassert(
-            HDstrcmp(en1->name[idx1[u - 1]], en1->name[idx1[u]]) < 0);
-        HDassert(
-            HDstrcmp(en2->name[idx2[u - 1]], en2->name[idx2[u]]) < 0);
+        HDassert(HDstrcmp(en1->name[idx1[u - 1]], en1->name[idx1[u]]) < 0);
+        HDassert(HDstrcmp(en2->name[idx2[u - 1]], en2->name[idx2[u]]) < 0);
     }
 #endif
 
@@ -4657,8 +4636,7 @@ enum_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
                 idx = (lt + rt) / 2;
 
                 /* compare */
-                if ((cmp = HDstrcmp(en1->name[idx1[u]],
-                                    en2->name[idx2[idx]])) < 0)
+                if ((cmp = HDstrcmp(en1->name[idx1[u]], en2->name[idx2[idx]])) < 0)
                     rt = idx;
                 else
                     lt = idx + 1;
@@ -4666,7 +4644,8 @@ enum_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
             /* Leave, if we couldn't find match */
             if (cmp)
                 HGOTO_DONE(-1);
-        } else {
+        }
+        else {
             /* Check for exact member name match when not doing
              * "superset" comparison
              */
@@ -4710,12 +4689,12 @@ done:
  *-------------------------------------------------------------------------
  */
 int
-H5T_cmp(const H5T_t * const dt1, const H5T_t * const dt2, hbool_t superset)
+H5T_cmp(const H5T_t *const dt1, const H5T_t *const dt2, hbool_t superset)
 {
     H5T_shared_t *sh1, *sh2;
-    unsigned  u;
-    int       tmp;
-    int       ret_value = 0;
+    unsigned      u;
+    int           tmp;
+    int           ret_value = 0;
 
     FUNC_ENTER_NOAPI_NOERR
 
@@ -4746,20 +4725,16 @@ H5T_cmp(const H5T_t * const dt1, const H5T_t * const dt2, hbool_t superset)
         case H5T_ENUM:
             HGOTO_DONE(enum_cmp(sh1, sh2, superset));
         case H5T_VLEN:
-            HDassert(sh1->u.vlen.type > H5T_VLEN_BADTYPE &&
-                     sh1->u.vlen.type < H5T_VLEN_MAXTYPE);
-            HDassert(sh2->u.vlen.type > H5T_VLEN_BADTYPE &&
-                     sh2->u.vlen.type < H5T_VLEN_MAXTYPE);
+            HDassert(sh1->u.vlen.type > H5T_VLEN_BADTYPE && sh1->u.vlen.type < H5T_VLEN_MAXTYPE);
+            HDassert(sh2->u.vlen.type > H5T_VLEN_BADTYPE && sh2->u.vlen.type < H5T_VLEN_MAXTYPE);
             HDassert(sh1->u.vlen.loc >= H5T_LOC_BADLOC && sh1->u.vlen.loc < H5T_LOC_MAXLOC);
             HDassert(sh2->u.vlen.loc >= H5T_LOC_BADLOC && sh2->u.vlen.loc < H5T_LOC_MAXLOC);
 
             /* Arbitrarily sort sequence VL datatypes before string VL datatypes */
-            if (sh1->u.vlen.type == H5T_VLEN_SEQUENCE &&
-                sh2->u.vlen.type == H5T_VLEN_STRING) {
+            if (sh1->u.vlen.type == H5T_VLEN_SEQUENCE && sh2->u.vlen.type == H5T_VLEN_STRING) {
                 HGOTO_DONE(-1);
             }
-            else if (sh1->u.vlen.type == H5T_VLEN_STRING &&
-                     sh2->u.vlen.type == H5T_VLEN_SEQUENCE) {
+            else if (sh1->u.vlen.type == H5T_VLEN_STRING && sh2->u.vlen.type == H5T_VLEN_SEQUENCE) {
                 HGOTO_DONE(1);
             }
             /* Arbitrarily sort VL datatypes in memory before disk */

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -4540,24 +4540,23 @@ compound_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
 
     /* Compare the members */
     for (u = 0; u < cmpd1->nmembs; u++) {
-        tmp = HDstrcmp(cmpd1->memb[idx1[u]].name,
-                       cmpd2->memb[idx2[u]].name);
-        if (tmp != 0)
+        const H5T_cmemb_t * const m1 = &cmpd1->memb[idx1[u]],
+                          * const m2 = &cmpd2->memb[idx2[u]];
+
+        if ((tmp = HDstrcmp(m1->name, m2->name)) != 0)
             HGOTO_DONE(tmp);
 
-        if (cmpd1->memb[idx1[u]].offset < cmpd2->memb[idx2[u]].offset)
+        if (m1->offset < m2->offset)
             HGOTO_DONE(-1);
-        if (cmpd1->memb[idx1[u]].offset > cmpd2->memb[idx2[u]].offset)
+        if (m1->offset > m2->offset)
             HGOTO_DONE(1);
 
-        if (cmpd1->memb[idx1[u]].size < cmpd2->memb[idx2[u]].size)
+        if (m1->size < m2->size)
             HGOTO_DONE(-1);
-        if (cmpd1->memb[idx1[u]].size > cmpd2->memb[idx2[u]].size)
+        if (m1->size > m2->size)
             HGOTO_DONE(1);
 
-        tmp = H5T_cmp(cmpd1->memb[idx1[u]].type,
-                      cmpd2->memb[idx2[u]].type, superset);
-        if (tmp != 0)
+        if ((tmp = H5T_cmp(m1->type, m2->type, superset)) != 0)
             HGOTO_DONE(tmp);
     }
 

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -4516,6 +4516,7 @@ compound_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
         bubblesort_indices_by_name(cmpd1, idx1);
         cmpd1->idx_name = idx1;
     }
+
     if ((idx2 = cmpd2->idx_name) == NULL) {
         idx2 = H5MM_malloc(cmpd2->nmembs * sizeof(cmpd2->idx_name[0]));
         if (NULL == idx2)

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -4494,7 +4494,7 @@ compound_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
 {
     int       ret_value = 0;
     int       tmp;
-    size_t *idx1 = NULL, *idx2 = NULL;
+    size_t *idx1, *idx2;
     size_t  u;
     H5T_compnd_t * const cmpd1 = &sh1->u.compnd, *cmpd2 = &sh2->u.compnd;
 

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -4586,13 +4586,12 @@ enum_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
     if (superset) {
         if (en1->nmembs > en2->nmembs)
             HGOTO_DONE(1);
-    } /* end if */
-    else {
+    } else {
         if (en1->nmembs < en2->nmembs)
             HGOTO_DONE(-1);
         if (en1->nmembs > en2->nmembs)
             HGOTO_DONE(1);
-    } /* end else */
+    }
 
     /* Build an index for each type so the names are sorted */
     if (NULL == (idx1 = H5MM_malloc(en1->nmembs * sizeof(idx1[0]))) ||
@@ -4668,8 +4667,7 @@ enum_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
             /* Leave, if we couldn't find match */
             if (cmp)
                 HGOTO_DONE(-1);
-        } /* end if */
-        else {
+        } else {
             /* Check for exact member name match when not doing
              * "superset" comparison
              */
@@ -4679,7 +4677,7 @@ enum_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
 
             /* Set index value appropriately */
             idx = u;
-        } /* end else */
+        }
 
         tmp = HDmemcmp((uint8_t *)en1->value + idx1[u] * base_size,
                        (uint8_t *)en2->value + idx2[idx] * base_size, base_size);

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -4546,10 +4546,8 @@ compound_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
     for (u = 0; u < cmpd1->nmembs; u++) {
         tmp = HDstrcmp(cmpd1->memb[idx1[u]].name,
                        cmpd2->memb[idx2[u]].name);
-        if (tmp < 0)
-            HGOTO_DONE(-1);
-        if (tmp > 0)
-            HGOTO_DONE(1);
+        if (tmp != 0)
+            HGOTO_DONE(tmp);
 
         if (cmpd1->memb[idx1[u]].offset < cmpd2->memb[idx2[u]].offset)
             HGOTO_DONE(-1);

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -3628,18 +3628,18 @@ H5T__complete_copy(H5T_t *new_dt, const H5T_t *old_dt, H5T_shared_t *reopened_fo
                 /* Apply the accumulated size change to the size of the compound struct */
                 new_dt->shared->size += (size_t)accum_change;
 
-                    /* Copy sorting index */
-                    if (new_dt->shared->u.compnd.idx_name!=NULL) {
-						unsigned * idx_name_orig = new_dt->shared->u.compnd.idx_name;
+                /* Copy sorting index */
+                if (new_dt->shared->u.compnd.idx_name != NULL) {
+                    unsigned * idx_name_orig = new_dt->shared->u.compnd.idx_name;
 
-						if(NULL == (new_dt->shared->u.compnd.idx_name = H5MM_malloc(new_dt->shared->u.compnd.nalloc * sizeof(H5T_cmemb_t))))
-                            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL, "memory allocation failed")
+                    if(NULL == (new_dt->shared->u.compnd.idx_name = H5MM_malloc(new_dt->shared->u.compnd.nalloc * sizeof(H5T_cmemb_t))))
+                        HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL, "memory allocation failed")
 
-                        H5MM_memcpy(new_dt->shared->u.compnd.idx_name, old_dt->shared->u.compnd.idx_name,
-                        new_dt->shared->u.compnd.nmembs * sizeof(unsigned));
-		    }
+                    H5MM_memcpy(new_dt->shared->u.compnd.idx_name, old_dt->shared->u.compnd.idx_name,
+                    new_dt->shared->u.compnd.nmembs * sizeof(unsigned));
                 }
-                break;
+            }
+            break;
 
             case H5T_ENUM:
                 /*

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -4511,7 +4511,7 @@ compound_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
     if ((idx2 = cmpd2->idx_name) == NULL) {
         cmpd2->idx_name = (unsigned *)H5MM_malloc(cmpd2->nmembs * sizeof(unsigned));
         if(NULL == (idx2 = cmpd2->idx_name))
-                HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, 0, "memory allocation failed")
+            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, 0, "memory allocation failed")
         for(u = 0; u < cmpd2->nmembs; u++)
                 idx2[u] = u;
         if(cmpd2->nmembs > 1) {

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -4601,10 +4601,8 @@ enum_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
     for (u = 0; u < en1->nmembs; u++)
         idx1[u] = u;
     if (en1->nmembs > 1) {
-        int i;
-        for (i = (int)en1->nmembs - 1, swapped = TRUE; swapped && i >= 0; --i) {
-            int j;
-
+        size_t i, j;
+        for (i = en1->nmembs - 1, swapped = TRUE; swapped && i > 0; --i) {
             for (j = 0, swapped = FALSE; j < i; j++)
                 if (HDstrcmp(en1->name[idx1[j]],
                              en1->name[idx1[j + 1]]) > 0) {
@@ -4618,11 +4616,9 @@ enum_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
     for (u = 0; u < en2->nmembs; u++)
         idx2[u] = u;
     if (en2->nmembs > 1) {
-        int i;
+        size_t i, j;
 
-        for (i = (int)en2->nmembs - 1, swapped = TRUE; swapped && i >= 0; --i) {
-            int j;
-
+        for (i = en2->nmembs - 1, swapped = TRUE; swapped && i > 0; --i) {
             for (j = 0, swapped = FALSE; j < i; j++)
                 if (HDstrcmp(en2->name[idx2[j]],
                              en2->name[idx2[j + 1]]) > 0) {
@@ -4636,11 +4632,11 @@ enum_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
 
 #ifdef H5T_DEBUG
     /* I don't quite trust the code above yet :-)  --RPM */
-    for (u = 0; u < en1->nmembs - 1; u++) {
+    for (u = 1; u < en1->nmembs; u++) {
         HDassert(
-            HDstrcmp(en1->name[idx1[u]], en1->name[idx1[u + 1]]));
+            HDstrcmp(en1->name[idx1[u - 1]], en1->name[idx1[u]]) < 0);
         HDassert(
-            HDstrcmp(en2->name[idx2[u]], en2->name[idx2[u + 1]]));
+            HDstrcmp(en2->name[idx2[u - 1]], en2->name[idx2[u]]) < 0);
     }
 #endif
 

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -3621,11 +3621,13 @@ H5T__complete_copy(H5T_t *new_dt, const H5T_t *old_dt, H5T_shared_t *reopened_fo
 
                 /* Copy sorting index */
                 if (ncmpd->idx_name != NULL) {
-                    if(NULL == (ncmpd->idx_name = H5MM_malloc(ncmpd->nalloc * sizeof(H5T_cmemb_t))))
+                    ncmpd->idx_name =
+                        H5MM_malloc(ncmpd->nalloc * sizeof(ncmpd->idx_name[0]));
+                    if (NULL == ncmpd->idx_name)
                         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL, "memory allocation failed")
 
                     H5MM_memcpy(ncmpd->idx_name, ocmpd->idx_name,
-                    ncmpd->nmembs * sizeof(unsigned));
+                        ncmpd->nmembs * sizeof(ncmpd->idx_name[0]));
                 }
             }
             break;

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -2568,7 +2568,7 @@ H5T__register(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_con
             size_t      na = MAX(32, 2 * H5T_g.asoft);
             H5T_soft_t *x;
 
-            if (NULL == (x = (H5T_soft_t *)H5MM_realloc(H5T_g.soft, na * sizeof(H5T_soft_t))))
+            if (NULL == (x = H5MM_realloc(H5T_g.soft, na * sizeof(H5T_soft_t))))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed")
             H5T_g.asoft = na;
             H5T_g.soft  = x;
@@ -4486,7 +4486,7 @@ compound_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
 
     /* Build an index for each type so the names are sorted */
     if ((idx1 = cmpd1->idx_name) == NULL) {
-        cmpd1->idx_name = (unsigned *)H5MM_malloc(cmpd1->nmembs * sizeof(unsigned));
+        cmpd1->idx_name = H5MM_malloc(cmpd1->nmembs * sizeof(unsigned));
         if(NULL == (idx1 = cmpd1->idx_name))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, 0, "memory allocation failed")
         for (u = 0; u < cmpd1->nmembs; u++)
@@ -4509,7 +4509,7 @@ compound_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
         }
     }
     if ((idx2 = cmpd2->idx_name) == NULL) {
-        cmpd2->idx_name = (unsigned *)H5MM_malloc(cmpd2->nmembs * sizeof(unsigned));
+        cmpd2->idx_name = H5MM_malloc(cmpd2->nmembs * sizeof(unsigned));
         if(NULL == (idx2 = cmpd2->idx_name))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, 0, "memory allocation failed")
         for(u = 0; u < cmpd2->nmembs; u++)
@@ -4599,8 +4599,8 @@ enum_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
     } /* end else */
 
     /* Build an index for each type so the names are sorted */
-    if (NULL == (idx1 = (unsigned *)H5MM_malloc(en1->nmembs * sizeof(unsigned))) ||
-        NULL == (idx2 = (unsigned *)H5MM_malloc(en2->nmembs * sizeof(unsigned))))
+    if (NULL == (idx1 = H5MM_malloc(en1->nmembs * sizeof(idx1[0]))) ||
+        NULL == (idx2 = H5MM_malloc(en2->nmembs * sizeof(idx2[0]))))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, 0, "memory allocation failed");
     for (u = 0; u < en1->nmembs; u++)
         idx1[u] = u;
@@ -5061,7 +5061,7 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
      * Make sure the first entry in the table is the no-op conversion path.
      */
     if (0 == H5T_g.npaths) {
-        if (NULL == (H5T_g.path = (H5T_path_t **)H5MM_malloc(128 * sizeof(H5T_path_t *))))
+        if (NULL == (H5T_g.path = H5MM_malloc(128 * sizeof(H5T_path_t *))))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
                         "memory allocation failed for type conversion path table")
         H5T_g.apaths = 128;
@@ -5289,7 +5289,7 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
             size_t       na = MAX(128, 2 * H5T_g.apaths);
             H5T_path_t **x;
 
-            if (NULL == (x = (H5T_path_t **)H5MM_realloc(H5T_g.path, na * sizeof(H5T_path_t *))))
+            if (NULL == (x = H5MM_realloc(H5T_g.path, na * sizeof(H5T_path_t *))))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed")
             H5T_g.apaths = na;
             H5T_g.path   = x;

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -3331,7 +3331,7 @@ H5T__create(H5T_class_t type, size_t size)
             if (type == H5T_COMPOUND) {
                 dt->shared->u.compnd.packed    = FALSE; /* Start out unpacked */
                 dt->shared->u.compnd.memb_size = 0;
-                dt->shared->u.compnd.idx_name=NULL;
+                dt->shared->u.compnd.idx_name = NULL;
             } /* end if */
             else if (type == H5T_OPAQUE)
                 /* Initialize the tag in case it's not set later.  A null tag will

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -4530,11 +4530,11 @@ compound_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
 
 #ifdef H5T_DEBUG
     /* I don't quite trust the code above yet :-)  --RPM */
-    for (u = 0; u < cmpd1->nmembs - 1; u++) {
-        HDassert(HDstrcmp(cmpd1->memb[idx1[u]].name,
-                          cmpd1->memb[idx1[u + 1]].name));
-        HDassert(HDstrcmp(cmpd2->memb[idx2[u]].name,
-                          cmpd2->memb[idx2[u + 1]].name));
+    for (u = 1; u < cmpd1->nmembs; u++) {
+        HDassert(HDstrcmp(cmpd1->memb[idx1[u - 1]].name,
+                          cmpd1->memb[idx1[u]].name) < 0);
+        HDassert(HDstrcmp(cmpd2->memb[idx2[u - 1]].name,
+                          cmpd2->memb[idx2[u]].name) < 0);
     }
 #endif
 

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -3414,9 +3414,6 @@ done:
  * Note:      Common code for both H5T_copy and H5T_copy_reopen, as part of
  *            the const-correct datatype copying routines.
  *
- * Programmer:  David Young
- *              January 18, 2020
- *
  *-------------------------------------------------------------------------
  */
 static H5T_t *
@@ -3468,9 +3465,6 @@ done:
  * Return:    Success:    Pointer to a new copy of the OLD_DT argument.
  *            Failure:    NULL
  *
- * Programmer:  David Young
- *              January 18, 2020
- *
  *-------------------------------------------------------------------------
  */
 static H5T_t *
@@ -3495,9 +3489,6 @@ done:
  *
  * Return:    Success:    Pointer to a new copy of the OLD_DT argument.
  *            Failure:    NULL
- *
- * Programmer:  David Young
- *              January 18, 2020
  *
  *-------------------------------------------------------------------------
  */
@@ -3526,9 +3517,6 @@ done:
  *            Failure:    negative
  *
  * Note:      Common code for both H5T_copy and H5T_copy_reopen.
- *
- * Programmer:  David Young
- *              January 18, 2020
  *
  *-------------------------------------------------------------------------
  */
@@ -3812,9 +3800,6 @@ done:
  *
  * Return:    Success:    Pointer to a new copy of the OLD_DT argument.
  *            Failure:    NULL
- *
- * Programmer:  David Young
- *              January 18, 2020
  *
  *-------------------------------------------------------------------------
  */

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -4499,7 +4499,7 @@ compound_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
         HGOTO_DONE(1);
 
     /* Build an index for each type so the names are sorted */
-    if(NULL == cmpd1->idx_name) {
+    if ((idx1 = cmpd1->idx_name) == NULL) {
         cmpd1->idx_name = (unsigned *)H5MM_malloc(cmpd1->nmembs * sizeof(unsigned));
         if(NULL == (idx1 = cmpd1->idx_name))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, 0, "memory allocation failed")
@@ -4522,10 +4522,7 @@ compound_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
             }
         }
     }
-    else {
-            idx1 = cmpd1->idx_name;
-    }
-    if(sh2->type == H5T_COMPOUND && NULL == cmpd2->idx_name) {
+    if ((idx2 = cmpd2->idx_name) == NULL) {
         cmpd2->idx_name = (unsigned *)H5MM_malloc(cmpd2->nmembs * sizeof(unsigned));
         if(NULL == (idx2 = cmpd2->idx_name))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, 0, "memory allocation failed")
@@ -4547,9 +4544,6 @@ compound_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
                     }
             }
         } /* end if */
-    }
-    else {
-        idx2 = cmpd2->idx_name;
     }
 
 #ifdef H5T_DEBUG

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -4553,57 +4553,57 @@ H5T_cmp(const H5T_t *dt1, const H5T_t *dt2, hbool_t superset)
 
             /* Build an index for each type so the names are sorted */
             if(NULL == dt1->shared->u.compnd.idx_name) {
-				dt1->shared->u.compnd.idx_name = (unsigned *)H5MM_malloc(dt1->shared->u.compnd.nmembs * sizeof(unsigned));
-				if(NULL == (idx1 = dt1->shared->u.compnd.idx_name))
-					HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, 0, "memory allocation failed")
-            for (u = 0; u < dt1->shared->u.compnd.nmembs; u++)
-					idx1[u] = u;
-				if(dt1->shared->u.compnd.nmembs > 1) {
-                int i;
+                dt1->shared->u.compnd.idx_name = (unsigned *)H5MM_malloc(dt1->shared->u.compnd.nmembs * sizeof(unsigned));
+                if(NULL == (idx1 = dt1->shared->u.compnd.idx_name))
+                        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, 0, "memory allocation failed")
+                for (u = 0; u < dt1->shared->u.compnd.nmembs; u++)
+                    idx1[u] = u;
+                if(dt1->shared->u.compnd.nmembs > 1) {
+                    int i;
 
-                for (i = (int)dt1->shared->u.compnd.nmembs - 1, swapped = TRUE; swapped && i >= 0; --i) {
-                    int j;
+                    for (i = (int)dt1->shared->u.compnd.nmembs - 1, swapped = TRUE; swapped && i >= 0; --i) {
+                        int j;
 
-                    for (j = 0, swapped = FALSE; j < i; j++)
-                        if (HDstrcmp(dt1->shared->u.compnd.memb[idx1[j]].name,
-                                     dt1->shared->u.compnd.memb[idx1[j + 1]].name) > 0) {
-                            unsigned tmp_idx = idx1[j];
-                            idx1[j]          = idx1[j + 1];
-                            idx1[j + 1]      = tmp_idx;
-                            swapped          = TRUE;
-                        }
+                        for (j = 0, swapped = FALSE; j < i; j++)
+                            if (HDstrcmp(dt1->shared->u.compnd.memb[idx1[j]].name,
+                                         dt1->shared->u.compnd.memb[idx1[j + 1]].name) > 0) {
+                                unsigned tmp_idx = idx1[j];
+                                idx1[j]          = idx1[j + 1];
+                                idx1[j + 1]      = tmp_idx;
+                                swapped          = TRUE;
+                            }
+                    }
                 }
-				}
-			}
-			else {
-				idx1 = dt1->shared->u.compnd.idx_name;
-			}
-			if(dt2->shared->type == H5T_COMPOUND && NULL == dt2->shared->u.compnd.idx_name) {
-				dt2->shared->u.compnd.idx_name = (unsigned *)H5MM_malloc(dt2->shared->u.compnd.nmembs * sizeof(unsigned));
-				if(NULL == (idx2 = dt2->shared->u.compnd.idx_name))
-					HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, 0, "memory allocation failed")
-				for(u = 0; u < dt2->shared->u.compnd.nmembs; u++)
-					idx2[u] = u;
-				if(dt2->shared->u.compnd.nmembs > 1) {
-					int i;
+            }
+            else {
+                    idx1 = dt1->shared->u.compnd.idx_name;
+            }
+            if(dt2->shared->type == H5T_COMPOUND && NULL == dt2->shared->u.compnd.idx_name) {
+                dt2->shared->u.compnd.idx_name = (unsigned *)H5MM_malloc(dt2->shared->u.compnd.nmembs * sizeof(unsigned));
+                if(NULL == (idx2 = dt2->shared->u.compnd.idx_name))
+                        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, 0, "memory allocation failed")
+                for(u = 0; u < dt2->shared->u.compnd.nmembs; u++)
+                        idx2[u] = u;
+                if(dt2->shared->u.compnd.nmembs > 1) {
+                    int i;
 
-                for (i = (int)dt2->shared->u.compnd.nmembs - 1, swapped = TRUE; swapped && i >= 0; --i) {
-                    int j;
+                    for (i = (int)dt2->shared->u.compnd.nmembs - 1, swapped = TRUE; swapped && i >= 0; --i) {
+                        int j;
 
-                    for (j = 0, swapped = FALSE; j < i; j++)
-                        if (HDstrcmp(dt2->shared->u.compnd.memb[idx2[j]].name,
-                                     dt2->shared->u.compnd.memb[idx2[j + 1]].name) > 0) {
-                            unsigned tmp_idx = idx2[j];
-                            idx2[j]          = idx2[j + 1];
-                            idx2[j + 1]      = tmp_idx;
-                            swapped          = TRUE;
-                        }
-                }
-            } /* end if */
-		}
-		else {
-			idx2 = dt2->shared->u.compnd.idx_name;
-		}
+                        for (j = 0, swapped = FALSE; j < i; j++)
+                            if (HDstrcmp(dt2->shared->u.compnd.memb[idx2[j]].name,
+                                         dt2->shared->u.compnd.memb[idx2[j + 1]].name) > 0) {
+                                unsigned tmp_idx = idx2[j];
+                                idx2[j]          = idx2[j + 1];
+                                idx2[j + 1]      = tmp_idx;
+                                swapped          = TRUE;
+                            }
+                    }
+                } /* end if */
+            }
+            else {
+                idx2 = dt2->shared->u.compnd.idx_name;
+            }
 
 #ifdef H5T_DEBUG
             /* I don't quite trust the code above yet :-)  --RPM */

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -4682,10 +4682,8 @@ enum_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
              * "superset" comparison
              */
             tmp = HDstrcmp(en1->name[idx1[u]], en2->name[idx2[u]]);
-            if (tmp < 0)
-                HGOTO_DONE(-1);
-            if (tmp > 0)
-                HGOTO_DONE(1);
+            if (tmp != 0)
+                HGOTO_DONE(tmp);
 
             /* Set index value appropriately */
             idx = u;
@@ -4693,10 +4691,8 @@ enum_cmp(H5T_shared_t * const sh1, H5T_shared_t * const sh2, bool superset)
 
         tmp = HDmemcmp((uint8_t *)en1->value + idx1[u] * base_size,
                        (uint8_t *)en2->value + idx2[idx] * base_size, base_size);
-        if (tmp < 0)
-            HGOTO_DONE(-1);
-        if (tmp > 0)
-            HGOTO_DONE(1);
+        if (tmp != 0)
+            HGOTO_DONE(tmp);
     }
 done:
 
@@ -4814,10 +4810,8 @@ H5T_cmp(const H5T_t * const dt1, const H5T_t * const dt2, hbool_t superset)
             }
 
             tmp = H5T_cmp(sh1->parent, sh2->parent, superset);
-            if (tmp < 0)
-                HGOTO_DONE(-1);
-            if (tmp > 0)
-                HGOTO_DONE(1);
+            if (tmp != 0)
+                HGOTO_DONE(tmp);
             break;
 
         case H5T_NO_CLASS:

--- a/src/H5Tcompound.c
+++ b/src/H5Tcompound.c
@@ -467,9 +467,6 @@ H5T__insert(H5T_t *parent, const char *name, size_t offset, const H5T_t *member)
         if (memb == NULL)
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL, "memory allocation failed")
 
-        if (pcmpd->idx_name != NULL)
-            pcmpd->idx_name = H5MM_xfree(pcmpd->idx_name);
-
         pcmpd->nalloc = na;
         pcmpd->memb   = memb;
     } /* end if */
@@ -484,6 +481,9 @@ H5T__insert(H5T_t *parent, const char *name, size_t offset, const H5T_t *member)
     pcmpd->sorted = H5T_SORT_NONE;
     pcmpd->nmembs++;
     pcmpd->memb_size += total_size;
+
+    /* Invalidate cached member-name order. */
+    pcmpd->idx_name = H5MM_xfree(pcmpd->idx_name);
 
     /* It should not be possible to get this far if the type is already packed
      * - the new member would overlap something */

--- a/src/H5Tcompound.c
+++ b/src/H5Tcompound.c
@@ -461,13 +461,13 @@ H5T__insert(H5T_t *parent, const char *name, size_t offset, const H5T_t *member)
 
     /* Lengthen member array if necessary */
     if (pcmpd->nmembs >= pcmpd->nalloc) {
-        unsigned     na = MAX(1, pcmpd->nalloc * 2);
-        H5T_cmemb_t *x = (H5T_cmemb_t *)H5MM_realloc(pcmpd->memb, na * sizeof(H5T_cmemb_t));
+        unsigned     na = MAX(1, pcmpd->nalloc * 2);    // XXX overflow risk
+        H5T_cmemb_t *memb = H5MM_realloc(pcmpd->memb, na * sizeof(memb[0]));
 
-        if (!x)
+        if (memb == NULL)
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL, "memory allocation failed")
         pcmpd->nalloc = na;
-        pcmpd->memb   = x;
+        pcmpd->memb   = memb;
     } /* end if */
 
     /* Add member to end of member array */

--- a/src/H5Tcompound.c
+++ b/src/H5Tcompound.c
@@ -466,6 +466,10 @@ H5T__insert(H5T_t *parent, const char *name, size_t offset, const H5T_t *member)
 
         if (memb == NULL)
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL, "memory allocation failed")
+
+        if (pcmpd->idx_name != NULL)
+            pcmpd->idx_name = H5MM_xfree(pcmpd->idx_name);
+
         pcmpd->nalloc = na;
         pcmpd->memb   = memb;
     } /* end if */

--- a/src/H5Tcompound.c
+++ b/src/H5Tcompound.c
@@ -426,12 +426,12 @@ done:
 herr_t
 H5T__insert(H5T_t *parent, const char *name, size_t offset, const H5T_t *member)
 {
-    unsigned idx; /* Index of member to insert */
-    size_t   total_size;
-    unsigned i;                   /* Local index variable */
-    herr_t   ret_value = SUCCEED; /* Return value */
-    H5T_shared_t * const msh = member->shared, * const psh = parent->shared;
-    H5T_compnd_t * const pcmpd = &psh->u.compnd;
+    unsigned            idx; /* Index of member to insert */
+    size_t              total_size;
+    unsigned            i;                   /* Local index variable */
+    herr_t              ret_value = SUCCEED; /* Return value */
+    H5T_shared_t *const msh = member->shared, *const psh = parent->shared;
+    H5T_compnd_t *const pcmpd = &psh->u.compnd;
 
     FUNC_ENTER_PACKAGE
 
@@ -449,10 +449,8 @@ H5T__insert(H5T_t *parent, const char *name, size_t offset, const H5T_t *member)
     /* Does the new member overlap any existing member ? */
     total_size = msh->size;
     for (i = 0; i < pcmpd->nmembs; i++)
-        if ((offset <= pcmpd->memb[i].offset &&
-             (offset + total_size) > pcmpd->memb[i].offset) ||
-            (pcmpd->memb[i].offset <= offset &&
-             (pcmpd->memb[i].offset + pcmpd->memb[i].size) > offset))
+        if ((offset <= pcmpd->memb[i].offset && (offset + total_size) > pcmpd->memb[i].offset) ||
+            (pcmpd->memb[i].offset <= offset && (pcmpd->memb[i].offset + pcmpd->memb[i].size) > offset))
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINSERT, FAIL, "member overlaps with another member")
 
     /* Does the new member overlap the end of the compound type? */
@@ -461,7 +459,7 @@ H5T__insert(H5T_t *parent, const char *name, size_t offset, const H5T_t *member)
 
     /* Lengthen member array if necessary */
     if (pcmpd->nmembs >= pcmpd->nalloc) {
-        unsigned     na = MAX(1, pcmpd->nalloc * 2);    // XXX overflow risk
+        unsigned     na   = MAX(1, pcmpd->nalloc * 2); // XXX overflow risk
         H5T_cmemb_t *memb = H5MM_realloc(pcmpd->memb, na * sizeof(memb[0]));
 
         if (memb == NULL)
@@ -472,7 +470,7 @@ H5T__insert(H5T_t *parent, const char *name, size_t offset, const H5T_t *member)
     } /* end if */
 
     /* Add member to end of member array */
-    idx                                       = pcmpd->nmembs;
+    idx                     = pcmpd->nmembs;
     pcmpd->memb[idx].name   = H5MM_xstrdup(name);
     pcmpd->memb[idx].offset = offset;
     pcmpd->memb[idx].size   = total_size;

--- a/src/H5Tcompound.c
+++ b/src/H5Tcompound.c
@@ -459,7 +459,7 @@ H5T__insert(H5T_t *parent, const char *name, size_t offset, const H5T_t *member)
     if ((offset + total_size) > psh->size)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINSERT, FAIL, "member extends past end of compound type")
 
-    /* Increase member array if necessary */
+    /* Lengthen member array if necessary */
     if (pcmpd->nmembs >= pcmpd->nalloc) {
         unsigned     na = MAX(1, pcmpd->nalloc * 2);
         H5T_cmemb_t *x = (H5T_cmemb_t *)H5MM_realloc(pcmpd->memb, na * sizeof(H5T_cmemb_t));

--- a/src/H5Tconv.c
+++ b/src/H5Tconv.c
@@ -2693,8 +2693,8 @@ H5T__conv_enum_init(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata)
      * symbol names and build a map from source member index to destination
      * member index.
      */
-    H5T__sort_name(src, NULL);
-    H5T__sort_name(dst, NULL);
+    H5T__sort_name(src->shared, NULL);
+    H5T__sort_name(dst->shared, NULL);
     if (NULL == (priv->src2dst = (int *)H5MM_malloc(src->shared->u.enumer.nmembs * sizeof(int))))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed")
     for (i = 0, j = 0; i < src->shared->u.enumer.nmembs && j < dst->shared->u.enumer.nmembs; i++, j++) {
@@ -2874,7 +2874,7 @@ H5T__conv_enum(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, si
              * sort keys are used here during conversion. See H5T__conv_enum_init(). But
              * we actually don't care about the source type's order when doing the O(1)
              * conversion algorithm, which is turned on by non-zero priv->length */
-            H5T__sort_name(dst, NULL);
+            H5T__sort_name(dst->shared, NULL);
             if (!priv->length)
                 H5T__sort_value(src, NULL);
 

--- a/src/H5Tenum.c
+++ b/src/H5Tenum.c
@@ -508,7 +508,7 @@ H5T__enum_valueof(const H5T_t *dt, const char *name, void *value /*out*/)
      * and search on the copied datatype to protect the original order. */
     if (NULL == (copied_dt = H5T_copy(dt, H5T_COPY_ALL)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "unable to copy data type");
-    if (H5T__sort_name(copied_dt, NULL) < 0)
+    if (H5T__sort_name(copied_dt->shared, NULL) < 0)
         HGOTO_ERROR(H5E_INTERNAL, H5E_CANTCOMPARE, FAIL, "value sort failed")
 
     lt = 0;

--- a/src/H5Tfields.c
+++ b/src/H5Tfields.c
@@ -293,15 +293,21 @@ H5T__sort_value(const H5T_t *dt, int *map)
 
     /* Use a bubble sort because we can short circuit */
     if (H5T_COMPOUND == dt->shared->type) {
-        if (H5T_SORT_VALUE != dt->shared->u.compnd.sorted) {
-            dt->shared->u.compnd.sorted = H5T_SORT_VALUE;
-            nmembs                      = dt->shared->u.compnd.nmembs;
+
+        H5T_compnd_t * const cmpd = &dt->shared->u.compnd;
+
+        /* Invalidate cached member-name order. */
+        cmpd->idx_name = H5MM_xfree(cmpd->idx_name);
+
+        if (H5T_SORT_VALUE != cmpd->sorted) {
+            cmpd->sorted = H5T_SORT_VALUE;
+            nmembs                      = cmpd->nmembs;
             for (i = nmembs - 1, swapped = TRUE; i > 0 && swapped; --i) {
                 for (j = 0, swapped = FALSE; j < i; j++) {
-                    if (dt->shared->u.compnd.memb[j].offset > dt->shared->u.compnd.memb[j + 1].offset) {
-                        H5T_cmemb_t tmp                  = dt->shared->u.compnd.memb[j];
-                        dt->shared->u.compnd.memb[j]     = dt->shared->u.compnd.memb[j + 1];
-                        dt->shared->u.compnd.memb[j + 1] = tmp;
+                    if (cmpd->memb[j].offset > cmpd->memb[j + 1].offset) {
+                        H5T_cmemb_t tmp                  = cmpd->memb[j];
+                        cmpd->memb[j]     = cmpd->memb[j + 1];
+                        cmpd->memb[j + 1] = tmp;
                         if (map) {
                             int x = map[j];
 
@@ -315,7 +321,7 @@ H5T__sort_value(const H5T_t *dt, int *map)
 #ifndef NDEBUG
             /* I never trust a sort :-) -RPM */
             for (i = 0; i < (nmembs - 1); i++)
-                HDassert(dt->shared->u.compnd.memb[i].offset < dt->shared->u.compnd.memb[i + 1].offset);
+                HDassert(cmpd->memb[i].offset < cmpd->memb[i + 1].offset);
 #endif
         } /* end if */
     }

--- a/src/H5Tfields.c
+++ b/src/H5Tfields.c
@@ -294,18 +294,18 @@ H5T__sort_value(const H5T_t *dt, int *map)
     /* Use a bubble sort because we can short circuit */
     if (H5T_COMPOUND == dt->shared->type) {
 
-        H5T_compnd_t * const cmpd = &dt->shared->u.compnd;
+        H5T_compnd_t *const cmpd = &dt->shared->u.compnd;
 
         /* Invalidate cached member-name order. */
         cmpd->idx_name = H5MM_xfree(cmpd->idx_name);
 
         if (H5T_SORT_VALUE != cmpd->sorted) {
             cmpd->sorted = H5T_SORT_VALUE;
-            nmembs                      = cmpd->nmembs;
+            nmembs       = cmpd->nmembs;
             for (i = nmembs - 1, swapped = TRUE; i > 0 && swapped; --i) {
                 for (j = 0, swapped = FALSE; j < i; j++) {
                     if (cmpd->memb[j].offset > cmpd->memb[j + 1].offset) {
-                        H5T_cmemb_t tmp                  = cmpd->memb[j];
+                        H5T_cmemb_t tmp   = cmpd->memb[j];
                         cmpd->memb[j]     = cmpd->memb[j + 1];
                         cmpd->memb[j + 1] = tmp;
                         if (map) {
@@ -409,17 +409,16 @@ H5T__sort_name(H5T_shared_t *sh, size_t *map)
             cmpd->idx_name = H5MM_xfree(cmpd->idx_name);
 
             cmpd->sorted = H5T_SORT_NAME;
-            nmembs                      = cmpd->nmembs;
+            nmembs       = cmpd->nmembs;
             for (i = nmembs - 1, swapped = TRUE; i > 0 && swapped; --i) {
                 for (j = 0, swapped = FALSE; j < i; j++) {
-                    if (HDstrcmp(cmpd->memb[j].name, cmpd->memb[j + 1].name) >
-                        0) {
-                        H5T_cmemb_t tmp                  = cmpd->memb[j];
+                    if (HDstrcmp(cmpd->memb[j].name, cmpd->memb[j + 1].name) > 0) {
+                        H5T_cmemb_t tmp   = cmpd->memb[j];
                         cmpd->memb[j]     = cmpd->memb[j + 1];
                         cmpd->memb[j + 1] = tmp;
-                        swapped                          = TRUE;
+                        swapped           = TRUE;
                         if (map) {
-                            size_t x      = map[j];
+                            size_t x   = map[j];
                             map[j]     = map[j + 1];
                             map[j + 1] = x;
                         }
@@ -429,8 +428,7 @@ H5T__sort_name(H5T_shared_t *sh, size_t *map)
 #ifndef NDEBUG
             /* I never trust a sort :-) -RPM */
             for (i = 0; i < nmembs - 1; i++) {
-                HDassert(HDstrcmp(cmpd->memb[i].name, cmpd->memb[i + 1].name) <
-                         0);
+                HDassert(HDstrcmp(cmpd->memb[i].name, cmpd->memb[i + 1].name) < 0);
             }
 #endif
         }
@@ -438,14 +436,14 @@ H5T__sort_name(H5T_shared_t *sh, size_t *map)
     else if (H5T_ENUM == sh->type) {
         if (H5T_SORT_NAME != sh->u.enumer.sorted) {
             sh->u.enumer.sorted = H5T_SORT_NAME;
-            nmembs                      = sh->u.enumer.nmembs;
-            size                        = sh->size;
+            nmembs              = sh->u.enumer.nmembs;
+            size                = sh->size;
             HDassert(size <= sizeof(tbuf));
             for (i = nmembs - 1, swapped = TRUE; i > 0 && swapped; --i) {
                 for (j = 0, swapped = FALSE; j < i; j++) {
                     if (HDstrcmp(sh->u.enumer.name[j], sh->u.enumer.name[j + 1]) > 0) {
                         /* Swap names */
-                        char *tmp                        = sh->u.enumer.name[j];
+                        char *tmp                = sh->u.enumer.name[j];
                         sh->u.enumer.name[j]     = sh->u.enumer.name[j + 1];
                         sh->u.enumer.name[j + 1] = tmp;
 
@@ -457,7 +455,7 @@ H5T__sort_name(H5T_shared_t *sh, size_t *map)
 
                         /* Swap map */
                         if (map) {
-                            size_t x      = map[j];
+                            size_t x   = map[j];
                             map[j]     = map[j + 1];
                             map[j + 1] = x;
                         }

--- a/src/H5Tfields.c
+++ b/src/H5Tfields.c
@@ -396,8 +396,6 @@ H5T__sort_name(H5T_shared_t *sh, size_t *map)
 
     FUNC_ENTER_PACKAGE_NOERR
 
-    /* Check args */
-    HDassert(dt);
     HDassert(H5T_COMPOUND == sh->type || H5T_ENUM == sh->type);
 
     /* Use a bubble sort because we can short circuit */

--- a/src/H5Tfields.c
+++ b/src/H5Tfields.c
@@ -403,15 +403,20 @@ H5T__sort_name(H5T_shared_t *sh, size_t *map)
     /* Use a bubble sort because we can short circuit */
     if (H5T_COMPOUND == sh->type) {
         if (H5T_SORT_NAME != sh->u.compnd.sorted) {
-            sh->u.compnd.sorted = H5T_SORT_NAME;
-            nmembs                      = sh->u.compnd.nmembs;
+            H5T_compnd_t *cmpd = &sh->u.compnd;
+
+            /* Invalidate cached member-name order. */
+            cmpd->idx_name = H5MM_xfree(cmpd->idx_name);
+
+            cmpd->sorted = H5T_SORT_NAME;
+            nmembs                      = cmpd->nmembs;
             for (i = nmembs - 1, swapped = TRUE; i > 0 && swapped; --i) {
                 for (j = 0, swapped = FALSE; j < i; j++) {
-                    if (HDstrcmp(sh->u.compnd.memb[j].name, sh->u.compnd.memb[j + 1].name) >
+                    if (HDstrcmp(cmpd->memb[j].name, cmpd->memb[j + 1].name) >
                         0) {
-                        H5T_cmemb_t tmp                  = sh->u.compnd.memb[j];
-                        sh->u.compnd.memb[j]     = sh->u.compnd.memb[j + 1];
-                        sh->u.compnd.memb[j + 1] = tmp;
+                        H5T_cmemb_t tmp                  = cmpd->memb[j];
+                        cmpd->memb[j]     = cmpd->memb[j + 1];
+                        cmpd->memb[j + 1] = tmp;
                         swapped                          = TRUE;
                         if (map) {
                             size_t x      = map[j];
@@ -424,7 +429,7 @@ H5T__sort_name(H5T_shared_t *sh, size_t *map)
 #ifndef NDEBUG
             /* I never trust a sort :-) -RPM */
             for (i = 0; i < nmembs - 1; i++) {
-                HDassert(HDstrcmp(sh->u.compnd.memb[i].name, sh->u.compnd.memb[i + 1].name) <
+                HDassert(HDstrcmp(cmpd->memb[i].name, cmpd->memb[i + 1].name) <
                          0);
             }
 #endif

--- a/src/H5Tpkg.h
+++ b/src/H5Tpkg.h
@@ -260,7 +260,7 @@ typedef struct H5T_compnd_t {
     hbool_t      packed;    /*are members packed together?       */
     H5T_cmemb_t *memb;      /*array of struct members	     */
     size_t       memb_size; /*total of all member sizes          */
-    unsigned 	*idx_name;	/*index to sort members by name		*/
+    size_t 	*idx_name;	/*index to sort members by name		*/
 } H5T_compnd_t;
 
 /* An enumeration datatype */

--- a/src/H5Tpkg.h
+++ b/src/H5Tpkg.h
@@ -881,7 +881,7 @@ H5_DLL herr_t H5T__get_member_value(const H5T_t *dt, unsigned membno, void *valu
 /* Field functions (for both compound & enumerated types) */
 H5_DLL char * H5T__get_member_name(H5T_t const *dt, unsigned membno);
 H5_DLL herr_t H5T__sort_value(const H5T_t *dt, int *map);
-H5_DLL herr_t H5T__sort_name(const H5T_t *dt, int *map);
+H5_DLL herr_t H5T__sort_name(H5T_shared_t *sh, size_t *map);
 
 /* Debugging functions */
 H5_DLL herr_t H5T__print_stats(H5T_path_t *path, int *nprint /*in,out*/);

--- a/src/H5Tpkg.h
+++ b/src/H5Tpkg.h
@@ -260,6 +260,7 @@ typedef struct H5T_compnd_t {
     hbool_t      packed;    /*are members packed together?       */
     H5T_cmemb_t *memb;      /*array of struct members	     */
     size_t       memb_size; /*total of all member sizes          */
+    unsigned 	*idx_name;	/*index to sort members by name		*/
 } H5T_compnd_t;
 
 /* An enumeration datatype */

--- a/src/H5Tpkg.h
+++ b/src/H5Tpkg.h
@@ -260,7 +260,7 @@ typedef struct H5T_compnd_t {
     hbool_t      packed;    /*are members packed together?       */
     H5T_cmemb_t *memb;      /*array of struct members	     */
     size_t       memb_size; /*total of all member sizes          */
-    size_t 	*idx_name;	/*index to sort members by name		*/
+    size_t *     idx_name;  /*index to sort members by name		*/
 } H5T_compnd_t;
 
 /* An enumeration datatype */

--- a/test/dtypes.c
+++ b/test/dtypes.c
@@ -70,8 +70,8 @@
         FAIL_STACK_ERROR                                                                                     \
     if ((NMEMBS) != H5I_nmembers(H5I_DATATYPE)) {                                                            \
         H5_FAILED();                                                                                         \
-        HDprintf("    #dtype ids expected: %lld; found: %lld\n", (long long)(NMEMBS),                        \
-                 (long long)H5I_nmembers(H5I_DATATYPE));                                                     \
+        HDprintf("    #dtype ids expected: %" PRId64 "; found: %" PRId64 "\n", (NMEMBS),                        \
+                 H5I_nmembers(H5I_DATATYPE));                                                     \
         goto error;                                                                                          \
     }
 
@@ -3450,7 +3450,7 @@ test_compound_16(void)
     if (open_dtypes[1]) {
         H5_FAILED();
         AT();
-        HDprintf("    H5Fget_obj_ids returned as second id: %lld; expected: 0\n", (long long)open_dtypes[1]);
+        HDprintf("    H5Fget_obj_ids returned as second id: %" PRIdHID "; expected: 0\n", open_dtypes[1]);
         goto error;
     }
 

--- a/test/dtypes.c
+++ b/test/dtypes.c
@@ -70,8 +70,8 @@
         FAIL_STACK_ERROR                                                                                     \
     if ((NMEMBS) != H5I_nmembers(H5I_DATATYPE)) {                                                            \
         H5_FAILED();                                                                                         \
-        HDprintf("    #dtype ids expected: %" PRId64 "; found: %" PRId64 "\n", (NMEMBS),                        \
-                 H5I_nmembers(H5I_DATATYPE));                                                     \
+        HDprintf("    #dtype ids expected: %" PRId64 "; found: %" PRId64 "\n", (NMEMBS),                     \
+                 H5I_nmembers(H5I_DATATYPE));                                                                \
         goto error;                                                                                          \
     }
 

--- a/test/dtypes.c
+++ b/test/dtypes.c
@@ -842,11 +842,12 @@ test_compound_2(void)
         }
     }
 
+    CHECK_NMEMBS(nmembs, st, dt)
+
     /* Release resources */
     HDfree(buf);
     HDfree(bkg);
     HDfree(orig);
-    CHECK_NMEMBS(nmembs, st, dt)
 
     PASSED();
 
@@ -1096,11 +1097,12 @@ test_compound_4(void)
         }
     }
 
+    CHECK_NMEMBS(nmembs, st, dt)
+
     /* Release resources */
     HDfree(buf);
     HDfree(bkg);
     HDfree(orig);
-    CHECK_NMEMBS(nmembs, st, dt)
 
     PASSED();
 

--- a/test/dtypes.c
+++ b/test/dtypes.c
@@ -781,11 +781,11 @@ test_compound_2(void)
         FAIL_STACK_ERROR
 
     /* Sizes should be the same, but be careful just in case */
-    if (NULL == (buf = (unsigned char *)HDmalloc(nelmts * MAX(sizeof(struct st), sizeof(struct dt)))))
+    if (NULL == (buf = HDmalloc(nelmts * MAX(sizeof(struct st), sizeof(struct dt)))))
         goto error;
-    if (NULL == (bkg = (unsigned char *)HDmalloc(nelmts * sizeof(struct dt))))
+    if (NULL == (bkg = HDmalloc(nelmts * sizeof(struct dt))))
         goto error;
-    if (NULL == (orig = (unsigned char *)HDmalloc(nelmts * sizeof(struct st))))
+    if (NULL == (orig = HDmalloc(nelmts * sizeof(struct st))))
         goto error;
     for (i = 0; i < (int)nelmts; i++) {
         s_ptr       = ((struct st *)((void *)orig)) + i;


### PR DESCRIPTION
I have extracted a couple of subroutines from H5T_cmp and simplified a lot, mainly by using temporary variables to replace repeated expressions. The code is more readable this way.

There are a lot of changes in this PR. It consists of 33 individual commits with descriptions. I recommend reading the individual commits.

I'm marking this WIP because I have some doubts about (re-)sorting compound-type members "on demand" in H5T_cmp.

It seems that applications probably can afford the time and space cost of the library keeping members sorted by both name and index, always. I don't think applications will change any type's members often enough to make an important performance difference. I don't think applications use types in numbers great enough that space will be a problem. Not so?

If the members are always stored in `offset` order, and there is always a `name`-ordered array of member indices alongside, then H5T_cmp does not have to allocate any memory. Right now, when an allocation fails, H5T_cmp returns 0, indicating arbitrarily that its H5T_t arguments are "equal". That sets up the library or application to fail mysteriously somewhere down the road.

Enum types, too, should keep their cases continually sorted, to avoid on-demand heap allocation.