### PR TITLE
Removes cruft from a few header files

### DIFF
--- a/src/H5ACpublic.h
+++ b/src/H5ACpublic.h
@@ -28,10 +28,6 @@
 #include "H5public.h"
 #include "H5Cpublic.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /****************************************************************************
  *
  * structure H5AC_cache_config_t
@@ -783,7 +779,4 @@ typedef struct H5AC_cache_image_config_t {
 
 //! <!-- [H5AC_cache_image_config_t_snip] -->
 
-#ifdef __cplusplus
-}
-#endif
 #endif

--- a/src/H5CSprivate.h
+++ b/src/H5CSprivate.h
@@ -17,10 +17,6 @@
 #ifndef H5CSprivate_H
 #define H5CSprivate_H
 
-#ifdef NOT_YET
-#include "H5CSpublic.h"
-#endif /* NOT_YET */
-
 /* Private headers needed by this file */
 #include "H5private.h"
 

--- a/src/H5CXprivate.h
+++ b/src/H5CXprivate.h
@@ -16,11 +16,6 @@
 #ifndef H5CXprivate_H
 #define H5CXprivate_H
 
-/* Include package's public header */
-#ifdef NOT_YET
-#include "H5CXpublic.h"
-#endif /* NOT_YET */
-
 /* Private headers needed by this file */
 #include "H5private.h"   /* Generic Functions                    */
 #include "H5ACprivate.h" /* Metadata cache                       */

--- a/src/H5Cpublic.h
+++ b/src/H5Cpublic.h
@@ -27,10 +27,6 @@
 /* Public headers needed by this file */
 #include "H5public.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 enum H5C_cache_incr_mode {
     H5C_incr__off,
     /**<Automatic cache size increase is disabled, and the remaining increment fields are ignored.*/
@@ -61,7 +57,4 @@ enum H5C_cache_decr_mode {
     /**<Automatic cache size decrease is enabled using the ageout with hit rate threshold algorithm.*/
 };
 
-#ifdef __cplusplus
-}
-#endif
 #endif

--- a/src/H5EAprivate.h
+++ b/src/H5EAprivate.h
@@ -26,11 +26,6 @@
 #ifndef H5EAprivate_H
 #define H5EAprivate_H
 
-/* Include package's public header */
-#ifdef NOT_YET
-#include "H5EApublic.h"
-#endif /* NOT_YET */
-
 /* Private headers needed by this file */
 #include "H5ACprivate.h" /* Metadata cache               */
 #include "H5Fprivate.h"  /* File access                  */

--- a/src/H5FAprivate.h
+++ b/src/H5FAprivate.h
@@ -24,11 +24,6 @@
 #ifndef H5FAprivate_H
 #define H5FAprivate_H
 
-/* Include package's public header */
-#ifdef NOT_YET
-#include "H5FApublic.h"
-#endif /* NOT_YET */
-
 /* Private headers needed by this file */
 #include "H5ACprivate.h" /* Metadata cache               */
 #include "H5Fprivate.h"  /* File access                  */

--- a/src/H5PBprivate.h
+++ b/src/H5PBprivate.h
@@ -23,11 +23,6 @@
 #ifndef H5PBprivate_H
 #define H5PBprivate_H
 
-/* Include package's public header */
-#ifdef NOT_YET
-#include "H5PBpublic.h"
-#endif /* NOT_YET */
-
 /* Private headers needed by this header */
 #include "H5private.h"   /* Generic Functions			*/
 #include "H5Fprivate.h"  /* File access				*/


### PR DESCRIPTION
* Unnecessary extern C guards in cache headers
* Non-existent H5Xpublic.h includes hidden behind NOT_YET symbols