### PR TITLE
Make a buffer bigger: GCC 8.3.0 warned that a `snprintf` may be

### DIFF
--- a/tools/src/h5perf/sio_engine.c
+++ b/tools/src/h5perf/sio_engine.c
@@ -1267,7 +1267,7 @@ done:
 static void
 do_cleanupfile(iotype iot, char *filename)
 {
-    char  temp[2048];
+    char  temp[4096 + sizeof("-?.h5")];
     int   j;
     hid_t driver;
 


### PR DESCRIPTION
truncated because the recipient buffer was too small, and the warning is
one that we promote to an error.  Now there is a warning that the buffer
is too big (-Wlarger-than=), but we don't promote those to errors, yet.