### PR TITLE
Revert "Fix metadata cache bug when resizing a pinned/protected entry"

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -1082,23 +1082,6 @@ Bug Fixes since HDF5-1.12.0 release
 ===================================
     Library
     -------
-    - Fixed a metadata cache bug when resizing a pinned/protected cache entry
-
-      When resizing a pinned/protected cache entry, the metadata
-      cache code previously would wait until after resizing the
-      entry to attempt to log the newly-dirtied entry. This would
-      cause H5C_resize_entry to mark the entry as dirty and make
-      H5AC_resize_entry think that it doesn't need to add the
-      newly-dirtied entry to the dirty entries skiplist.
-    
-      Thus, a subsequent H5AC__log_moved_entry would think it
-      needs to allocate a new entry for insertion into the dirty
-      entry skip list, since the entry doesn't exist on that list.
-      This causes an assertion failure, as the code to allocate a
-      new entry assumes that the entry is not dirty.
-
-      (JTH - 2022/01/12)
-
     - Fixed an H5Pget_filter_by_id1/2() assert w/ out of range filter IDs
 
       Both H5Pget_filter_by_id1 and 2 did not range check the filter ID, which

--- a/src/H5AC.c
+++ b/src/H5AC.c
@@ -1440,6 +1440,10 @@ H5AC_resize_entry(void *thing, size_t new_size)
     cache_ptr = entry_ptr->cache_ptr;
     HDassert(cache_ptr);
 
+    /* Resize the entry */
+    if (H5C_resize_entry(thing, new_size) < 0)
+        HGOTO_ERROR(H5E_CACHE, H5E_CANTRESIZE, FAIL, "can't resize entry")
+
 #ifdef H5_HAVE_PARALLEL
     {
         H5AC_aux_t *aux_ptr;
@@ -1450,10 +1454,6 @@ H5AC_resize_entry(void *thing, size_t new_size)
                 HGOTO_ERROR(H5E_CACHE, H5E_CANTMARKDIRTY, FAIL, "can't log dirtied entry")
     }
 #endif /* H5_HAVE_PARALLEL */
-
-    /* Resize the entry */
-    if (H5C_resize_entry(thing, new_size) < 0)
-        HGOTO_ERROR(H5E_CACHE, H5E_CANTRESIZE, FAIL, "can't resize entry")
 
 done:
     /* If currently logging, generate a message */


### PR DESCRIPTION
Reverts HDFGroup/hdf5#1358