### PR TITLE
Removes bin/README

### DIFF
--- a/bin/README
+++ b/bin/README
@@ -1,2 +1,0 @@
-The daily tests run copies of some of the scripts in this directory from another repository, notably snapshot and runtest.  The copies in this directory should work, but are not used in daily tests, though they should be tested occasionally.  
-


### PR DESCRIPTION
This README file refers to scripts that were removed when the MANIFEST
went away.