### PR TITLE
Fixes a bug in the FSM section merge code exposed by VFD SWMR

### DIFF
--- a/src/H5FSsection.c
+++ b/src/H5FSsection.c
@@ -1601,7 +1601,7 @@ H5FS_sect_try_merge(H5F_t *f, H5FS_t *fspace, H5FS_section_info_t *sect, unsigne
     } /* end if */
     else {
         /* Check if section is merged */
-        if (sect->size > saved_fs_size) {
+        if (sect->size != saved_fs_size) {
             if (H5FS__sect_link(fspace, sect, flags) < 0)
                 HGOTO_ERROR(H5E_FSPACE, H5E_CANTINSERT, FAIL,
                             "can't insert free space section into skip list")


### PR DESCRIPTION
From Vailin:

    Fix the FSM bug when setting the FSM threshold to a non-default value.
    Check for smaller or larger section size after merging and shrinking a
    section, for this case is the section that is smaller than threshold
    (see H5MF_xfree() in H5MF.c). It is possible for the section to be
    smaller after merging/shrinking (see H5MF__sect_large_shrink() in
    H5MFsection.c).