### PR TITLE
New API for memory management via VFDs

### DIFF
--- a/src/H5.c
+++ b/src/H5.c
@@ -1272,7 +1272,7 @@ H5allocate_memory2(hid_t file_id, size_t size, hbool_t clear)
         uint64_t               flags   = H5FD_CTL__FAIL_IF_UNKNOWN_FLAG;
 
         if (NULL == (file_driver = H5FD_get_file_driver(file_id)))
-            HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "unable to obtain file driver handle")
+            HGOTO_ERROR(H5E_VFL, H5E_BADID, NULL, "unable to obtain file driver handle")
 
         /* Initialize ctl alloc arguments */
         alloc_args.size      = size;
@@ -1398,7 +1398,7 @@ H5resize_memory2(hid_t file_id, void *mem, size_t size)
         uint64_t               flags   = H5FD_CTL__FAIL_IF_UNKNOWN_FLAG;
 
         if (NULL == (file_driver = H5FD_get_file_driver(file_id)))
-            HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "unable to obtain file driver handle")
+            HGOTO_ERROR(H5E_VFL, H5E_BADID, NULL, "unable to obtain file driver handle")
 
         /* Initialize ctl alloc arguments */
         alloc_args.size      = size;
@@ -1483,7 +1483,7 @@ H5free_memory2(hid_t file_id, void *mem)
         uint64_t               flags   = H5FD_CTL__FAIL_IF_UNKNOWN_FLAG;
 
         if (NULL == (file_driver = H5FD_get_file_driver(file_id)))
-            HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FALSE, "unable to obtain file driver handle")
+            HGOTO_ERROR(H5E_VFL, H5E_BADID, FALSE, "unable to obtain file driver handle")
 
         /* Initialize ctl alloc arguments */
         free_args.buf   = mem;

--- a/src/H5Eint.c
+++ b/src/H5Eint.c
@@ -955,3 +955,43 @@ H5E_dump_api_stack(hbool_t is_api)
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5E_dump_api_stack() */
+
+/*----------------------------------------------------------------------------
+ * Function:    H5E_last_error
+ *
+ * Purpose:     Private function to retrieve the major and minor numbers from
+ *              the most recent frame of the error stack.
+ *
+ * Return:      TRUE if the most recent error was successfully copied to the
+ *              provided arguments, FALSE otherwise.
+ *
+ * Programmer:	Lucas C. Villa Real
+ *              Tuesday, March 29, 2022
+ *
+ *----------------------------------------------------------------------------
+ */
+hbool_t
+H5E_last_error(hid_t *major, hid_t *minor)
+{
+    H5E_t   *estack    = NULL;  /* Error stack */
+    hbool_t  ret_value = FALSE; /* Return value */
+
+    FUNC_ENTER_NOAPI(FALSE)
+
+    /* Sanity check */
+    HDassert(major);
+    HDassert(minor);
+
+    estack = H5E__get_my_stack();
+    if (NULL == estack)
+        HGOTO_ERROR(H5E_ERROR, H5E_CANTGET, FALSE, "can't get current error stack")
+
+    if (estack->nused) {
+        *major = estack->slot[estack->nused-1].maj_num;
+        *minor = estack->slot[estack->nused-1].min_num;
+        ret_value = TRUE;
+    }
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5E_last_error() */

--- a/src/H5Eint.c
+++ b/src/H5Eint.c
@@ -957,7 +957,7 @@ H5E_dump_api_stack(hbool_t is_api)
 } /* end H5E_dump_api_stack() */
 
 /*----------------------------------------------------------------------------
- * Function:    H5E_last_error
+ * Function:    H5E_get_last_error
  *
  * Purpose:     Private function to retrieve the major and minor numbers from
  *              the most recent frame of the error stack.
@@ -971,7 +971,7 @@ H5E_dump_api_stack(hbool_t is_api)
  *----------------------------------------------------------------------------
  */
 hbool_t
-H5E_last_error(hid_t *major, hid_t *minor)
+H5E_get_last_error(hid_t *major, hid_t *minor)
 {
     H5E_t   *estack    = NULL;  /* Error stack */
     hbool_t  ret_value = FALSE; /* Return value */
@@ -994,4 +994,4 @@ H5E_last_error(hid_t *major, hid_t *minor)
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
-} /* end H5E_last_error() */
+} /* end H5E_get_last_error() */

--- a/src/H5Eprivate.h
+++ b/src/H5Eprivate.h
@@ -186,5 +186,6 @@ H5_DLL herr_t H5E_printf_stack(H5E_t *estack, const char *file, const char *func
                                hid_t maj_id, hid_t min_id, const char *fmt, ...) H5_ATTR_FORMAT(printf, 8, 9);
 H5_DLL herr_t H5E_clear_stack(H5E_t *estack);
 H5_DLL herr_t H5E_dump_api_stack(hbool_t is_api);
+H5_DLL hbool_t H5E_get_last_error(hid_t *major, hid_t *minor);
 
 #endif /* H5Eprivate_H */

--- a/src/H5FDdevelop.h
+++ b/src/H5FDdevelop.h
@@ -260,6 +260,8 @@ H5_DLL herr_t  H5FDlock(H5FD_t *file, hbool_t rw);
 H5_DLL herr_t  H5FDunlock(H5FD_t *file);
 H5_DLL herr_t  H5FDdelete(const char *name, hid_t fapl_id);
 H5_DLL herr_t  H5FDctl(H5FD_t *file, uint64_t op_code, uint64_t flags, const void *input, void **output);
+H5_DLL herr_t  H5FDalloc_mem(H5FD_t *file, H5FD_ctl_alloc_args_t *args, void **out);
+H5_DLL herr_t  H5FDfree_mem(H5FD_t *file, H5FD_ctl_free_args_t *args);
 
 #ifdef __cplusplus
 }

--- a/src/H5FDdevelop.h
+++ b/src/H5FDdevelop.h
@@ -260,8 +260,6 @@ H5_DLL herr_t  H5FDlock(H5FD_t *file, hbool_t rw);
 H5_DLL herr_t  H5FDunlock(H5FD_t *file);
 H5_DLL herr_t  H5FDdelete(const char *name, hid_t fapl_id);
 H5_DLL herr_t  H5FDctl(H5FD_t *file, uint64_t op_code, uint64_t flags, const void *input, void **output);
-H5_DLL herr_t  H5FDalloc_mem(H5FD_t *file, H5FD_ctl_alloc_args_t *args, void **out);
-H5_DLL herr_t  H5FDfree_mem(H5FD_t *file, H5FD_ctl_free_args_t *args);
 
 #ifdef __cplusplus
 }

--- a/src/H5FDmpio.c
+++ b/src/H5FDmpio.c
@@ -1956,7 +1956,7 @@ H5FD__mpio_ctl(H5FD_t *_file, uint64_t op_code, uint64_t flags, const void H5_AT
         default: /* unknown op code */
             if (flags & H5FD_CTL__FAIL_IF_UNKNOWN_FLAG) {
 
-                HGOTO_ERROR(H5E_VFL, H5E_FCNTL, FAIL, "unknown op_code and fail if unknown")
+                HGOTO_ERROR(H5E_VFL, H5E_UNSUPPORTED, FAIL, "unknown op_code and fail if unknown")
             }
             break;
     }

--- a/src/H5FDmulti.c
+++ b/src/H5FDmulti.c
@@ -2264,7 +2264,7 @@ H5FD_multi_ctl(H5FD_t *_file, uint64_t op_code, uint64_t flags, const void *inpu
         /* Unknown op code */
         default:
             if (flags & H5FD_CTL__FAIL_IF_UNKNOWN_FLAG)
-                H5Epush_ret(func, H5E_ERR_CLS, H5E_VFL, H5E_FCNTL,
+                H5Epush_ret(func, H5E_ERR_CLS, H5E_VFL, H5E_UNSUPPORTED,
                             "VFD ctl request failed (unknown op code and fail if unknown flag is set)", -1);
 
             break;

--- a/src/H5FDprivate.h
+++ b/src/H5FDprivate.h
@@ -148,6 +148,7 @@ H5_DLL herr_t  H5FD_delete(const char *name, hid_t fapl_id);
 H5_DLL herr_t  H5FD_ctl(H5FD_t *file, uint64_t op_code, uint64_t flags, const void *input, void **output);
 H5_DLL herr_t  H5FD_get_fileno(const H5FD_t *file, unsigned long *filenum);
 H5_DLL herr_t  H5FD_get_vfd_handle(H5FD_t *file, hid_t fapl, void **file_handle);
+H5_DLL H5FD_t *H5FD_get_file_driver(hid_t file_id);
 H5_DLL herr_t  H5FD_set_base_addr(H5FD_t *file, haddr_t base_addr);
 H5_DLL haddr_t H5FD_get_base_addr(const H5FD_t *file);
 H5_DLL herr_t  H5FD_set_paged_aggr(H5FD_t *file, hbool_t paged);

--- a/src/H5FDpublic.h
+++ b/src/H5FDpublic.h
@@ -196,6 +196,7 @@
 #define H5FD_CTL__MEM_ALLOC                   5
 #define H5FD_CTL__MEM_FREE                    6
 #define H5FD_CTL__MEM_COPY                    7
+#define H5FD_CTL__MEM_QUERY_SUPPORTED_FLAGS   8
 
 /* ctl function flags: */
 
@@ -390,6 +391,35 @@ typedef struct H5FD_ctl_memcpy_args_t {
     size_t      len;     /**< Length of data to copy from source buffer */
 } H5FD_ctl_memcpy_args_t;
 //! <!-- [H5FD_ctl_memcpy_args_t_snip] -->
+
+/**
+ * Define structure to hold "ctl memory alloc" parameters
+ */
+//! <!-- [H5FD_ctl_alloc_args_t_snip] -->
+typedef struct H5FD_ctl_alloc_args_t {
+    hsize_t       size;      /**< Memory allocation size */
+    hsize_t       alignment; /**< Desired memory alignment */
+    unsigned long flags;     /**< Request flags (H5FD_ALLOC*) */
+    const void   *args;      /**< Optional arguments wanted by the VFD given the request flags */
+} H5FD_ctl_alloc_args_t;
+//! <!-- [H5FD_ctl_alloc_args_t_snip] -->
+
+/**
+ * Define structure to hold "ctl memory free" parameters
+ */
+//! <!-- [H5FD_ctl_free_args_t_snip] -->
+typedef struct H5FD_ctl_free_args_t {
+    void         *buf;   /**< Pointer to memory space to be freed */
+    unsigned long flags; /**< Request flags (H5FD_MEM*) */
+    const void   *args;  /**< Optional arguments wanted by the VFD given the request flags */
+} H5FD_ctl_free_args_t;
+//! <!-- [H5FD_ctl_free_args_t_snip] -->
+
+/**
+ * H5FD_MEM request flags
+ */
+/* Handle memory request asynchronously */
+#define H5FD_MEM_ASYNC       0x00000001
 
 /********************/
 /* Public Variables */

--- a/src/H5FDpublic.h
+++ b/src/H5FDpublic.h
@@ -196,7 +196,7 @@
 #define H5FD_CTL__MEM_ALLOC                   5
 #define H5FD_CTL__MEM_FREE                    6
 #define H5FD_CTL__MEM_COPY                    7
-#define H5FD_CTL__MEM_QUERY_SUPPORTED_FLAGS   8
+#define H5FD_CTL__MEM_REALLOC                 8
 
 /* ctl function flags: */
 
@@ -400,7 +400,7 @@ typedef struct H5FD_ctl_alloc_args_t {
     hsize_t       size;      /**< Memory allocation size */
     hsize_t       alignment; /**< Desired memory alignment */
     unsigned long flags;     /**< Request flags (H5FD_ALLOC*) */
-    const void   *args;      /**< Optional arguments wanted by the VFD given the request flags */
+    void         *args;      /**< Optional arguments wanted by the VFD given the request flags */
 } H5FD_ctl_alloc_args_t;
 //! <!-- [H5FD_ctl_alloc_args_t_snip] -->
 
@@ -420,6 +420,8 @@ typedef struct H5FD_ctl_free_args_t {
  */
 /* Handle memory request asynchronously */
 #define H5FD_MEM_ASYNC       0x00000001
+/* Set memory values to zero */
+#define H5FD_MEM_CLEAR       0x00000002
 
 /********************/
 /* Public Variables */

--- a/src/H5FDsec2.c
+++ b/src/H5FDsec2.c
@@ -1085,7 +1085,7 @@ H5FD__sec2_ctl(H5FD_t *_file, uint64_t op_code, uint64_t flags, const void H5_AT
         /* Unknown op code */
         default:
             if (flags & H5FD_CTL__FAIL_IF_UNKNOWN_FLAG)
-                HGOTO_ERROR(H5E_VFL, H5E_FCNTL, FAIL, "unknown op_code and fail if unknown flag is set")
+                HGOTO_ERROR(H5E_VFL, H5E_UNSUPPORTED, FAIL, "unknown op_code and fail if unknown flag is set")
             break;
     }
 

--- a/src/H5Ipublic.h
+++ b/src/H5Ipublic.h
@@ -56,11 +56,6 @@ typedef enum H5I_type_t {
 } H5I_type_t;
 //! <!-- [H5I_type_t_snip] -->
 
-/**
- * Type of IDs to return to users
- */
-typedef int64_t hid_t;
-
 #define PRIdHID PRId64
 #define PRIxHID PRIx64
 #define PRIXHID PRIX64

--- a/src/H5Zdevelop.h
+++ b/src/H5Zdevelop.h
@@ -391,6 +391,21 @@ H5_DLL herr_t H5Zregister(const void *cls);
  * \since 1.6.0
  */
 H5_DLL herr_t H5Zunregister(H5Z_filter_t id);
+/**
+ * \ingroup H5Z
+ *
+ * \brief Retrieves the file identifier associated with an I/O filter pipeline
+ *
+ * \return \hid_t
+ *
+ * \details This function enables I/O filter callbacks to obtain the file
+ *          identifier associated with the data buffer being processed. It
+ *          can be called from any one of the  filter callback routines,
+ *          namely "can_apply", "set_local", and "filter".
+ *
+ * \since 1.13.0
+ */
+H5_DLL hid_t H5Zget_pipeline_file_id(void);
 
 #ifdef __cplusplus
 }

--- a/src/H5Zprivate.h
+++ b/src/H5Zprivate.h
@@ -80,12 +80,12 @@ H5_DLL herr_t H5Z_append(struct H5O_pline_t *pline, H5Z_filter_t filter, unsigne
                          const unsigned int cd_values[]);
 H5_DLL herr_t H5Z_modify(const struct H5O_pline_t *pline, H5Z_filter_t filter, unsigned flags,
                          size_t cd_nelmts, const unsigned int cd_values[]);
-H5_DLL herr_t H5Z_pipeline(const struct H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*in,out*/,
-                           H5Z_EDC_t edc_read, H5Z_cb_t cb_struct, size_t *nbytes /*in,out*/,
-                           size_t *buf_size /*in,out*/, void **buf /*in,out*/);
+H5_DLL herr_t H5Z_pipeline(const struct H5O_pline_t *pline, hid_t file_id, unsigned flags,
+                           unsigned *filter_mask /*in,out*/, H5Z_EDC_t edc_read, H5Z_cb_t cb_struct,
+                           size_t *nbytes /*in,out*/, size_t *buf_size /*in,out*/, void **buf /*in,out*/);
 H5_DLL H5Z_class2_t *H5Z_find(H5Z_filter_t id);
-H5_DLL herr_t        H5Z_can_apply(hid_t dcpl_id, hid_t type_id);
-H5_DLL herr_t        H5Z_set_local(hid_t dcpl_id, hid_t type_id);
+H5_DLL herr_t        H5Z_can_apply(hid_t file_id, hid_t dcpl_id, hid_t type_id);
+H5_DLL herr_t        H5Z_set_local(hid_t file_id, hid_t dcpl_id, hid_t type_id);
 H5_DLL herr_t        H5Z_can_apply_direct(const struct H5O_pline_t *pline);
 H5_DLL herr_t        H5Z_set_local_direct(const struct H5O_pline_t *pline);
 H5_DLL htri_t        H5Z_ignore_filters(hid_t dcpl_id, const H5T_t *type, const H5S_t *space);

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -258,6 +258,12 @@ typedef bool hbool_t;
  */
 typedef int htri_t;
 
+/**
+ * Type of IDs to return to users. See the definition of H5I_type_t on
+ * H5Ipublic.h for a list of possible values a hid_t can take.
+ */
+typedef int64_t hid_t;
+
 /* The signed version of size_t
  *
  * ssize_t is POSIX and not defined in any C standard. It's used in some
@@ -742,6 +748,7 @@ H5_DLL herr_t H5is_library_threadsafe(hbool_t *is_ts);
  *
  */
 H5_DLL herr_t H5free_memory(void *mem);
+H5_DLL herr_t H5free_memory2(hid_t file_id, void *mem);
 /**
  * \ingroup H5
  * \brief Frees memory allocated by the HDF5 library
@@ -798,6 +805,7 @@ H5_DLL herr_t H5free_memory(void *mem);
  *
  */
 H5_DLL void *H5allocate_memory(size_t size, hbool_t clear);
+H5_DLL void *H5allocate_memory2(hid_t file_id, size_t size, hbool_t clear);
 /**
  * \ingroup H5
  * \brief Resizes and, if required, re-allocates memory that will later be
@@ -872,6 +880,7 @@ H5_DLL void *H5allocate_memory(size_t size, hbool_t clear);
  *
  */
 H5_DLL void *H5resize_memory(void *mem, size_t size);
+H5_DLL void *H5resize_memory2(hid_t file_id, void *mem, size_t size);
 
 #ifdef __cplusplus
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -377,6 +377,7 @@ set (H5_TESTS
     timer
     cmpd_dtransform
     event_set
+    filter_file_id
 )
 if (HDF5_BUILD_UTILS)
   set (H5_TESTS ${H5_TESTS} mirror_vfd)

--- a/test/filter_file_id.c
+++ b/test/filter_file_id.c
@@ -1,0 +1,259 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by The HDF Group.                                               *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of HDF5. The full HDF5 copyright notice, including      *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the root of the source code       *
+ * distribution tree, or in https://www.hdfgroup.org/licenses.               *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*
+ * Programmer:	Lucas C. Villa Real
+ *              25 March 2022
+ *
+ * Purpose:	Tests H5Zget_pipeline_file_id() function
+ */
+#include "h5test.h"
+
+#include "H5CXprivate.h" /* API Contexts                         */
+
+const char *FILENAME[] = {"filter_file_id", NULL};
+
+#define GROUP_NAME        "test_group"
+#define DSET_NAME         "test_dataset"
+#define FILENAME_BUF_SIZE 1024
+#define DSET_DIM1         100
+#define DSET_DIM2         200
+#define FILTER_CHUNK_DIM1 2
+#define FILTER_CHUNK_DIM2 25
+#define GROUP_ITERATION   1000
+
+#define H5Z_FILTER_DUMMY 312
+
+static herr_t set_local_cb(hid_t dcpl_id, hid_t type_id, hid_t space_id);
+static htri_t can_apply_cb(hid_t dcpl_id, hid_t type_id, hid_t space_id);
+static size_t filter_cb(unsigned int flags, size_t cd_nelmts, const unsigned int *cd_values, size_t nbytes,
+                         size_t *buf_size, void **buf);
+
+/* Dummy filter for test_filters only */
+const H5Z_class2_t H5Z_DUMMY[1] = {{
+    H5Z_CLASS_T_VERS, /* H5Z_class_t version              */
+    H5Z_FILTER_DUMMY, /* Filter ID number                 */
+    1, 1,             /* Encoding and decoding enabled    */
+    "dummy",          /* Filter name for debugging        */
+    can_apply_cb,     /* The "can apply" callback         */
+    set_local_cb,     /* The "set local" callback         */
+    filter_cb,        /* The actual filter function       */
+}};
+
+/*-------------------------------------------------------------------------
+ * Function:    set_local_cb
+ *
+ * Purpose:     A dummy set_local method that doesn't do anything (except
+ *              for testing of API calls).
+ *
+ * Return:      Success: 0
+ *              Failure: -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t set_local_cb(hid_t dcpl_id, hid_t type_id, hid_t space_id)
+{
+    TESTING("I/O filter 'set_local' callback");
+    return 0;
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    can_apply_cb
+ *
+ * Purpose:     A dummy can_apply method that doesn't do anything (except
+ *              for testing of API calls).
+ *
+ * Return:      Success: 0
+ *              Failure: -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static htri_t can_apply_cb(hid_t dcpl_id, hid_t type_id, hid_t space_id)
+{
+    TESTING("I/O filter 'can_apply' callback");
+    return 0;
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    filter_cb
+ *
+ * Purpose:     A dummy compression method that doesn't do anything (except
+ *              for testing of API calls).
+ *
+ * Return:      Data chunk size
+ *
+ *-------------------------------------------------------------------------
+ */
+static size_t
+filter_cb(unsigned int H5_ATTR_UNUSED flags, size_t H5_ATTR_UNUSED cd_nelmts,
+           const unsigned int H5_ATTR_UNUSED *cd_values, size_t nbytes, size_t H5_ATTR_UNUSED *buf_size,
+           void H5_ATTR_UNUSED **buf)
+{
+    TESTING("I/O filter 'filter' callback");
+    return nbytes;
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    test_filter
+ *
+ * Purpose:     Tests filter callbacks
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+test_filter(hid_t fapl_id)
+{
+    hid_t         fid1     = H5I_INVALID_HID;
+    hid_t         dcpl_id  = H5I_INVALID_HID;
+    hid_t         gcpl_id  = H5I_INVALID_HID;
+    hid_t         gid      = H5I_INVALID_HID;
+    hid_t         gid_loop = H5I_INVALID_HID;
+    hid_t         did      = H5I_INVALID_HID;
+    hid_t         sid      = H5I_INVALID_HID;
+    int           i, j, n;
+    char          group_name[32];
+    char          filename[FILENAME_BUF_SIZE];
+    const hsize_t chunk_dims[2] = {FILTER_CHUNK_DIM1, FILTER_CHUNK_DIM2}; /* Chunk dimensions */
+    hsize_t       dims[2];
+    int **        buf      = NULL;
+    int *         buf_data = NULL;
+    herr_t        ret;
+
+    TESTING("Retrieval of pipeline file handle");
+
+    /* Set up data array */
+    if (NULL == (buf_data = (int *)HDcalloc(DSET_DIM1 * DSET_DIM2, sizeof(int))))
+        TEST_ERROR;
+    for (i = 0; i < DSET_DIM1 * DSET_DIM2; i++)
+        buf_data[i] = i;
+
+    /* Create file */
+    h5_fixname(FILENAME[0], fapl_id, filename, sizeof(filename));
+    if ((fid1 = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id)) < 0)
+        goto error;
+
+    /* Register DUMMY filter */
+    if (H5Zregister(H5Z_DUMMY) < 0)
+        goto error;
+    if (H5Zfilter_avail(H5Z_FILTER_DUMMY) != TRUE)
+        goto error;
+
+    /* Use DUMMY filter for creating datasets */
+    if ((dcpl_id = H5Pcreate(H5P_DATASET_CREATE)) < 0)
+        goto error;
+    if (H5Pset_chunk(dcpl_id, 2, chunk_dims) < 0)
+        goto error;
+    if (H5Pset_filter(dcpl_id, H5Z_FILTER_DUMMY, 0, (size_t)0, NULL) < 0)
+        goto error;
+
+    /* Create the dataspace */
+    dims[0] = DSET_DIM1;
+    dims[1] = DSET_DIM2;
+    if ((sid = H5Screate_simple(2, dims, NULL)) < 0)
+        goto error;
+
+    /* Create a dataset */
+    if ((did = H5Dcreate2(fid1, DSET_NAME, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl_id, H5P_DEFAULT)) < 0)
+        goto error;
+
+    /* Write the data to the dataset */
+    if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_data) < 0)
+        goto error;
+
+    /* Close the dataset */
+    if (H5Dclose(did) < 0)
+        goto error;
+
+    /* Unregister the filter */
+    if (H5Zunregister(H5Z_FILTER_DUMMY) < 0)
+        goto error;
+
+    /* Clean up objects used for this test */
+    if (H5Pclose(dcpl_id) < 0)
+        goto error;
+    if (H5Fclose(fid1) < 0)
+        goto error;
+
+    HDfree(buf_data);
+
+    PASSED();
+    return SUCCEED;
+
+error:
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(fid1);
+        H5Pclose(dcpl_id);
+        H5Pclose(gcpl_id);
+        H5Gclose(gid);
+        H5Gclose(gid_loop);
+        H5Dclose(did);
+        H5Sclose(sid);
+    }
+    H5E_END_TRY;
+
+    HDfree(buf_data);
+
+    return FAIL;
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    main
+ *
+ * Purpose:     Tests retrieval of pipeline's file handle
+ *
+ * Return:      EXIT_SUCCESS/EXIT_FAILURE
+ *
+ *-------------------------------------------------------------------------
+ */
+int
+main(void)
+{
+    hid_t   fapl_id        = H5I_INVALID_HID;
+    int     nerrors        = 0;
+    hbool_t api_ctx_pushed = FALSE; /* Whether API context pushed */
+
+    /* Testing setup */
+    h5_reset();
+    fapl_id = h5_fileaccess();
+
+    /* Push API context */
+    if (H5CX_push() < 0)
+        FAIL_STACK_ERROR
+    api_ctx_pushed = TRUE;
+
+    /* Test unregistering filter in its own file */
+    nerrors += (test_filter(fapl_id) < 0 ? 1 : 0);
+
+    h5_cleanup(FILENAME, fapl_id);
+
+    if (nerrors)
+        goto error;
+    HDprintf("All filter pipeline file handle tests passed.\n");
+
+    /* Pop API context */
+    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
+        FAIL_STACK_ERROR
+    api_ctx_pushed = FALSE;
+
+    HDexit(EXIT_SUCCESS);
+
+error:
+    nerrors = MAX(1, nerrors);
+    HDprintf("***** %d FILTER PIPELINE FILE HANDLE TEST%s FAILED! *****\n", nerrors, 1 == nerrors ? "" : "S");
+
+    if (api_ctx_pushed)
+        H5CX_pop(FALSE);
+
+    HDexit(EXIT_FAILURE);
+} /* end main() */

--- a/test/filter_file_id.c
+++ b/test/filter_file_id.c
@@ -17,27 +17,315 @@
  */
 #include "h5test.h"
 
-#include "H5CXprivate.h" /* API Contexts                         */
-
 const char *FILENAME[] = {"filter_file_id", NULL};
 
-#define GROUP_NAME        "test_group"
 #define DSET_NAME         "test_dataset"
 #define FILENAME_BUF_SIZE 1024
 #define DSET_DIM1         100
 #define DSET_DIM2         200
-#define FILTER_CHUNK_DIM1 2
-#define FILTER_CHUNK_DIM2 25
-#define GROUP_ITERATION   1000
 
 #define H5Z_FILTER_DUMMY 312
 
-static herr_t set_local_cb(hid_t dcpl_id, hid_t type_id, hid_t space_id);
-static htri_t can_apply_cb(hid_t dcpl_id, hid_t type_id, hid_t space_id);
-static size_t filter_cb(unsigned int flags, size_t cd_nelmts, const unsigned int *cd_values, size_t nbytes,
-                         size_t *buf_size, void **buf);
+/*
+ * Define a global file id that we can use to compare against the
+ * output of H5Zget_pipeline_file_id().
+ */
+static hid_t file_id_g = H5I_INVALID_HID;
 
-/* Dummy filter for test_filters only */
+
+/*
+ * Callbacks for test VFD
+ */
+typedef struct VFD_handle_t {
+    H5FD_t    driver_handle; /* public field, must be first */
+    char      name[256];
+    off_t     file_size;
+    haddr_t   eoa;
+    int       fd;
+} VFD_handle_t;
+
+static H5FD_t *
+H5FD__ctl_test_vfd_open(const char *name, unsigned H5_ATTR_UNUSED flags,
+                        hid_t H5_ATTR_UNUSED fapl_id, haddr_t H5_ATTR_UNUSED maxaddr)
+{
+    int           fd;
+    struct stat   statbuf;
+    VFD_handle_t *ret_val = NULL;
+
+    if ((fd = open(name, O_RDONLY)) < 0) {
+        HDprintf("Failed to open %s: %s\n", name, strerror(errno));
+        return NULL;
+    }
+
+    if (fstat(fd, &statbuf) < 0) {
+        HDprintf("Failed to stat %s: %s\n", name, strerror(errno));
+        close(fd);
+        return NULL;
+    }
+
+    ret_val = HDcalloc(1, sizeof(VFD_handle_t));
+    ret_val->file_size = statbuf.st_size;
+    ret_val->fd        = fd;
+    ret_val->eoa       = 0;
+    snprintf(ret_val->name, sizeof(ret_val->name)-1, "%s", name);
+
+    return (H5FD_t *) ret_val;
+}
+
+static herr_t
+H5FD__ctl_test_vfd_close(H5FD_t *_file)
+{
+    const VFD_handle_t *file_driver = (const VFD_handle_t *) _file;
+    close(file_driver->fd);
+    HDfree(_file);
+    return SUCCEED;
+}
+
+static haddr_t
+H5FD__ctl_test_vfd_get_eoa(const H5FD_t H5_ATTR_UNUSED *file, H5FD_mem_t H5_ATTR_UNUSED type)
+{
+    const VFD_handle_t *file_driver = (const VFD_handle_t *) file;
+    return (haddr_t) file_driver->eoa;
+}
+
+static herr_t
+H5FD__ctl_test_vfd_set_eoa(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t addr)
+{
+    VFD_handle_t *file_driver = (VFD_handle_t *) _file;
+    file_driver->eoa = addr;
+    return SUCCEED;
+}
+
+static haddr_t
+H5FD__ctl_test_vfd_get_eof(const H5FD_t H5_ATTR_UNUSED *file, H5FD_mem_t H5_ATTR_UNUSED type)
+{
+    const VFD_handle_t *file_driver = (const VFD_handle_t *) file;
+    return (haddr_t) file_driver->file_size;
+}
+
+static herr_t
+H5FD__ctl_test_vfd_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type,
+                        hid_t H5_ATTR_UNUSED fapl_id, haddr_t addr, size_t size,
+                        void *buf)
+{
+    const VFD_handle_t *file_driver = (const VFD_handle_t *) _file;
+    pread(file_driver->fd, buf, size, (off_t) addr);
+    return SUCCEED;
+}
+
+static herr_t
+H5FD__ctl_test_vfd_write(H5FD_t H5_ATTR_UNUSED *_file, H5FD_mem_t H5_ATTR_UNUSED type,
+                         hid_t H5_ATTR_UNUSED fapl_id, haddr_t H5_ATTR_UNUSED addr,
+                         size_t H5_ATTR_UNUSED size, const void H5_ATTR_UNUSED *buf)
+{
+    return FAIL;
+}
+
+static herr_t
+H5FD__ctl_test_vfd_ctl(H5FD_t H5_ATTR_UNUSED *_file, uint64_t op_code, uint64_t flags,
+                       const void *input, void **output)
+{
+    const H5FD_ctl_alloc_args_t *alloc_args;
+    const H5FD_ctl_free_args_t  *free_args;
+    herr_t                       ret_value = SUCCEED;
+
+    FUNC_ENTER_NOAPI(FAIL);
+
+    switch (op_code) {
+        case H5FD_CTL__MEM_ALLOC:
+            alloc_args = (const H5FD_ctl_alloc_args_t *) input;
+            if (alloc_args->flags & H5FD_MEM_CLEAR)
+                *output = calloc(sizeof(char), alloc_args->size);
+            else
+                *output = malloc(alloc_args->size);
+            break;
+        case H5FD_CTL__MEM_REALLOC:
+            alloc_args = (const H5FD_ctl_alloc_args_t *) input;
+            *output = alloc_args->args; /* quiet const warnings */
+            *output = realloc(*output, alloc_args->size);
+            break;
+        case H5FD_CTL__MEM_FREE:
+            free_args = (const H5FD_ctl_free_args_t *) input;
+            free(free_args->buf);
+            break;
+
+        /* Unknown op code */
+        default:
+            if (flags & H5FD_CTL__FAIL_IF_UNKNOWN_FLAG)
+                HGOTO_ERROR(H5E_VFL, H5E_UNSUPPORTED, FAIL, "unknown opcode")
+            break;
+    }
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+}
+
+static const H5FD_class_t H5FD_ctl_test_vfd_g = {
+    (H5FD_class_value_t)201,    /* value                 */
+    "ctl_test_vfd",             /* name                  */
+    HADDR_MAX,                  /* maxaddr               */
+    H5F_CLOSE_SEMI,             /* fc_degree             */
+    NULL,                       /* terminate             */
+    NULL,                       /* sb_size               */
+    NULL,                       /* sb_encode             */
+    NULL,                       /* sb_decode             */
+    0,                          /* fapl_size             */
+    NULL,                       /* fapl_get              */
+    NULL,                       /* fapl_copy             */
+    NULL,                       /* fapl_free             */
+    0,                          /* dxpl_size             */
+    NULL,                       /* dxpl_copy             */
+    NULL,                       /* dxpl_free             */
+    H5FD__ctl_test_vfd_open,    /* open                  */
+    H5FD__ctl_test_vfd_close,   /* close                 */
+    NULL,                       /* cmp                   */
+    NULL,                       /* query                 */
+    NULL,                       /* get_type_map          */
+    NULL,                       /* alloc                 */
+    NULL,                       /* free                  */
+    H5FD__ctl_test_vfd_get_eoa, /* get_eoa               */
+    H5FD__ctl_test_vfd_set_eoa, /* set_eoa               */
+    H5FD__ctl_test_vfd_get_eof, /* get_eof               */
+    NULL,                       /* get_handle            */
+    H5FD__ctl_test_vfd_read,    /* read                  */
+    H5FD__ctl_test_vfd_write,   /* write                 */
+    NULL,                       /* flush                 */
+    NULL,                       /* truncate              */
+    NULL,                       /* lock                  */
+    NULL,                       /* unlock                */
+    NULL,                       /* del                   */
+    H5FD__ctl_test_vfd_ctl,     /* ctl                   */
+    H5FD_FLMAP_DICHOTOMY        /* fl_map                */
+};
+
+
+/*
+ * Core test function
+ */
+static hbool_t
+check_pipeline_file_id(void)
+{
+    int     i;
+    void   *data = NULL;
+    size_t  alloc_size = 1024 * 1024 * 10;
+
+    /* Test H5Zget_pipeline_file_id */
+    hid_t pipeline_file_id = H5Zget_pipeline_file_id();
+    if (pipeline_file_id < 0) {
+        HDputs("failed to get file handle from pipeline");
+        return FALSE;
+    } else if (pipeline_file_id != file_id_g) {
+        HDprintf("unexpected file handle obtained. expected %ld, got %ld\n",
+            file_id_g, pipeline_file_id);
+        return FALSE;
+    }
+
+    /* Memory management functions loop. Here we test memory allocation
+     * with the clear flag set (e.g., calloc,memset) and unset (such as
+     * a plain malloc call).
+     */
+    for (i=0; i<2; ++i) {
+        hbool_t clear_mem = i == 0 ? FALSE : TRUE;
+
+        /* Test H5allocate_memory2 */
+        data = H5allocate_memory2(pipeline_file_id, alloc_size, clear_mem);
+        if (NULL == data) {
+            HDprintf("failed to allocate memory, clear flag=%d\n", clear_mem);
+            return FALSE;
+        }
+
+        /* Test H5resize_memory2 */
+        data = H5resize_memory2(pipeline_file_id, data, alloc_size * 2);
+        if (NULL == data) {
+            HDprintf("failed to resize memory\n");
+            return FALSE;
+        }
+
+        /* Test H5free_memory2 */
+        if (FAIL == H5free_memory2(pipeline_file_id, data)) {
+            HDprintf("failed to free memory\n");
+            return FALSE;
+        }
+    }
+
+    return TRUE;
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    set_local_cb
+ *
+ * Purpose:     A dummy set_local method that doesn't do anything (except
+ *              for testing of API calls).
+ *
+ * Return:      Success: 1
+ *              Failure: -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+set_local_cb(hid_t H5_ATTR_UNUSED dcpl_id,
+             hid_t H5_ATTR_UNUSED type_id,
+             hid_t H5_ATTR_UNUSED space_id)
+{
+    TESTING_2("I/O filter 'set_local' callback");
+
+    if (FALSE == check_pipeline_file_id())
+        return -1;
+
+    PASSED();
+    return 1;
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    can_apply_cb
+ *
+ * Purpose:     A dummy can_apply method that doesn't do anything (except
+ *              for testing of API calls).
+ *
+ * Return:      Success: 1
+ *              Failure: -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static htri_t
+can_apply_cb(hid_t H5_ATTR_UNUSED dcpl_id,
+             hid_t H5_ATTR_UNUSED type_id,
+             hid_t H5_ATTR_UNUSED space_id)
+{
+    TESTING_2("I/O filter 'can_apply' callback");
+
+    if (FALSE == check_pipeline_file_id())
+        return -1;
+
+    PASSED();
+    return 1;
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    filter_cb
+ *
+ * Purpose:     A dummy compression method that doesn't do anything (except
+ *              for testing of API calls).
+ *
+ * Return:      Data chunk size on success, 0 on failure.
+ *
+ *-------------------------------------------------------------------------
+ */
+static size_t
+filter_cb(unsigned int H5_ATTR_UNUSED flags, size_t H5_ATTR_UNUSED cd_nelmts,
+           const unsigned int H5_ATTR_UNUSED *cd_values, size_t nbytes, size_t H5_ATTR_UNUSED *buf_size,
+           void H5_ATTR_UNUSED **buf)
+{
+    TESTING_2("I/O filter 'filter' callback");
+
+    if (FALSE == check_pipeline_file_id())
+        return 0;
+
+    PASSED();
+    return nbytes;
+}
+
+/* Filter definition */
 const H5Z_class2_t H5Z_DUMMY[1] = {{
     H5Z_CLASS_T_VERS, /* H5Z_class_t version              */
     H5Z_FILTER_DUMMY, /* Filter ID number                 */
@@ -49,87 +337,26 @@ const H5Z_class2_t H5Z_DUMMY[1] = {{
 }};
 
 /*-------------------------------------------------------------------------
- * Function:    set_local_cb
+ * Function:    test_filter_write
  *
- * Purpose:     A dummy set_local method that doesn't do anything (except
- *              for testing of API calls).
- *
- * Return:      Success: 0
- *              Failure: -1
- *
- *-------------------------------------------------------------------------
- */
-static herr_t set_local_cb(hid_t dcpl_id, hid_t type_id, hid_t space_id)
-{
-    TESTING("I/O filter 'set_local' callback");
-    return 0;
-}
-
-/*-------------------------------------------------------------------------
- * Function:    can_apply_cb
- *
- * Purpose:     A dummy can_apply method that doesn't do anything (except
- *              for testing of API calls).
- *
- * Return:      Success: 0
- *              Failure: -1
- *
- *-------------------------------------------------------------------------
- */
-static htri_t can_apply_cb(hid_t dcpl_id, hid_t type_id, hid_t space_id)
-{
-    TESTING("I/O filter 'can_apply' callback");
-    return 0;
-}
-
-/*-------------------------------------------------------------------------
- * Function:    filter_cb
- *
- * Purpose:     A dummy compression method that doesn't do anything (except
- *              for testing of API calls).
- *
- * Return:      Data chunk size
- *
- *-------------------------------------------------------------------------
- */
-static size_t
-filter_cb(unsigned int H5_ATTR_UNUSED flags, size_t H5_ATTR_UNUSED cd_nelmts,
-           const unsigned int H5_ATTR_UNUSED *cd_values, size_t nbytes, size_t H5_ATTR_UNUSED *buf_size,
-           void H5_ATTR_UNUSED **buf)
-{
-    TESTING("I/O filter 'filter' callback");
-    return nbytes;
-}
-
-/*-------------------------------------------------------------------------
- * Function:    test_filter
- *
- * Purpose:     Tests filter callbacks
+ * Purpose:     Create an HDF5 file compressed with the H5Z_DUMMY filter.
  *
  * Return:      SUCCEED/FAIL
  *
  *-------------------------------------------------------------------------
  */
 static herr_t
-test_filter(hid_t fapl_id)
+test_filter_write(const char *filename, hid_t fapl_id)
 {
-    hid_t         fid1     = H5I_INVALID_HID;
     hid_t         dcpl_id  = H5I_INVALID_HID;
-    hid_t         gcpl_id  = H5I_INVALID_HID;
-    hid_t         gid      = H5I_INVALID_HID;
-    hid_t         gid_loop = H5I_INVALID_HID;
-    hid_t         did      = H5I_INVALID_HID;
-    hid_t         sid      = H5I_INVALID_HID;
-    int           i, j, n;
-    char          group_name[32];
-    char          filename[FILENAME_BUF_SIZE];
-    const hsize_t chunk_dims[2] = {FILTER_CHUNK_DIM1, FILTER_CHUNK_DIM2}; /* Chunk dimensions */
+    hid_t         dset_id  = H5I_INVALID_HID;
+    hid_t         space_id = H5I_INVALID_HID;
+    int           i;
+    const hsize_t chunk_dims[2] = {DSET_DIM1, DSET_DIM2};
     hsize_t       dims[2];
-    int **        buf      = NULL;
     int *         buf_data = NULL;
-    herr_t        ret;
 
-    TESTING("Retrieval of pipeline file handle");
+    HDprintf("Testing retrieval of pipeline file id and memory management VFD ctls\n");
 
     /* Set up data array */
     if (NULL == (buf_data = (int *)HDcalloc(DSET_DIM1 * DSET_DIM2, sizeof(int))))
@@ -138,8 +365,7 @@ test_filter(hid_t fapl_id)
         buf_data[i] = i;
 
     /* Create file */
-    h5_fixname(FILENAME[0], fapl_id, filename, sizeof(filename));
-    if ((fid1 = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id)) < 0)
+    if ((file_id_g = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id)) < 0)
         goto error;
 
     /* Register DUMMY filter */
@@ -159,46 +385,108 @@ test_filter(hid_t fapl_id)
     /* Create the dataspace */
     dims[0] = DSET_DIM1;
     dims[1] = DSET_DIM2;
-    if ((sid = H5Screate_simple(2, dims, NULL)) < 0)
+    if ((space_id = H5Screate_simple(2, dims, NULL)) < 0)
         goto error;
 
     /* Create a dataset */
-    if ((did = H5Dcreate2(fid1, DSET_NAME, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl_id, H5P_DEFAULT)) < 0)
+    if ((dset_id = H5Dcreate2(file_id_g, DSET_NAME, H5T_NATIVE_INT, space_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT)) < 0)
         goto error;
 
     /* Write the data to the dataset */
-    if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_data) < 0)
+    if (H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_data) < 0)
         goto error;
 
-    /* Close the dataset */
-    if (H5Dclose(did) < 0)
+    /* Clean up objects used for this test */
+    if (H5Dclose(dset_id) < 0)
+        goto error;
+    if (H5Sclose(space_id) < 0)
+        goto error;
+    if (H5Pclose(dcpl_id) < 0)
+        goto error;
+    if (H5Fclose(file_id_g) < 0)
         goto error;
 
     /* Unregister the filter */
     if (H5Zunregister(H5Z_FILTER_DUMMY) < 0)
         goto error;
 
-    /* Clean up objects used for this test */
-    if (H5Pclose(dcpl_id) < 0)
-        goto error;
-    if (H5Fclose(fid1) < 0)
-        goto error;
-
     HDfree(buf_data);
 
-    PASSED();
     return SUCCEED;
 
 error:
     H5E_BEGIN_TRY
     {
-        H5Fclose(fid1);
+        H5Dclose(dset_id);
+        H5Sclose(space_id);
         H5Pclose(dcpl_id);
-        H5Pclose(gcpl_id);
-        H5Gclose(gid);
-        H5Gclose(gid_loop);
-        H5Dclose(did);
-        H5Sclose(sid);
+        H5Fclose(file_id_g);
+    }
+    H5E_END_TRY;
+
+    HDfree(buf_data);
+
+    return FAIL;
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    test_filter_read
+ *
+ * Purpose:     Read an HDF5 file compressed with the H5Z_DUMMY filter.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+test_filter_read(const char *filename, hid_t fapl_id)
+{
+    hid_t         dset_id  = H5I_INVALID_HID;
+    int *         buf_data = NULL;
+
+    HDprintf("Testing retrieval of pipeline file id and memory management VFD ctls, custom VFD\n");
+
+    /* Register DUMMY filter */
+    if (H5Zregister(H5Z_DUMMY) < 0)
+        goto error;
+    if (H5Zfilter_avail(H5Z_FILTER_DUMMY) != TRUE)
+        goto error;
+
+    /* Set up data array */
+    if (NULL == (buf_data = (int *)HDcalloc(DSET_DIM1 * DSET_DIM2, sizeof(int))))
+        TEST_ERROR;
+
+    /* Create file */
+    if ((file_id_g = H5Fopen(filename, H5F_ACC_RDONLY, fapl_id)) < 0)
+        goto error;
+
+    /* Open the dataset */
+    if ((dset_id = H5Dopen2(file_id_g, DSET_NAME, H5P_DEFAULT)) < 0)
+        goto error;
+
+    /* Read the data from the dataset */
+    if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_data) < 0)
+        goto error;
+
+    /* Clean up objects used for this test */
+    if (H5Dclose(dset_id) < 0)
+        goto error;
+    if (H5Fclose(file_id_g) < 0)
+        goto error;
+
+    /* Unregister the filter */
+    if (H5Zunregister(H5Z_FILTER_DUMMY) < 0)
+        goto error;
+
+    HDfree(buf_data);
+
+    return SUCCEED;
+
+error:
+    H5E_BEGIN_TRY
+    {
+        H5Fclose(file_id_g);
+        H5Dclose(dset_id);
     }
     H5E_END_TRY;
 
@@ -219,21 +507,25 @@ error:
 int
 main(void)
 {
+    char    filename[FILENAME_BUF_SIZE];
     hid_t   fapl_id        = H5I_INVALID_HID;
+    hid_t   driver_id      = H5I_INVALID_HID;
     int     nerrors        = 0;
-    hbool_t api_ctx_pushed = FALSE; /* Whether API context pushed */
 
     /* Testing setup */
     h5_reset();
     fapl_id = h5_fileaccess();
+    h5_fixname(FILENAME[0], fapl_id, filename, sizeof(filename));
 
-    /* Push API context */
-    if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
-    api_ctx_pushed = TRUE;
+    /* Launch test with the default VFD */
+    nerrors += (test_filter_write(filename, fapl_id) < 0 ? 1 : 0);
 
-    /* Test unregistering filter in its own file */
-    nerrors += (test_filter(fapl_id) < 0 ? 1 : 0);
+    /* Launch test with our dummy VFD */
+    if ((driver_id = H5FDregister(&H5FD_ctl_test_vfd_g)) < 0)
+        PUTS_ERROR("failed to register VFD for testing");
+    if (H5Pset_driver(fapl_id, driver_id, NULL) < 0)
+        PUTS_ERROR("failed to set testing VFD on fapl");
+    nerrors += (test_filter_read(filename, fapl_id) < 0 ? 1 : 0);
 
     h5_cleanup(FILENAME, fapl_id);
 
@@ -241,19 +533,11 @@ main(void)
         goto error;
     HDprintf("All filter pipeline file handle tests passed.\n");
 
-    /* Pop API context */
-    if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
-    api_ctx_pushed = FALSE;
-
     HDexit(EXIT_SUCCESS);
 
 error:
     nerrors = MAX(1, nerrors);
     HDprintf("***** %d FILTER PIPELINE FILE HANDLE TEST%s FAILED! *****\n", nerrors, 1 == nerrors ? "" : "S");
-
-    if (api_ctx_pushed)
-        H5CX_pop(FALSE);
 
     HDexit(EXIT_FAILURE);
 } /* end main() */

--- a/test/vfd.c
+++ b/test/vfd.c
@@ -3915,6 +3915,109 @@ error:
 }
 
 /*-------------------------------------------------------------------------
+ * Function:    test_mem_ctl
+ *
+ * Purpose:     Tests memory-related "ctl" callbacks of the VFD driver
+ *
+ * Return:      Non-negative on success/Negative on failure
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+test_mem_ctl(const char *driver_name)
+{
+    H5FD_t                *file_drv_ptr = NULL;
+    uint64_t               ctl_flag;
+    hid_t                  fid      = H5I_INVALID_HID;
+    hid_t                  fapl_id  = H5I_INVALID_HID;
+    char                   filename[1024];
+    void                  *alloc_buf = NULL;
+    unsigned long          supported_flags, *flag_ptr;
+    H5FD_ctl_alloc_args_t  alloc_args;
+    H5FD_ctl_free_args_t   free_args;
+    char                   test_msg[64];
+
+    snprintf(test_msg, sizeof(test_msg), "VFD mem ctl callbacks (%s driver)", driver_name);
+    TESTING(test_msg);
+    HDputs("");
+
+    /* Register VFD for test */
+    if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0)
+        PUTS_ERROR("couldn't create FAPL");
+    if (H5Pset_driver_by_name(fapl_id, driver_name, NULL) < 0) {
+        snprintf(test_msg, sizeof(test_msg), "couldn't set %s VFD on FAPL", driver_name);
+        PUTS_ERROR(test_msg);
+    }
+
+    /* Reuse the filename delegated for test_ctl() */
+    h5_fixname(FILENAME[14], fapl_id, filename, sizeof(filename));
+
+    /* Make sure it's not present at the start of the test */
+    if (HDaccess(filename, F_OK) != -1)
+        if (HDremove(filename) < 0)
+            FAIL_PUTS_ERROR("unable to remove backing store file");
+
+    if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id)) < 0)
+        TEST_ERROR;
+    if (H5Fclose(fid) < 0)
+        TEST_ERROR;
+
+    if (NULL == (file_drv_ptr = H5FDopen(filename, H5F_ACC_RDWR, fapl_id, HADDR_UNDEF)))
+        PUTS_ERROR("couldn't get pointer to H5FD_t structure");
+
+    /* Query supported alloc flags */
+    TESTING_2("mem query supported flags")
+    flag_ptr = &supported_flags;
+    ctl_flag = 0 == strcmp(driver_name, "sec2") ? 0 : H5FD_CTL__FAIL_IF_UNKNOWN_FLAG;
+    if (H5FDctl(file_drv_ptr, H5FD_CTL__MEM_QUERY_SUPPORTED_FLAGS, ctl_flag, NULL, (void **) &flag_ptr) < 0)
+        TEST_ERROR;
+    PASSED();
+
+    /* Alloc + Free */
+    TESTING_2("mem_alloc")
+    memset(&alloc_args, 0, sizeof(alloc_args));
+    alloc_args.size = 1024 * 1024;
+    if (H5FDalloc_mem(file_drv_ptr, &alloc_args, &alloc_buf) < 0)
+        TEST_ERROR;
+    PASSED();
+
+    TESTING_2("mem_free");
+    memset(&free_args, 0, sizeof(free_args));
+    free_args.buf = alloc_buf;
+    if (H5FDfree_mem(file_drv_ptr, &free_args) < 0)
+        TEST_ERROR;
+    PASSED();
+
+    TESTING_2("test cleanup")
+
+    if (H5Pclose(fapl_id) < 0)
+        TEST_ERROR;
+
+    if (H5FDclose(file_drv_ptr) < 0)
+        PUTS_ERROR("couldn't close H5FD_t structure pointer");
+    file_drv_ptr = NULL;
+
+    if (HDaccess(filename, F_OK) != -1)
+        if (HDremove(filename) < 0)
+            FAIL_PUTS_ERROR("unable to remove backing store file");
+
+    PASSED();
+
+    return 0;
+
+error:
+    H5E_BEGIN_TRY
+    {
+        H5Pclose(fapl_id);
+        H5FDclose(file_drv_ptr);
+    }
+    H5E_END_TRY;
+
+    return -1;
+}
+
+
+/*-------------------------------------------------------------------------
  * Function:    main
  *
  * Purpose:     Tests the basic features of Virtual File Drivers
@@ -3957,6 +4060,7 @@ main(void)
     nerrors += test_ros3() < 0 ? 1 : 0;
     nerrors += test_splitter() < 0 ? 1 : 0;
     nerrors += test_ctl() < 0 ? 1 : 0;
+    nerrors += test_mem_ctl("sec2") < 0 ? 1 : 0;
 
     if (nerrors) {
         HDprintf("***** %d Virtual File Driver TEST%s FAILED! *****\n", nerrors, nerrors > 1 ? "S" : "");


### PR DESCRIPTION
With the introduction of VFD plugins, it is now possible to have virtual
file drivers that specialize on data transfer between storage and
hardware accelerators. The GDS (GPUDirect Storage) VFD is one such
example that enables I/O between NVMe storage and GPU memory.

GDS allocates device memory using vendor-specific APIs that are not meant
to be exposed elsewhere in the HDF5 core library. Yet, other components
such as I/O filters would benefit from having access to the memory
allocator used by the VFD, as that could save data copies across device
and host memory, for instance.

This commit introduces two high-level memory management interfaces that
enable memory allocation/deallocation through the VFD driver (falling
back to the existing `H5MM_malloc/xfree` functions when the VFD does not
provide a custom implementation). The functions are implemented on top
of the H5FD ctl interface and are described in details below.

`H5FDalloc_mem()`: allocate memory via the file driver. If the driver does
not support the `H5FD_CTL__MEM_ALLOC` opcode then the operation falls back
to allocation via system memory (i.e., `H5MM_malloc()`). The input
arguments to that CTL operation are given by the `H5FD_ctl_alloc_args_t`
structure:

```
typedef struct H5FD_ctl_alloc_args_t {
    hsize_t       size;      /**< Memory allocation size */
    hsize_t       alignment; /**< Desired memory alignment */
    unsigned long flags;     /**< Request flags (H5FD_ALLOC*) */
    const void   *args;      /**< Optional arguments wanted by the VFD
                                  given the request flags */
} H5FD_ctl_alloc_args_t;
```

The `flags` and `args` members have been introduced to support fancy
memory allocators such as `cudaMallocAsync()` (which takes a stream ID
as argument), and Xilinx' platform extension to OpenCL which enables
`clCreateBuffer()` to take a target memory bank ID argument.

`H5FDfree_mem()`: release memory previously allocated via `H5FDalloc_mem()`.
If the driver does not support the `H5FD_CTL__MEM_FREE` opcode, memory is
freed via `H5MM_xfree()`. Input arguments are given by the
`H5FD_ctl_free_args_t` structure:

```
typedef struct H5FD_ctl_free_args_t {
    void         *buf;   /**< Pointer to memory space to be freed */
    unsigned long flags; /**< Request flags (H5FD_MEM*) */
    const void   *args;  /**< Optional arguments wanted by the VFD
                              given the request flags */
} H5FD_ctl_free_args_t;
```

The same observations regarding `flags` and `args` apply here.

An application can query the supported flags by calling `H5FDctl` with
the new `H5FD_CTL__MEM_QUERY_SUPPORTED_FLAGS` opcode:

```
unsigned long supported_flags = 0;
unsigned long *flag_ptr = &supported_flags;
opcode = H5FD_CTL__MEM_QUERY_SUPPORTED_FLAGS;
H5FDctl(file_drv_ptr, opcode, 0, NULL, (void **) &flag_ptr);
```

This commit introduces a single `H5FD_MEM_ASYNC` flag. Other flags may be
added in the future depending on use-cases and demand.

Signed-off-by: Lucas C. Villa Real <lucasvr@br.ibm.com>