### PR TITLE
remove old attribute before inserting renamed attribute

### DIFF
--- a/src/H5Adense.c
+++ b/src/H5Adense.c
@@ -945,7 +945,7 @@ H5A__dense_rename(H5F_t *f, const H5O_ainfo_t *ainfo, const char *old_name, cons
     /* Delete old attribute from dense storage */
     if (H5A__dense_remove(f, ainfo, old_name) < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTDELETE, FAIL, "unable to delete attribute in dense storage")
-        
+
     /* Insert renamed attribute back into dense storage */
     /* (Possibly making it shared) */
     if (H5A__dense_insert(f, ainfo, attr_copy) < 0)

--- a/test/tattr.c
+++ b/test/tattr.c
@@ -2804,6 +2804,10 @@ test_attr_dense_rename(hid_t fcpl, hid_t fapl)
         CHECK(ret, FAIL, "H5Aclose");
     } /* end for */
 
+    /* Delete last attribute */
+    ret = H5Adelete(dataset, attrname);
+    CHECK(ret, FAIL, "H5Adelete");
+    
     /* Close Dataset */
     ret = H5Dclose(dataset);
     CHECK(ret, FAIL, "H5Dclose");

--- a/test/tattr.c
+++ b/test/tattr.c
@@ -2807,7 +2807,7 @@ test_attr_dense_rename(hid_t fcpl, hid_t fapl)
     /* Delete last attribute */
     ret = H5Adelete(dataset, attrname);
     CHECK(ret, FAIL, "H5Adelete");
-    
+
     /* Close Dataset */
     ret = H5Dclose(dataset);
     CHECK(ret, FAIL, "H5Dclose");


### PR DESCRIPTION
Proof of #1388 

Update: added possible fix.

This changes the order of processing. The old attribute is removed from dense storage before the renamed attribute is inserted. With the former behavior, deleting a renamed attribute wasn't possible any more.

Questions:

Why is removing/inserting from/in dense storage needed anyway? Wouldn't just updating the indexes with the new name be sufficient? I'm sure I'm missing background information on the hdf5 internals, so any pointers are welcome.



