### PR TITLE
Revert "Open bsd fixes"

### DIFF
--- a/config/cmake_ext_mod/ConfigureChecks.cmake
+++ b/config/cmake_ext_mod/ConfigureChecks.cmake
@@ -223,63 +223,65 @@ set (LINUX_LFS 0)
 set (HDF_EXTRA_C_FLAGS)
 set (HDF_EXTRA_FLAGS)
 if (MINGW OR NOT WINDOWS)
-  if (CMAKE_SYSTEM_NAME MATCHES "Linux")
-	# Linux Specific flags
-	# This was originally defined as _POSIX_SOURCE which was updated to
-	# _POSIX_C_SOURCE=199506L to expose a greater amount of POSIX
-	# functionality so clock_gettime and CLOCK_MONOTONIC are defined
-	# correctly. This was later updated to 200112L so that
-	# posix_memalign() is visible for the direct VFD code on Linux
-	# systems.
-	# POSIX feature information can be found in the gcc manual at:
-	# http://www.gnu.org/s/libc/manual/html_node/Feature-Test-Macros.html
-	set (HDF_EXTRA_C_FLAGS -D_POSIX_C_SOURCE=200809L)
+  # Might want to check explicitly for Linux and possibly Cygwin
+  # instead of checking for not Solaris or Darwin.
+  if (NOT ${HDF_PREFIX}_HAVE_SOLARIS AND NOT ${HDF_PREFIX}_HAVE_DARWIN)
+  # Linux Specific flags
+  # This was originally defined as _POSIX_SOURCE which was updated to
+  # _POSIX_C_SOURCE=199506L to expose a greater amount of POSIX
+  # functionality so clock_gettime and CLOCK_MONOTONIC are defined
+  # correctly. This was later updated to 200112L so that
+  # posix_memalign() is visible for the direct VFD code on Linux
+  # systems.
+  # POSIX feature information can be found in the gcc manual at:
+  # http://www.gnu.org/s/libc/manual/html_node/Feature-Test-Macros.html
+  set (HDF_EXTRA_C_FLAGS -D_POSIX_C_SOURCE=200809L)
 
-	# Need to add this so that O_DIRECT is visible for the direct
-	# VFD on Linux systems.
-	set (HDF_EXTRA_C_FLAGS ${HDF_EXTRA_C_FLAGS} -D_GNU_SOURCE)
+  # Need to add this so that O_DIRECT is visible for the direct
+  # VFD on Linux systems.
+  set (HDF_EXTRA_C_FLAGS ${HDF_EXTRA_C_FLAGS} -D_GNU_SOURCE)
 
-	option (HDF_ENABLE_LARGE_FILE "Enable support for large (64-bit) files on Linux." ON)
-	if (HDF_ENABLE_LARGE_FILE AND NOT DEFINED TEST_LFS_WORKS_RUN)
-	  set (msg "Performing TEST_LFS_WORKS")
-	  try_run (TEST_LFS_WORKS_RUN   TEST_LFS_WORKS_COMPILE
-		  ${CMAKE_BINARY_DIR}
-		  ${HDF_RESOURCES_EXT_DIR}/HDFTests.c
-		  COMPILE_DEFINITIONS "-DTEST_LFS_WORKS"
-	  )
+  option (HDF_ENABLE_LARGE_FILE "Enable support for large (64-bit) files on Linux." ON)
+  if (HDF_ENABLE_LARGE_FILE AND NOT DEFINED TEST_LFS_WORKS_RUN)
+    set (msg "Performing TEST_LFS_WORKS")
+    try_run (TEST_LFS_WORKS_RUN   TEST_LFS_WORKS_COMPILE
+        ${CMAKE_BINARY_DIR}
+        ${HDF_RESOURCES_EXT_DIR}/HDFTests.c
+        COMPILE_DEFINITIONS "-DTEST_LFS_WORKS"
+    )
 
-	  # The LARGEFILE definitions were from the transition period
-	  # and are probably no longer needed. The FILE_OFFSET_BITS
-	  # check should be generalized for all POSIX systems as it
-	  # is in the Autotools.
-	  if (TEST_LFS_WORKS_COMPILE)
-		if (TEST_LFS_WORKS_RUN MATCHES 0)
-		  set (TEST_LFS_WORKS 1 CACHE INTERNAL ${msg})
-		  set (LARGEFILE 1)
-		  set (HDF_EXTRA_FLAGS ${HDF_EXTRA_FLAGS} -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE)
-		  if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15.0")
-			message (VERBOSE "${msg}... yes")
-		  endif ()
-		else ()
-		  set (TEST_LFS_WORKS "" CACHE INTERNAL ${msg})
-		  if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15.0")
-			message (VERBOSE "${msg}... no")
-		  endif ()
-		  file (APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
-				"Test TEST_LFS_WORKS Run failed with the following exit code:\n ${TEST_LFS_WORKS_RUN}\n"
-		  )
-		endif ()
-	  else ()
-		set (TEST_LFS_WORKS "" CACHE INTERNAL ${msg})
-		if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15.0")
-			message (VERBOSE "${msg}... no")
-		endif ()
-		file (APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
-			"Test TEST_LFS_WORKS Compile failed\n"
-		)
-	  endif ()
-	endif ()
-    set (CMAKE_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS} ${HDF_EXTRA_FLAGS})
+    # The LARGEFILE definitions were from the transition period
+    # and are probably no longer needed. The FILE_OFFSET_BITS
+    # check should be generalized for all POSIX systems as it
+    # is in the Autotools.
+    if (TEST_LFS_WORKS_COMPILE)
+      if (TEST_LFS_WORKS_RUN MATCHES 0)
+        set (TEST_LFS_WORKS 1 CACHE INTERNAL ${msg})
+        set (LARGEFILE 1)
+        set (HDF_EXTRA_FLAGS ${HDF_EXTRA_FLAGS} -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE)
+        if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15.0")
+          message (VERBOSE "${msg}... yes")
+        endif ()
+      else ()
+        set (TEST_LFS_WORKS "" CACHE INTERNAL ${msg})
+        if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15.0")
+          message (VERBOSE "${msg}... no")
+        endif ()
+        file (APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+              "Test TEST_LFS_WORKS Run failed with the following exit code:\n ${TEST_LFS_WORKS_RUN}\n"
+        )
+      endif ()
+    else ()
+      set (TEST_LFS_WORKS "" CACHE INTERNAL ${msg})
+      if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15.0")
+          message (VERBOSE "${msg}... no")
+      endif ()
+      file (APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+          "Test TEST_LFS_WORKS Compile failed\n"
+      )
+    endif ()
+  endif ()
+  set (CMAKE_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS} ${HDF_EXTRA_FLAGS})
   endif ()
 endif ()
 

--- a/src/H5detect.c
+++ b/src/H5detect.c
@@ -205,11 +205,14 @@ precision(detected_t *d)
 }
 
 /*-------------------------------------------------------------------------
- * Function:    DETECT_I
+ * Function:    DETECT_I/DETECT_BYTE
  *
- * Purpose:     This macro takes a type like `int' and a base name like
+ * Purpose:     These macro takes a type like `int' and a base name like
  *              `nati' and detects the byte order.  The VAR is used to
  *              construct the names of the C variables defined.
+ *
+ *              DETECT_I is used for types that are larger than one byte,
+ *              DETECT_BYTE is used for types that are exactly one byte.
  *
  * Return:      void
  *
@@ -244,8 +247,17 @@ precision(detected_t *d)
         }                                                                                                    \
     }
 
+#define DETECT_BYTE(TYPE, VAR, INFO)                                                                         \
+    {                                                                                                        \
+        HDcompile_assert(sizeof(TYPE) == 1);                                                                 \
+                                                                                                             \
+        DETECT_I_BYTE_CORE(TYPE, VAR, INFO, int)                                                             \
+    }
+
 #define DETECT_I(TYPE, VAR, INFO)                                                                            \
     {                                                                                                        \
+        HDcompile_assert(sizeof(TYPE) > 1);                                                                  \
+                                                                                                             \
         DETECT_I_BYTE_CORE(TYPE, VAR, INFO, TYPE)                                                            \
     }
 
@@ -1220,9 +1232,9 @@ bit.\n";
 static void HDF_NO_UBSAN
 detect_C89_integers(void)
 {
-    DETECT_I(signed char, SCHAR, d_g[nd_g]);
+    DETECT_BYTE(signed char, SCHAR, d_g[nd_g]);
     nd_g++;
-    DETECT_I(unsigned char, UCHAR, d_g[nd_g]);
+    DETECT_BYTE(unsigned char, UCHAR, d_g[nd_g]);
     nd_g++;
     DETECT_I(short, SHORT, d_g[nd_g]);
     nd_g++;
@@ -1266,17 +1278,17 @@ detect_C89_floats(void)
 static void HDF_NO_UBSAN
 detect_C99_integers8(void)
 {
-    DETECT_I(int8_t, INT8, d_g[nd_g]);
+    DETECT_BYTE(int8_t, INT8, d_g[nd_g]);
     nd_g++;
-    DETECT_I(uint8_t, UINT8, d_g[nd_g]);
+    DETECT_BYTE(uint8_t, UINT8, d_g[nd_g]);
     nd_g++;
-    DETECT_I(int_least8_t, INT_LEAST8, d_g[nd_g]);
+    DETECT_BYTE(int_least8_t, INT_LEAST8, d_g[nd_g]);
     nd_g++;
-    DETECT_I(uint_least8_t, UINT_LEAST8, d_g[nd_g]);
+    DETECT_BYTE(uint_least8_t, UINT_LEAST8, d_g[nd_g]);
     nd_g++;
-    DETECT_I(int_fast8_t, INT_FAST8, d_g[nd_g]);
+    DETECT_BYTE(int_fast8_t, INT_FAST8, d_g[nd_g]);
     nd_g++;
-    DETECT_I(uint_fast8_t, UINT_FAST8, d_g[nd_g]);
+    DETECT_BYTE(uint_fast8_t, UINT_FAST8, d_g[nd_g]);
     nd_g++;
 }
 

--- a/test/app_ref.c
+++ b/test/app_ref.c
@@ -69,10 +69,8 @@ Abrt_Handler(int H5_ATTR_UNUSED sig)
 {
     int i, n;
 
-    const char *string = " ID reference count: ";
     for (i = 0; i < T_NUMCLASSES; i++) {
-        HDfprintf(stderr, "%s%s", IDNAME[i], string);
-        n = (int)(strlen(IDNAME[i]) + strlen(string));
+        HDfprintf(stderr, "%s ID reference count: %n", IDNAME[i], &n);
         HDfprintf(stderr, "%*d\n", (n < ERR_WIDTH) ? (ERR_WIDTH - n) : 0, rc[i]);
     }
 }


### PR DESCRIPTION
Reverts HDFGroup/hdf5#1195

Switching DETECT_BYTE to DETECT_I for 8 byte types doesn't work on our big-endian Power8 machine because switching the last parameter of DETECT_I_BYTE_CORE from "int" to the 8 byte type incorrectly sets dt->shared->u.atomic.order = H5T_ORDER_LE on a big-endian machine.  

@seanm, no problems otherwise.
