### PR TITLE
Fix for FSM section code bug when section shrinks

### DIFF
--- a/bin/checkposix
+++ b/bin/checkposix
@@ -115,7 +115,7 @@ foreach $arg (@ARGV) {
 
             # These are really HDF5 functions/macros even though they don't
             # start with `h' or `H'.
-            next if $name =~ /^FUNC_(ENTER|LEAVE)(_(NO)?API|_PACKAGE|_STATIC)?(_NOFS|_NOCLEAR|_NOINIT|_NOPUSH)?(_NOFUNC|_TAG)?$/;
+            next if $name =~ /^FUNC_(ENTER|LEAVE)(_(NO)?API|_PACKAGE|_STATIC)?(_NAMECHECK_ONLY|_NOFS|_NOCLEAR|_NOINIT|_NOPUSH)?(_NOFUNC|_TAG)?$/;
             next if $name =~ /^(BEGIN|END)_FUNC$/;
             next if $name =~ /^U?INT(8|16|32|64)(ENCODE|DECODE)(_VAR)?$/;
             next if $name =~ /^CI_(PRINT_STATS|INC_SRC|INC_DST)$/;
@@ -123,10 +123,13 @@ foreach $arg (@ARGV) {
             next if $name =~ /^(MIN3?|MAX3?|NELMTS|POWER_OF_TWO|REGION_OVERFLOW)$/;
             next if $name =~ /^(SIZE_OVERFLOW|UNIQUE_MEMBERS|S_ISDIR)$/;
             next if $name =~ /^addr_defined$/;
+            next if $name =~ /^TERMINATOR$/;
 
-            # These functions/macros are exempt.
-            # op, cb, and OP are often spuriously flagged so ignore them.
-            next if $name =~ /^(main|op|cb|OP)$/;
+            # Ignore callback invocation
+            next if $name =~ /^(op|cb|OP|iter_op|func)$/;
+
+            # Ignore main
+            next if $name =~ /^main$/;
 
             # This often appears in preprocessor lines that span multiple lines
             next if $name =~ /^(defined)$/;

--- a/src/H5AC.c
+++ b/src/H5AC.c
@@ -2432,7 +2432,7 @@ done:
 /*------------------------------------------------------------------------------
  * Function:    H5AC_expunge_tag_type_metadata()
  *
- * Purpose:     Wrapper for cache level function which expunge entries with
+ * Purpose:     Wrapper for cache level function which expunges entries with
  *              a specific tag and type id.
  *
  * Return:      SUCCEED on success, FAIL otherwise.

--- a/src/H5Cpkg.h
+++ b/src/H5Cpkg.h
@@ -53,7 +53,7 @@
 
 /* Cache configuration settings */
 #define H5C__HASH_TABLE_LEN     (64 * 1024) /* must be a power of 2 */
-#define H5C__H5C_T_MAGIC    0x005CAC0E
+#define H5C__H5C_T_MAGIC        0x005CAC0E
 
 
 /* Initial allocated size of the "flush_dep_parent" array */

--- a/src/H5Dmpio.c
+++ b/src/H5Dmpio.c
@@ -446,7 +446,7 @@ static FILE *            debug_stream             = NULL;
     do {                                                                                                     \
         if (debug_stream && H5D_MPIO_DEBUG_THIS_RANK(rank)) {                                                \
             HDfprintf(debug_stream, "%*s(Rank %d) " string "\n", debug_indent, "", rank);                    \
-            fflush(debug_stream);                                                                            \
+            HDfflush(debug_stream);                                                                          \
         }                                                                                                    \
     } while (0)
 
@@ -455,7 +455,7 @@ static FILE *            debug_stream             = NULL;
     do {                                                                                                     \
         if (debug_stream && H5D_MPIO_DEBUG_THIS_RANK(rank)) {                                                \
             HDfprintf(debug_stream, "%*s(Rank %d) " string "\n", debug_indent, "", rank, __VA_ARGS__);       \
-            fflush(debug_stream);                                                                            \
+            HDfflush(debug_stream);                                                                          \
         }                                                                                                    \
     } while (0)
 
@@ -465,7 +465,7 @@ static FILE *            debug_stream             = NULL;
                                                                                                              \
         if (trace_flag) {                                                                                    \
             H5D_MPIO_DEBUG_VA(rank, "%s%s", trace_in_pre, __func__);                                         \
-            debug_indent += (int)strlen(trace_in_pre);                                                       \
+            debug_indent += (int)HDstrlen(trace_in_pre);                                                     \
         }                                                                                                    \
     } while (0)
 
@@ -474,7 +474,7 @@ static FILE *            debug_stream             = NULL;
         hbool_t trace_flag = H5D_mpio_debug_flags_s[(int)'t'];                                               \
                                                                                                              \
         if (trace_flag) {                                                                                    \
-            debug_indent -= (int)strlen(trace_out_pre);                                                      \
+            debug_indent -= (int)HDstrlen(trace_out_pre);                                                    \
             H5D_MPIO_DEBUG_VA(rank, "%s%s", trace_out_pre, __func__);                                        \
         }                                                                                                    \
     } while (0)
@@ -1141,8 +1141,8 @@ H5D__chunk_collective_io(H5D_io_info_t *io_info, const H5D_type_info_t *type_inf
             HGOTO_ERROR(H5E_IO, H5E_OPENERROR, FAIL, "couldn't open debugging log file")
 
         /* Print a short header for this I/O operation */
-        time_now = time(NULL);
-        HDfprintf(debug_log_file, "##### %s", asctime(localtime(&time_now)));
+        time_now = HDtime(NULL);
+        HDfprintf(debug_log_file, "##### %s", HDasctime(HDlocaltime(&time_now)));
 
         debug_stream = debug_log_file;
     }

--- a/src/H5FDdevelop.h
+++ b/src/H5FDdevelop.h
@@ -223,6 +223,9 @@ struct H5FD_t {
     hbool_t paged_aggr; /* Paged aggregation for file space is enabled or not */
 };
 
+/* VFD initialization function */
+typedef hid_t (*H5FD_init_t)(void);
+
 /********************/
 /* Public Variables */
 /********************/
@@ -235,7 +238,7 @@ struct H5FD_t {
 extern "C" {
 #endif
 
-H5_DLL hid_t  H5FDperform_init(hid_t (*)(void));
+H5_DLL hid_t  H5FDperform_init(H5FD_init_t op);
 H5_DLL hid_t  H5FDregister(const H5FD_class_t *cls);
 H5_DLL htri_t H5FDis_driver_registered_by_name(const char *driver_name);
 H5_DLL htri_t H5FDis_driver_registered_by_value(H5FD_class_value_t driver_value);

--- a/src/H5FDfamily.c
+++ b/src/H5FDfamily.c
@@ -233,20 +233,20 @@ H5FD__family_get_default_printf_filename(const char *old_filename)
         HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "can't allocate new filename buffer")
 
     /* Determine if filename contains a ".h5" extension. */
-    if ((file_extension = strstr(old_filename, ".h5"))) {
+    if ((file_extension = HDstrstr(old_filename, ".h5"))) {
         /* Insert the printf format between the filename and ".h5" extension. */
         HDstrcpy(tmp_buffer, old_filename);
-        file_extension = strstr(tmp_buffer, ".h5");
+        file_extension = HDstrstr(tmp_buffer, ".h5");
         HDsprintf(file_extension, "%s%s", suffix, ".h5");
     }
-    else if ((file_extension = strrchr(old_filename, '.'))) {
+    else if ((file_extension = HDstrrchr(old_filename, '.'))) {
         char *new_extension_loc = NULL;
 
         /* If the filename doesn't contain a ".h5" extension, but contains
          * AN extension, just insert the printf format before that extension.
          */
         HDstrcpy(tmp_buffer, old_filename);
-        new_extension_loc = strrchr(tmp_buffer, '.');
+        new_extension_loc = HDstrrchr(tmp_buffer, '.');
         HDsprintf(new_extension_loc, "%s%s", suffix, file_extension);
     }
     else {

--- a/src/H5FDperform.c
+++ b/src/H5FDperform.c
@@ -29,13 +29,14 @@
  * Function:    H5FDperform_init
  *
  * Purpose:     Ensure that the library is initialized and then call
- *              the provided VFD initializer.
+ *              the provided VFD initializer
  *
- * Return:      Success:        identifier for the VFD just initialized
+ * Return:      Success:        Identifier for the VFD just initialized
  *              Failure:        H5I_INVALID_HID
  *-------------------------------------------------------------------------
  */
-hid_t H5FDperform_init(hid_t (*init)(void))
+hid_t
+H5FDperform_init(H5FD_init_t op)
 {
     hid_t ret_value = H5I_INVALID_HID; /* Return value */
 
@@ -43,16 +44,16 @@ hid_t H5FDperform_init(hid_t (*init)(void))
     /*NO TRACE*/
 
     /* It is possible that an application will evaluate an
-     * `H5FD_*` symbol (`H5FD_FAMILY`, `H5FD_MULTI`, `H5FD_SEC2`, et
-     * cetera) before the library has had an opportunity to initialize.
-     * Call H5_init_library() to make sure that the library has been
-     * initialized before `init` is run.
+     * `H5FD_*` symbol (`H5FD_FAMILY`, `H5FD_MULTI`, `H5FD_SEC2`, etc.
+     * before the library has had an opportunity to initialize. Call
+     * H5_init_library() to make sure that the library has been initialized
+     * before `init` is run.
      */
-    if (H5_init_library() < 0) {
+    if (H5_init_library() < 0)
         HGOTO_ERROR(H5E_FUNC, H5E_CANTINIT, H5I_INVALID_HID, "library initialization failed")
-    }
 
-    ret_value = init();
+    ret_value = op();
+
 done:
     FUNC_LEAVE_API_NOINIT(ret_value)
 }

--- a/src/H5FDsplitter.c
+++ b/src/H5FDsplitter.c
@@ -527,20 +527,20 @@ H5FD__splitter_get_default_wo_path(char *new_path, size_t new_path_len, const ch
         HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, "filename exceeds max length")
 
     /* Determine if filename contains a ".h5" extension. */
-    if ((file_extension = strstr(base_filename, ".h5"))) {
+    if ((file_extension = HDstrstr(base_filename, ".h5"))) {
         /* Insert the suffix between the filename and ".h5" extension. */
         HDstrcpy(new_path, base_filename);
-        file_extension = strstr(new_path, ".h5");
+        file_extension = HDstrstr(new_path, ".h5");
         HDsprintf(file_extension, "%s%s", suffix, ".h5");
     }
-    else if ((file_extension = strrchr(base_filename, '.'))) {
+    else if ((file_extension = HDstrrchr(base_filename, '.'))) {
         char *new_extension_loc = NULL;
 
         /* If the filename doesn't contain a ".h5" extension, but contains
          * AN extension, just insert the suffix before that extension.
          */
         HDstrcpy(new_path, base_filename);
-        new_extension_loc = strrchr(new_path, '.');
+        new_extension_loc = HDstrrchr(new_path, '.');
         HDsprintf(new_extension_loc, "%s%s", suffix, file_extension);
     }
     else {

--- a/src/H5FSsection.c
+++ b/src/H5FSsection.c
@@ -1601,7 +1601,7 @@ H5FS_sect_try_merge(H5F_t *f, H5FS_t *fspace, H5FS_section_info_t *sect, unsigne
     } /* end if */
     else {
         /* Check if section is merged */
-        if (sect->size > saved_fs_size) {
+        if (sect->size != saved_fs_size) {
             if (H5FS__sect_link(fspace, sect, flags) < 0)
                 HGOTO_ERROR(H5E_FSPACE, H5E_CANTINSERT, FAIL,
                             "can't insert free space section into skip list")

--- a/src/H5Oflush.c
+++ b/src/H5Oflush.c
@@ -37,7 +37,6 @@
 #include "H5CXprivate.h" /* API Contexts */
 #include "H5Dprivate.h"  /* Datasets */
 #include "H5Eprivate.h"  /* Errors   */
-#include "H5ESprivate.h" /* Event Sets */
 #include "H5Fprivate.h"  /* Files    */
 #include "H5Gprivate.h"  /* Groups   */
 #include "H5Iprivate.h"  /* IDs      */

--- a/src/H5Pfapl.c
+++ b/src/H5Pfapl.c
@@ -1248,8 +1248,8 @@ H5P_set_driver_by_name(H5P_genplist_t *plist, const char *driver_name, const cha
 
     FUNC_ENTER_NOAPI(FAIL)
 
-    assert(plist);
-    assert(driver_name);
+    HDassert(plist);
+    HDassert(driver_name);
 
     /* Register the driver */
     if ((new_driver_id = H5FD_register_driver_by_name(driver_name, app_ref)) < 0)
@@ -1336,8 +1336,8 @@ H5P_set_driver_by_value(H5P_genplist_t *plist, H5FD_class_value_t driver_value, 
 
     FUNC_ENTER_NOAPI(FAIL)
 
-    assert(plist);
-    assert(driver_value >= 0);
+    HDassert(plist);
+    HDassert(driver_value >= 0);
 
     /* Register the driver */
     if ((new_driver_id = H5FD_register_driver_by_value(driver_value, app_ref)) < 0)


### PR DESCRIPTION
If the FSM section is merged it could have shrunk (via H5MF__sect_large_shrink) so the > check is inappropriate and should be !=.