### PR TITLE
Remove const from the argv tools/tests main sig.

### DIFF
--- a/hl/tools/h5watch/extend_dset.c
+++ b/hl/tools/h5watch/extend_dset.c
@@ -392,7 +392,7 @@ error:
  ***********************************************************************
  */
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     char *dname = NULL;
     char *fname = NULL;

--- a/hl/tools/h5watch/h5watch.c
+++ b/hl/tools/h5watch/h5watch.c
@@ -51,7 +51,7 @@ static herr_t process_cmpd_fields(hid_t fid, char *dsetname);
 static herr_t check_dataset(hid_t fid, char *dsetname);
 static void   leave(int ret);
 static void   usage(const char *prog);
-static void   parse_command_line(int argc, const char *argv[]);
+static void   parse_command_line(int argc, char *argv[]);
 
 /*
  * Command-line options: The user can only specify long-named parameters.
@@ -665,7 +665,7 @@ usage(const char *prog)
  *-------------------------------------------------------------------------
  */
 static void
-parse_command_line(int argc, const char *argv[])
+parse_command_line(int argc, char *argv[])
 {
     int opt; /* Command line option */
     int tmp;

--- a/hl/tools/h5watch/h5watch.c
+++ b/hl/tools/h5watch/h5watch.c
@@ -677,7 +677,7 @@ parse_command_line(int argc, char *argv[])
     }
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case '?':
             case 'h': /* --help */

--- a/hl/tools/h5watch/h5watch.c
+++ b/hl/tools/h5watch/h5watch.c
@@ -51,7 +51,7 @@ static herr_t process_cmpd_fields(hid_t fid, char *dsetname);
 static herr_t check_dataset(hid_t fid, char *dsetname);
 static void   leave(int ret);
 static void   usage(const char *prog);
-static void   parse_command_line(int argc, char *argv[]);
+static void   parse_command_line(int argc, const char *const *argv);
 
 /*
  * Command-line options: The user can only specify long-named parameters.
@@ -665,7 +665,7 @@ usage(const char *prog)
  *-------------------------------------------------------------------------
  */
 static void
-parse_command_line(int argc, char *argv[])
+parse_command_line(int argc, const char *const *argv)
 {
     int opt; /* Command line option */
     int tmp;
@@ -677,7 +677,7 @@ parse_command_line(int argc, char *argv[])
     }
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case '?':
             case 'h': /* --help */
@@ -819,7 +819,7 @@ main(int argc, char *argv[])
     }
 
     /* parse command line options */
-    parse_command_line(argc, argv);
+    parse_command_line(argc, (const char *const *)argv);
 
     if (argc <= H5_optind) {
         error_msg("missing dataset name\n");

--- a/hl/tools/h5watch/h5watch.c
+++ b/hl/tools/h5watch/h5watch.c
@@ -790,7 +790,7 @@ catch_signal(int H5_ATTR_UNUSED signo)
  *-------------------------------------------------------------------------
  */
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     char  drivername[50]; /* VFD name */
     char *fname = NULL;   /* File name */

--- a/hl/tools/h5watch/h5watch.c
+++ b/hl/tools/h5watch/h5watch.c
@@ -677,7 +677,7 @@ parse_command_line(int argc, char *argv[])
     }
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case '?':
             case 'h': /* --help */

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -2602,7 +2602,7 @@ struct h5_long_options {
                                  */
 };
 
-H5_DLL int H5_get_option(int argc, const char **argv, const char *opt, const struct h5_long_options *l_opt);
+H5_DLL int H5_get_option(int argc, char **argv, const char *opt, const struct h5_long_options *l_opt);
 
 #ifdef H5_HAVE_PARALLEL
 /* Generic MPI functions */

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -2602,7 +2602,8 @@ struct h5_long_options {
                                  */
 };
 
-H5_DLL int H5_get_option(int argc, const char* const *argv, const char *opt, const struct h5_long_options *l_opt);
+H5_DLL int H5_get_option(int argc, const char *const *argv, const char *opt,
+                         const struct h5_long_options *l_opt);
 
 #ifdef H5_HAVE_PARALLEL
 /* Generic MPI functions */

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -2602,7 +2602,7 @@ struct h5_long_options {
                                  */
 };
 
-H5_DLL int H5_get_option(int argc, char **argv, const char *opt, const struct h5_long_options *l_opt);
+H5_DLL int H5_get_option(int argc, const char* const *argv, const char *opt, const struct h5_long_options *l_opt);
 
 #ifdef H5_HAVE_PARALLEL
 /* Generic MPI functions */

--- a/src/H5system.c
+++ b/src/H5system.c
@@ -956,7 +956,7 @@ const char *H5_optarg;     /* Flag argument (or value)               */
  *-------------------------------------------------------------------------
  */
 int
-H5_get_option(int argc, const char **argv, const char *opts, const struct h5_long_options *l_opts)
+H5_get_option(int argc, char **argv, const char *opts, const struct h5_long_options *l_opts)
 {
     static int sp      = 1;   /* character index in current token */
     int        optchar = '?'; /* option character passed back to user */

--- a/src/H5system.c
+++ b/src/H5system.c
@@ -956,7 +956,7 @@ const char *H5_optarg;     /* Flag argument (or value)               */
  *-------------------------------------------------------------------------
  */
 int
-H5_get_option(int argc, const char* const *argv, const char *opts, const struct h5_long_options *l_opts)
+H5_get_option(int argc, const char *const *argv, const char *opts, const struct h5_long_options *l_opts)
 {
     static int sp      = 1;   /* character index in current token */
     int        optchar = '?'; /* option character passed back to user */

--- a/src/H5system.c
+++ b/src/H5system.c
@@ -956,7 +956,7 @@ const char *H5_optarg;     /* Flag argument (or value)               */
  *-------------------------------------------------------------------------
  */
 int
-H5_get_option(int argc, char **argv, const char *opts, const struct h5_long_options *l_opts)
+H5_get_option(int argc, const char* const *argv, const char *opts, const struct h5_long_options *l_opts)
 {
     static int sp      = 1;   /* character index in current token */
     int        optchar = '?'; /* option character passed back to user */

--- a/test/flushrefresh.c
+++ b/test/flushrefresh.c
@@ -93,7 +93,7 @@ FILE *errorfile;
 /* ===================== */
 
 /* Main */
-int main(int argc, const char *argv[]);
+int main(int argc, char *argv[]);
 
 /* Flush Test Framework */
 herr_t test_flush(void);
@@ -137,7 +137,7 @@ herr_t end_verification(void);
  *-------------------------------------------------------------------------
  */
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     /* Variables */
     const char *envval = NULL;

--- a/test/swmr_addrem_writer.c
+++ b/test/swmr_addrem_writer.c
@@ -283,7 +283,7 @@ usage(void)
 }
 
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     hid_t    fid;                /* File ID for file opened */
     long     nops        = 0;    /* # of times to grow or shrink the dataset */

--- a/test/swmr_generator.c
+++ b/test/swmr_generator.c
@@ -258,7 +258,7 @@ usage(void)
 } /* end usage() */
 
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     int         comp_level  = -1;    /* Compression level (-1 is no compression) */
     hbool_t     verbose     = TRUE;  /* Whether to emit some informational messages */

--- a/test/swmr_reader.c
+++ b/test/swmr_reader.c
@@ -387,7 +387,7 @@ usage(void)
 }
 
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     long     nseconds     = 0;     /* # of seconds to test */
     int      poll_time    = 1;     /* # of seconds between polling */

--- a/test/swmr_remove_reader.c
+++ b/test/swmr_remove_reader.c
@@ -371,7 +371,7 @@ usage(void)
 }
 
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     long     nseconds    = 0;  /* # of seconds to test */
     int      poll_time   = 1;  /* # of seconds between polling */

--- a/test/swmr_remove_writer.c
+++ b/test/swmr_remove_writer.c
@@ -217,7 +217,7 @@ usage(void)
 }
 
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     hid_t    fid;                /* File ID for file opened */
     long     nshrinks    = 0;    /* # of times to shrink the dataset */

--- a/test/swmr_sparse_reader.c
+++ b/test/swmr_sparse_reader.c
@@ -342,7 +342,7 @@ usage(void)
 } /* end usage() */
 
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     long     nrecords     = 0; /* # of records to read */
     int      poll_time    = 1; /* # of seconds to sleep when waiting for writer */

--- a/test/swmr_sparse_writer.c
+++ b/test/swmr_sparse_writer.c
@@ -318,7 +318,7 @@ usage(void)
 }
 
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     hid_t    fid;                /* File ID for file opened */
     long     nrecords    = 0;    /* # of records to append */

--- a/test/swmr_start_write.c
+++ b/test/swmr_start_write.c
@@ -352,7 +352,7 @@ usage(void)
  *H5Fstart_swmr_write(), add_records(), H5Fclose().
  */
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     hid_t       fid;                  /* File ID for file opened */
     long        nrecords     = 0;     /* # of records to append */

--- a/test/swmr_writer.c
+++ b/test/swmr_writer.c
@@ -275,7 +275,7 @@ usage(void)
 }
 
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     hid_t    fid;                  /* File ID for file opened */
     long     nrecords     = 0;     /* # of records to append */

--- a/tools/src/h5copy/h5copy.c
+++ b/tools/src/h5copy/h5copy.c
@@ -212,7 +212,7 @@ parse_flag(const char *s_flag, unsigned *flag)
  */
 
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     hid_t              fid_src = H5I_INVALID_HID;
     hid_t              fid_dst = H5I_INVALID_HID;

--- a/tools/src/h5copy/h5copy.c
+++ b/tools/src/h5copy/h5copy.c
@@ -242,7 +242,7 @@ main(int argc, char *argv[])
     } /* end if */
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'd':
                 oname_dst = HDstrdup(H5_optarg);

--- a/tools/src/h5copy/h5copy.c
+++ b/tools/src/h5copy/h5copy.c
@@ -242,7 +242,7 @@ main(int argc, char *argv[])
     } /* end if */
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'd':
                 oname_dst = HDstrdup(H5_optarg);

--- a/tools/src/h5diff/h5diff_common.c
+++ b/tools/src/h5diff/h5diff_common.c
@@ -238,7 +238,7 @@ parse_command_line(int argc, char *argv[], const char **fname1, const char **fna
     exclude_attr_head = NULL;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             default:
                 usage();

--- a/tools/src/h5diff/h5diff_common.c
+++ b/tools/src/h5diff/h5diff_common.c
@@ -206,8 +206,8 @@ parse_subset_params(const char *dset)
  */
 
 void
-parse_command_line(int argc, char *argv[], const char **fname1, const char **fname2,
-                   const char **objname1, const char **objname2, diff_opt_t *opts)
+parse_command_line(int argc, char *argv[], const char **fname1, const char **fname2, const char **objname1,
+                   const char **objname2, diff_opt_t *opts)
 {
     int                       i;
     int                       opt;

--- a/tools/src/h5diff/h5diff_common.c
+++ b/tools/src/h5diff/h5diff_common.c
@@ -206,7 +206,7 @@ parse_subset_params(const char *dset)
  */
 
 void
-parse_command_line(int argc, const char *argv[], const char **fname1, const char **fname2,
+parse_command_line(int argc, char *argv[], const char **fname1, const char **fname2,
                    const char **objname1, const char **objname2, diff_opt_t *opts)
 {
     int                       i;

--- a/tools/src/h5diff/h5diff_common.c
+++ b/tools/src/h5diff/h5diff_common.c
@@ -206,8 +206,8 @@ parse_subset_params(const char *dset)
  */
 
 void
-parse_command_line(int argc, const char *const *argv, const char **fname1, const char **fname2, const char **objname1,
-                   const char **objname2, diff_opt_t *opts)
+parse_command_line(int argc, const char *const *argv, const char **fname1, const char **fname2,
+                   const char **objname1, const char **objname2, diff_opt_t *opts)
 {
     int                       i;
     int                       opt;

--- a/tools/src/h5diff/h5diff_common.c
+++ b/tools/src/h5diff/h5diff_common.c
@@ -206,7 +206,7 @@ parse_subset_params(const char *dset)
  */
 
 void
-parse_command_line(int argc, char *argv[], const char **fname1, const char **fname2, const char **objname1,
+parse_command_line(int argc, const char *const *argv, const char **fname1, const char **fname2, const char **objname1,
                    const char **objname2, diff_opt_t *opts)
 {
     int                       i;
@@ -238,7 +238,7 @@ parse_command_line(int argc, char *argv[], const char **fname1, const char **fna
     exclude_attr_head = NULL;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             default:
                 usage();

--- a/tools/src/h5diff/h5diff_common.c
+++ b/tools/src/h5diff/h5diff_common.c
@@ -238,7 +238,7 @@ parse_command_line(int argc, char *argv[], const char **fname1, const char **fna
     exclude_attr_head = NULL;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             default:
                 usage();

--- a/tools/src/h5diff/h5diff_common.h
+++ b/tools/src/h5diff/h5diff_common.h
@@ -23,7 +23,7 @@ extern "C" {
 #endif
 
 void usage(void);
-void parse_command_line(int argc, const char *argv[], const char **fname1, const char **fname2,
+void parse_command_line(int argc, char *argv[], const char **fname1, const char **fname2,
                         const char **objname1, const char **objname2, diff_opt_t *opts);
 void h5diff_exit(int status);
 void print_info(diff_opt_t *opts);

--- a/tools/src/h5diff/h5diff_common.h
+++ b/tools/src/h5diff/h5diff_common.h
@@ -23,7 +23,7 @@ extern "C" {
 #endif
 
 void usage(void);
-void parse_command_line(int argc, char *argv[], const char **fname1, const char **fname2,
+void parse_command_line(int argc, const char *const *argv, const char **fname1, const char **fname2,
                         const char **objname1, const char **objname2, diff_opt_t *opts);
 void h5diff_exit(int status);
 void print_info(diff_opt_t *opts);

--- a/tools/src/h5diff/h5diff_main.c
+++ b/tools/src/h5diff/h5diff_main.c
@@ -65,7 +65,7 @@
  */
 
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     int         ret;
     int         i;

--- a/tools/src/h5diff/h5diff_main.c
+++ b/tools/src/h5diff/h5diff_main.c
@@ -86,7 +86,7 @@ main(int argc, char *argv[])
      * process the command-line
      *-------------------------------------------------------------------------
      */
-    parse_command_line(argc, argv, &fname1, &fname2, &objname1, &objname2, &opts);
+    parse_command_line(argc, (const char *const *)argv, &fname1, &fname2, &objname1, &objname2, &opts);
 
     /* enable error reporting if command line option */
     h5tools_error_report();

--- a/tools/src/h5diff/ph5diff_main.c
+++ b/tools/src/h5diff/ph5diff_main.c
@@ -72,7 +72,7 @@ main(int argc, char *argv[])
 
         g_Parallel = 0;
 
-        parse_command_line(argc, argv, &fname1, &fname2, &objname1, &objname2, &opts);
+        parse_command_line(argc, (const char *const *)argv, &fname1, &fname2, &objname1, &objname2, &opts);
 
         h5diff(fname1, fname2, objname1, objname2, &opts);
 
@@ -83,7 +83,7 @@ main(int argc, char *argv[])
 
         /* Have the manager process the command-line */
         if (nID == 0) {
-            parse_command_line(argc, argv, &fname1, &fname2, &objname1, &objname2, &opts);
+            parse_command_line(argc, (const char *const *)argv, &fname1, &fname2, &objname1, &objname2, &opts);
 
             h5diff(fname1, fname2, objname1, objname2, &opts);
 

--- a/tools/src/h5diff/ph5diff_main.c
+++ b/tools/src/h5diff/ph5diff_main.c
@@ -44,7 +44,7 @@ static void ph5diff_worker(int);
  */
 
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     int         nID      = 0;
     const char *fname1   = NULL;

--- a/tools/src/h5diff/ph5diff_main.c
+++ b/tools/src/h5diff/ph5diff_main.c
@@ -83,7 +83,8 @@ main(int argc, char *argv[])
 
         /* Have the manager process the command-line */
         if (nID == 0) {
-            parse_command_line(argc, (const char *const *)argv, &fname1, &fname2, &objname1, &objname2, &opts);
+            parse_command_line(argc, (const char *const *)argv, &fname1, &fname2, &objname1, &objname2,
+                               &opts);
 
             h5diff(fname1, fname2, objname1, objname2, &opts);
 

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -848,7 +848,7 @@ parse_command_line(int argc, char *argv[])
     }
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
 parse_start:
         switch ((char)opt) {
             case 'R':
@@ -1198,7 +1198,7 @@ parse_start:
                         default:
                             goto end_collect;
                     }
-                } while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF);
+                } while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF);
 
 end_collect:
                 last_was_dset = FALSE;

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -1198,7 +1198,7 @@ parse_start:
                         default:
                             goto end_collect;
                     }
-                } while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF);
+                } while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF);
 
 end_collect:
                 last_was_dset = FALSE;

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -828,7 +828,7 @@ free_handler(struct handler_t *hand, int len)
  *-------------------------------------------------------------------------
  */
 static struct handler_t *
-parse_command_line(int argc, const char *argv[])
+parse_command_line(int argc, char *argv[])
 {
     struct handler_t *hand      = NULL;
     struct handler_t *last_dset = NULL;

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -848,7 +848,7 @@ parse_command_line(int argc, char *argv[])
     }
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
 parse_start:
         switch ((char)opt) {
             case 'R':

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -828,7 +828,7 @@ free_handler(struct handler_t *hand, int len)
  *-------------------------------------------------------------------------
  */
 static struct handler_t *
-parse_command_line(int argc, char *argv[])
+parse_command_line(int argc, const char *const *argv)
 {
     struct handler_t *hand      = NULL;
     struct handler_t *last_dset = NULL;
@@ -848,7 +848,7 @@ parse_command_line(int argc, char *argv[])
     }
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
 parse_start:
         switch ((char)opt) {
             case 'R':
@@ -1198,7 +1198,7 @@ parse_start:
                         default:
                             goto end_collect;
                     }
-                } while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF);
+                } while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF);
 
 end_collect:
                 last_was_dset = FALSE;
@@ -1349,7 +1349,7 @@ main(int argc, char *argv[])
     /* Initialize h5tools lib */
     h5tools_init();
 
-    if ((hand = parse_command_line(argc, argv)) == NULL) {
+    if ((hand = parse_command_line(argc, (const char *const *)argv)) == NULL) {
         goto done;
     }
 

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -1329,7 +1329,7 @@ error:
  *-------------------------------------------------------------------------
  */
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     hid_t             fid     = H5I_INVALID_HID;
     hid_t             gid     = H5I_INVALID_HID;

--- a/tools/src/h5format_convert/h5format_convert.c
+++ b/tools/src/h5format_convert/h5format_convert.c
@@ -94,7 +94,7 @@ usage(const char *prog)
  *-------------------------------------------------------------------------
  */
 static int
-parse_command_line(int argc, char **argv)
+parse_command_line(int argc, const char *const *argv)
 {
     int opt;
 
@@ -106,7 +106,7 @@ parse_command_line(int argc, char **argv)
     }
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'h':
                 usage(h5tools_getprogname());
@@ -394,7 +394,7 @@ main(int argc, char *argv[])
     h5tools_init();
 
     /* Parse command line options */
-    if (parse_command_line(argc, argv) < 0)
+    if (parse_command_line(argc, (const char *const *)argv) < 0)
         goto done;
     else if (verbose_g)
         HDfprintf(stdout, "Process command line options\n");

--- a/tools/src/h5format_convert/h5format_convert.c
+++ b/tools/src/h5format_convert/h5format_convert.c
@@ -106,7 +106,7 @@ parse_command_line(int argc, char **argv)
     }
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'h':
                 usage(h5tools_getprogname());

--- a/tools/src/h5format_convert/h5format_convert.c
+++ b/tools/src/h5format_convert/h5format_convert.c
@@ -106,7 +106,7 @@ parse_command_line(int argc, char **argv)
     }
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'h':
                 usage(h5tools_getprogname());

--- a/tools/src/h5format_convert/h5format_convert.c
+++ b/tools/src/h5format_convert/h5format_convert.c
@@ -383,7 +383,7 @@ error:
  *-------------------------------------------------------------------------
  */
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     hid_t fid = H5I_INVALID_HID;
 

--- a/tools/src/h5format_convert/h5format_convert.c
+++ b/tools/src/h5format_convert/h5format_convert.c
@@ -94,7 +94,7 @@ usage(const char *prog)
  *-------------------------------------------------------------------------
  */
 static int
-parse_command_line(int argc, const char **argv)
+parse_command_line(int argc, char **argv)
 {
     int opt;
 

--- a/tools/src/h5jam/h5jam.c
+++ b/tools/src/h5jam/h5jam.c
@@ -149,7 +149,7 @@ parse_command_line(int argc, const char *argv[])
  *-------------------------------------------------------------------------
  */
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     int       ufid  = -1;
     int       h5fid = -1;

--- a/tools/src/h5jam/h5jam.c
+++ b/tools/src/h5jam/h5jam.c
@@ -109,7 +109,7 @@ parse_command_line(int argc, char *argv[])
     int opt = FALSE;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'o':
                 output_file = HDstrdup(H5_optarg);

--- a/tools/src/h5jam/h5jam.c
+++ b/tools/src/h5jam/h5jam.c
@@ -109,7 +109,7 @@ parse_command_line(int argc, char *argv[])
     int opt = FALSE;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'o':
                 output_file = HDstrdup(H5_optarg);

--- a/tools/src/h5jam/h5jam.c
+++ b/tools/src/h5jam/h5jam.c
@@ -22,7 +22,7 @@
 herr_t  write_pad(int ofile, hsize_t old_where, hsize_t *new_where);
 hsize_t compute_user_block_size(hsize_t);
 hsize_t copy_some_to_file(int, int, hsize_t, hsize_t, ssize_t);
-void    parse_command_line(int, char *[]);
+void    parse_command_line(int, const char *const *);
 
 int   do_clobber  = FALSE;
 char *output_file = NULL;
@@ -104,12 +104,12 @@ leave(int ret)
  */
 
 void
-parse_command_line(int argc, char *argv[])
+parse_command_line(int argc, const char *const *argv)
 {
     int opt = FALSE;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'o':
                 output_file = HDstrdup(H5_optarg);
@@ -174,7 +174,7 @@ main(int argc, char *argv[])
     /* Initialize h5tools lib */
     h5tools_init();
 
-    parse_command_line(argc, argv);
+    parse_command_line(argc, (const char *const *)argv);
 
     /* enable error reporting if command line option */
     h5tools_error_report();

--- a/tools/src/h5jam/h5jam.c
+++ b/tools/src/h5jam/h5jam.c
@@ -22,7 +22,7 @@
 herr_t  write_pad(int ofile, hsize_t old_where, hsize_t *new_where);
 hsize_t compute_user_block_size(hsize_t);
 hsize_t copy_some_to_file(int, int, hsize_t, hsize_t, ssize_t);
-void    parse_command_line(int, const char *[]);
+void    parse_command_line(int, char *[]);
 
 int   do_clobber  = FALSE;
 char *output_file = NULL;
@@ -104,7 +104,7 @@ leave(int ret)
  */
 
 void
-parse_command_line(int argc, const char *argv[])
+parse_command_line(int argc, char *argv[])
 {
     int opt = FALSE;
 

--- a/tools/src/h5jam/h5unjam.c
+++ b/tools/src/h5jam/h5unjam.c
@@ -97,7 +97,7 @@ parse_command_line(int argc, char *argv[])
     int opt = FALSE;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'o':
                 output_file = HDstrdup(H5_optarg);

--- a/tools/src/h5jam/h5unjam.c
+++ b/tools/src/h5jam/h5unjam.c
@@ -92,12 +92,12 @@ usage(const char *prog)
  *-------------------------------------------------------------------------
  */
 static int
-parse_command_line(int argc, char *argv[])
+parse_command_line(int argc, const char *const *argv)
 {
     int opt = FALSE;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'o':
                 output_file = HDstrdup(H5_optarg);
@@ -189,7 +189,7 @@ main(int argc, char *argv[])
     /* Initialize h5tools lib  */
     h5tools_init();
 
-    if (EXIT_FAILURE == parse_command_line(argc, argv))
+    if (EXIT_FAILURE == parse_command_line(argc, (const char *const *)argv))
         goto done;
 
     /* enable error reporting if command line option */

--- a/tools/src/h5jam/h5unjam.c
+++ b/tools/src/h5jam/h5unjam.c
@@ -97,7 +97,7 @@ parse_command_line(int argc, char *argv[])
     int opt = FALSE;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'o':
                 output_file = HDstrdup(H5_optarg);

--- a/tools/src/h5jam/h5unjam.c
+++ b/tools/src/h5jam/h5unjam.c
@@ -172,7 +172,7 @@ leave(int ret)
  *-------------------------------------------------------------------------
  */
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     hid_t     ifile = H5I_INVALID_HID;
     hid_t     plist = H5I_INVALID_HID;

--- a/tools/src/h5jam/h5unjam.c
+++ b/tools/src/h5jam/h5unjam.c
@@ -92,7 +92,7 @@ usage(const char *prog)
  *-------------------------------------------------------------------------
  */
 static int
-parse_command_line(int argc, const char *argv[])
+parse_command_line(int argc, char *argv[])
 {
     int opt = FALSE;
 

--- a/tools/src/h5ls/h5ls.c
+++ b/tools/src/h5ls/h5ls.c
@@ -2646,7 +2646,7 @@ leave(int ret)
  *-------------------------------------------------------------------------
  */
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     hid_t              file_id = H5I_INVALID_HID;
     char *             fname = NULL, *oname = NULL, *x = NULL;

--- a/tools/src/h5perf/pio_perf.c
+++ b/tools/src/h5perf/pio_perf.c
@@ -188,7 +188,7 @@ typedef struct _minmax {
 
 /* local functions */
 static off_t           parse_size_directive(const char *size);
-static struct options *parse_command_line(int argc, char *argv[]);
+static struct options *parse_command_line(int argc, const char *const *argv);
 static void            run_test_loop(struct options *options);
 static int             run_test(iotype iot, parameters parms, struct options *opts);
 static void            output_all_info(minmax *mm, int count, int indent_level);
@@ -260,7 +260,7 @@ main(int argc, char *argv[])
     pio_comm_g = MPI_COMM_WORLD;
 
     h5_set_info_object();
-    opts = parse_command_line(argc, argv);
+    opts = parse_command_line(argc, (const char *const *)argv);
 
     if (!opts) {
         exit_value = EXIT_FAILURE;
@@ -1276,7 +1276,7 @@ report_parameters(struct options *opts)
  *    Added 2D testing (Christian Chilan, 10. August 2005)
  */
 static struct options *
-parse_command_line(int argc, char *argv[])
+parse_command_line(int argc, const char *const *argv)
 {
     register int    opt;
     struct options *cl_opts;
@@ -1305,7 +1305,7 @@ parse_command_line(int argc, char *argv[])
     cl_opts->h5_write_only = FALSE; /* Do both read and write by default */
     cl_opts->verify        = FALSE; /* No Verify data correctness by default */
 
-    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'a':
                 cl_opts->h5_alignment = parse_size_directive(H5_optarg);

--- a/tools/src/h5perf/pio_perf.c
+++ b/tools/src/h5perf/pio_perf.c
@@ -1305,7 +1305,7 @@ parse_command_line(int argc, char *argv[])
     cl_opts->h5_write_only = FALSE; /* Do both read and write by default */
     cl_opts->verify        = FALSE; /* No Verify data correctness by default */
 
-    while ((opt = H5_get_option(argc, (const char **)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'a':
                 cl_opts->h5_alignment = parse_size_directive(H5_optarg);

--- a/tools/src/h5perf/pio_perf.c
+++ b/tools/src/h5perf/pio_perf.c
@@ -1305,7 +1305,7 @@ parse_command_line(int argc, char *argv[])
     cl_opts->h5_write_only = FALSE; /* Do both read and write by default */
     cl_opts->verify        = FALSE; /* No Verify data correctness by default */
 
-    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'a':
                 cl_opts->h5_alignment = parse_size_directive(H5_optarg);

--- a/tools/src/h5perf/sio_perf.c
+++ b/tools/src/h5perf/sio_perf.c
@@ -164,7 +164,7 @@ typedef struct {
 
 /* local functions */
 static hsize_t         parse_size_directive(const char *size);
-static struct options *parse_command_line(int argc, const char *argv[]);
+static struct options *parse_command_line(int argc, char *argv[]);
 static void            run_test_loop(struct options *options);
 static int             run_test(iotype iot, parameters parms, struct options *opts);
 static void            output_all_info(minmax *mm, int count, int indent_level);
@@ -817,7 +817,7 @@ report_parameters(struct options *opts)
  *    Added multidimensional testing (Christian Chilan, April, 2008)
  */
 static struct options *
-parse_command_line(int argc, const char *argv[])
+parse_command_line(int argc, char *argv[])
 {
     int             opt;
     struct options *cl_opts;

--- a/tools/src/h5perf/sio_perf.c
+++ b/tools/src/h5perf/sio_perf.c
@@ -857,7 +857,7 @@ parse_command_line(int argc, char *argv[])
     cl_opts->h5_extendable = FALSE; /* Use extendable dataset */
     cl_opts->verify        = FALSE; /* No Verify data correctness by default */
 
-    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'a':
                 cl_opts->h5_alignment = parse_size_directive(H5_optarg);

--- a/tools/src/h5perf/sio_perf.c
+++ b/tools/src/h5perf/sio_perf.c
@@ -185,7 +185,7 @@ static void report_parameters(struct options *opts);
  * Modifications:
  */
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     int             exit_value = EXIT_SUCCESS;
     struct options *opts       = NULL;

--- a/tools/src/h5perf/sio_perf.c
+++ b/tools/src/h5perf/sio_perf.c
@@ -164,7 +164,7 @@ typedef struct {
 
 /* local functions */
 static hsize_t         parse_size_directive(const char *size);
-static struct options *parse_command_line(int argc, char *argv[]);
+static struct options *parse_command_line(int argc, const char *const *argv);
 static void            run_test_loop(struct options *options);
 static int             run_test(iotype iot, parameters parms, struct options *opts);
 static void            output_all_info(minmax *mm, int count, int indent_level);
@@ -197,7 +197,7 @@ main(int argc, char *argv[])
 
     output = stdout;
 
-    opts = parse_command_line(argc, argv);
+    opts = parse_command_line(argc, (const char *const *)argv);
 
     if (!opts) {
         exit_value = EXIT_FAILURE;
@@ -817,7 +817,7 @@ report_parameters(struct options *opts)
  *    Added multidimensional testing (Christian Chilan, April, 2008)
  */
 static struct options *
-parse_command_line(int argc, char *argv[])
+parse_command_line(int argc, const char *const *argv)
 {
     int             opt;
     struct options *cl_opts;
@@ -857,7 +857,7 @@ parse_command_line(int argc, char *argv[])
     cl_opts->h5_extendable = FALSE; /* Use extendable dataset */
     cl_opts->verify        = FALSE; /* No Verify data correctness by default */
 
-    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'a':
                 cl_opts->h5_alignment = parse_size_directive(H5_optarg);

--- a/tools/src/h5perf/sio_perf.c
+++ b/tools/src/h5perf/sio_perf.c
@@ -857,7 +857,7 @@ parse_command_line(int argc, char *argv[])
     cl_opts->h5_extendable = FALSE; /* Use extendable dataset */
     cl_opts->verify        = FALSE; /* No Verify data correctness by default */
 
-    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'a':
                 cl_opts->h5_alignment = parse_size_directive(H5_optarg);

--- a/tools/src/h5repack/h5repack_main.c
+++ b/tools/src/h5repack/h5repack_main.c
@@ -528,7 +528,7 @@ parse_command_line(int argc, char **argv, pack_opt_t *options)
     HDmemset(&out_vfd_info, 0, sizeof(h5tools_vfd_info_t));
 
     /* parse command line options */
-    while (EOF != (opt = H5_get_option(argc, argv, s_opts, l_opts))) {
+    while (EOF != (opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts))) {
         switch ((char)opt) {
 
             /* -i for backward compatibility */

--- a/tools/src/h5repack/h5repack_main.c
+++ b/tools/src/h5repack/h5repack_main.c
@@ -528,7 +528,7 @@ parse_command_line(int argc, char **argv, pack_opt_t *options)
     HDmemset(&out_vfd_info, 0, sizeof(h5tools_vfd_info_t));
 
     /* parse command line options */
-    while (EOF != (opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts))) {
+    while (EOF != (opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts))) {
         switch ((char)opt) {
 
             /* -i for backward compatibility */

--- a/tools/src/h5repack/h5repack_main.c
+++ b/tools/src/h5repack/h5repack_main.c
@@ -928,7 +928,7 @@ done:
  *-------------------------------------------------------------------------
  */
 int
-main(int argc, const char **argv)
+main(int argc, char **argv)
 {
     pack_opt_t options; /*the global options */
     int        parse_ret;

--- a/tools/src/h5repack/h5repack_main.c
+++ b/tools/src/h5repack/h5repack_main.c
@@ -18,7 +18,7 @@
 /* Name of tool */
 #define PROGRAMNAME "h5repack"
 
-static int  parse_command_line(int argc, const char **argv, pack_opt_t *options);
+static int  parse_command_line(int argc, char **argv, pack_opt_t *options);
 static void leave(int ret) H5_ATTR_NORETURN;
 
 /* module-scoped variables */
@@ -507,7 +507,7 @@ set_sort_order(const char *form)
  *-------------------------------------------------------------------------
  */
 static int
-parse_command_line(int argc, const char **argv, pack_opt_t *options)
+parse_command_line(int argc, char **argv, pack_opt_t *options)
 {
     h5tools_vol_info_t in_vol_info;
     h5tools_vol_info_t out_vol_info;

--- a/tools/src/h5repack/h5repack_main.c
+++ b/tools/src/h5repack/h5repack_main.c
@@ -18,7 +18,7 @@
 /* Name of tool */
 #define PROGRAMNAME "h5repack"
 
-static int  parse_command_line(int argc, char **argv, pack_opt_t *options);
+static int  parse_command_line(int argc, const char *const *argv, pack_opt_t *options);
 static void leave(int ret) H5_ATTR_NORETURN;
 
 /* module-scoped variables */
@@ -507,7 +507,7 @@ set_sort_order(const char *form)
  *-------------------------------------------------------------------------
  */
 static int
-parse_command_line(int argc, char **argv, pack_opt_t *options)
+parse_command_line(int argc, const char *const *argv, pack_opt_t *options)
 {
     h5tools_vol_info_t in_vol_info;
     h5tools_vol_info_t out_vol_info;
@@ -528,7 +528,7 @@ parse_command_line(int argc, char **argv, pack_opt_t *options)
     HDmemset(&out_vfd_info, 0, sizeof(h5tools_vfd_info_t));
 
     /* parse command line options */
-    while (EOF != (opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts))) {
+    while (EOF != (opt = H5_get_option(argc, argv, s_opts, l_opts))) {
         switch ((char)opt) {
 
             /* -i for backward compatibility */
@@ -958,7 +958,7 @@ main(int argc, char **argv)
     /* Initialize default indexing options */
     sort_by = H5_INDEX_CRT_ORDER;
 
-    parse_ret = parse_command_line(argc, argv, &options);
+    parse_ret = parse_command_line(argc, (const char *const *)argv, &options);
     if (parse_ret < 0) {
         HDprintf("Error occurred while parsing command-line options\n");
         h5tools_setstatus(EXIT_FAILURE);

--- a/tools/src/h5stat/h5stat.c
+++ b/tools/src/h5stat/h5stat.c
@@ -837,7 +837,7 @@ parse_command_line(int argc, char *argv[], struct handler_t **hand_ret)
     struct handler_t *hand = NULL;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'h':
                 usage(h5tools_getprogname());

--- a/tools/src/h5stat/h5stat.c
+++ b/tools/src/h5stat/h5stat.c
@@ -830,14 +830,14 @@ hand_free(struct handler_t *hand)
  *-------------------------------------------------------------------------
  */
 static int
-parse_command_line(int argc, char *argv[], struct handler_t **hand_ret)
+parse_command_line(int argc, const char *const *argv, struct handler_t **hand_ret)
 {
     int               opt;
     unsigned          u;
     struct handler_t *hand = NULL;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'h':
                 usage(h5tools_getprogname());
@@ -1693,7 +1693,7 @@ main(int argc, char *argv[])
 
     HDmemset(&iter, 0, sizeof(iter));
 
-    if (parse_command_line(argc, argv, &hand) < 0)
+    if (parse_command_line(argc, (const char *const *)argv, &hand) < 0)
         goto done;
 
     /* enable error reporting if command line option */

--- a/tools/src/h5stat/h5stat.c
+++ b/tools/src/h5stat/h5stat.c
@@ -1677,7 +1677,7 @@ print_statistics(const char *name, const iter_t *iter)
  *-------------------------------------------------------------------------
  */
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     iter_t            iter;
     const char *      fname   = NULL;

--- a/tools/src/h5stat/h5stat.c
+++ b/tools/src/h5stat/h5stat.c
@@ -837,7 +837,7 @@ parse_command_line(int argc, char *argv[], struct handler_t **hand_ret)
     struct handler_t *hand = NULL;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'h':
                 usage(h5tools_getprogname());

--- a/tools/src/h5stat/h5stat.c
+++ b/tools/src/h5stat/h5stat.c
@@ -830,7 +830,7 @@ hand_free(struct handler_t *hand)
  *-------------------------------------------------------------------------
  */
 static int
-parse_command_line(int argc, const char *argv[], struct handler_t **hand_ret)
+parse_command_line(int argc, char *argv[], struct handler_t **hand_ret)
 {
     int               opt;
     unsigned          u;

--- a/tools/src/misc/h5clear.c
+++ b/tools/src/misc/h5clear.c
@@ -224,7 +224,7 @@ leave(int ret)
  *-------------------------------------------------------------------------
  */
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     char *   fname = NULL;            /* File name */
     hid_t    fapl  = H5I_INVALID_HID; /* File access property list */

--- a/tools/src/misc/h5clear.c
+++ b/tools/src/misc/h5clear.c
@@ -109,7 +109,7 @@ usage(const char *prog)
  *-------------------------------------------------------------------------
  */
 static int
-parse_command_line(int argc, char **argv)
+parse_command_line(int argc, const char *const *argv)
 {
     int opt;
 
@@ -121,7 +121,7 @@ parse_command_line(int argc, char **argv)
     }
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'h':
                 usage(h5tools_getprogname());
@@ -240,7 +240,7 @@ main(int argc, char *argv[])
     h5tools_init();
 
     /* Parse command line options */
-    if (parse_command_line(argc, argv) < 0)
+    if (parse_command_line(argc, (const char *const *)argv) < 0)
         goto done;
 
     if (fname_g == NULL)

--- a/tools/src/misc/h5clear.c
+++ b/tools/src/misc/h5clear.c
@@ -121,7 +121,7 @@ parse_command_line(int argc, char **argv)
     }
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'h':
                 usage(h5tools_getprogname());

--- a/tools/src/misc/h5clear.c
+++ b/tools/src/misc/h5clear.c
@@ -109,7 +109,7 @@ usage(const char *prog)
  *-------------------------------------------------------------------------
  */
 static int
-parse_command_line(int argc, const char **argv)
+parse_command_line(int argc, char **argv)
 {
     int opt;
 

--- a/tools/src/misc/h5clear.c
+++ b/tools/src/misc/h5clear.c
@@ -121,7 +121,7 @@ parse_command_line(int argc, char **argv)
     }
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'h':
                 usage(h5tools_getprogname());

--- a/tools/src/misc/h5delete.c
+++ b/tools/src/misc/h5delete.c
@@ -29,7 +29,7 @@ usage(void)
 }
 
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     hbool_t     quiet = FALSE;
     const char *name  = NULL;

--- a/tools/src/misc/h5mkgrp.c
+++ b/tools/src/misc/h5mkgrp.c
@@ -152,7 +152,7 @@ parse_command_line(int argc, char *argv[], mkgrp_opt_t *options)
     HDmemset(&vfd_info, 0, sizeof(h5tools_vfd_info_t));
 
     /* Parse command line options */
-    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             /* Display 'help' */
             case 'h':

--- a/tools/src/misc/h5mkgrp.c
+++ b/tools/src/misc/h5mkgrp.c
@@ -131,7 +131,7 @@ usage(const char *prog)
  *-------------------------------------------------------------------------
  */
 static int
-parse_command_line(int argc, char *argv[], mkgrp_opt_t *options)
+parse_command_line(int argc, const char *const *argv, mkgrp_opt_t *options)
 {
     int                opt;        /* Option from command line */
     size_t             curr_group; /* Current group name to copy */
@@ -152,7 +152,7 @@ parse_command_line(int argc, char *argv[], mkgrp_opt_t *options)
     HDmemset(&vfd_info, 0, sizeof(h5tools_vfd_info_t));
 
     /* Parse command line options */
-    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             /* Display 'help' */
             case 'h':
@@ -303,7 +303,7 @@ main(int argc, char *argv[])
     }
 
     /* Parse command line */
-    if (parse_command_line(argc, argv, &params_g) < 0) {
+    if (parse_command_line(argc, (const char *const *)argv, &params_g) < 0) {
         error_msg("unable to parse command line arguments\n");
         leave(EXIT_FAILURE);
     }

--- a/tools/src/misc/h5mkgrp.c
+++ b/tools/src/misc/h5mkgrp.c
@@ -281,7 +281,7 @@ parse_command_line(int argc, const char *argv[], mkgrp_opt_t *options)
  *-------------------------------------------------------------------------
  */
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     hid_t  fid     = H5I_INVALID_HID; /* HDF5 file ID */
     hid_t  lcpl_id = H5I_INVALID_HID; /* Link creation property list ID */

--- a/tools/src/misc/h5mkgrp.c
+++ b/tools/src/misc/h5mkgrp.c
@@ -152,7 +152,7 @@ parse_command_line(int argc, char *argv[], mkgrp_opt_t *options)
     HDmemset(&vfd_info, 0, sizeof(h5tools_vfd_info_t));
 
     /* Parse command line options */
-    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             /* Display 'help' */
             case 'h':

--- a/tools/src/misc/h5mkgrp.c
+++ b/tools/src/misc/h5mkgrp.c
@@ -131,7 +131,7 @@ usage(const char *prog)
  *-------------------------------------------------------------------------
  */
 static int
-parse_command_line(int argc, const char *argv[], mkgrp_opt_t *options)
+parse_command_line(int argc, char *argv[], mkgrp_opt_t *options)
 {
     int                opt;        /* Option from command line */
     size_t             curr_group; /* Current group name to copy */

--- a/tools/test/h5dump/binread.c
+++ b/tools/test/h5dump/binread.c
@@ -59,7 +59,7 @@ usage(void)
  */
 
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     FILE * stream;
     size_t numread;

--- a/tools/test/h5jam/getub.c
+++ b/tools/test/h5jam/getub.c
@@ -15,7 +15,7 @@
 #include "h5tools.h"
 #include "h5tools_utils.h"
 
-void parse_command_line(int argc, char *argv[]);
+void parse_command_line(int argc, const char *const *argv);
 
 /* Name of tool */
 #define PROGRAM_NAME "getub"
@@ -52,12 +52,12 @@ usage(const char *prog)
  *-------------------------------------------------------------------------
  */
 void
-parse_command_line(int argc, char *argv[])
+parse_command_line(int argc, const char *const *argv)
 {
     int opt;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'c':
                 nbytes = HDstrdup(H5_optarg);
@@ -91,7 +91,7 @@ main(int argc, char *argv[])
     /* Initialize h5tools lib */
     h5tools_init();
 
-    parse_command_line(argc, argv);
+    parse_command_line(argc, (const char *const *)argv);
 
     if (NULL == nbytes) {
         /* missing arg */

--- a/tools/test/h5jam/getub.c
+++ b/tools/test/h5jam/getub.c
@@ -15,7 +15,7 @@
 #include "h5tools.h"
 #include "h5tools_utils.h"
 
-void parse_command_line(int argc, const char *argv[]);
+void parse_command_line(int argc, char *argv[]);
 
 /* Name of tool */
 #define PROGRAM_NAME "getub"
@@ -52,7 +52,7 @@ usage(const char *prog)
  *-------------------------------------------------------------------------
  */
 void
-parse_command_line(int argc, const char *argv[])
+parse_command_line(int argc, char *argv[])
 {
     int opt;
 

--- a/tools/test/h5jam/getub.c
+++ b/tools/test/h5jam/getub.c
@@ -77,7 +77,7 @@ parse_command_line(int argc, const char *argv[])
 } /* end parse_command_line() */
 
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     int      fd = H5I_INVALID_HID;
     unsigned size;

--- a/tools/test/h5jam/getub.c
+++ b/tools/test/h5jam/getub.c
@@ -57,7 +57,7 @@ parse_command_line(int argc, char *argv[])
     int opt;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'c':
                 nbytes = HDstrdup(H5_optarg);

--- a/tools/test/h5jam/getub.c
+++ b/tools/test/h5jam/getub.c
@@ -57,7 +57,7 @@ parse_command_line(int argc, char *argv[])
     int opt;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'c':
                 nbytes = HDstrdup(H5_optarg);

--- a/tools/test/h5jam/tellub.c
+++ b/tools/test/h5jam/tellub.c
@@ -56,12 +56,12 @@ usage(const char *prog)
  */
 
 static void
-parse_command_line(int argc, char *argv[])
+parse_command_line(int argc, const char *const *argv)
 {
     int opt;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'h':
                 usage(h5tools_getprogname());
@@ -113,7 +113,7 @@ main(int argc, char *argv[])
     /* Initialize h5tools lib */
     h5tools_init();
 
-    parse_command_line(argc, argv);
+    parse_command_line(argc, (const char *const *)argv);
 
     /* enable error reporting if command line option */
     h5tools_error_report();

--- a/tools/test/h5jam/tellub.c
+++ b/tools/test/h5jam/tellub.c
@@ -98,7 +98,7 @@ leave(int ret)
  *-------------------------------------------------------------------------
  */
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     char *  ifname;
     hid_t   ifile = H5I_INVALID_HID;

--- a/tools/test/h5jam/tellub.c
+++ b/tools/test/h5jam/tellub.c
@@ -56,7 +56,7 @@ usage(const char *prog)
  */
 
 static void
-parse_command_line(int argc, const char *argv[])
+parse_command_line(int argc, char *argv[])
 {
     int opt;
 

--- a/tools/test/h5jam/tellub.c
+++ b/tools/test/h5jam/tellub.c
@@ -61,7 +61,7 @@ parse_command_line(int argc, char *argv[])
     int opt;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'h':
                 usage(h5tools_getprogname());

--- a/tools/test/h5jam/tellub.c
+++ b/tools/test/h5jam/tellub.c
@@ -61,7 +61,7 @@ parse_command_line(int argc, char *argv[])
     int opt;
 
     /* parse command line options */
-    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) != EOF) {
+    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'h':
                 usage(h5tools_getprogname());

--- a/tools/test/perform/pio_standalone.h
+++ b/tools/test/perform/pio_standalone.h
@@ -461,7 +461,7 @@ struct h5_long_options {
                                  */
 };
 
-extern int H5_get_option(int argc, const char **argv, const char *opt, const struct h5_long_options *l_opt);
+extern int H5_get_option(int argc, char **argv, const char *opt, const struct h5_long_options *l_opt);
 
 extern int nCols; /*max number of columns for outputting  */
 

--- a/tools/test/perform/pio_standalone.h
+++ b/tools/test/perform/pio_standalone.h
@@ -461,7 +461,7 @@ struct h5_long_options {
                                  */
 };
 
-extern int H5_get_option(int argc, char **argv, const char *opt, const struct h5_long_options *l_opt);
+extern int H5_get_option(int argc, const char* const *argv, const char *opt, const struct h5_long_options *l_opt);
 
 extern int nCols; /*max number of columns for outputting  */
 

--- a/tools/test/perform/pio_standalone.h
+++ b/tools/test/perform/pio_standalone.h
@@ -461,7 +461,8 @@ struct h5_long_options {
                                  */
 };
 
-extern int H5_get_option(int argc, const char* const *argv, const char *opt, const struct h5_long_options *l_opt);
+extern int H5_get_option(int argc, const char *const *argv, const char *opt,
+                         const struct h5_long_options *l_opt);
 
 extern int nCols; /*max number of columns for outputting  */
 

--- a/tools/test/perform/sio_standalone.h
+++ b/tools/test/perform/sio_standalone.h
@@ -476,7 +476,7 @@ struct h5_long_options {
                                  */
 };
 
-extern int H5_get_option(int argc, const char **argv, const char *opt, const struct h5_long_options *l_opt);
+extern int H5_get_option(int argc, char **argv, const char *opt, const struct h5_long_options *l_opt);
 
 extern int nCols; /*max number of columns for outputting  */
 

--- a/tools/test/perform/sio_standalone.h
+++ b/tools/test/perform/sio_standalone.h
@@ -476,7 +476,7 @@ struct h5_long_options {
                                  */
 };
 
-extern int H5_get_option(int argc, char **argv, const char *opt, const struct h5_long_options *l_opt);
+extern int H5_get_option(int argc, const char* const *argv, const char *opt, const struct h5_long_options *l_opt);
 
 extern int nCols; /*max number of columns for outputting  */
 

--- a/tools/test/perform/sio_standalone.h
+++ b/tools/test/perform/sio_standalone.h
@@ -476,7 +476,8 @@ struct h5_long_options {
                                  */
 };
 
-extern int H5_get_option(int argc, const char* const *argv, const char *opt, const struct h5_long_options *l_opt);
+extern int H5_get_option(int argc, const char *const *argv, const char *opt,
+                         const struct h5_long_options *l_opt);
 
 extern int nCols; /*max number of columns for outputting  */
 

--- a/tools/test/perform/zip_perf.c
+++ b/tools/test/perform/zip_perf.c
@@ -489,7 +489,7 @@ do_write_test(unsigned long file_size, unsigned long min_buf_size, unsigned long
  * Modifications:
  */
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     unsigned long min_buf_size = 128 * ONE_KB, max_buf_size = ONE_MB;
     unsigned long file_size = 64 * ONE_MB;

--- a/tools/test/perform/zip_perf.c
+++ b/tools/test/perform/zip_perf.c
@@ -500,7 +500,7 @@ main(int argc, char *argv[])
     /* Initialize h5tools lib */
     h5tools_init();
 
-    while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) > 0) {
+    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) > 0) {
         switch ((char)opt) {
             case '0':
             case '1':

--- a/tools/test/perform/zip_perf.c
+++ b/tools/test/perform/zip_perf.c
@@ -500,7 +500,7 @@ main(int argc, char *argv[])
     /* Initialize h5tools lib */
     h5tools_init();
 
-    while ((opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts)) > 0) {
+    while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) > 0) {
         switch ((char)opt) {
             case '0':
             case '1':

--- a/utils/tools/h5dwalk/h5dwalk.c
+++ b/utils/tools/h5dwalk/h5dwalk.c
@@ -1392,7 +1392,7 @@ main(int argc, char *argv[])
     mfu_pred *pred_head = NULL;
 
     while (!tool_selected) {
-        opt = H5_get_option(argc, argv, s_opts, l_opts);
+        opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts);
         switch ((char)opt) {
             default:
                 usage();

--- a/utils/tools/h5dwalk/h5dwalk.c
+++ b/utils/tools/h5dwalk/h5dwalk.c
@@ -1392,7 +1392,7 @@ main(int argc, char *argv[])
     mfu_pred *pred_head = NULL;
 
     while (!tool_selected) {
-        opt = H5_get_option(argc, (const char* const *)argv, s_opts, l_opts);
+        opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts);
         switch ((char)opt) {
             default:
                 usage();

--- a/utils/tools/h5dwalk/h5dwalk.c
+++ b/utils/tools/h5dwalk/h5dwalk.c
@@ -1322,7 +1322,7 @@ process_input_file(char *inputname, int myrank, int size)
 }
 
 int
-main(int argc, const char *argv[])
+main(int argc, char *argv[])
 {
     int i;
     int rc = 0;
@@ -1352,7 +1352,7 @@ main(int argc, const char *argv[])
     if (env_var) {
 		int enable = HDatoi(env_var);
 		if (enable) {
-			
+
 		}
     }
 #endif


### PR DESCRIPTION
Clang compiles of before after show a reduction in warnings for "const" from 327 to 263 and results in no "const" warnings in main functions of tools/tests.