### PR TITLE
H5_now_usec arithmetic fix

### DIFF
--- a/src/H5timer.c
+++ b/src/H5timer.c
@@ -183,31 +183,33 @@ H5_now(void)
  *
  *-------------------------------------------------------------------------
  */
+#if defined(H5_HAVE_CLOCK_GETTIME)
 uint64_t
 H5_now_usec(void)
 {
-    uint64_t now; /* Current time, in microseconds */
+    struct timespec ts;
 
-#if defined(H5_HAVE_CLOCK_GETTIME)
-    {
-        struct timespec ts;
+    HDclock_gettime(CLOCK_MONOTONIC, &ts);
 
-        HDclock_gettime(CLOCK_MONOTONIC, &ts);
-        now = (uint64_t)(ts.tv_sec * (1000 * 1000)) + (uint64_t)(ts.tv_nsec / 1000);
-    }
+    return (uint64_t)ts.tv_sec * 1000L * 1000L + (uint64_t)ts.tv_nsec / 1000;
+}
 #elif defined(H5_HAVE_GETTIMEOFDAY)
-    {
-        struct timeval now_tv;
+uint64_t
+H5_now_usec(void)
+{
+    struct timeval tv;
 
-        HDgettimeofday(&now_tv, NULL);
-        now = (uint64_t)(now_tv.tv_sec * (1000 * 1000)) + (uint64_t)now_tv.tv_usec;
-    }
+    HDgettimeofday(&tv, NULL);
+
+    return (uint64_t)tv.tv_sec * 1000L * 1000L + (uint64_t)tv.tv_usec;
+}
 #else  /* H5_HAVE_GETTIMEOFDAY */
-    now       = (uint64_t)(HDtime(NULL) * (1000 * 1000));
+uint64_t
+H5_now_usec(void)
+{
+    return (uint64_t)HDtime(NULL) * 1000L * 1000L;
+}
 #endif /* H5_HAVE_GETTIMEOFDAY */
-
-    return (now);
-} /* end H5_now_usec() */
 
 /*--------------------------------------------------------------------------
  * Function:    H5_get_time

--- a/src/H5timer.c
+++ b/src/H5timer.c
@@ -292,7 +292,7 @@ H5__timer_get_timevals(H5_timevals_t *times /*in,out*/)
         if (HDgetrusage(RUSAGE_SELF, &res) < 0)
             return -1;
         times->system = (double)res.ru_stime.tv_sec + ((double)res.ru_stime.tv_usec / 1.0E6);
-        times->user   = (double)res.ru_utime.tv_sec + ((double)res.ru_utime.tv_usec / 1.0E6);
+        times->user = (double)res.ru_utime.tv_sec + ((double)res.ru_utime.tv_usec / 1.0E6);
     }
 #else
     /* No suitable way to get system/user times */


### PR DESCRIPTION
Sparingly use casts and the constant suffix "L" to ensure that the  H5_now_usec products are performed with 64 bits of precision or more and to quiet GCC 8.3.0's sign-conversion warnings.

While I am here, move the conditional compilation outside of H5_now_usec for clarity.