### PR TITLE
Remove H5_NO_ALIGNMENT_RESTRICTIONS

### DIFF
--- a/config/cmake/ConfigureChecks.cmake
+++ b/config/cmake/ConfigureChecks.cmake
@@ -416,7 +416,3 @@ H5ConversionTests (${HDF_PREFIX}_LLONG_TO_LDOUBLE_CORRECT "Checking IF correctly
 # some long double values
 #-----------------------------------------------------------------------------
 H5ConversionTests (${HDF_PREFIX}_DISABLE_SOME_LDOUBLE_CONV "Checking IF the cpu is power9 and cannot correctly converting long double values")
-# ----------------------------------------------------------------------
-# Check if pointer alignments are enforced
-#-----------------------------------------------------------------------------
-H5ConversionTests (${HDF_PREFIX}_NO_ALIGNMENT_RESTRICTIONS "Checking IF alignment restrictions are strictly enforced")

--- a/config/cmake/ConversionTests.c
+++ b/config/cmake/ConversionTests.c
@@ -234,59 +234,6 @@ done:
 }
 #endif
 
-#ifdef H5_NO_ALIGNMENT_RESTRICTIONS_TEST
-
-#include <stdlib.h>
-#include <string.h>
-
-typedef struct {
-    size_t len;
-    void *p;
-} hvl_t;
-
-#ifdef FC_DUMMY_MAIN
-#ifndef FC_DUMMY_MAIN_EQ_F77
-#  ifdef __cplusplus
-extern "C"
-#  endif
-int FC_DUMMY_MAIN()
-{ return 1;}
-#endif
-#endif
-int HDF_NO_UBSAN
-main ()
-{
-
-    char *chp = "beefs";
-    char **chpp = malloc (2 * sizeof (char *));
-    char **chpp2;
-    hvl_t vl = { 12345, (void *) chp };
-    hvl_t *vlp;
-    hvl_t *vlp2;
-
-    memcpy ((void *) ((char *) chpp + 1), &chp, sizeof (char *));
-    chpp2 = (char **) ((char *) chpp + 1);
-    if (strcmp (*chpp2, chp)) {
-        free (chpp);
-        return 1;
-    }
-    free (chpp);
-
-    vlp = malloc (2 * sizeof (hvl_t));
-    memcpy ((void *) ((char *) vlp + 1), &vl, sizeof (hvl_t));
-    vlp2 = (hvl_t *) ((char *) vlp + 1);
-    if (vlp2->len != vl.len || vlp2->p != vl.p) {
-        free (vlp);
-        return 1;
-    }
-    free (vlp);
-
-  ;
-  return 0;
-}
-
-#endif
-
 #ifdef H5_DISABLE_SOME_LDOUBLE_CONV_TEST
 
 #include <stdio.h>

--- a/config/cmake/H5pubconf.h.in
+++ b/config/cmake/H5pubconf.h.in
@@ -431,9 +431,6 @@
 /* Define to enable internal memory allocation sanity checking. */
 #cmakedefine H5_MEMORY_ALLOC_SANITY_CHECK @H5_MEMORY_ALLOC_SANITY_CHECK@
 
-/* Define if we can violate pointer alignment restrictions */
-#cmakedefine H5_NO_ALIGNMENT_RESTRICTIONS @H5_NO_ALIGNMENT_RESTRICTIONS@
-
 /* Define if deprecated public API symbols are disabled */
 #cmakedefine H5_NO_DEPRECATED_SYMBOLS @H5_NO_DEPRECATED_SYMBOLS@
 

--- a/configure.ac
+++ b/configure.ac
@@ -4009,25 +4009,6 @@ AC_ARG_ENABLE([embedded-libinfo],
 
 
 ## ----------------------------------------------------------------------
-## Check if pointer alignments are enforced
-##
-AC_MSG_CHECKING([if alignment restrictions are strictly enforced])
-
-TEST_SRC="`(echo \"#define H5_NO_ALIGNMENT_RESTRICTIONS_TEST 1\"; cat $srcdir/config/cmake/ConversionTests.c)`"
-
-AC_RUN_IFELSE([
-    AC_LANG_SOURCE([$TEST_SRC])
-    ], [
-    AC_DEFINE([NO_ALIGNMENT_RESTRICTIONS], [1], [Define if we can violate pointer alignment restrictions])
-    AC_MSG_RESULT([no])
-    ], [
-    AC_MSG_RESULT([yes])
-    ], [
-    AC_MSG_RESULT([unknown, assuming yes])
-    ])
-
-
-## ----------------------------------------------------------------------
 ## Restore user's CFLAGS.
 CFLAGS="$saved_user_CFLAGS"
 FCFLAGS="$saved_user_FCFLAGS"

--- a/src/H5Tvlen.c
+++ b/src/H5Tvlen.c
@@ -377,7 +377,10 @@ H5T__vlen_mem_seq_getlen(H5VL_object_t H5_ATTR_UNUSED *file, const void *_vl, si
     HDassert(_vl);
     HDassert(len);
 
-    memcpy(&vl, _vl, sizeof(hvl_t));
+    /* Copy to ensure correct alignment.  memcpy is best here because
+     * it optimizes to fast code.
+     */
+    HDmemcpy(&vl, _vl, sizeof(hvl_t));
 
     *len = vl.len;
 
@@ -405,7 +408,8 @@ H5T__vlen_mem_seq_getptr(void *_vl)
 
     /* check parameters, return result */
     HDassert(_vl);
-    memcpy(&vl, _vl, sizeof(hvl_t));
+    /* Copy to ensure correct alignment. */
+    HDmemcpy(&vl, _vl, sizeof(hvl_t));
 
     FUNC_LEAVE_NOAPI(vl.p)
 } /* end H5T__vlen_mem_seq_getptr() */
@@ -432,7 +436,8 @@ H5T__vlen_mem_seq_isnull(const H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, hb
     /* Check parameters */
     HDassert(_vl);
 
-    memcpy(&vl, _vl, sizeof(hvl_t));
+    /* Copy to ensure correct alignment. */
+    HDmemcpy(&vl, _vl, sizeof(hvl_t));
 
     *isnull = ((vl.len == 0 || vl.p == NULL) ? TRUE : FALSE);
 
@@ -493,7 +498,8 @@ H5T__vlen_mem_seq_read(H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, void *buf,
     /* check parameters, copy data */
     HDassert(buf);
     HDassert(_vl);
-    memcpy(&vl, _vl, sizeof(hvl_t));
+    /* Copy to ensure correct alignment. */
+    HDmemcpy(&vl, _vl, sizeof(hvl_t));
     HDassert(vl.p);
 
     H5MM_memcpy(buf, vl.p, len);
@@ -577,7 +583,8 @@ H5T__vlen_mem_str_getlen(H5VL_object_t H5_ATTR_UNUSED *file, const void *_vl, si
     /* check parameters */
     HDassert(_vl);
 
-    memcpy(&s, _vl, sizeof(char *));
+    /* Copy to ensure correct alignment. */
+    HDmemcpy(&s, _vl, sizeof(char *));
 
     *len = HDstrlen(s);
 
@@ -605,7 +612,8 @@ H5T__vlen_mem_str_getptr(void *_vl)
 
     /* check parameters */
     HDassert(_vl);
-    memcpy(&s, _vl, sizeof(char *));
+    /* Copy to ensure correct alignment. */
+    HDmemcpy(&s, _vl, sizeof(char *));
 
     FUNC_LEAVE_NOAPI(s)
 } /* end H5T__vlen_mem_str_getptr() */
@@ -629,7 +637,8 @@ H5T__vlen_mem_str_isnull(const H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, hb
 
     FUNC_ENTER_STATIC_NOERR
 
-    memcpy(&s, _vl, sizeof(char *));
+    /* Copy to ensure correct alignment. */
+    HDmemcpy(&s, _vl, sizeof(char *));
 
     *isnull = (s == NULL ? TRUE : FALSE);
 
@@ -684,7 +693,8 @@ H5T__vlen_mem_str_read(H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, void *buf,
         /* check parameters */
         HDassert(buf);
         HDassert(_vl);
-        memcpy(&s, _vl, sizeof(char *));
+        /* Copy to ensure correct alignment. */
+        HDmemcpy(&s, _vl, sizeof(char *));
 
         H5MM_memcpy(buf, s, len);
     } /* end if */

--- a/src/H5Tvlen.c
+++ b/src/H5Tvlen.c
@@ -369,11 +369,7 @@ done:
 static herr_t
 H5T__vlen_mem_seq_getlen(H5VL_object_t H5_ATTR_UNUSED *file, const void *_vl, size_t *len)
 {
-#ifdef H5_NO_ALIGNMENT_RESTRICTIONS
-    const hvl_t *vl = (const hvl_t *)_vl; /* Pointer to the user's hvl_t information */
-#else
     hvl_t vl; /* User's hvl_t information */
-#endif
 
     FUNC_ENTER_STATIC_NOERR
 
@@ -381,13 +377,9 @@ H5T__vlen_mem_seq_getlen(H5VL_object_t H5_ATTR_UNUSED *file, const void *_vl, si
     HDassert(_vl);
     HDassert(len);
 
-#ifdef H5_NO_ALIGNMENT_RESTRICTIONS
-    *len = vl->len;
-#else
-    H5MM_memcpy(&vl, _vl, sizeof(hvl_t));
+    memcpy(&vl, _vl, sizeof(hvl_t));
 
     *len = vl.len;
-#endif
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5T__vlen_mem_seq_getlen() */
@@ -407,25 +399,15 @@ H5T__vlen_mem_seq_getlen(H5VL_object_t H5_ATTR_UNUSED *file, const void *_vl, si
 static void *
 H5T__vlen_mem_seq_getptr(void *_vl)
 {
-#ifdef H5_NO_ALIGNMENT_RESTRICTIONS
-    const hvl_t *vl = (const hvl_t *)_vl; /* Pointer to the user's hvl_t information */
-#else
     hvl_t vl; /* User's hvl_t information */
-#endif
 
     FUNC_ENTER_STATIC_NOERR
 
     /* check parameters, return result */
-#ifdef H5_NO_ALIGNMENT_RESTRICTIONS
-    HDassert(vl);
-
-    FUNC_LEAVE_NOAPI(vl->p)
-#else
     HDassert(_vl);
-    H5MM_memcpy(&vl, _vl, sizeof(hvl_t));
+    memcpy(&vl, _vl, sizeof(hvl_t));
 
     FUNC_LEAVE_NOAPI(vl.p)
-#endif
 } /* end H5T__vlen_mem_seq_getptr() */
 
 /*-------------------------------------------------------------------------
@@ -443,24 +425,16 @@ H5T__vlen_mem_seq_getptr(void *_vl)
 static herr_t
 H5T__vlen_mem_seq_isnull(const H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, hbool_t *isnull)
 {
-#ifdef H5_NO_ALIGNMENT_RESTRICTIONS
-    const hvl_t *vl = (const hvl_t *)_vl; /* Pointer to the user's hvl_t information */
-#else
     hvl_t vl; /* User's hvl_t information */
-#endif
 
     FUNC_ENTER_STATIC_NOERR
 
     /* Check parameters */
     HDassert(_vl);
 
-#ifdef H5_NO_ALIGNMENT_RESTRICTIONS
-    *isnull = ((vl->len == 0 || vl->p == NULL) ? TRUE : FALSE);
-#else
-    H5MM_memcpy(&vl, _vl, sizeof(hvl_t));
+    memcpy(&vl, _vl, sizeof(hvl_t));
 
     *isnull = ((vl.len == 0 || vl.p == NULL) ? TRUE : FALSE);
-#endif
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5T__vlen_mem_seq_isnull() */
@@ -512,27 +486,17 @@ H5T__vlen_mem_seq_setnull(H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, void H5
 static herr_t
 H5T__vlen_mem_seq_read(H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, void *buf, size_t len)
 {
-#ifdef H5_NO_ALIGNMENT_RESTRICTIONS
-    const hvl_t *vl = (const hvl_t *)_vl; /* Pointer to the user's hvl_t information */
-#else
     hvl_t vl; /* User's hvl_t information */
-#endif
 
     FUNC_ENTER_STATIC_NOERR
 
     /* check parameters, copy data */
     HDassert(buf);
-#ifdef H5_NO_ALIGNMENT_RESTRICTIONS
-    HDassert(vl && vl->p);
-
-    H5MM_memcpy(buf, vl->p, len);
-#else
     HDassert(_vl);
-    H5MM_memcpy(&vl, _vl, sizeof(hvl_t));
+    memcpy(&vl, _vl, sizeof(hvl_t));
     HDassert(vl.p);
 
     H5MM_memcpy(buf, vl.p, len);
-#endif
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5T__vlen_mem_seq_read() */
@@ -606,20 +570,14 @@ done:
 static herr_t
 H5T__vlen_mem_str_getlen(H5VL_object_t H5_ATTR_UNUSED *file, const void *_vl, size_t *len)
 {
-#ifdef H5_NO_ALIGNMENT_RESTRICTIONS
-    const char *s = *(const char *const *)_vl; /* Pointer to the user's string information */
-#else
     const char *s = NULL; /* Pointer to the user's string information */
-#endif
 
     FUNC_ENTER_STATIC_NOERR
 
     /* check parameters */
     HDassert(_vl);
 
-#ifndef H5_NO_ALIGNMENT_RESTRICTIONS
-    H5MM_memcpy(&s, _vl, sizeof(char *));
-#endif
+    memcpy(&s, _vl, sizeof(char *));
 
     *len = HDstrlen(s);
 
@@ -641,21 +599,13 @@ H5T__vlen_mem_str_getlen(H5VL_object_t H5_ATTR_UNUSED *file, const void *_vl, si
 static void *
 H5T__vlen_mem_str_getptr(void *_vl)
 {
-#ifdef H5_NO_ALIGNMENT_RESTRICTIONS
-    char *s = *(char **)_vl; /* Pointer to the user's string information */
-#else
     char *      s = NULL; /* Pointer to the user's string information */
-#endif
 
     FUNC_ENTER_STATIC_NOERR
 
     /* check parameters */
-#ifdef H5_NO_ALIGNMENT_RESTRICTIONS
-    HDassert(s);
-#else
     HDassert(_vl);
-    H5MM_memcpy(&s, _vl, sizeof(char *));
-#endif
+    memcpy(&s, _vl, sizeof(char *));
 
     FUNC_LEAVE_NOAPI(s)
 } /* end H5T__vlen_mem_str_getptr() */
@@ -675,17 +625,11 @@ H5T__vlen_mem_str_getptr(void *_vl)
 static herr_t
 H5T__vlen_mem_str_isnull(const H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, hbool_t *isnull)
 {
-#ifdef H5_NO_ALIGNMENT_RESTRICTIONS
-    char *s = *(char **)_vl; /* Pointer to the user's string information */
-#else
     char *s = NULL; /* Pointer to the user's string information */
-#endif
 
     FUNC_ENTER_STATIC_NOERR
 
-#ifndef H5_NO_ALIGNMENT_RESTRICTIONS
-    H5MM_memcpy(&s, _vl, sizeof(char *));
-#endif
+    memcpy(&s, _vl, sizeof(char *));
 
     *isnull = (s == NULL ? TRUE : FALSE);
 
@@ -732,23 +676,15 @@ H5T__vlen_mem_str_setnull(H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, void H5
 static herr_t
 H5T__vlen_mem_str_read(H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, void *buf, size_t len)
 {
-#ifdef H5_NO_ALIGNMENT_RESTRICTIONS
-    char *s = *(char **)_vl; /* Pointer to the user's string information */
-#else
     char *s;        /* Pointer to the user's string information */
-#endif
 
     FUNC_ENTER_STATIC_NOERR
 
     if (len > 0) {
         /* check parameters */
         HDassert(buf);
-#ifdef H5_NO_ALIGNMENT_RESTRICTIONS
-        HDassert(s);
-#else
         HDassert(_vl);
-        H5MM_memcpy(&s, _vl, sizeof(char *));
-#endif
+        memcpy(&s, _vl, sizeof(char *));
 
         H5MM_memcpy(buf, s, len);
     } /* end if */

--- a/src/H5Tvlen.c
+++ b/src/H5Tvlen.c
@@ -599,7 +599,7 @@ H5T__vlen_mem_str_getlen(H5VL_object_t H5_ATTR_UNUSED *file, const void *_vl, si
 static void *
 H5T__vlen_mem_str_getptr(void *_vl)
 {
-    char *      s = NULL; /* Pointer to the user's string information */
+    char *s = NULL; /* Pointer to the user's string information */
 
     FUNC_ENTER_STATIC_NOERR
 
@@ -676,7 +676,7 @@ H5T__vlen_mem_str_setnull(H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, void H5
 static herr_t
 H5T__vlen_mem_str_read(H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, void *buf, size_t len)
 {
-    char *s;        /* Pointer to the user's string information */
+    char *s; /* Pointer to the user's string information */
 
     FUNC_ENTER_STATIC_NOERR
 


### PR DESCRIPTION
Do not conditionally compile code that uses a pointer dereference and assignment to copy a potentially unaligned variable to aligned automatic storage, or vice versa.  Instead, always use naked `memcpy(3)`s. Disassembling the generated code reveals that the `memcpy(3)`s optimize (`-O3`) to a single `mov` instruction for x86_64, which is not strict about alignment.

This change reduces the size of code and scripts by 143 lines, eases our way to cross-compilation, and avoids invoking undefined behavior.