### PR TITLE
Removes the STATIC flavor of FUNC_ENTER macros

### DIFF
--- a/src/H5A.c
+++ b/src/H5A.c
@@ -117,7 +117,7 @@ H5A__create_common(H5VL_object_t *vol_obj, H5VL_loc_params_t *loc_params, const 
     void *attr      = NULL;            /* Attribute created */
     hid_t ret_value = H5I_INVALID_HID; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(vol_obj);
@@ -162,7 +162,7 @@ H5A__create_api_common(hid_t loc_id, const char *attr_name, hid_t type_id, hid_t
     H5VL_loc_params_t loc_params;                     /* Location parameters for object access */
     hid_t             ret_value = H5I_INVALID_HID;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (H5I_ATTR == H5I_get_type(loc_id))
@@ -308,7 +308,7 @@ H5A__create_by_name_api_common(hid_t loc_id, const char *obj_name, const char *a
     H5VL_loc_params_t loc_params;                     /* Location parameters for object access */
     hid_t             ret_value = H5I_INVALID_HID;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (H5I_ATTR == H5I_get_type(loc_id))
@@ -453,7 +453,7 @@ H5A__open_common(H5VL_object_t *vol_obj, H5VL_loc_params_t *loc_params, const ch
     void *attr      = NULL; /* attr object from VOL connector */
     hid_t ret_value = H5I_INVALID_HID;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(vol_obj);
@@ -497,7 +497,7 @@ H5A__open_api_common(hid_t loc_id, const char *attr_name, hid_t aapl_id, void **
     H5VL_loc_params_t loc_params;                     /* Location parameters for object access */
     hid_t             ret_value = H5I_INVALID_HID;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (H5I_ATTR == H5I_get_type(loc_id))
@@ -619,7 +619,7 @@ H5A__open_by_name_api_common(hid_t loc_id, const char *obj_name, const char *att
     H5VL_loc_params_t loc_params;                     /* Location parameters for object access */
     hid_t             ret_value = H5I_INVALID_HID;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (H5I_ATTR == H5I_get_type(loc_id))
@@ -751,7 +751,7 @@ H5A__open_by_idx_api_common(hid_t loc_id, const char *obj_name, H5_index_t idx_t
     H5VL_loc_params_t loc_params;                     /* Location parameters for object access */
     hid_t             ret_value = H5I_INVALID_HID;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (H5I_ATTR == H5I_get_type(loc_id))
@@ -887,7 +887,7 @@ H5A__write_api_common(hid_t attr_id, hid_t type_id, const void *buf, void **toke
         (_vol_obj_ptr ? _vol_obj_ptr : &tmp_vol_obj); /* Ptr to object ptr for loc_id */
     herr_t ret_value = SUCCEED;                       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (H5I_DATATYPE != H5I_get_type(type_id))
@@ -995,7 +995,7 @@ H5A__read_api_common(hid_t attr_id, hid_t dtype_id, void *buf, void **token_ptr,
         (_vol_obj_ptr ? _vol_obj_ptr : &tmp_vol_obj); /* Ptr to object ptr for loc_id */
     herr_t ret_value = SUCCEED;                       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (H5I_DATATYPE != H5I_get_type(dtype_id))
@@ -1587,7 +1587,7 @@ H5A__rename_common(H5VL_object_t *vol_obj, H5VL_loc_params_t *loc_params, const 
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(vol_obj);
@@ -1632,7 +1632,7 @@ H5A__rename_api_common(hid_t loc_id, const char *old_name, const char *new_name,
     H5VL_loc_params_t loc_params;                     /* Location parameters for object access */
     herr_t            ret_value = SUCCEED;            /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (H5I_ATTR == H5I_get_type(loc_id))
@@ -1745,7 +1745,7 @@ H5A__rename_by_name_api_common(hid_t loc_id, const char *obj_name, const char *o
     H5VL_loc_params_t loc_params;                     /* Location parameters for object access */
     herr_t            ret_value = SUCCEED;            /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (H5I_ATTR == H5I_get_type(loc_id))
@@ -2330,7 +2330,7 @@ H5A__exists_common(H5VL_object_t *vol_obj, H5VL_loc_params_t *loc_params, const 
     H5VL_attr_specific_args_t vol_cb_args;         /* Arguments to VOL callback */
     herr_t                    ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(vol_obj);
@@ -2371,7 +2371,7 @@ H5A__exists_api_common(hid_t obj_id, const char *attr_name, hbool_t *attr_exists
     H5VL_loc_params_t loc_params;                     /* Location parameters for object access */
     herr_t            ret_value = SUCCEED;            /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (H5I_ATTR == H5I_get_type(obj_id))
@@ -2487,7 +2487,7 @@ H5A__exists_by_name_api_common(hid_t loc_id, const char *obj_name, const char *a
     H5VL_loc_params_t loc_params;                     /* Location parameters for object access */
     herr_t            ret_value = SUCCEED;            /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (H5I_ATTR == H5I_get_type(loc_id))

--- a/src/H5AC.c
+++ b/src/H5AC.c
@@ -2178,7 +2178,7 @@ H5AC__check_if_write_permitted(const H5F_t
 #endif /* H5_HAVE_PARALLEL */
     hbool_t write_permitted = TRUE;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #ifdef H5_HAVE_PARALLEL
     /* Sanity checks */
@@ -2225,7 +2225,7 @@ H5AC__ext_config_2_int_config(const H5AC_cache_config_t *ext_conf_ptr, H5C_auto_
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if ((ext_conf_ptr == NULL) || (ext_conf_ptr->version != H5AC__CURR_CACHE_CONFIG_VERSION) ||
         (int_conf_ptr == NULL))
@@ -2562,7 +2562,7 @@ H5AC__verify_tag(const H5AC_class_t *type)
     haddr_t tag;                 /* Entry tag to validate */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get the current tag */
     tag = H5CX_get_tag();

--- a/src/H5ACmpio.c
+++ b/src/H5ACmpio.c
@@ -273,7 +273,7 @@ H5AC__broadcast_candidate_list(H5AC_t *cache_ptr, unsigned *num_entries_ptr, had
     unsigned    num_entries;
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(cache_ptr != NULL);
@@ -353,7 +353,7 @@ H5AC__broadcast_clean_list_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_uda
     H5AC_addr_list_ud_t *udata           = (H5AC_addr_list_ud_t *)_udata; /* Context for callback */
     haddr_t              addr;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(slist_entry_ptr);
@@ -406,7 +406,7 @@ H5AC__broadcast_clean_list(H5AC_t *cache_ptr)
     unsigned    num_entries = 0;
     herr_t      ret_value   = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(cache_ptr != NULL);
@@ -493,7 +493,7 @@ H5AC__construct_candidate_list(H5AC_t *cache_ptr, H5AC_aux_t H5_ATTR_NDEBUG_UNUS
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(cache_ptr != NULL);
@@ -549,7 +549,7 @@ H5AC__copy_candidate_list_to_buffer_cb(void *_item, void H5_ATTR_UNUSED *_key, v
     H5AC_slist_entry_t * slist_entry_ptr = (H5AC_slist_entry_t *)_item;   /* Address of item */
     H5AC_addr_list_ud_t *udata           = (H5AC_addr_list_ud_t *)_udata; /* Context for callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(slist_entry_ptr);
@@ -607,7 +607,7 @@ H5AC__copy_candidate_list_to_buffer(const H5AC_t *cache_ptr, unsigned *num_entri
     unsigned            num_entries = 0;
     herr_t              ret_value   = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(cache_ptr != NULL);
@@ -1221,7 +1221,7 @@ H5AC__propagate_and_apply_candidate_list(H5F_t *f)
     unsigned    num_candidates = 0;
     herr_t      ret_value      = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f != NULL);
@@ -1384,7 +1384,7 @@ H5AC__propagate_flushed_and_still_clean_entries_list(H5F_t *f)
     H5AC_aux_t *aux_ptr;
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f != NULL);
@@ -1435,7 +1435,7 @@ H5AC__receive_haddr_list(MPI_Comm mpi_comm, unsigned *num_entries_ptr, haddr_t *
     unsigned num_entries;
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(num_entries_ptr != NULL);
@@ -1507,7 +1507,7 @@ H5AC__receive_and_apply_clean_list(H5F_t *f)
     unsigned    num_entries   = 0;
     herr_t      ret_value     = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f != NULL);
@@ -1567,7 +1567,7 @@ H5AC__receive_candidate_list(const H5AC_t *cache_ptr, unsigned *num_entries_ptr,
     H5AC_aux_t *aux_ptr;
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(cache_ptr != NULL);
@@ -1648,7 +1648,7 @@ H5AC__rsp__dist_md_write__flush(H5F_t *f)
     unsigned    num_entries = 0;
     herr_t      ret_value   = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f != NULL);
@@ -1792,7 +1792,7 @@ H5AC__rsp__dist_md_write__flush_to_min_clean(H5F_t *f)
     hbool_t     evictions_enabled;
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f != NULL);
@@ -1873,7 +1873,7 @@ H5AC__rsp__p0_only__flush(H5F_t *f)
     int         mpi_result;
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f != NULL);
@@ -1987,7 +1987,7 @@ H5AC__rsp__p0_only__flush_to_min_clean(H5F_t *f)
     hbool_t     evictions_enabled;
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f != NULL);
@@ -2236,7 +2236,7 @@ H5AC__tidy_cache_0_lists(H5AC_t *cache_ptr, unsigned num_candidates, haddr_t *ca
     H5AC_aux_t *aux_ptr;
     unsigned    u;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(cache_ptr != NULL);

--- a/src/H5ACproxy_entry.c
+++ b/src/H5ACproxy_entry.c
@@ -249,7 +249,7 @@ H5AC__proxy_entry_add_child_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_ud
     H5AC_proxy_entry_t *pentry    = (H5AC_proxy_entry_t *)_udata; /* Pointer to the proxy entry */
     int                 ret_value = H5_ITER_CONT;                 /* Callback return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Add flush dependency on parent for proxy entry */
     if (H5AC_create_flush_dependency(parent, pentry) < 0)
@@ -342,7 +342,7 @@ H5AC__proxy_entry_remove_child_cb(void *_item, void H5_ATTR_UNUSED *_key, void *
     H5AC_proxy_entry_t *pentry    = (H5AC_proxy_entry_t *)_udata; /* Pointer to the proxy entry */
     int                 ret_value = H5_ITER_CONT;                 /* Callback return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Remove flush dependency on parent for proxy entry */
     if (H5AC_destroy_flush_dependency(parent, pentry) < 0)
@@ -451,7 +451,7 @@ H5AC_proxy_entry_dest(H5AC_proxy_entry_t *pentry)
 static herr_t
 H5AC__proxy_entry_image_len(const void H5_ATTR_UNUSED *thing, size_t *image_len)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image_len);
@@ -480,7 +480,7 @@ static herr_t
 H5AC__proxy_entry_serialize(const H5F_t H5_ATTR_UNUSED *f, void H5_ATTR_UNUSED *image,
                             size_t H5_ATTR_UNUSED len, void H5_ATTR_UNUSED *thing)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         /* Should never be invoked */
         HDassert(0 && "Invalid callback?!?");
@@ -508,7 +508,7 @@ H5AC__proxy_entry_notify(H5AC_notify_action_t action, void *_thing)
     H5AC_proxy_entry_t *pentry    = (H5AC_proxy_entry_t *)_thing;
     herr_t              ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(pentry);
@@ -632,7 +632,7 @@ H5AC__proxy_entry_free_icr(void *_thing)
     H5AC_proxy_entry_t *pentry    = (H5AC_proxy_entry_t *)_thing;
     herr_t              ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Destroy the proxy entry */
     if (H5AC_proxy_entry_dest(pentry) < 0)

--- a/src/H5Abtree2.c
+++ b/src/H5Abtree2.c
@@ -152,7 +152,7 @@ H5A__dense_fh_name_cmp(const void *obj, size_t obj_len, void *_udata)
     hbool_t took_ownership = FALSE;   /* Whether the "found" operator took ownership of the attribute */
     herr_t  ret_value      = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Decode attribute information */
     if (NULL ==
@@ -203,7 +203,7 @@ H5A__dense_btree2_name_store(void *_nrecord, const void *_udata)
     const H5A_bt2_ud_ins_t *  udata   = (const H5A_bt2_ud_ins_t *)_udata;
     H5A_dense_bt2_name_rec_t *nrecord = (H5A_dense_bt2_name_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Copy user information info native record */
     nrecord->id     = udata->id;
@@ -235,7 +235,7 @@ H5A__dense_btree2_name_compare(const void *_bt2_udata, const void *_bt2_rec, int
     const H5A_dense_bt2_name_rec_t *bt2_rec   = (const H5A_dense_bt2_name_rec_t *)_bt2_rec;
     herr_t                          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(bt2_udata);
@@ -301,7 +301,7 @@ H5A__dense_btree2_name_encode(uint8_t *raw, const void *_nrecord, void H5_ATTR_U
 {
     const H5A_dense_bt2_name_rec_t *nrecord = (const H5A_dense_bt2_name_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Encode the record's fields */
     H5MM_memcpy(raw, nrecord->id.id, (size_t)H5O_FHEAP_ID_LEN);
@@ -331,7 +331,7 @@ H5A__dense_btree2_name_decode(const uint8_t *raw, void *_nrecord, void H5_ATTR_U
 {
     H5A_dense_bt2_name_rec_t *nrecord = (H5A_dense_bt2_name_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Decode the record's fields */
     H5MM_memcpy(nrecord->id.id, raw, (size_t)H5O_FHEAP_ID_LEN);
@@ -362,7 +362,7 @@ H5A__dense_btree2_name_debug(FILE *stream, int indent, int fwidth, const void *_
 {
     const H5A_dense_bt2_name_rec_t *nrecord = (const H5A_dense_bt2_name_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDfprintf(stream, "%*s%-*s {%016" PRIx64 ", %02" PRIx8 ", %u, %08" PRIx32 "}\n", indent, "", fwidth,
               "Record:", nrecord->id.val, nrecord->flags, (unsigned)nrecord->corder, nrecord->hash);
@@ -389,7 +389,7 @@ H5A__dense_btree2_corder_store(void *_nrecord, const void *_udata)
     const H5A_bt2_ud_ins_t *    udata   = (const H5A_bt2_ud_ins_t *)_udata;
     H5A_dense_bt2_corder_rec_t *nrecord = (H5A_dense_bt2_corder_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Copy user information info native record */
     nrecord->id     = udata->id;
@@ -419,7 +419,7 @@ H5A__dense_btree2_corder_compare(const void *_bt2_udata, const void *_bt2_rec, i
     const H5A_bt2_ud_common_t *       bt2_udata = (const H5A_bt2_ud_common_t *)_bt2_udata;
     const H5A_dense_bt2_corder_rec_t *bt2_rec   = (const H5A_dense_bt2_corder_rec_t *)_bt2_rec;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(bt2_udata);
@@ -454,7 +454,7 @@ H5A__dense_btree2_corder_encode(uint8_t *raw, const void *_nrecord, void H5_ATTR
 {
     const H5A_dense_bt2_corder_rec_t *nrecord = (const H5A_dense_bt2_corder_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Encode the record's fields */
     H5MM_memcpy(raw, nrecord->id.id, (size_t)H5O_FHEAP_ID_LEN);
@@ -483,7 +483,7 @@ H5A__dense_btree2_corder_decode(const uint8_t *raw, void *_nrecord, void H5_ATTR
 {
     H5A_dense_bt2_corder_rec_t *nrecord = (H5A_dense_bt2_corder_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Decode the record's fields */
     H5MM_memcpy(nrecord->id.id, raw, (size_t)H5O_FHEAP_ID_LEN);
@@ -513,7 +513,7 @@ H5A__dense_btree2_corder_debug(FILE *stream, int indent, int fwidth, const void 
 {
     const H5A_dense_bt2_corder_rec_t *nrecord = (const H5A_dense_bt2_corder_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDfprintf(stream, "%*s%-*s {%016" PRIx64 ", %02" PRIx8 ", %u}\n", indent, "", fwidth,
               "Record:", nrecord->id.val, nrecord->flags, (unsigned)nrecord->corder);

--- a/src/H5Adense.c
+++ b/src/H5Adense.c
@@ -277,7 +277,7 @@ H5A__dense_fnd_cb(const H5A_t *attr, hbool_t *took_ownership, void *_user_attr)
     const H5A_t **user_attr = (const H5A_t **)_user_attr; /* User data from v2 B-tree attribute lookup */
     herr_t        ret_value = SUCCEED;                    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(attr);
@@ -580,7 +580,7 @@ H5A__dense_write_bt2_cb2(void *_record, void *_op_data, hbool_t *changed)
     H5A_dense_bt2_corder_rec_t *record = (H5A_dense_bt2_corder_rec_t *)_record; /* Record from B-tree */
     H5O_fheap_id_t *new_heap_id        = (H5O_fheap_id_t *)_op_data; /* "op data" from v2 B-tree modify */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(record);
@@ -617,7 +617,7 @@ H5A__dense_write_bt2_cb(void *_record, void *_op_data, hbool_t *changed)
     uint8_t                   attr_buf[H5A_ATTR_BUF_SIZE]; /* Buffer for serializing attribute */
     herr_t                    ret_value = SUCCEED;         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(record);
@@ -820,7 +820,7 @@ H5A__dense_copy_fh_cb(const void *obj, size_t obj_len, void *_udata)
     H5A_fh_ud_cp_t *udata     = (H5A_fh_ud_cp_t *)_udata; /* User data for fractal heap 'op' callback */
     herr_t          ret_value = SUCCEED;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Decode attribute information & keep a copy */
     /* (we make a copy instead of calling the user/library callback directly in
@@ -1046,7 +1046,7 @@ H5A__dense_iterate_bt2_cb(const void *_record, void *_bt2_udata)
     H5A_bt2_ud_it_t *bt2_udata = (H5A_bt2_ud_it_t *)_bt2_udata; /* User data for callback */
     herr_t           ret_value = H5_ITER_CONT;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check for skipping attributes */
     if (bt2_udata->skip > 0)
@@ -1276,7 +1276,7 @@ H5A__dense_remove_bt2_cb(const void *_record, void *_udata)
     H5B2_t *bt2_corder = NULL;    /* v2 B-tree handle for creation order index */
     herr_t  ret_value  = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check for removing the link from the creation order index */
     if (H5F_addr_defined(udata->corder_bt2_addr)) {
@@ -1428,7 +1428,7 @@ H5A__dense_remove_by_idx_bt2_cb(const void *_record, void *_bt2_udata)
     hbool_t use_sh_loc;          /* Whether to use the attribute's shared location or the separate one */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Set up the user data for fractal heap 'op' callback */
     fh_udata.f      = bt2_udata->f;
@@ -1762,7 +1762,7 @@ H5A__dense_delete_bt2_cb(const void *_record, void *_bt2_udata)
     H5A_t *              attr      = NULL;                              /* Attribute being removed */
     herr_t               ret_value = SUCCEED;                           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check for shared attribute */
     if (record->flags & H5O_MSG_FLAG_SHARED) {

--- a/src/H5Aint.c
+++ b/src/H5Aint.c
@@ -474,7 +474,7 @@ H5A__open_common(const H5G_loc_t *loc, H5A_t *attr)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(loc);
@@ -1249,7 +1249,7 @@ H5A__close_cb(H5VL_object_t *attr_vol_obj, void **request)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(attr_vol_obj);
@@ -1478,7 +1478,7 @@ H5A__compact_build_table_cb(H5O_t H5_ATTR_UNUSED *oh, H5O_mesg_t *mesg /*in,out*
     H5A_compact_bt_ud_t *udata     = (H5A_compact_bt_ud_t *)_udata; /* Operator user data */
     herr_t               ret_value = H5_ITER_CONT;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(mesg);
@@ -1594,7 +1594,7 @@ H5A__dense_build_table_cb(const H5A_t *attr, void *_udata)
     H5A_dense_bt_ud_t *udata     = (H5A_dense_bt_ud_t *)_udata; /* 'User data' passed in */
     herr_t             ret_value = H5_ITER_CONT;                /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(attr);
@@ -1720,7 +1720,7 @@ done:
 static int
 H5A__attr_cmp_name_inc(const void *attr1, const void *attr2)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(
         HDstrcmp((*(const H5A_t *const *)attr1)->shared->name, (*(const H5A_t *const *)attr2)->shared->name))
@@ -1746,7 +1746,7 @@ H5A__attr_cmp_name_inc(const void *attr1, const void *attr2)
 static int
 H5A__attr_cmp_name_dec(const void *attr1, const void *attr2)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(
         HDstrcmp((*(const H5A_t *const *)attr2)->shared->name, (*(const H5A_t *const *)attr1)->shared->name))
@@ -1773,7 +1773,7 @@ H5A__attr_cmp_corder_inc(const void *attr1, const void *attr2)
 {
     int ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if ((*(const H5A_t *const *)attr1)->shared->crt_idx < (*(const H5A_t *const *)attr2)->shared->crt_idx)
         ret_value = -1;
@@ -1807,7 +1807,7 @@ H5A__attr_cmp_corder_dec(const void *attr1, const void *attr2)
 {
     int ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if ((*(const H5A_t *const *)attr1)->shared->crt_idx < (*(const H5A_t *const *)attr2)->shared->crt_idx)
         ret_value = 1;
@@ -1835,7 +1835,7 @@ H5A__attr_cmp_corder_dec(const void *attr1, const void *attr2)
 static herr_t
 H5A__attr_sort_table(H5A_attr_table_t *atable, H5_index_t idx_type, H5_iter_order_t order)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(atable);
@@ -2503,7 +2503,7 @@ H5A__dense_post_copy_file_cb(const H5A_t *attr_src, void *_udata)
     H5A_t *                 attr_dst  = NULL;
     herr_t                  ret_value = H5_ITER_CONT; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(attr_src);
@@ -2653,7 +2653,7 @@ H5A__iterate_common(hid_t loc_id, H5_index_t idx_type, H5_iter_order_t order, hs
     hsize_t last_attr;           /* Index of last attribute examined */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Call attribute iteration routine */
     last_attr = start_idx = (idx ? *idx : 0);

--- a/src/H5B.c
+++ b/src/H5B.c
@@ -388,7 +388,7 @@ H5B__split(H5F_t *f, H5B_ins_ud_t *bt_ud, unsigned idx, void *udata, H5B_ins_ud_
     double         split_ratios[3];     /* B-tree split ratios */
     herr_t         ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -693,7 +693,7 @@ H5B__insert_child(H5B_t *bt, unsigned *bt_flags, unsigned idx, haddr_t child, H5
     H5B_shared_t *shared; /* Pointer to shared B-tree info */
     uint8_t *     base;   /* Base offset for move */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(bt);
     HDassert(bt_flags);
@@ -787,7 +787,7 @@ H5B__insert_helper(H5F_t *f, H5B_ins_ud_t *bt_ud, const H5B_class_t *type, uint8
     H5B_ins_t      my_ins          = H5B_INS_ERROR;
     H5B_ins_t      ret_value       = H5B_INS_ERROR; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments
@@ -1120,7 +1120,7 @@ H5B__iterate_helper(H5F_t *f, const H5B_class_t *type, haddr_t addr, H5B_operato
     unsigned       u;                        /* Local index variable */
     herr_t         ret_value = H5_ITER_CONT; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -1235,7 +1235,7 @@ H5B__remove_helper(H5F_t *f, haddr_t addr, const H5B_class_t *type, int level, u
     int            cmp       = 1;       /* Key comparison value */
     H5B_ins_t      ret_value = H5B_INS_ERROR;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(f);
     HDassert(H5F_addr_defined(addr));
@@ -1778,7 +1778,7 @@ H5B__copy(const H5B_t *old_bt)
     H5B_shared_t *shared;           /* Pointer to shared B-tree info */
     H5B_t *       ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -1848,7 +1848,7 @@ H5B__get_info_helper(H5F_t *f, const H5B_class_t *type, haddr_t addr, const H5B_
     haddr_t        left_child;          /* Address of left-most child in node */
     herr_t         ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.

--- a/src/H5B2cache.c
+++ b/src/H5B2cache.c
@@ -165,7 +165,7 @@ H5B2__cache_hdr_get_initial_load_size(void *_udata, size_t *image_len)
 {
     H5B2_hdr_cache_ud_t *udata = (H5B2_hdr_cache_ud_t *)_udata; /* User data for callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(udata);
@@ -199,7 +199,7 @@ H5B2__cache_hdr_verify_chksum(const void *_image, size_t len, void H5_ATTR_UNUSE
     uint32_t       computed_chksum;                 /* Computed metadata checksum value */
     htri_t         ret_value = TRUE;                /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -239,7 +239,7 @@ H5B2__cache_hdr_deserialize(const void *_image, size_t H5_ATTR_UNUSED len, void 
     const uint8_t *      image     = (const uint8_t *)_image; /* Pointer into raw data buffer */
     H5B2_hdr_t *         ret_value = NULL;                    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -328,7 +328,7 @@ H5B2__cache_hdr_image_len(const void *_thing, size_t *image_len)
 {
     const H5B2_hdr_t *hdr = (const H5B2_hdr_t *)_thing; /* Pointer to the B-tree header */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(hdr);
@@ -359,7 +359,7 @@ H5B2__cache_hdr_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_UNUSED le
     uint8_t *   image = (uint8_t *)_image;    /* Pointer into raw data buffer */
     uint32_t    metadata_chksum;              /* Computed metadata checksum value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check arguments */
     HDassert(f);
@@ -427,7 +427,7 @@ H5B2__cache_hdr_notify(H5AC_notify_action_t action, void *_thing)
     H5B2_hdr_t *hdr       = (H5B2_hdr_t *)_thing;
     herr_t      ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -516,7 +516,7 @@ H5B2__cache_hdr_free_icr(void *thing)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(thing);
@@ -546,7 +546,7 @@ H5B2__cache_int_get_initial_load_size(void *_udata, size_t *image_len)
 {
     H5B2_internal_cache_ud_t *udata = (H5B2_internal_cache_ud_t *)_udata; /* User data for callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(udata);
@@ -582,7 +582,7 @@ H5B2__cache_int_verify_chksum(const void *_image, size_t H5_ATTR_UNUSED len, voi
     uint32_t                  computed_chksum;  /* Computed metadata checksum value */
     htri_t                    ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -628,7 +628,7 @@ H5B2__cache_int_deserialize(const void *_image, size_t H5_ATTR_UNUSED len, void 
     H5B2_internal_t *         ret_value = NULL;                   /* Return value */
     int                       node_nrec = 0;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -742,7 +742,7 @@ H5B2__cache_int_image_len(const void *_thing, size_t *image_len)
     const H5B2_internal_t *internal =
         (const H5B2_internal_t *)_thing; /* Pointer to the B-tree internal node */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(internal);
@@ -778,7 +778,7 @@ H5B2__cache_int_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_UNUSED le
     unsigned         u;                                    /* Local index variable */
     herr_t           ret_value = SUCCEED;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(f);
@@ -858,7 +858,7 @@ H5B2__cache_int_notify(H5AC_notify_action_t action, void *_thing)
     H5B2_internal_t *internal  = (H5B2_internal_t *)_thing;
     herr_t           ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -935,7 +935,7 @@ H5B2__cache_int_free_icr(void *_thing)
     H5B2_internal_t *internal  = (H5B2_internal_t *)_thing;
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(internal);
@@ -965,7 +965,7 @@ H5B2__cache_leaf_get_initial_load_size(void *_udata, size_t *image_len)
 {
     H5B2_leaf_cache_ud_t *udata = (H5B2_leaf_cache_ud_t *)_udata; /* User data for callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(udata);
@@ -1001,7 +1001,7 @@ H5B2__cache_leaf_verify_chksum(const void *_image, size_t H5_ATTR_UNUSED len, vo
     uint32_t                  computed_chksum;  /* Computed metadata checksum value */
     htri_t                    ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -1044,7 +1044,7 @@ H5B2__cache_leaf_deserialize(const void *_image, size_t H5_ATTR_UNUSED len, void
     unsigned              u;                               /* Local index variable */
     H5B2_leaf_t *         ret_value = NULL;                /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -1134,7 +1134,7 @@ H5B2__cache_leaf_image_len(const void *_thing, size_t *image_len)
 {
     const H5B2_leaf_t *leaf = (const H5B2_leaf_t *)_thing; /* Pointer to the B-tree leaf node  */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(leaf);
@@ -1170,7 +1170,7 @@ H5B2__cache_leaf_serialize(const H5F_t H5_ATTR_UNUSED *f, void *_image, size_t H
     unsigned     u;                             /* Local index variable */
     herr_t       ret_value = SUCCEED;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(f);
@@ -1237,7 +1237,7 @@ H5B2__cache_leaf_notify(H5AC_notify_action_t action, void *_thing)
     H5B2_leaf_t *leaf      = (H5B2_leaf_t *)_thing;
     herr_t       ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -1314,7 +1314,7 @@ H5B2__cache_leaf_free_icr(void *_thing)
     H5B2_leaf_t *leaf      = (H5B2_leaf_t *)_thing;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(leaf);

--- a/src/H5B2int.c
+++ b/src/H5B2int.c
@@ -2013,7 +2013,7 @@ H5B2__update_child_flush_depends(H5B2_hdr_t *hdr, unsigned depth, H5B2_node_ptr_
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(hdr);

--- a/src/H5B2internal.c
+++ b/src/H5B2internal.c
@@ -742,7 +742,7 @@ H5B2__shadow_internal(H5B2_internal_t *internal, H5B2_node_ptr_t *curr_node_ptr)
     H5B2_hdr_t *hdr;                 /* B-tree header */
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.

--- a/src/H5B2leaf.c
+++ b/src/H5B2leaf.c
@@ -702,7 +702,7 @@ H5B2__shadow_leaf(H5B2_leaf_t *leaf, H5B2_node_ptr_t *curr_node_ptr)
     H5B2_hdr_t *hdr;                 /* B-tree header */
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.

--- a/src/H5B2test.c
+++ b/src/H5B2test.c
@@ -134,7 +134,7 @@ H5B2__test_crt_context(void *_f)
     H5B2_test_ctx_t *ctx;              /* Callback context structure */
     void *           ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);
@@ -171,7 +171,7 @@ H5B2__test_dst_context(void *_ctx)
 {
     H5B2_test_ctx_t *ctx = (H5B2_test_ctx_t *)_ctx; /* Callback context structure */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -198,7 +198,7 @@ H5B2__test_dst_context(void *_ctx)
 static herr_t
 H5B2__test_store(void *nrecord, const void *udata)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     *(hsize_t *)nrecord = *(const hsize_t *)udata;
 
@@ -222,7 +222,7 @@ H5B2__test_store(void *nrecord, const void *udata)
 static herr_t
 H5B2__test_compare(const void *rec1, const void *rec2, int *result)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     *result = (int)(*(const hssize_t *)rec1 - *(const hssize_t *)rec2);
 
@@ -247,7 +247,7 @@ H5B2__test_encode(uint8_t *raw, const void *nrecord, void *_ctx)
 {
     H5B2_test_ctx_t *ctx = (H5B2_test_ctx_t *)_ctx; /* Callback context structure */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -275,7 +275,7 @@ H5B2__test_decode(const uint8_t *raw, void *nrecord, void *_ctx)
 {
     H5B2_test_ctx_t *ctx = (H5B2_test_ctx_t *)_ctx; /* Callback context structure */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -301,7 +301,7 @@ H5B2__test_decode(const uint8_t *raw, void *nrecord, void *_ctx)
 static herr_t
 H5B2__test_debug(FILE *stream, int indent, int fwidth, const void *record, const void H5_ATTR_UNUSED *_udata)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(record);
 
@@ -326,7 +326,7 @@ H5B2__test_debug(FILE *stream, int indent, int fwidth, const void *record, const
 static herr_t
 H5B2__test2_store(void *nrecord, const void *udata)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     *(H5B2_test_rec_t *)nrecord = *(const H5B2_test_rec_t *)udata;
 
@@ -350,7 +350,7 @@ H5B2__test2_store(void *nrecord, const void *udata)
 static herr_t
 H5B2__test2_compare(const void *rec1, const void *rec2, int *result)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     *result = (int)(((const H5B2_test_rec_t *)rec1)->key - ((const H5B2_test_rec_t *)rec2)->key);
 
@@ -375,7 +375,7 @@ H5B2__test2_encode(uint8_t *raw, const void *nrecord, void *_ctx)
 {
     H5B2_test_ctx_t *ctx = (H5B2_test_ctx_t *)_ctx; /* Callback context structure */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -404,7 +404,7 @@ H5B2__test2_decode(const uint8_t *raw, void *nrecord, void *_ctx)
 {
     H5B2_test_ctx_t *ctx = (H5B2_test_ctx_t *)_ctx; /* Callback context structure */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -431,7 +431,7 @@ H5B2__test2_decode(const uint8_t *raw, void *nrecord, void *_ctx)
 static herr_t
 H5B2__test2_debug(FILE *stream, int indent, int fwidth, const void *record, const void H5_ATTR_UNUSED *_udata)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(record);
 

--- a/src/H5Bcache.c
+++ b/src/H5Bcache.c
@@ -99,7 +99,7 @@ H5B__cache_get_initial_load_size(void *_udata, size_t *image_len)
     H5B_cache_ud_t *udata = (H5B_cache_ud_t *)_udata; /* User data for callback */
     H5B_shared_t *  shared;                           /* Pointer to shared B-tree info */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(udata);
@@ -140,7 +140,7 @@ H5B__cache_deserialize(const void *_image, size_t H5_ATTR_UNUSED len, void *_uda
     unsigned        u;                                /* Local index variable */
     H5B_t *         ret_value = NULL;                 /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(image);
@@ -238,7 +238,7 @@ H5B__cache_image_len(const void *_thing, size_t *image_len)
     const H5B_t * bt = (const H5B_t *)_thing; /* Pointer to the B-tree node */
     H5B_shared_t *shared;                     /* Pointer to shared B-tree info */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(bt);
@@ -276,7 +276,7 @@ H5B__cache_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_UNUSED len, vo
     unsigned      u;                         /* Local index counter */
     herr_t        ret_value = SUCCEED;       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(image);
@@ -354,7 +354,7 @@ H5B__cache_free_icr(void *thing)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(thing);

--- a/src/H5C.c
+++ b/src/H5C.c
@@ -678,7 +678,7 @@ H5C__free_tag_list_cb(void *_item, void H5_ATTR_UNUSED *key, void H5_ATTR_UNUSED
 {
     H5C_tag_info_t *tag_info = (H5C_tag_info_t *)_item;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(tag_info);
 
@@ -4131,7 +4131,7 @@ H5C__pin_entry_from_client(H5C_t
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(cache_ptr);
@@ -4175,9 +4175,9 @@ H5C__unpin_entry_real(H5C_t *cache_ptr, H5C_cache_entry_t *entry_ptr, hbool_t up
     herr_t ret_value = SUCCEED; /* Return value */
 
 #if H5C_DO_SANITY_CHECKS
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 #else
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 #endif
 
     /* Sanity checking */
@@ -4218,7 +4218,7 @@ H5C__unpin_entry_from_client(H5C_t *cache_ptr, H5C_cache_entry_t *entry_ptr, hbo
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checking */
     HDassert(cache_ptr);
@@ -4276,7 +4276,7 @@ H5C__auto_adjust_cache_size(H5F_t *f, hbool_t write_permitted)
     enum H5C_resize_status status    = in_spec; /* will change if needed */
     herr_t                 ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(f);
     HDassert(cache_ptr);
@@ -4556,7 +4556,7 @@ H5C__autoadjust__ageout(H5F_t *f, double hit_rate, enum H5C_resize_status *statu
     size_t test_size;
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(f);
     HDassert(cache_ptr);
@@ -4652,7 +4652,7 @@ H5C__autoadjust__ageout__cycle_epoch_marker(H5C_t *cache_ptr)
     int    i;
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(cache_ptr);
     HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
@@ -4755,7 +4755,7 @@ H5C__autoadjust__ageout__evict_aged_out_entries(H5F_t *f, hbool_t write_permitte
     H5C_cache_entry_t *prev_ptr;
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(f);
     HDassert(cache_ptr);
@@ -4938,7 +4938,7 @@ H5C__autoadjust__ageout__insert_new_marker(H5C_t *cache_ptr)
     int    i;
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(cache_ptr);
     HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
@@ -5003,7 +5003,7 @@ H5C__autoadjust__ageout__remove_all_markers(H5C_t *cache_ptr)
     int    i;
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(cache_ptr);
     HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
@@ -5073,7 +5073,7 @@ H5C__autoadjust__ageout__remove_excess_markers(H5C_t *cache_ptr)
     int    i;
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(cache_ptr);
     HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
@@ -5151,7 +5151,7 @@ H5C__flash_increase_cache_size(H5C_t *cache_ptr, size_t old_entry_size, size_t n
     double                 hit_rate;
     herr_t                 ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(cache_ptr);
     HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
@@ -5343,7 +5343,7 @@ H5C__flush_invalidate_cache(H5F_t *f, unsigned flags)
     H5C_ring_t ring;
     herr_t     ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(f);
     HDassert(f->shared);
@@ -5536,7 +5536,7 @@ H5C__flush_invalidate_ring(H5F_t *f, H5C_ring_t ring, unsigned flags)
 #endif /* H5C_DO_SANITY_CHECKS */
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(f);
     HDassert(f->shared);
@@ -6058,7 +6058,7 @@ H5C__flush_ring(H5F_t *f, H5C_ring_t ring, unsigned flags)
     int    i;
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(cache_ptr);
     HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
@@ -7043,7 +7043,7 @@ H5C__verify_len_eoa(H5F_t *f, const H5C_class_t *type, haddr_t addr, size_t *len
     haddr_t    eoa;                 /* End-of-allocation in the file */
     herr_t     ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* if type == H5FD_MEM_GHEAP, H5F_block_read() forces
      * type to H5FD_MEM_DRAW via its call to H5F__accum_read().
@@ -7114,7 +7114,7 @@ H5C__load_entry(H5F_t *f,
 #endif                                 /* H5_HAVE_PARALLEL */
     void *ret_value = NULL;            /* Return value                             */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -8206,7 +8206,7 @@ H5C__mark_flush_dep_dirty(H5C_cache_entry_t *entry)
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(entry);
@@ -8253,7 +8253,7 @@ H5C__mark_flush_dep_clean(H5C_cache_entry_t *entry)
     int    i;                   /* Local index variable */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(entry);
@@ -8301,7 +8301,7 @@ H5C__mark_flush_dep_serialized(H5C_cache_entry_t *entry_ptr)
     int    i;                   /* Local index variable */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(entry_ptr);
@@ -8351,7 +8351,7 @@ H5C__mark_flush_dep_unserialized(H5C_cache_entry_t *entry_ptr)
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(entry_ptr);
@@ -8400,7 +8400,7 @@ H5C__assert_flush_dep_nocycle(const H5C_cache_entry_t *entry, const H5C_cache_en
 {
     unsigned u; /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(entry);
@@ -8639,7 +8639,7 @@ H5C__serialize_ring(H5F_t *f, H5C_ring_t ring)
     H5C_cache_entry_t *entry_ptr;
     herr_t             ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -8876,7 +8876,7 @@ H5C__serialize_single_entry(H5F_t *f, H5C_t *cache_ptr, H5C_cache_entry_t *entry
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -8955,7 +8955,7 @@ H5C__generate_image(H5F_t *f, H5C_t *cache_ptr, H5C_cache_entry_t *entry_ptr)
     unsigned serialize_flags = H5C__SERIALIZE_NO_FLAGS_SET;
     herr_t   ret_value       = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);

--- a/src/H5CS.c
+++ b/src/H5CS.c
@@ -82,7 +82,7 @@ H5CS__get_stack(void)
 {
     H5CS_t *fstack;
 
-    FUNC_ENTER_STATIC_NOERR_NOFS
+    FUNC_ENTER_PACKAGE_NOERR_NOFS
 
     fstack = H5TS_get_thread_local_value(H5TS_funcstk_key_g);
     if (!fstack) {

--- a/src/H5CX.c
+++ b/src/H5CX.c
@@ -705,7 +705,7 @@ H5CX__get_context(void)
 {
     H5CX_node_t **ctx = NULL;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     ctx = (H5CX_node_t **)H5TS_get_thread_local_value(H5TS_apictx_key_g);
 
@@ -754,7 +754,7 @@ H5CX__push_common(H5CX_node_t *cnode)
 {
     H5CX_node_t **head = NULL; /* Pointer to head of API context list */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(cnode);
@@ -3588,9 +3588,9 @@ H5CX__pop_common(hbool_t update_dxpl_props)
     H5CX_node_t * ret_value = NULL; /* Return value */
 
 #ifdef H5_HAVE_PARALLEL
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 #else
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 #endif
 
     /* Sanity check */

--- a/src/H5Cepoch.c
+++ b/src/H5Cepoch.c
@@ -106,7 +106,7 @@ const H5AC_class_t H5AC_EPOCH_MARKER[1] = {
 static herr_t
 H5C__epoch_marker_get_initial_load_size(void H5_ATTR_UNUSED *udata_ptr, size_t H5_ATTR_UNUSED *image_len_ptr)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 
@@ -117,7 +117,7 @@ static herr_t
 H5C__epoch_marker_get_final_load_size(const void H5_ATTR_UNUSED *image_ptr, size_t H5_ATTR_UNUSED image_len,
                                       void H5_ATTR_UNUSED *udata_ptr, size_t H5_ATTR_UNUSED *actual_len)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 
@@ -128,7 +128,7 @@ static htri_t
 H5C__epoch_marker_verify_chksum(const void H5_ATTR_UNUSED *image_ptr, size_t H5_ATTR_UNUSED len,
                                 void H5_ATTR_UNUSED *udata_ptr)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 
@@ -139,7 +139,7 @@ static void *
 H5C__epoch_marker_deserialize(const void H5_ATTR_UNUSED *image_ptr, size_t H5_ATTR_UNUSED len,
                               void H5_ATTR_UNUSED *udata, hbool_t H5_ATTR_UNUSED *dirty_ptr)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 
@@ -149,7 +149,7 @@ H5C__epoch_marker_deserialize(const void H5_ATTR_UNUSED *image_ptr, size_t H5_AT
 static herr_t
 H5C__epoch_marker_image_len(const void H5_ATTR_UNUSED *thing, size_t H5_ATTR_UNUSED *image_len_ptr)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 
@@ -162,7 +162,7 @@ H5C__epoch_marker_pre_serialize(H5F_t H5_ATTR_UNUSED *f, void H5_ATTR_UNUSED *th
                                 haddr_t H5_ATTR_UNUSED *new_addr_ptr, size_t H5_ATTR_UNUSED *new_len_ptr,
                                 unsigned H5_ATTR_UNUSED *flags_ptr)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 
@@ -173,7 +173,7 @@ static herr_t
 H5C__epoch_marker_serialize(const H5F_t H5_ATTR_UNUSED *f, void H5_ATTR_UNUSED *image_ptr,
                             size_t H5_ATTR_UNUSED len, void H5_ATTR_UNUSED *thing)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 
@@ -183,7 +183,7 @@ H5C__epoch_marker_serialize(const H5F_t H5_ATTR_UNUSED *f, void H5_ATTR_UNUSED *
 static herr_t
 H5C__epoch_marker_notify(H5C_notify_action_t H5_ATTR_UNUSED action, void H5_ATTR_UNUSED *thing)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 
@@ -193,7 +193,7 @@ H5C__epoch_marker_notify(H5C_notify_action_t H5_ATTR_UNUSED action, void H5_ATTR
 static herr_t
 H5C__epoch_marker_free_icr(void H5_ATTR_UNUSED *thing)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 
@@ -203,7 +203,7 @@ H5C__epoch_marker_free_icr(void H5_ATTR_UNUSED *thing)
 static herr_t
 H5C__epoch_marker_fsf_size(const void H5_ATTR_UNUSED *thing, hsize_t H5_ATTR_UNUSED *fsf_size_ptr)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 

--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -230,7 +230,7 @@ H5C__construct_cache_image_buffer(H5F_t *f, H5C_t *cache_ptr)
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -814,7 +814,7 @@ done:
 static herr_t
 H5C__free_image_entries_array(H5C_t *cache_ptr)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(cache_ptr);
@@ -977,7 +977,7 @@ H5C__read_cache_image(H5F_t *f, H5C_t *cache_ptr)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -1199,7 +1199,7 @@ H5C__image_entry_cmp(const void *_entry1, const void *_entry2)
         (const H5C_image_entry_t *)_entry2; /* Pointer to second image entry to compare */
     int ret_value = 0;                      /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(entry1);
@@ -1689,7 +1689,7 @@ H5C__cache_image_block_entry_header_size(const H5F_t *f)
 {
     size_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set return value */
     ret_value = (size_t)(1 +                  /* type                     */
@@ -1725,7 +1725,7 @@ H5C__cache_image_block_header_size(const H5F_t *f)
 {
     size_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set return value */
     ret_value = (size_t)(4 +                  /* signature           */
@@ -1763,7 +1763,7 @@ H5C__decode_cache_image_header(const H5F_t *f, H5C_t *cache_ptr, const uint8_t *
     const uint8_t *p;
     herr_t         ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(cache_ptr);
@@ -1860,7 +1860,7 @@ H5C__decode_cache_image_entry(const H5F_t *f, const H5C_t *cache_ptr, const uint
     const uint8_t *    p;
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -2016,7 +2016,7 @@ H5C__destroy_pf_entry_child_flush_deps(H5C_t *cache_ptr, H5C_cache_entry_t *pf_e
     hbool_t            found;
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(cache_ptr);
@@ -2132,7 +2132,7 @@ H5C__encode_cache_image_header(const H5F_t *f, const H5C_t *cache_ptr, uint8_t *
     uint8_t *p;                   /* Pointer into cache image buffer */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(cache_ptr);
@@ -2208,7 +2208,7 @@ H5C__encode_cache_image_entry(H5F_t *f, H5C_t *cache_ptr, uint8_t **buf, unsigne
     unsigned           u;                   /* Local index value */
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -2368,7 +2368,7 @@ H5C__prep_for_file_close__compute_fd_heights(const H5C_t *cache_ptr)
     unsigned           u; /* Local index variable */
     herr_t             ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* sanity checks */
     HDassert(cache_ptr);
@@ -2590,7 +2590,7 @@ done:
 static void
 H5C__prep_for_file_close__compute_fd_heights_real(H5C_cache_entry_t *entry_ptr, uint32_t fd_height)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(entry_ptr);
@@ -2642,7 +2642,7 @@ H5C__prep_for_file_close__setup_image_entries_array(H5C_t *cache_ptr)
     unsigned           u;                   /* Local index variable */
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(cache_ptr);
@@ -2786,7 +2786,7 @@ H5C__prep_for_file_close__scan_entries(const H5F_t *f, H5C_t *cache_ptr)
     unsigned           j;
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -3022,7 +3022,7 @@ H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
     unsigned           u, v;                /* Local index variable */
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -3234,7 +3234,7 @@ H5C__reconstruct_cache_entry(const H5F_t *f, H5C_t *cache_ptr, const uint8_t **b
     hbool_t            file_is_rw;
     H5C_cache_entry_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(cache_ptr);
@@ -3404,7 +3404,7 @@ H5C__write_cache_image_superblock_msg(H5F_t *f, hbool_t create)
     unsigned mesg_flags = H5O_MSG_FLAG_FAIL_IF_UNKNOWN_ALWAYS;
     herr_t   ret_value  = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -3459,7 +3459,7 @@ H5C__write_cache_image(H5F_t *f, const H5C_t *cache_ptr)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);

--- a/src/H5Clog_json.c
+++ b/src/H5Clog_json.c
@@ -164,7 +164,7 @@ H5C__json_write_log_message(H5C_log_json_udata_t *json_udata)
     size_t n_chars;
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -292,7 +292,7 @@ H5C__json_tear_down_logging(H5C_log_info_t *log_info)
     H5C_log_json_udata_t *json_udata = NULL;
     herr_t                ret_value  = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(log_info);
@@ -337,7 +337,7 @@ H5C__json_write_start_log_msg(void *udata)
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -380,7 +380,7 @@ H5C__json_write_stop_log_msg(void *udata)
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -422,7 +422,7 @@ H5C__json_write_create_cache_log_msg(void *udata, herr_t fxn_ret_value)
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -464,7 +464,7 @@ H5C__json_write_destroy_cache_log_msg(void *udata)
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -505,7 +505,7 @@ H5C__json_write_evict_cache_log_msg(void *udata, herr_t fxn_ret_value)
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -547,7 +547,7 @@ H5C__json_write_expunge_entry_log_msg(void *udata, haddr_t address, int type_id,
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -591,7 +591,7 @@ H5C__json_write_flush_cache_log_msg(void *udata, herr_t fxn_ret_value)
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -634,7 +634,7 @@ H5C__json_write_insert_entry_log_msg(void *udata, haddr_t address, int type_id, 
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -681,7 +681,7 @@ H5C__json_write_mark_entry_dirty_log_msg(void *udata, const H5C_cache_entry_t *e
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -725,7 +725,7 @@ H5C__json_write_mark_entry_clean_log_msg(void *udata, const H5C_cache_entry_t *e
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -770,7 +770,7 @@ H5C__json_write_mark_unserialized_entry_log_msg(void *udata, const H5C_cache_ent
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -815,7 +815,7 @@ H5C__json_write_mark_serialized_entry_log_msg(void *udata, const H5C_cache_entry
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -860,7 +860,7 @@ H5C__json_write_move_entry_log_msg(void *udata, haddr_t old_addr, haddr_t new_ad
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -906,7 +906,7 @@ H5C__json_write_pin_entry_log_msg(void *udata, const H5C_cache_entry_t *entry, h
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -952,7 +952,7 @@ H5C__json_write_create_fd_log_msg(void *udata, const H5C_cache_entry_t *parent,
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -1001,7 +1001,7 @@ H5C__json_write_protect_entry_log_msg(void *udata, const H5C_cache_entry_t *entr
     char                  rw_s[16];
     herr_t                ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -1055,7 +1055,7 @@ H5C__json_write_resize_entry_log_msg(void *udata, const H5C_cache_entry_t *entry
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -1100,7 +1100,7 @@ H5C__json_write_unpin_entry_log_msg(void *udata, const H5C_cache_entry_t *entry,
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -1146,7 +1146,7 @@ H5C__json_write_destroy_fd_log_msg(void *udata, const H5C_cache_entry_t *parent,
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -1194,7 +1194,7 @@ H5C__json_write_unprotect_entry_log_msg(void *udata, haddr_t address, int type_i
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -1240,7 +1240,7 @@ H5C__json_write_set_cache_config_log_msg(void *udata, const H5AC_cache_config_t 
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);
@@ -1283,7 +1283,7 @@ H5C__json_write_remove_entry_log_msg(void *udata, const H5C_cache_entry_t *entry
     H5C_log_json_udata_t *json_udata = (H5C_log_json_udata_t *)(udata);
     herr_t                ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(json_udata);

--- a/src/H5Clog_trace.c
+++ b/src/H5Clog_trace.c
@@ -159,7 +159,7 @@ H5C__trace_write_log_message(H5C_log_trace_udata_t *trace_udata)
     size_t n_chars;
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -290,7 +290,7 @@ H5C__trace_tear_down_logging(H5C_log_info_t *log_info)
     H5C_log_trace_udata_t *trace_udata = NULL;
     herr_t                 ret_value   = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(log_info);
@@ -335,7 +335,7 @@ H5C__trace_write_expunge_entry_log_msg(void *udata, haddr_t address, int type_id
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -371,7 +371,7 @@ H5C__trace_write_flush_cache_log_msg(void *udata, herr_t fxn_ret_value)
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -407,7 +407,7 @@ H5C__trace_write_insert_entry_log_msg(void *udata, haddr_t address, int type_id,
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -443,7 +443,7 @@ H5C__trace_write_mark_entry_dirty_log_msg(void *udata, const H5C_cache_entry_t *
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -480,7 +480,7 @@ H5C__trace_write_mark_entry_clean_log_msg(void *udata, const H5C_cache_entry_t *
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -518,7 +518,7 @@ H5C__trace_write_mark_unserialized_entry_log_msg(void *udata, const H5C_cache_en
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -556,7 +556,7 @@ H5C__trace_write_mark_serialized_entry_log_msg(void *udata, const H5C_cache_entr
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -594,7 +594,7 @@ H5C__trace_write_move_entry_log_msg(void *udata, haddr_t old_addr, haddr_t new_a
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -630,7 +630,7 @@ H5C__trace_write_pin_entry_log_msg(void *udata, const H5C_cache_entry_t *entry, 
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -669,7 +669,7 @@ H5C__trace_write_create_fd_log_msg(void *udata, const H5C_cache_entry_t *parent,
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -709,7 +709,7 @@ H5C__trace_write_protect_entry_log_msg(void *udata, const H5C_cache_entry_t *ent
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -747,7 +747,7 @@ H5C__trace_write_resize_entry_log_msg(void *udata, const H5C_cache_entry_t *entr
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -784,7 +784,7 @@ H5C__trace_write_unpin_entry_log_msg(void *udata, const H5C_cache_entry_t *entry
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -823,7 +823,7 @@ H5C__trace_write_destroy_fd_log_msg(void *udata, const H5C_cache_entry_t *parent
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -863,7 +863,7 @@ H5C__trace_write_unprotect_entry_log_msg(void *udata, haddr_t address, int type_
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -900,7 +900,7 @@ H5C__trace_write_set_cache_config_log_msg(void *udata, const H5AC_cache_config_t
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);
@@ -949,7 +949,7 @@ H5C__trace_write_remove_entry_log_msg(void *udata, const H5C_cache_entry_t *entr
     H5C_log_trace_udata_t *trace_udata = (H5C_log_trace_udata_t *)(udata);
     herr_t                 ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(trace_udata);

--- a/src/H5Cmpio.c
+++ b/src/H5Cmpio.c
@@ -955,7 +955,7 @@ H5C__collective_write(H5F_t *f)
     size_t           buf_count;
     herr_t           ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f != NULL);
@@ -1125,7 +1125,7 @@ H5C__flush_candidate_entries(H5F_t *f, unsigned entries_to_flush[H5C_RING_NTYPES
     H5C_t *    cache_ptr;
     herr_t     ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(f);
     HDassert(f->shared);
@@ -1245,7 +1245,7 @@ H5C__flush_candidates_in_ring(H5F_t *f, H5C_ring_t ring, unsigned entries_to_flu
     H5C_cache_entry_t *entry_ptr;
     herr_t             ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);

--- a/src/H5Cprefetched.c
+++ b/src/H5Cprefetched.c
@@ -109,7 +109,7 @@ static herr_t
 H5C__prefetched_entry_get_initial_load_size(void H5_ATTR_UNUSED *udata_ptr,
                                             size_t H5_ATTR_UNUSED *image_len_ptr)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 
@@ -121,7 +121,7 @@ H5C__prefetched_entry_get_final_load_size(const void H5_ATTR_UNUSED *image_ptr,
                                           size_t H5_ATTR_UNUSED image_len, void H5_ATTR_UNUSED *udata_ptr,
                                           size_t H5_ATTR_UNUSED *actual_len_ptr)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 
@@ -132,7 +132,7 @@ static htri_t
 H5C__prefetched_entry_verify_chksum(const void H5_ATTR_UNUSED *image_ptr, size_t H5_ATTR_UNUSED len,
                                     void H5_ATTR_UNUSED *udata_ptr)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 
@@ -143,7 +143,7 @@ static void *
 H5C__prefetched_entry_deserialize(const void H5_ATTR_UNUSED *image_ptr, size_t H5_ATTR_UNUSED len,
                                   void H5_ATTR_UNUSED *udata, hbool_t H5_ATTR_UNUSED *dirty_ptr)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 
@@ -153,7 +153,7 @@ H5C__prefetched_entry_deserialize(const void H5_ATTR_UNUSED *image_ptr, size_t H
 static herr_t
 H5C__prefetched_entry_image_len(const void H5_ATTR_UNUSED *thing, size_t H5_ATTR_UNUSED *image_len_ptr)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 
@@ -166,7 +166,7 @@ H5C__prefetched_entry_pre_serialize(H5F_t H5_ATTR_UNUSED *f, void H5_ATTR_UNUSED
                                     haddr_t H5_ATTR_UNUSED *new_addr_ptr, size_t H5_ATTR_UNUSED *new_len_ptr,
                                     unsigned H5_ATTR_UNUSED *flags_ptr)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 
@@ -177,7 +177,7 @@ static herr_t
 H5C__prefetched_entry_serialize(const H5F_t H5_ATTR_UNUSED *f, void H5_ATTR_UNUSED *image_ptr,
                                 size_t H5_ATTR_UNUSED len, void H5_ATTR_UNUSED *thing)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 
@@ -208,7 +208,7 @@ H5C__prefetched_entry_notify(H5C_notify_action_t action, void *_thing)
     unsigned           u;
     herr_t             ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(entry_ptr);
@@ -286,7 +286,7 @@ H5C__prefetched_entry_free_icr(void *_thing)
     H5C_cache_entry_t *entry_ptr = (H5C_cache_entry_t *)_thing;
     herr_t             ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(entry_ptr);
@@ -313,7 +313,7 @@ done:
 static herr_t
 H5C__prefetched_entry_fsf_size(const void H5_ATTR_UNUSED *thing, hsize_t H5_ATTR_UNUSED *fsf_size_ptr)
 {
-    FUNC_ENTER_STATIC_NOERR /* Yes, even though this pushes an error on the stack */
+    FUNC_ENTER_PACKAGE_NOERR /* Yes, even though this pushes an error on the stack */
 
         HERROR(H5E_CACHE, H5E_SYSTEM, "called unreachable fcn.");
 

--- a/src/H5Ctag.c
+++ b/src/H5Ctag.c
@@ -357,7 +357,7 @@ H5C__iter_tagged_entries_real(H5C_t *cache, haddr_t tag, H5C_tag_iter_cb_t cb, v
     herr_t          ret_value = SUCCEED; /* Return value */
 
     /* Function enter macro */
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(cache != NULL);
@@ -458,7 +458,7 @@ H5C__evict_tagged_entries_cb(H5C_cache_entry_t *entry, void *_ctx)
     int                       ret_value = H5_ITER_CONT;               /* Return value */
 
     /* Function enter macro */
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Santify checks */
     HDassert(entry);
@@ -585,7 +585,7 @@ static int
 H5C__mark_tagged_entries_cb(H5C_cache_entry_t *entry, void H5_ATTR_UNUSED *_ctx)
 {
     /* Function enter macro */
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(entry);
@@ -618,7 +618,7 @@ H5C__mark_tagged_entries(H5C_t *cache, haddr_t tag)
     herr_t ret_value = SUCCEED; /* Return value */
 
     /* Function enter macro */
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(cache);
@@ -810,7 +810,7 @@ H5C__expunge_tag_type_metadata_cb(H5C_cache_entry_t *entry, void *_ctx)
     int                      ret_value = H5_ITER_CONT;              /* Return value */
 
     /* Function enter macro */
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Santify checks */
     HDassert(entry);

--- a/src/H5Ctest.c
+++ b/src/H5Ctest.c
@@ -91,7 +91,7 @@ H5C__verify_cork_tag_test_cb(H5C_cache_entry_t *entry, void *_ctx)
     int                     ret_value = H5_ITER_CONT;             /* Return value */
 
     /* Function enter macro */
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Santify checks */
     HDassert(entry);

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -97,7 +97,7 @@ H5D__create_api_common(hid_t loc_id, const char *name, hid_t type_id, hid_t spac
     H5VL_loc_params_t loc_params;                     /* Location parameters for object access */
     hid_t             ret_value = H5I_INVALID_HID;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (!name)
@@ -340,7 +340,7 @@ H5D__open_api_common(hid_t loc_id, const char *name, hid_t dapl_id, void **token
     H5VL_loc_params_t loc_params;                     /* Location parameters for object access */
     hid_t             ret_value = H5I_INVALID_HID;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     if (!name)
@@ -558,7 +558,7 @@ H5D__get_space_api_common(hid_t dset_id, void **token_ptr, H5VL_object_t **_vol_
     H5VL_dataset_get_args_t vol_cb_args;                 /* Arguments to VOL callback */
     hid_t                   ret_value = H5I_INVALID_HID; /* Return value         */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     if (NULL == (*vol_obj_ptr = (H5VL_object_t *)H5I_object_verify(dset_id, H5I_DATASET)))
@@ -946,7 +946,7 @@ H5D__read_api_common(hid_t dset_id, hid_t mem_type_id, hid_t mem_space_id, hid_t
         (_vol_obj_ptr ? _vol_obj_ptr : &tmp_vol_obj); /* Ptr to object ptr for loc_id */
     herr_t ret_value = SUCCEED;                       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (mem_space_id < 0)
@@ -1145,7 +1145,7 @@ H5D__write_api_common(hid_t dset_id, hid_t mem_type_id, hid_t mem_space_id, hid_
         (_vol_obj_ptr ? _vol_obj_ptr : &tmp_vol_obj); /* Ptr to object ptr for loc_id */
     herr_t ret_value = SUCCEED;                       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (mem_space_id < 0)
@@ -1760,7 +1760,7 @@ H5D__set_extent_api_common(hid_t dset_id, const hsize_t size[], void **token_ptr
     H5VL_dataset_specific_args_t vol_cb_args;         /* Arguments to VOL callback */
     herr_t                       ret_value = SUCCEED; /* Return value                 */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     if (NULL == (*vol_obj_ptr = (H5VL_object_t *)H5I_object_verify(dset_id, H5I_DATASET)))

--- a/src/H5Dbtree.c
+++ b/src/H5Dbtree.c
@@ -206,7 +206,7 @@ H5D__btree_get_shared(const H5F_t H5_ATTR_UNUSED *f, const void *_udata)
 {
     const H5D_chunk_common_ud_t *udata = (const H5D_chunk_common_ud_t *)_udata;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(udata);
     HDassert(udata->storage);
@@ -245,7 +245,7 @@ H5D__btree_new_node(H5F_t H5_ATTR_NDEBUG_UNUSED *f, H5B_ins_t op, void *_lt_key,
     unsigned         u;
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -312,7 +312,7 @@ H5D__btree_cmp2(void *_lt_key, void *_udata, void *_rt_key)
     H5D_chunk_common_ud_t *udata     = (H5D_chunk_common_ud_t *)_udata;
     int                    ret_value = -1; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(lt_key);
     HDassert(rt_key);
@@ -360,7 +360,7 @@ H5D__btree_cmp3(void *_lt_key, void *_udata, void *_rt_key)
     H5D_chunk_common_ud_t *udata     = (H5D_chunk_common_ud_t *)_udata;
     int                    ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(lt_key);
     HDassert(rt_key);
@@ -424,7 +424,7 @@ H5D__btree_found(H5F_t H5_ATTR_UNUSED *f, haddr_t addr, const void *_lt_key, hbo
     unsigned               u;
     herr_t                 ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(f);
@@ -472,7 +472,7 @@ H5D__chunk_disjoint(unsigned n, const hsize_t *scaled1, const hsize_t *scaled2)
     unsigned u;                 /* Local index variable */
     hbool_t  ret_value = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(n);
@@ -529,7 +529,7 @@ H5D__btree_insert(H5F_t H5_ATTR_NDEBUG_UNUSED *f, haddr_t H5_ATTR_NDEBUG_UNUSED 
     unsigned         u;
     H5B_ins_t        ret_value = H5B_INS_ERROR; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -612,7 +612,7 @@ H5D__btree_remove(H5F_t *f, haddr_t addr, void *_lt_key /*in,out */, hbool_t *lt
     H5D_btree_key_t *lt_key    = (H5D_btree_key_t *)_lt_key;
     H5B_ins_t        ret_value = H5B_INS_REMOVE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Remove raw data chunk from file */
     H5_CHECK_OVERFLOW(lt_key->nbytes, uint32_t, hsize_t);
@@ -648,7 +648,7 @@ H5D__btree_decode_key(const H5B_shared_t *shared, const uint8_t *raw, void *_key
     unsigned                  u;                             /* Local index variable */
     herr_t                    ret_value = SUCCEED;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(shared);
@@ -697,7 +697,7 @@ H5D__btree_encode_key(const H5B_shared_t *shared, uint8_t *raw, const void *_key
     hsize_t                   tmp_offset; /* Temporary coordinate offset, from file */
     unsigned                  u;          /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(shared);
@@ -738,7 +738,7 @@ H5D__btree_debug_key(FILE *stream, int indent, int fwidth, const void *_key, con
     const H5D_btree_dbg_t *udata = (const H5D_btree_dbg_t *)_udata;
     unsigned               u;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(key);
 
@@ -770,7 +770,7 @@ H5D__btree_shared_free(void *_shared)
     H5B_shared_t *shared    = (H5B_shared_t *)_shared;
     herr_t        ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Free the chunk layout information */
     shared->udata = H5FL_FREE(H5O_layout_chunk_t, shared->udata);
@@ -803,7 +803,7 @@ H5D__btree_shared_create(const H5F_t *f, H5O_storage_chunk_t *store, const H5O_l
     size_t              sizeof_rkey;         /* Size of raw (disk) key	     */
     herr_t              ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Set the raw key size */
     sizeof_rkey = 4 +                /*storage size		*/
@@ -850,7 +850,7 @@ H5D__btree_idx_init(const H5D_chk_idx_info_t *idx_info, const H5S_t H5_ATTR_UNUS
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -894,7 +894,7 @@ H5D__btree_idx_create(const H5D_chk_idx_info_t *idx_info)
     H5D_chunk_common_ud_t udata;               /* User data for B-tree callback */
     herr_t                ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -931,7 +931,7 @@ done:
 static hbool_t
 H5D__btree_idx_is_space_alloc(const H5O_storage_chunk_t *storage)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(storage);
@@ -957,7 +957,7 @@ H5D__btree_idx_insert(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata,
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(idx_info);
     HDassert(idx_info->f);
@@ -998,7 +998,7 @@ H5D__btree_idx_get_addr(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udat
     hbool_t found;               /* Whether chunk was found */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(idx_info);
     HDassert(idx_info->f);
@@ -1042,7 +1042,7 @@ H5D__btree_idx_iterate_cb(H5F_t H5_ATTR_UNUSED *f, const void *_lt_key, haddr_t 
     H5D_chunk_rec_t        chunk_rec;                                 /* Generic chunk record for callback */
     int                    ret_value = -1;                            /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check for memcpy() */
     HDcompile_assert(offsetof(H5D_chunk_rec_t, nbytes) == offsetof(H5D_btree_key_t, nbytes));
@@ -1082,7 +1082,7 @@ H5D__btree_idx_iterate(const H5D_chk_idx_info_t *idx_info, H5D_chunk_cb_func_t c
     H5D_btree_it_ud_t udata;          /* User data for B-tree iterator callback */
     int               ret_value = -1; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(idx_info);
     HDassert(idx_info->f);
@@ -1125,7 +1125,7 @@ H5D__btree_idx_remove(const H5D_chk_idx_info_t *idx_info, H5D_chunk_common_ud_t 
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(idx_info);
     HDassert(idx_info->f);
@@ -1164,7 +1164,7 @@ H5D__btree_idx_delete(const H5D_chk_idx_info_t *idx_info)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -1222,7 +1222,7 @@ H5D__btree_idx_copy_setup(const H5D_chk_idx_info_t *idx_info_src, const H5D_chk_
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC_TAG(H5AC__COPIED_TAG)
+    FUNC_ENTER_PACKAGE_TAG(H5AC__COPIED_TAG)
 
     HDassert(idx_info_src);
     HDassert(idx_info_src->f);
@@ -1269,7 +1269,7 @@ H5D__btree_idx_copy_shutdown(H5O_storage_chunk_t *storage_src, H5O_storage_chunk
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(storage_src);
     HDassert(storage_dst);
@@ -1304,7 +1304,7 @@ H5D__btree_idx_size(const H5D_chk_idx_info_t *idx_info, hsize_t *index_size)
     H5B_info_t            bt_info;             /* B-tree info */
     herr_t                ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -1345,7 +1345,7 @@ done:
 static herr_t
 H5D__btree_idx_reset(H5O_storage_chunk_t *storage, hbool_t reset_addr)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(storage);
 
@@ -1372,7 +1372,7 @@ H5D__btree_idx_reset(H5O_storage_chunk_t *storage, hbool_t reset_addr)
 static herr_t
 H5D__btree_idx_dump(const H5O_storage_chunk_t *storage, FILE *stream)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(storage);
     HDassert(stream);
@@ -1399,7 +1399,7 @@ H5D__btree_idx_dest(const H5D_chk_idx_info_t *idx_info)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(idx_info);
     HDassert(idx_info->f);

--- a/src/H5Dbtree2.c
+++ b/src/H5Dbtree2.c
@@ -219,7 +219,7 @@ H5D__bt2_crt_context(void *_udata)
     uint32_t *        my_dim    = NULL;                   /* Pointer to copy of chunk dimension size */
     void *            ret_value = NULL;                   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(udata);
@@ -273,7 +273,7 @@ H5D__bt2_dst_context(void *_ctx)
 {
     H5D_bt2_ctx_t *ctx = (H5D_bt2_ctx_t *)_ctx; /* Callback context structure */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -305,7 +305,7 @@ H5D__bt2_store(void *record, const void *_udata)
 {
     const H5D_bt2_ud_t *udata = (const H5D_bt2_ud_t *)_udata; /* User data */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     *(H5D_chunk_rec_t *)record = udata->rec;
 
@@ -334,7 +334,7 @@ H5D__bt2_compare(const void *_udata, const void *_rec2, int *result)
     const H5D_chunk_rec_t *rec2      = (const H5D_chunk_rec_t *)_rec2; /* The native record */
     herr_t                 ret_value = SUCCEED;                        /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(rec1);
@@ -366,7 +366,7 @@ H5D__bt2_unfilt_encode(uint8_t *raw, const void *_record, void *_ctx)
     const H5D_chunk_rec_t *record = (const H5D_chunk_rec_t *)_record; /* The native record */
     unsigned               u;                                         /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -400,7 +400,7 @@ H5D__bt2_unfilt_decode(const uint8_t *raw, void *_record, void *_ctx)
     H5D_chunk_rec_t *record = (H5D_chunk_rec_t *)_record; /* The native record */
     unsigned         u;                                   /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -434,7 +434,7 @@ H5D__bt2_unfilt_debug(FILE *stream, int indent, int fwidth, const void *_record,
     const H5D_bt2_ctx_t *  ctx    = (const H5D_bt2_ctx_t *)_ctx;      /* Callback context */
     unsigned               u;                                         /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(record);
@@ -471,7 +471,7 @@ H5D__bt2_filt_encode(uint8_t *raw, const void *_record, void *_ctx)
     const H5D_chunk_rec_t *record = (const H5D_chunk_rec_t *)_record; /* The native record */
     unsigned               u;                                         /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -509,7 +509,7 @@ H5D__bt2_filt_decode(const uint8_t *raw, void *_record, void *_ctx)
     H5D_chunk_rec_t *record = (H5D_chunk_rec_t *)_record; /* The native record */
     unsigned         u;                                   /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -548,7 +548,7 @@ H5D__bt2_filt_debug(FILE *stream, int indent, int fwidth, const void *_record, c
     const H5D_bt2_ctx_t *  ctx    = (const H5D_bt2_ctx_t *)_ctx;      /* Callback context */
     unsigned               u;                                         /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(record);
@@ -583,7 +583,7 @@ static herr_t
 H5D__bt2_idx_init(const H5D_chk_idx_info_t H5_ATTR_UNUSED *idx_info, const H5S_t H5_ATTR_UNUSED *space,
                   haddr_t dset_ohdr_addr)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(H5F_addr_defined(dset_ohdr_addr));
@@ -615,7 +615,7 @@ H5D__btree2_idx_depend(const H5D_chk_idx_info_t *idx_info)
     H5AC_proxy_entry_t *oh_proxy;            /* Dataset's object header proxy */
     herr_t              ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -678,7 +678,7 @@ H5D__bt2_idx_open(const H5D_chk_idx_info_t *idx_info)
     H5D_bt2_ctx_ud_t u_ctx;               /* user data for creating context */
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -729,7 +729,7 @@ H5D__bt2_idx_create(const H5D_chk_idx_info_t *idx_info)
     H5D_bt2_ctx_ud_t u_ctx;               /* data for context call */
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -802,7 +802,7 @@ done:
 static hbool_t
 H5D__bt2_idx_is_space_alloc(const H5O_storage_chunk_t *storage)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(storage);
@@ -830,7 +830,7 @@ H5D__bt2_mod_cb(void *_record, void *_op_data, hbool_t *changed)
     H5D_bt2_ud_t *   op_data = (H5D_bt2_ud_t *)_op_data;   /* User data for v2 B-tree calls */
     H5D_chunk_rec_t *record  = (H5D_chunk_rec_t *)_record; /* Chunk record */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 /* Sanity check */
 #ifndef NDEBUG
@@ -878,7 +878,7 @@ H5D__bt2_idx_insert(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata,
     unsigned     u;                   /* Local index variable */
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -942,7 +942,7 @@ done:
 static herr_t
 H5D__bt2_found_cb(const void *nrecord, void *op_data)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     *(H5D_chunk_rec_t *)op_data = *(const H5D_chunk_rec_t *)nrecord;
 
@@ -972,7 +972,7 @@ H5D__bt2_idx_get_addr(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata)
     hbool_t         found;               /* Whether chunk was found */
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -1066,7 +1066,7 @@ H5D__bt2_idx_iterate_cb(const void *_record, void *_udata)
     const H5D_chunk_rec_t *record    = (const H5D_chunk_rec_t *)_record; /* Native record */
     int                    ret_value = -1;                               /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Make "generic chunk" callback */
     if ((ret_value = (udata->cb)(record, udata->udata)) < 0)
@@ -1094,7 +1094,7 @@ H5D__bt2_idx_iterate(const H5D_chk_idx_info_t *idx_info, H5D_chunk_cb_func_t chu
     H5D_bt2_it_ud_t udata;            /* User data for B-tree iterator callback */
     int             ret_value = FAIL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -1153,7 +1153,7 @@ H5D__bt2_remove_cb(const void *_record, void *_udata)
     H5F_t *                f         = (H5F_t *)_udata;                  /* User data for removal callback */
     herr_t                 ret_value = SUCCEED;                          /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -1186,7 +1186,7 @@ H5D__bt2_idx_remove(const H5D_chk_idx_info_t *idx_info, H5D_chunk_common_ud_t *u
     unsigned     u;                   /* Local index variable */
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -1248,7 +1248,7 @@ H5D__bt2_idx_delete(const H5D_chk_idx_info_t *idx_info)
     H5D_bt2_ctx_ud_t u_ctx;               /* data for context call */
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -1299,7 +1299,7 @@ H5D__bt2_idx_copy_setup(const H5D_chk_idx_info_t *idx_info_src, const H5D_chk_id
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Source file */
     HDassert(idx_info_src);
@@ -1352,7 +1352,7 @@ H5D__bt2_idx_copy_shutdown(H5O_storage_chunk_t *storage_src, H5O_storage_chunk_t
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(storage_src);
@@ -1392,7 +1392,7 @@ H5D__bt2_idx_size(const H5D_chk_idx_info_t *idx_info, hsize_t *index_size)
     H5B2_t *bt2_cdset = NULL;    /* Pointer to v2 B-tree structure */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -1437,7 +1437,7 @@ done:
 static herr_t
 H5D__bt2_idx_reset(H5O_storage_chunk_t *storage, hbool_t reset_addr)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(storage);
@@ -1464,7 +1464,7 @@ H5D__bt2_idx_reset(H5O_storage_chunk_t *storage, hbool_t reset_addr)
 static herr_t
 H5D__bt2_idx_dump(const H5O_storage_chunk_t *storage, FILE *stream)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(storage);
@@ -1491,7 +1491,7 @@ H5D__bt2_idx_dest(const H5D_chk_idx_info_t *idx_info)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -700,7 +700,7 @@ H5D__chunk_set_info_real(H5O_layout_chunk_t *layout, unsigned ndims, const hsize
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(layout);
@@ -852,7 +852,7 @@ H5D__chunk_construct(H5F_t H5_ATTR_UNUSED *f, H5D_t *dset)
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -920,7 +920,7 @@ H5D__chunk_init(H5F_t *f, const H5D_t *const dset, hid_t dapl_id)
     H5O_storage_chunk_t *sc        = &(dset->shared->layout.storage.u.chunk);
     herr_t               ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);
@@ -1080,7 +1080,7 @@ H5D__chunk_io_init(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsi
     unsigned     u;                        /* Local index variable */
     herr_t       ret_value = SUCCEED;      /* Return value        */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get layout for dataset */
     fm->layout = &(dataset->shared->layout);
@@ -1174,7 +1174,7 @@ H5D__chunk_io_init_selections(const H5D_io_info_t *io_info, const H5D_type_info_
     char         bogus;                            /* "bogus" buffer to pass to selection iterator */
     herr_t       ret_value = SUCCEED;              /* Return value        */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Special case for only one element in selection */
     /* (usually appending a record) */
@@ -1375,7 +1375,7 @@ H5D__chunk_mem_alloc(size_t size, const H5O_pline_t *pline)
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(size);
 
@@ -1406,7 +1406,7 @@ H5D__chunk_mem_xfree(void *chk, const void *_pline)
 {
     const H5O_pline_t *pline = (const H5O_pline_t *)_pline;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (chk) {
         if (pline && pline->nused)
@@ -1450,7 +1450,7 @@ H5D__chunk_mem_realloc(void *chk, size_t size, const H5O_pline_t *pline)
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(size);
     HDassert(pline);
@@ -1485,7 +1485,7 @@ H5D__free_chunk_info(void *item, void H5_ATTR_UNUSED *key, void H5_ATTR_UNUSED *
 {
     H5D_chunk_info_t *chunk_info = (H5D_chunk_info_t *)item;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(chunk_info);
 
@@ -1531,7 +1531,7 @@ H5D__create_chunk_map_single(H5D_chunk_map_t *fm, const H5D_io_info_t
     unsigned          u;                           /* Local index variable */
     herr_t            ret_value = SUCCEED;         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(fm->f_ndims > 0);
@@ -1625,7 +1625,7 @@ H5D__create_chunk_file_map_all(H5D_chunk_map_t *fm, const H5D_io_info_t
     unsigned u;                               /* Local index variable */
     herr_t   ret_value = SUCCEED;             /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(fm->f_ndims > 0);
@@ -1828,7 +1828,7 @@ H5D__create_chunk_file_map_hyper(H5D_chunk_map_t *fm, const H5D_io_info_t
     unsigned u;                              /* Local index variable */
     herr_t   ret_value = SUCCEED;            /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(fm->f_ndims > 0);
@@ -2000,7 +2000,7 @@ H5D__create_chunk_mem_map_hyper(const H5D_chunk_map_t *fm)
     unsigned          u;                            /* Local index variable */
     herr_t            ret_value = SUCCEED;          /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(fm->f_ndims > 0);
@@ -2123,7 +2123,7 @@ H5D__create_chunk_mem_map_1d(const H5D_chunk_map_t *fm)
     H5SL_node_t *     curr_node;           /* Current node in skip list */
     herr_t            ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(fm->f_ndims > 0);
@@ -2210,7 +2210,7 @@ H5D__chunk_file_cb(void H5_ATTR_UNUSED *elem, const H5T_t H5_ATTR_UNUSED *type, 
     unsigned                  u;                                 /* Local index variable */
     herr_t                    ret_value = SUCCEED;               /* Return value        */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Calculate the index of this chunk */
     chunk_index = H5VM_chunk_index_scaled(ndims, coords, fm->layout->u.chunk.dim,
@@ -2324,7 +2324,7 @@ H5D__chunk_mem_cb(void H5_ATTR_UNUSED *elem, const H5T_t H5_ATTR_UNUSED *type, u
     hsize_t           chunk_index;                 /* Chunk index */
     herr_t            ret_value = SUCCEED;         /* Return value        */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Calculate the index of this chunk */
     chunk_index = H5VM_chunk_index(ndims, coords, fm->layout->u.chunk.dim, fm->layout->u.chunk.down_chunks);
@@ -2486,7 +2486,7 @@ H5D__chunk_may_use_select_io(const H5D_io_info_t *io_info)
     const H5D_t *dataset   = NULL; /* Local pointer to dataset info */
     htri_t       ret_value = FAIL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(io_info);
@@ -2567,7 +2567,7 @@ H5D__chunk_read(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize_
     haddr_t       chunk_addrs_static[8];       /* Static buffer for chunk_addrs */
     herr_t        ret_value = SUCCEED;         /*return value        */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(io_info);
@@ -2839,7 +2839,7 @@ H5D__chunk_write(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsize
     haddr_t       chunk_addrs_static[8];       /* Static buffer for chunk_addrs */
     herr_t        ret_value = SUCCEED;         /* Return value        */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(io_info);
@@ -3177,7 +3177,7 @@ H5D__chunk_flush(H5D_t *dset)
     unsigned        nerrors   = 0;       /* Count of any errors encountered when flushing chunks */
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(dset);
@@ -3212,7 +3212,7 @@ H5D__chunk_io_term(const H5D_chunk_map_t *fm)
 {
     herr_t ret_value = SUCCEED; /*return value        */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Single element I/O vs. multiple element I/O cleanup */
     if (fm->use_single) {
@@ -3268,7 +3268,7 @@ H5D__chunk_dest(H5D_t *dset)
     H5O_storage_chunk_t *sc        = &(dset->shared->layout.storage.u.chunk);
     herr_t               ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC_TAG(dset->oloc.addr)
+    FUNC_ENTER_PACKAGE_TAG(dset->oloc.addr)
 
     /* Sanity checks */
     HDassert(dset);
@@ -3351,7 +3351,7 @@ done:
 static herr_t
 H5D__chunk_cinfo_cache_reset(H5D_chunk_cached_t *last)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(last);
@@ -3377,7 +3377,7 @@ H5D__chunk_cinfo_cache_reset(H5D_chunk_cached_t *last)
 static herr_t
 H5D__chunk_cinfo_cache_update(H5D_chunk_cached_t *last, const H5D_chunk_ud_t *udata)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(last);
@@ -3415,7 +3415,7 @@ H5D__chunk_cinfo_cache_found(const H5D_chunk_cached_t *last, H5D_chunk_ud_t *uda
 {
     hbool_t ret_value = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(last);
@@ -3520,7 +3520,7 @@ H5D__chunk_hash_val(const H5D_shared_t *shared, const hsize_t *scaled)
     unsigned ret   = 0;             /* Value to return */
     unsigned u;                     /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(shared);
@@ -3717,7 +3717,7 @@ H5D__chunk_flush_entry(const H5D_t *dset, H5D_rdcc_ent_t *ent, hbool_t reset)
     H5O_storage_chunk_t *sc                 = &(dset->shared->layout.storage.u.chunk);
     herr_t               ret_value          = SUCCEED; /* Return value            */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(dset);
     HDassert(dset->shared);
@@ -3906,7 +3906,7 @@ H5D__chunk_cache_evict(const H5D_t *dset, H5D_rdcc_ent_t *ent, hbool_t flush)
     H5D_rdcc_t *rdcc      = &(dset->shared->cache.chunk);
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(dset);
@@ -3992,7 +3992,7 @@ H5D__chunk_cache_prune(const H5D_t *dset, size_t size)
     int               nerrors   = 0;       /* Accumulated error count during preemptions */
     herr_t            ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Preemption is accomplished by having multiple pointers (currently two)
@@ -4120,7 +4120,7 @@ H5D__chunk_lock(const H5D_io_info_t *io_info, H5D_chunk_ud_t *udata, hbool_t rel
     void *              chunk           = NULL;  /*the file chunk    */
     void *              ret_value       = NULL;  /* Return value         */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(io_info);
@@ -4508,7 +4508,7 @@ H5D__chunk_unlock(const H5D_io_info_t *io_info, const H5D_chunk_ud_t *udata, hbo
     const H5D_rdcc_t *  rdcc      = &(io_info->dset->shared->cache.chunk);
     herr_t              ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(io_info);
@@ -4603,7 +4603,7 @@ H5D__chunk_allocated_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
 {
     hsize_t *nbytes = (hsize_t *)_udata;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     *(hsize_t *)nbytes += chunk_rec->nbytes;
 
@@ -5348,7 +5348,7 @@ H5D__chunk_collective_fill(const H5D_t *dset, H5D_chunk_coll_fill_info_t *chunk_
     size_t           i;                   /* Local index variable */
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * If a separate fill buffer is provided for partial chunks, ensure
@@ -5581,7 +5581,7 @@ H5D__chunk_cmp_coll_fill_info(const void *_entry1, const void *_entry2)
     const struct chunk_coll_fill_info *entry1;
     const struct chunk_coll_fill_info *entry2;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     entry1 = (const struct chunk_coll_fill_info *)_entry1;
     entry2 = (const struct chunk_coll_fill_info *)_entry2;
@@ -5622,7 +5622,7 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, hbool_t new_unfilt_chunk)
     unsigned             u;                       /* Local index variable */
     herr_t               ret_value = SUCCEED;     /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get the chunk's size */
     HDassert(layout->u.chunk.size > 0);
@@ -6162,7 +6162,7 @@ H5D__chunk_addrmap_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
     unsigned            rank  = udata->common.layout->ndims - 1; /* # of dimensions of dataset */
     hsize_t             chunk_index;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Compute the index for this chunk */
     chunk_index = H5VM_array_offset_pre(rank, udata->common.layout->down_chunks, chunk_rec->scaled);
@@ -6446,7 +6446,7 @@ H5D__chunk_copy_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
     H5Z_cb_t filter_cb;                /* Filter failure callback struct */
     int      ret_value = H5_ITER_CONT; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get 'size_t' local value for number of bytes in chunk */
     H5_CHECKED_ASSIGN(nbytes, size_t, chunk_rec->nbytes, uint32_t);
@@ -7037,7 +7037,7 @@ H5D__chunk_dump_index_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
 {
     H5D_chunk_it_ud4_t *udata = (H5D_chunk_it_ud4_t *)_udata; /* User data from caller */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (udata->stream) {
         unsigned u; /* Local index variable */
@@ -7213,7 +7213,7 @@ H5D__nonexistent_readvv_cb(hsize_t H5_ATTR_UNUSED dst_off, hsize_t src_off, size
     hbool_t                fb_info_init = FALSE;   /* Whether the fill value buffer has been initialized */
     herr_t                 ret_value    = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Initialize the fill value buffer */
     if (H5D__fill_init(&fb_info, (udata->rbuf + src_off), NULL, NULL, NULL, NULL,
@@ -7262,7 +7262,7 @@ H5D__nonexistent_readvv(const H5D_io_info_t *io_info, size_t chunk_max_nseq, siz
     H5D_chunk_readvv_ud_t udata;          /* User data for H5VM_opvv() operator */
     ssize_t               ret_value = -1; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(io_info);
@@ -7308,7 +7308,7 @@ H5D__chunk_is_partial_edge_chunk(unsigned dset_ndims, const uint32_t *chunk_dims
     unsigned u;                 /* Local index variable */
     hbool_t  ret_value = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(scaled);
@@ -7346,7 +7346,7 @@ H5D__chunk_file_alloc(const H5D_chk_idx_info_t *idx_info, const H5F_block_t *old
     hbool_t alloc_chunk = FALSE;   /* Whether to allocate chunk */
     herr_t  ret_value   = SUCCEED; /* Return value         */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(idx_info);
@@ -7483,7 +7483,7 @@ H5D__chunk_format_convert_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
     void *              buf       = NULL;                     /* Pointer to buffer of chunk data */
     int                 ret_value = H5_ITER_CONT;             /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Set up */
     new_idx_info = udata->new_idx_info;
@@ -7613,7 +7613,7 @@ H5D__chunk_index_empty_cb(const H5D_chunk_rec_t H5_ATTR_UNUSED *chunk_rec, void 
     hbool_t *empty     = (hbool_t *)_udata;
     int      ret_value = H5_ITER_STOP;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     *empty = FALSE;
 
@@ -7700,7 +7700,7 @@ H5D__get_num_chunks_cb(const H5D_chunk_rec_t H5_ATTR_UNUSED *chunk_rec, void *_u
     hsize_t *num_chunks = (hsize_t *)_udata;
     int      ret_value  = H5_ITER_CONT; /* Callback return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(num_chunks);
 
@@ -7792,7 +7792,7 @@ H5D__get_chunk_info_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
     H5D_chunk_info_iter_ud_t *chunk_info = (H5D_chunk_info_iter_ud_t *)_udata;
     int                       ret_value  = H5_ITER_CONT; /* Callback return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(chunk_rec);
@@ -7933,7 +7933,7 @@ H5D__get_chunk_info_by_coord_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
     hsize_t                   ii;                       /* Local index value */
     int                       ret_value = H5_ITER_CONT; /* Callback return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(chunk_rec);
@@ -8070,7 +8070,7 @@ H5D__chunk_iter_cb(const H5D_chunk_rec_t *chunk_rec, void *udata)
     const H5D_chunk_iter_ud_t *data      = (H5D_chunk_iter_ud_t *)udata;
     int                        ret_value = H5_ITER_CONT;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check for callback failure and pass along return value */
     if ((ret_value = (data->op)(chunk_rec->scaled, chunk_rec->filter_mask, chunk_rec->chunk_addr,

--- a/src/H5Dcompact.c
+++ b/src/H5Dcompact.c
@@ -176,7 +176,7 @@ H5D__compact_construct(H5F_t *f, H5D_t *dset)
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -225,7 +225,7 @@ done:
 static hbool_t
 H5D__compact_is_space_alloc(const H5O_storage_t H5_ATTR_UNUSED *storage)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(storage);
@@ -251,7 +251,7 @@ H5D__compact_io_init(H5D_io_info_t *io_info, const H5D_type_info_t H5_ATTR_UNUSE
                      hsize_t H5_ATTR_UNUSED nelmts, H5S_t H5_ATTR_UNUSED *file_space,
                      H5S_t H5_ATTR_UNUSED *mem_space, H5D_chunk_map_t H5_ATTR_UNUSED *cm)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     io_info->store->compact.buf   = io_info->dset->shared->layout.storage.u.compact.buf;
     io_info->store->compact.dirty = &io_info->dset->shared->layout.storage.u.compact.dirty;
@@ -278,7 +278,7 @@ H5D__compact_iovv_memmanage_cb(hsize_t dst_off, hsize_t src_off, size_t len, voi
     H5FD_t *                         file_handle = NULL;
     herr_t                           ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Retrieve pointer to file driver structure for ctl call */
     if (H5F_shared_get_file_driver(udata->f_sh, &file_handle) < 0)
@@ -326,7 +326,7 @@ H5D__compact_readvv(const H5D_io_info_t *io_info, size_t dset_max_nseq, size_t *
 {
     ssize_t ret_value = -1; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(io_info);
 
@@ -385,7 +385,7 @@ H5D__compact_writevv(const H5D_io_info_t *io_info, size_t dset_max_nseq, size_t 
 {
     ssize_t ret_value = -1; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(io_info);
 
@@ -436,7 +436,7 @@ H5D__compact_flush(H5D_t *dset)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(dset);
@@ -469,7 +469,7 @@ done:
 static herr_t
 H5D__compact_dest(H5D_t *dset)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(dset);

--- a/src/H5Dcontig.c
+++ b/src/H5Dcontig.c
@@ -382,7 +382,7 @@ H5D__contig_construct(H5F_t *f, H5D_t *dset)
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -453,7 +453,7 @@ H5D__contig_init(H5F_t H5_ATTR_UNUSED *f, const H5D_t *dset, hid_t H5_ATTR_UNUSE
     size_t  tmp_sieve_buf_size;  /* Temporary holder for sieve buffer size */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);
@@ -575,7 +575,7 @@ H5D__contig_io_init(H5D_io_info_t *io_info, const H5D_type_info_t H5_ATTR_UNUSED
     htri_t use_selection_io = FALSE;   /* Whether to use selection I/O */
     htri_t ret_value        = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     io_info->store->contig.dset_addr = io_info->dset->shared->layout.storage.u.contig.addr;
     io_info->store->contig.dset_size = io_info->dset->shared->layout.storage.u.contig.size;
@@ -608,7 +608,7 @@ H5D__contig_may_use_select_io(const H5D_io_info_t *io_info, H5D_io_op_type_t op_
     const H5D_t *dataset   = io_info->dset; /* Local pointer to dataset info */
     htri_t       ret_value = FAIL;          /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(io_info);
@@ -761,7 +761,7 @@ H5D__contig_write_one(H5D_io_info_t *io_info, hsize_t offset, size_t size)
     size_t  mem_curr_seq  = 0;       /* "Current sequence" in memory */
     herr_t  ret_value     = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(io_info);
 
@@ -804,7 +804,7 @@ H5D__contig_readvv_sieve_cb(hsize_t dst_off, hsize_t src_off, size_t len, void *
     hsize_t min;                 /* temporary minimum value (avoids some ugly macro nesting) */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Stash local copies of these value */
     if (dset_contig->sieve_buf != NULL) {
@@ -958,7 +958,7 @@ H5D__contig_readvv_cb(hsize_t dst_off, hsize_t src_off, size_t len, void *_udata
     H5D_contig_readvv_ud_t *udata = (H5D_contig_readvv_ud_t *)_udata; /* User data for H5VM_opvv() operator */
     herr_t                  ret_value = SUCCEED;                      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Write data */
     if (H5F_shared_block_read(udata->f_sh, H5FD_MEM_DRAW, (udata->dset_addr + dst_off), len,
@@ -994,7 +994,7 @@ H5D__contig_readvv(const H5D_io_info_t *io_info, size_t dset_max_nseq, size_t *d
 {
     ssize_t ret_value = -1; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(io_info);
@@ -1071,7 +1071,7 @@ H5D__contig_writevv_sieve_cb(hsize_t dst_off, hsize_t src_off, size_t len, void 
     hsize_t min;                 /* temporary minimum value (avoids some ugly macro nesting) */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Stash local copies of these values */
     if (dset_contig->sieve_buf != NULL) {
@@ -1276,7 +1276,7 @@ H5D__contig_writevv_cb(hsize_t dst_off, hsize_t src_off, size_t len, void *_udat
         (H5D_contig_writevv_ud_t *)_udata; /* User data for H5VM_opvv() operator */
     herr_t ret_value = SUCCEED;            /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Write data */
     if (H5F_shared_block_write(udata->f_sh, H5FD_MEM_DRAW, (udata->dset_addr + dst_off), len,
@@ -1312,7 +1312,7 @@ H5D__contig_writevv(const H5D_io_info_t *io_info, size_t dset_max_nseq, size_t *
 {
     ssize_t ret_value = -1; /* Return value (Size of sequence in bytes) */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(io_info);
@@ -1375,7 +1375,7 @@ H5D__contig_flush(H5D_t *dset)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(dset);

--- a/src/H5Dearray.c
+++ b/src/H5Dearray.c
@@ -219,7 +219,7 @@ H5D__earray_crt_context(void *_udata)
     H5D_earray_ctx_ud_t *udata = (H5D_earray_ctx_ud_t *)_udata; /* User data for extensible array context */
     void *               ret_value = NULL;                      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(udata);
@@ -266,7 +266,7 @@ H5D__earray_dst_context(void *_ctx)
 {
     H5D_earray_ctx_t *ctx = (H5D_earray_ctx_t *)_ctx; /* Extensible array callback context */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(ctx);
@@ -295,7 +295,7 @@ H5D__earray_fill(void *nat_blk, size_t nelmts)
 {
     haddr_t fill_val = H5D_EARRAY_FILL; /* Value to fill elements with */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(nat_blk);
@@ -325,7 +325,7 @@ H5D__earray_encode(void *raw, const void *_elmt, size_t nelmts, void *_ctx)
     H5D_earray_ctx_t *ctx  = (H5D_earray_ctx_t *)_ctx; /* Extensible array callback context */
     const haddr_t *   elmt = (const haddr_t *)_elmt;   /* Convenience pointer to native elements */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(raw);
@@ -369,7 +369,7 @@ H5D__earray_decode(const void *_raw, void *_elmt, size_t nelmts, void *_ctx)
     haddr_t *         elmt = (haddr_t *)_elmt;         /* Convenience pointer to native elements */
     const uint8_t *   raw  = (const uint8_t *)_raw;    /* Convenience pointer to raw elements */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(raw);
@@ -410,7 +410,7 @@ H5D__earray_debug(FILE *stream, int indent, int fwidth, hsize_t idx, const void 
 {
     char temp_str[128]; /* Temporary string, for formatting */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(stream);
@@ -441,7 +441,7 @@ H5D__earray_filt_fill(void *nat_blk, size_t nelmts)
 {
     H5D_earray_filt_elmt_t fill_val = H5D_EARRAY_FILT_FILL; /* Value to fill elements with */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(nat_blk);
@@ -474,7 +474,7 @@ H5D__earray_filt_encode(void *_raw, const void *_elmt, size_t nelmts, void *_ctx
     const H5D_earray_filt_elmt_t *elmt =
         (const H5D_earray_filt_elmt_t *)_elmt; /* Convenience pointer to native elements */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(raw);
@@ -521,7 +521,7 @@ H5D__earray_filt_decode(const void *_raw, void *_elmt, size_t nelmts, void *_ctx
         (H5D_earray_filt_elmt_t *)_elmt;        /* Convenience pointer to native elements */
     const uint8_t *raw = (const uint8_t *)_raw; /* Convenience pointer to raw elements */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(raw);
@@ -566,7 +566,7 @@ H5D__earray_filt_debug(FILE *stream, int indent, int fwidth, hsize_t idx, const 
         (const H5D_earray_filt_elmt_t *)_elmt; /* Convenience pointer to native elements */
     char temp_str[128];                        /* Temporary string, for formatting */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(stream);
@@ -602,7 +602,7 @@ H5D__earray_crt_dbg_context(H5F_t *f, haddr_t obj_addr)
     H5O_layout_t         layout;             /* Layout message */
     void *               ret_value = NULL;   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -673,7 +673,7 @@ H5D__earray_dst_dbg_context(void *_dbg_ctx)
     H5D_earray_ctx_ud_t *dbg_ctx =
         (H5D_earray_ctx_ud_t *)_dbg_ctx; /* Context for extensible array callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(dbg_ctx);
@@ -706,7 +706,7 @@ H5D__earray_idx_depend(const H5D_chk_idx_info_t *idx_info)
     H5AC_proxy_entry_t *oh_proxy;            /* Dataset's object header proxy */
     herr_t              ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -770,7 +770,7 @@ H5D__earray_idx_open(const H5D_chk_idx_info_t *idx_info)
     H5D_earray_ctx_ud_t udata;               /* User data for extensible array open call */
     herr_t              ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -824,7 +824,7 @@ H5D__earray_idx_init(const H5D_chk_idx_info_t *idx_info, const H5S_t *space, had
     unsigned u;                          /* Local index variable */
     herr_t   ret_value = SUCCEED;        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -893,7 +893,7 @@ H5D__earray_idx_create(const H5D_chk_idx_info_t *idx_info)
     H5D_earray_ctx_ud_t udata;               /* User data for extensible array create call */
     herr_t              ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -970,7 +970,7 @@ done:
 static hbool_t
 H5D__earray_idx_is_space_alloc(const H5O_storage_chunk_t *storage)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(storage);
@@ -996,7 +996,7 @@ H5D__earray_idx_insert(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata
     H5EA_t *ea;                  /* Pointer to extensible array structure */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -1067,7 +1067,7 @@ H5D__earray_idx_get_addr(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *uda
     hsize_t idx;                 /* Array index of chunk */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -1160,7 +1160,7 @@ done:
 static herr_t
 H5D__earray_idx_resize(H5O_layout_chunk_t *layout)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(layout);
@@ -1213,7 +1213,7 @@ H5D__earray_idx_iterate_cb(hsize_t H5_ATTR_UNUSED idx, const void *_elmt, void *
     int                 curr_dim;                             /* Current dimension */
     int                 ret_value = H5_ITER_CONT;             /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Compose generic chunk record for callback */
     if (udata->filtered) {
@@ -1276,7 +1276,7 @@ H5D__earray_idx_iterate(const H5D_chk_idx_info_t *idx_info, H5D_chunk_cb_func_t 
     H5EA_stat_t ea_stat;                  /* Extensible array statistics */
     int         ret_value = H5_ITER_CONT; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -1348,7 +1348,7 @@ H5D__earray_idx_remove(const H5D_chk_idx_info_t *idx_info, H5D_chunk_common_ud_t
     hsize_t idx;                 /* Array index of chunk */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -1461,7 +1461,7 @@ H5D__earray_idx_delete_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
     H5F_t *f         = (H5F_t *)_udata; /* User data for callback */
     int    ret_value = H5_ITER_CONT;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(chunk_rec);
@@ -1501,7 +1501,7 @@ H5D__earray_idx_delete(const H5D_chk_idx_info_t *idx_info)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -1556,7 +1556,7 @@ H5D__earray_idx_copy_setup(const H5D_chk_idx_info_t *idx_info_src, const H5D_chk
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info_src);
@@ -1609,7 +1609,7 @@ H5D__earray_idx_copy_shutdown(H5O_storage_chunk_t *storage_src, H5O_storage_chun
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(storage_src);
@@ -1649,7 +1649,7 @@ H5D__earray_idx_size(const H5D_chk_idx_info_t *idx_info, hsize_t *index_size)
     H5EA_stat_t ea_stat;             /* Extensible array statistics */
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -1700,7 +1700,7 @@ done:
 static herr_t
 H5D__earray_idx_reset(H5O_storage_chunk_t *storage, hbool_t reset_addr)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(storage);
@@ -1730,7 +1730,7 @@ H5D__earray_idx_reset(H5O_storage_chunk_t *storage, hbool_t reset_addr)
 static herr_t
 H5D__earray_idx_dump(const H5O_storage_chunk_t *storage, FILE *stream)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(storage);
@@ -1758,7 +1758,7 @@ H5D__earray_idx_dest(const H5D_chk_idx_info_t *idx_info)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);

--- a/src/H5Defl.c
+++ b/src/H5Defl.c
@@ -126,7 +126,7 @@ H5D__efl_construct(H5F_t *f, H5D_t *dset)
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -213,7 +213,7 @@ H5D__efl_io_init(H5D_io_info_t *io_info, const H5D_type_info_t H5_ATTR_UNUSED *t
                  hsize_t H5_ATTR_UNUSED nelmts, H5S_t H5_ATTR_UNUSED *file_space,
                  H5S_t H5_ATTR_UNUSED *mem_space, H5D_chunk_map_t H5_ATTR_UNUSED *cm)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     H5MM_memcpy(&io_info->store->efl, &(io_info->dset->shared->dcpl_cache.efl), sizeof(H5O_efl_t));
 
@@ -250,7 +250,7 @@ H5D__efl_read(const H5O_efl_t *efl, const H5D_t *dset, haddr_t addr, size_t size
     char *  full_name = NULL;    /* File name with prefix */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(efl && efl->nused > 0);
@@ -338,7 +338,7 @@ H5D__efl_write(const H5O_efl_t *efl, const H5D_t *dset, haddr_t addr, size_t siz
     char *  full_name = NULL;    /* File name with prefix */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(efl && efl->nused > 0);
@@ -417,7 +417,7 @@ H5D__efl_readvv_cb(hsize_t dst_off, hsize_t src_off, size_t len, void *_udata)
     H5D_efl_readvv_ud_t *udata     = (H5D_efl_readvv_ud_t *)_udata; /* User data for H5VM_opvv() operator */
     herr_t               ret_value = SUCCEED;                       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Read data */
     if (H5D__efl_read(udata->efl, udata->dset, dst_off, len, (udata->rbuf + src_off)) < 0)
@@ -450,7 +450,7 @@ H5D__efl_readvv(const H5D_io_info_t *io_info, size_t dset_max_nseq, size_t *dset
     H5D_efl_readvv_ud_t udata;          /* User data for H5VM_opvv() operator */
     ssize_t             ret_value = -1; /* Return value (Total size of sequence in bytes) */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(io_info);
@@ -497,7 +497,7 @@ H5D__efl_writevv_cb(hsize_t dst_off, hsize_t src_off, size_t len, void *_udata)
     H5D_efl_writevv_ud_t *udata     = (H5D_efl_writevv_ud_t *)_udata; /* User data for H5VM_opvv() operator */
     herr_t                ret_value = SUCCEED;                        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Write data */
     if (H5D__efl_write(udata->efl, udata->dset, dst_off, len, (udata->wbuf + src_off)) < 0)
@@ -530,7 +530,7 @@ H5D__efl_writevv(const H5D_io_info_t *io_info, size_t dset_max_nseq, size_t *dse
     H5D_efl_writevv_ud_t udata;          /* User data for H5VM_opvv() operator */
     ssize_t              ret_value = -1; /* Return value (Total size of sequence in bytes) */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(io_info);

--- a/src/H5Dfarray.c
+++ b/src/H5Dfarray.c
@@ -218,7 +218,7 @@ H5D__farray_crt_context(void *_udata)
     H5D_farray_ctx_ud_t *udata     = (H5D_farray_ctx_ud_t *)_udata; /* User data for fixed array context */
     void *               ret_value = NULL;                          /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(udata);
@@ -264,7 +264,7 @@ H5D__farray_dst_context(void *_ctx)
 {
     H5D_farray_ctx_t *ctx = (H5D_farray_ctx_t *)_ctx; /* Fixed array callback context */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(ctx);
@@ -293,7 +293,7 @@ H5D__farray_fill(void *nat_blk, size_t nelmts)
 {
     haddr_t fill_val = H5D_FARRAY_FILL; /* Value to fill elements with */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(nat_blk);
@@ -323,7 +323,7 @@ H5D__farray_encode(void *raw, const void *_elmt, size_t nelmts, void *_ctx)
     H5D_farray_ctx_t *ctx  = (H5D_farray_ctx_t *)_ctx; /* Fixed array callback context */
     const haddr_t *   elmt = (const haddr_t *)_elmt;   /* Convenience pointer to native elements */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(raw);
@@ -367,7 +367,7 @@ H5D__farray_decode(const void *_raw, void *_elmt, size_t nelmts, void *_ctx)
     haddr_t *         elmt = (haddr_t *)_elmt;         /* Convenience pointer to native elements */
     const uint8_t *   raw  = (const uint8_t *)_raw;    /* Convenience pointer to raw elements */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(raw);
@@ -408,7 +408,7 @@ H5D__farray_debug(FILE *stream, int indent, int fwidth, hsize_t idx, const void 
 {
     char temp_str[128]; /* Temporary string, for formatting */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(stream);
@@ -444,7 +444,7 @@ H5D__farray_crt_dbg_context(H5F_t *f, haddr_t obj_addr)
     H5O_layout_t         layout;             /* Layout message */
     void *               ret_value = NULL;   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -514,7 +514,7 @@ H5D__farray_dst_dbg_context(void *_dbg_ctx)
 {
     H5D_farray_ctx_ud_t *dbg_ctx = (H5D_farray_ctx_ud_t *)_dbg_ctx; /* Context for fixed array callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(dbg_ctx);
@@ -543,7 +543,7 @@ H5D__farray_filt_fill(void *nat_blk, size_t nelmts)
 {
     H5D_farray_filt_elmt_t fill_val = H5D_FARRAY_FILT_FILL; /* Value to fill elements with */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(nat_blk);
@@ -576,7 +576,7 @@ H5D__farray_filt_encode(void *_raw, const void *_elmt, size_t nelmts, void *_ctx
     const H5D_farray_filt_elmt_t *elmt =
         (const H5D_farray_filt_elmt_t *)_elmt; /* Convenience pointer to native elements */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(raw);
@@ -623,7 +623,7 @@ H5D__farray_filt_decode(const void *_raw, void *_elmt, size_t nelmts, void *_ctx
         (H5D_farray_filt_elmt_t *)_elmt;        /* Convenience pointer to native elements */
     const uint8_t *raw = (const uint8_t *)_raw; /* Convenience pointer to raw elements */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(raw);
@@ -668,7 +668,7 @@ H5D__farray_filt_debug(FILE *stream, int indent, int fwidth, hsize_t idx, const 
         (const H5D_farray_filt_elmt_t *)_elmt; /* Convenience pointer to native elements */
     char temp_str[128];                        /* Temporary string, for formatting */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(stream);
@@ -704,7 +704,7 @@ H5D__farray_idx_depend(const H5D_chk_idx_info_t *idx_info)
     H5AC_proxy_entry_t *oh_proxy;            /* Dataset's object header proxy */
     herr_t              ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -760,7 +760,7 @@ static herr_t
 H5D__farray_idx_init(const H5D_chk_idx_info_t *idx_info, const H5S_t H5_ATTR_UNUSED *space,
                      haddr_t dset_ohdr_addr)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(idx_info);
@@ -792,7 +792,7 @@ H5D__farray_idx_open(const H5D_chk_idx_info_t *idx_info)
     H5D_farray_ctx_ud_t udata;               /* User data for fixed array open call */
     herr_t              ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -849,7 +849,7 @@ H5D__farray_idx_create(const H5D_chk_idx_info_t *idx_info)
     H5D_farray_ctx_ud_t udata;               /* User data for fixed array create call */
     herr_t              ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -920,7 +920,7 @@ done:
 static hbool_t
 H5D__farray_idx_is_space_alloc(const H5O_storage_chunk_t *storage)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(storage);
@@ -946,7 +946,7 @@ H5D__farray_idx_insert(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata
     H5FA_t *fa;                  /* Pointer to fixed array structure */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -1017,7 +1017,7 @@ H5D__farray_idx_get_addr(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *uda
     hsize_t idx;                 /* Array index of chunk */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -1096,7 +1096,7 @@ H5D__farray_idx_iterate_cb(hsize_t H5_ATTR_UNUSED idx, const void *_elmt, void *
     int                 curr_dim;                             /* Current dimension */
     int                 ret_value = H5_ITER_CONT;             /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Compose generic chunk record for callback */
     if (udata->filtered) {
@@ -1155,7 +1155,7 @@ H5D__farray_idx_iterate(const H5D_chk_idx_info_t *idx_info, H5D_chunk_cb_func_t 
     H5FA_stat_t fa_stat;          /* Fixed array statistics */
     int         ret_value = FAIL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -1228,7 +1228,7 @@ H5D__farray_idx_remove(const H5D_chk_idx_info_t *idx_info, H5D_chunk_common_ud_t
     hsize_t idx;                 /* Array index of chunk */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -1323,7 +1323,7 @@ H5D__farray_idx_delete_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
     H5F_t *f         = (H5F_t *)_udata; /* User data for callback */
     int    ret_value = H5_ITER_CONT;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(chunk_rec);
@@ -1359,7 +1359,7 @@ H5D__farray_idx_delete(const H5D_chk_idx_info_t *idx_info)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -1414,7 +1414,7 @@ H5D__farray_idx_copy_setup(const H5D_chk_idx_info_t *idx_info_src, const H5D_chk
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info_src);
@@ -1467,7 +1467,7 @@ H5D__farray_idx_copy_shutdown(H5O_storage_chunk_t *storage_src, H5O_storage_chun
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(storage_src);
@@ -1507,7 +1507,7 @@ H5D__farray_idx_size(const H5D_chk_idx_info_t *idx_info, hsize_t *index_size)
     H5FA_stat_t fa_stat;             /* Fixed array statistics */
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -1557,7 +1557,7 @@ done:
 static herr_t
 H5D__farray_idx_reset(H5O_storage_chunk_t *storage, hbool_t reset_addr)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(storage);
@@ -1585,7 +1585,7 @@ H5D__farray_idx_reset(H5O_storage_chunk_t *storage, hbool_t reset_addr)
 static herr_t
 H5D__farray_idx_dump(const H5O_storage_chunk_t *storage, FILE *stream)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(storage);
@@ -1613,7 +1613,7 @@ H5D__farray_idx_dest(const H5D_chk_idx_info_t *idx_info)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);

--- a/src/H5Dfill.c
+++ b/src/H5Dfill.c
@@ -590,7 +590,7 @@ done:
 static herr_t
 H5D__fill_release(H5D_fill_buf_info_t *fb_info)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(fb_info);

--- a/src/H5Dint.c
+++ b/src/H5Dint.c
@@ -288,7 +288,7 @@ H5D__close_cb(H5VL_object_t *dset_vol_obj, void **request)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(dset_vol_obj);
@@ -423,7 +423,7 @@ H5D__new(hid_t dcpl_id, hid_t dapl_id, hbool_t creating, hbool_t vl_type)
     H5P_genplist_t *plist;            /* Property list created */
     H5D_shared_t *  ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate new shared dataset structure */
     if (NULL == (new_dset = H5FL_MALLOC(H5D_shared_t)))
@@ -495,7 +495,7 @@ H5D__init_type(H5F_t *file, const H5D_t *dset, hid_t type_id, const H5T_t *type)
     hbool_t use_at_least_v18;    /* Flag indicating to use at least v18 format versions */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checking */
     HDassert(file);
@@ -567,7 +567,7 @@ H5D__cache_dataspace_info(const H5D_t *dset)
     unsigned u;                   /* Local index value */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checking */
     HDassert(dset);
@@ -606,7 +606,7 @@ H5D__init_space(H5F_t *file, const H5D_t *dset, const H5S_t *space)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checking */
     HDassert(file);
@@ -652,7 +652,7 @@ H5D__use_minimized_dset_headers(H5F_t *file, hbool_t *minimize)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
     HDassert(minimize);
@@ -693,7 +693,7 @@ H5D__calculate_minimum_header_size(H5F_t *file, H5D_t *dset, H5O_t *ohdr)
     size_t      get_value        = 0;
     size_t      ret_value        = 0;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
     HDassert(dset);
@@ -811,7 +811,7 @@ H5D__prepare_minimized_oh(H5F_t *file, H5D_t *dset, H5O_loc_t *oloc)
     size_t ohdr_size = 0;
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
     HDassert(dset);
@@ -858,7 +858,7 @@ H5D__update_oh_info(H5F_t *file, H5D_t *dset, hid_t dapl_id)
     hbool_t          use_minimized_header = FALSE;   /* Flag to use minimized dataset object headers */
     herr_t           ret_value            = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checking */
     HDassert(file);
@@ -1060,7 +1060,7 @@ H5D__build_file_prefix(const H5D_t *dset, H5F_prefix_open_t prefix_type, char **
     size_t      file_prefix_len;     /* length of expanded prefix                      */
     herr_t      ret_value = SUCCEED; /* Return value                                   */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(dset);
@@ -1598,7 +1598,7 @@ H5D__append_flush_setup(H5D_t *dset, hid_t dapl_id)
 {
     herr_t ret_value = SUCCEED; /* return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(dset);
@@ -1677,7 +1677,7 @@ H5D__open_oid(H5D_t *dataset, hid_t dapl_id)
     hbool_t         layout_init = FALSE;   /* Flag to indicate that chunk information was initialized */
     herr_t          ret_value   = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC_TAG(dataset->oloc.addr)
+    FUNC_ENTER_PACKAGE_TAG(dataset->oloc.addr)
 
     /* check args */
     HDassert(dataset);
@@ -2388,7 +2388,7 @@ H5D__init_storage(const H5D_io_info_t *io_info, hbool_t full_overwrite, hsize_t 
     const H5D_t *dset      = io_info->dset; /* dataset pointer */
     herr_t       ret_value = SUCCEED;       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(dset);
 
@@ -2565,7 +2565,7 @@ H5D__vlen_get_buf_size_alloc(size_t size, void *info)
     H5D_vlen_bufsize_common_t *vlen_bufsize_com = (H5D_vlen_bufsize_common_t *)info;
     void *                     ret_value        = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check for increasing the size of the temporary space for VL data */
     if (size > vlen_bufsize_com->vl_tbuf_size) {
@@ -2601,7 +2601,7 @@ H5D__vlen_get_buf_size_cb(void H5_ATTR_UNUSED *elem, hid_t type_id, unsigned H5_
     H5D_vlen_bufsize_native_t *vlen_bufsize = (H5D_vlen_bufsize_native_t *)op_data;
     herr_t                     ret_value    = H5_ITER_CONT; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(H5I_DATATYPE == H5I_get_type(type_id));
@@ -2747,7 +2747,7 @@ H5D__vlen_get_buf_size_gen_cb(void H5_ATTR_UNUSED *elem, hid_t type_id, unsigned
     H5T_t *                     dt;                  /* Datatype for operation */
     herr_t                      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(point);
@@ -2908,7 +2908,7 @@ H5D__check_filters(H5D_t *dataset)
     H5O_fill_t *fill;                /* Dataset's fill value */
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(dataset);
@@ -3466,7 +3466,7 @@ H5D__flush_all_cb(void *_dataset, hid_t H5_ATTR_UNUSED id, void *_udata)
     H5F_t *f         = (H5F_t *)_udata;   /* User data for callback */
     int    ret_value = H5_ITER_CONT;      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(dataset);

--- a/src/H5Dio.c
+++ b/src/H5Dio.c
@@ -538,7 +538,7 @@ done:
 static herr_t
 H5D__ioinfo_init(H5D_t *dset, const H5D_type_info_t *type_info, H5D_storage_t *store, H5D_io_info_t *io_info)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(dset);
@@ -609,7 +609,7 @@ H5D__typeinfo_init(const H5D_t *dset, hid_t mem_type_id, hbool_t do_write, H5D_t
     H5Z_data_xform_t *data_transform;      /* Data transform info */
     herr_t            ret_value = SUCCEED; /* Return value	*/
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(type_info);
@@ -779,7 +779,7 @@ H5D__ioinfo_adjust(H5D_io_info_t *io_info, const H5D_t *dset, const H5S_t *file_
 {
     herr_t ret_value = SUCCEED; /* Return value	*/
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(dset);
@@ -891,7 +891,7 @@ done:
 static herr_t
 H5D__typeinfo_term(const H5D_type_info_t *type_info)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check for releasing datatype conversion & background buffers */
     if (type_info->tconv_buf_allocated) {

--- a/src/H5Dmpio.c
+++ b/src/H5Dmpio.c
@@ -508,7 +508,7 @@ static FILE *            debug_stream             = NULL;
 static void
 H5D__mpio_parse_debug_str(const char *s)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(s);
 
@@ -555,7 +555,7 @@ H5D__mpio_debug_init(void)
     const char *debug_str;
     herr_t      ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(!H5D_mpio_debug_inited);
 
@@ -963,7 +963,7 @@ H5D__mpio_get_sum_chunk(const H5D_io_info_t *io_info, const H5D_chunk_map_t *fm,
     int    mpi_code; /* MPI return code */
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get the number of chunks to perform I/O on */
     num_chunkf     = 0;
@@ -1110,7 +1110,7 @@ H5D__chunk_collective_io(H5D_io_info_t *io_info, const H5D_type_info_t *type_inf
     int    mpi_size;
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(io_info);
@@ -1348,7 +1348,7 @@ H5D__link_chunk_collective_io(H5D_io_info_t *io_info, const H5D_type_info_t *typ
     int    mpi_code;                     /* MPI return code */
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Set the actual-chunk-opt-mode property. */
     H5CX_set_mpio_actual_chunk_opt(H5D_MPIO_LINK_CHUNK);
@@ -1707,7 +1707,7 @@ H5D__link_chunk_filtered_collective_io(H5D_io_info_t *io_info, const H5D_type_in
     int                                mpi_code;
     herr_t                             ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(io_info);
     HDassert(type_info);
@@ -1907,7 +1907,7 @@ H5D__multi_chunk_collective_io(H5D_io_info_t *io_info, const H5D_type_info_t *ty
         H5D_MPIO_NO_COLLECTIVE; /* Local variable for tracking the I/O mode used. */
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Set the actual chunk opt mode property */
     H5CX_set_mpio_actual_chunk_opt(H5D_MPIO_MULTI_CHUNK);
@@ -2159,7 +2159,7 @@ H5D__multi_chunk_filtered_collective_io(H5D_io_info_t *io_info, const H5D_type_i
     int                                mpi_code;
     herr_t                             ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(io_info);
     HDassert(type_info);
@@ -2385,7 +2385,7 @@ H5D__inter_collective_io(H5D_io_info_t *io_info, const H5D_type_info_t *type_inf
 #endif
     herr_t ret_value = SUCCEED; /* return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #ifdef H5Dmpio_DEBUG
     mpi_rank = H5F_mpi_get_rank(io_info->dset->oloc.file);
@@ -2498,7 +2498,7 @@ H5D__final_collective_io(H5D_io_info_t *io_info, const H5D_type_info_t *type_inf
 #endif
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #ifdef H5Dmpio_DEBUG
     mpi_rank = H5F_mpi_get_rank(io_info->dset->oloc.file);
@@ -2550,7 +2550,7 @@ H5D__cmp_chunk_addr(const void *chunk_addr_info1, const void *chunk_addr_info2)
 {
     haddr_t addr1 = HADDR_UNDEF, addr2 = HADDR_UNDEF;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     addr1 = ((const H5D_chunk_addr_info_t *)chunk_addr_info1)->chunk_addr;
     addr2 = ((const H5D_chunk_addr_info_t *)chunk_addr_info2)->chunk_addr;
@@ -2581,7 +2581,7 @@ H5D__cmp_filtered_collective_io_info_entry(const void *filtered_collective_io_in
     haddr_t                                  addr2 = HADDR_UNDEF;
     int                                      ret_value;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     entry1 = (const H5D_filtered_collective_io_info_t *)filtered_collective_io_info_entry1;
     entry2 = (const H5D_filtered_collective_io_info_t *)filtered_collective_io_info_entry2;
@@ -2633,7 +2633,7 @@ H5D__cmp_chunk_redistribute_info(const void *_entry1, const void *_entry2)
     hsize_t                              chunk_index2;
     int                                  ret_value;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     entry1 = (const H5D_chunk_redistribute_info_t *)_entry1;
     entry2 = (const H5D_chunk_redistribute_info_t *)_entry2;
@@ -2676,7 +2676,7 @@ H5D__cmp_chunk_redistribute_info_orig_owner(const void *_entry1, const void *_en
     int                                  owner2 = -1;
     int                                  ret_value;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     entry1 = (const H5D_chunk_redistribute_info_t *)_entry1;
     entry2 = (const H5D_chunk_redistribute_info_t *)_entry2;
@@ -2756,7 +2756,7 @@ H5D__sort_chunk(H5D_io_info_t *io_info, const H5D_chunk_map_t *fm,
     int                     i;                   /* Local index variable */
     herr_t                  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Calculate the actual threshold to obtain all chunk addresses collectively
      *  The bigger this number is, the more possible the use of obtaining chunk
@@ -2943,7 +2943,7 @@ H5D__obtain_mpio_mode(H5D_io_info_t *io_info, H5D_chunk_map_t *fm, uint8_t assig
     int                     mpi_code;
     herr_t                  ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Assign the rank 0 to the root */
     root = 0;
@@ -3119,7 +3119,7 @@ H5D__mpio_collective_filtered_chunk_io_setup(const H5D_io_info_t *io_info, const
     size_t                             i;
     herr_t                             ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(io_info);
     HDassert(type_info);
@@ -3339,7 +3339,7 @@ H5D__mpio_redistribute_shared_chunks(H5D_filtered_collective_io_info_t *chunk_li
     int     mpi_code;
     herr_t  ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(chunk_list || 0 == chunk_list_num_entries);
     HDassert(io_info);
@@ -3484,7 +3484,7 @@ H5D__mpio_redistribute_shared_chunks_int(H5D_filtered_collective_io_info_t *chun
     int          mpi_code;
     herr_t       ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(num_chunks_assigned_map);
     HDassert(chunk_list || 0 == num_chunks_assigned_map[mpi_rank]);
@@ -3820,7 +3820,7 @@ H5D__mpio_share_chunk_modification_data(H5D_filtered_collective_io_info_t *chunk
     int                                mpi_code;
     herr_t                             ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(chunk_list_num_entries);
     HDassert(chunk_list || 0 == *chunk_list_num_entries);
@@ -4173,7 +4173,7 @@ done:
 
     FUNC_LEAVE_NOAPI(ret_value)
 #else
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
     HERROR(
         H5E_DATASET, H5E_WRITEERROR,
         "unable to send chunk modification data between MPI ranks - MPI version < 3 (MPI_Ibarrier missing)")
@@ -4210,7 +4210,7 @@ H5D__mpio_collective_filtered_chunk_common_io(H5D_filtered_collective_io_info_t 
     int           mpi_code;
     herr_t        ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(chunk_list || 0 == chunk_list_num_entries);
     HDassert(io_info);
@@ -4344,7 +4344,7 @@ H5D__mpio_collective_filtered_chunk_read(H5D_filtered_collective_io_info_t *chun
     void *              base_read_buf = NULL;
     herr_t              ret_value     = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(chunk_list || 0 == chunk_list_num_entries);
     HDassert(io_info);
@@ -4567,7 +4567,7 @@ H5D__mpio_collective_filtered_chunk_update(H5D_filtered_collective_io_info_t *ch
     void *              base_read_buf = NULL;
     herr_t              ret_value     = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(chunk_list || 0 == chunk_list_num_entries);
     HDassert((chunk_msg_bufs && chunk_hash_table) || 0 == chunk_msg_bufs_len);
@@ -4908,7 +4908,7 @@ H5D__mpio_collective_filtered_chunk_reallocate(H5D_filtered_collective_io_info_t
     int                     mpi_code;
     herr_t                  ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(chunk_list || 0 == chunk_list_num_entries);
     HDassert(io_info);
@@ -5098,7 +5098,7 @@ H5D__mpio_collective_filtered_chunk_reinsert(H5D_filtered_collective_io_info_t *
     int            mpi_code;
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(chunk_list || 0 == chunk_list_num_entries);
     HDassert(io_info);
@@ -5308,7 +5308,7 @@ H5D__mpio_get_chunk_redistribute_info_types(MPI_Datatype *contig_type, hbool_t *
     int          mpi_code;
     herr_t       ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(contig_type);
     HDassert(contig_type_derived);
@@ -5449,7 +5449,7 @@ H5D__mpio_get_chunk_alloc_info_types(MPI_Datatype *contig_type, hbool_t *contig_
     int          mpi_code;
     herr_t       ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(contig_type);
     HDassert(contig_type_derived);
@@ -5580,7 +5580,7 @@ H5D__mpio_get_chunk_insert_info_types(MPI_Datatype *contig_type, hbool_t *contig
     int          mpi_code;
     herr_t       ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(contig_type);
     HDassert(contig_type_derived);
@@ -5706,7 +5706,7 @@ H5D__mpio_collective_filtered_io_type(H5D_filtered_collective_io_info_t *chunk_l
     int       mpi_code;
     herr_t    ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(chunk_list || 0 == num_entries);
     HDassert(new_mem_type);
@@ -5943,7 +5943,7 @@ H5D__mpio_dump_collective_filtered_chunk_list(H5D_filtered_collective_io_info_t 
     size_t                             i;
     herr_t                             ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     H5D_MPIO_DEBUG(mpi_rank, "CHUNK LIST: [");
     for (i = 0; i < chunk_list_num_entries; i++) {

--- a/src/H5Dnone.c
+++ b/src/H5Dnone.c
@@ -117,7 +117,7 @@ H5D__none_idx_create(const H5D_chk_idx_info_t *idx_info)
     haddr_t addr;                /* The address of dataset chunks */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info);
@@ -158,7 +158,7 @@ done:
 static hbool_t
 H5D__none_idx_is_space_alloc(const H5O_storage_chunk_t *storage)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(storage);
@@ -181,7 +181,7 @@ H5D__none_idx_is_space_alloc(const H5O_storage_chunk_t *storage)
 static herr_t
 H5D__none_idx_get_addr(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -229,7 +229,7 @@ H5D__none_idx_iterate(const H5D_chk_idx_info_t *idx_info, H5D_chunk_cb_func_t ch
     hsize_t         idx;                      /* Array index of chunk */
     int             ret_value = H5_ITER_CONT; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -303,7 +303,7 @@ static herr_t
 H5D__none_idx_remove(const H5D_chk_idx_info_t H5_ATTR_UNUSED *idx_info,
                      H5D_chunk_common_ud_t H5_ATTR_UNUSED *udata)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* NO OP */
 
@@ -328,7 +328,7 @@ H5D__none_idx_delete(const H5D_chk_idx_info_t *idx_info)
     hsize_t nbytes;              /* Size of all chunks */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -367,7 +367,7 @@ H5D__none_idx_copy_setup(const H5D_chk_idx_info_t H5_ATTR_NDEBUG_UNUSED *idx_inf
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info_src);
@@ -414,7 +414,7 @@ done:
 static herr_t
 H5D__none_idx_size(const H5D_chk_idx_info_t H5_ATTR_UNUSED *idx_info, hsize_t *index_size)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(index_size);
@@ -438,7 +438,7 @@ H5D__none_idx_size(const H5D_chk_idx_info_t H5_ATTR_UNUSED *idx_info, hsize_t *i
 static herr_t
 H5D__none_idx_reset(H5O_storage_chunk_t *storage, hbool_t reset_addr)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(storage);
@@ -464,7 +464,7 @@ H5D__none_idx_reset(H5O_storage_chunk_t *storage, hbool_t reset_addr)
 static herr_t
 H5D__none_idx_dump(const H5O_storage_chunk_t *storage, FILE *stream)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(storage);

--- a/src/H5Doh.c
+++ b/src/H5Doh.c
@@ -99,7 +99,7 @@ H5O__dset_get_copy_file_udata(void)
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate space for the 'copy file' user data for copying datasets */
     if (NULL == (ret_value = H5FL_CALLOC(H5D_copy_file_ud_t)))
@@ -127,7 +127,7 @@ H5O__dset_free_copy_file_udata(void *_udata)
 {
     H5D_copy_file_ud_t *udata = (H5D_copy_file_ud_t *)_udata;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(udata);
@@ -173,7 +173,7 @@ H5O__dset_isa(const H5O_t *oh)
     htri_t exists;           /* Flag if header message of interest exists */
     htri_t ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(oh);
 
@@ -213,7 +213,7 @@ H5O__dset_open(const H5G_loc_t *obj_loc, H5I_type_t *opened_type)
     hid_t  dapl_id;          /* dapl to use to open this dataset */
     void * ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(obj_loc);
 
@@ -276,7 +276,7 @@ H5O__dset_create(H5F_t *f, void *_crt_info, H5G_loc_t *obj_loc)
     H5D_t *           dset      = NULL;                          /* New dataset created */
     void *            ret_value = NULL;                          /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -324,7 +324,7 @@ H5O__dset_get_oloc(hid_t obj_id)
     H5D_t *    dset;             /* Dataset opened */
     H5O_loc_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get the dataset */
     if (NULL == (dset = (H5D_t *)H5VL_object(obj_id)))
@@ -362,7 +362,7 @@ H5O__dset_bh_info(const H5O_loc_t *loc, H5O_t *oh, H5_ih_info_t *bh_info)
     htri_t       exists;              /* Flag if header message of interest exists */
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(loc);
@@ -442,7 +442,7 @@ H5O__dset_flush(void *_obj_ptr)
     H5O_type_t obj_type;                 /* Type of object at location */
     herr_t     ret_value = SUCCEED;      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(dset);
     HDassert(&dset->oloc);

--- a/src/H5Dscatgath.c
+++ b/src/H5Dscatgath.c
@@ -96,7 +96,7 @@ H5D__scatter_file(const H5D_io_info_t *_io_info, H5S_sel_iter_t *iter, size_t ne
     size_t        vec_size;              /* Vector length */
     herr_t        ret_value = SUCCEED;   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(_io_info);
@@ -193,7 +193,7 @@ H5D__gather_file(const H5D_io_info_t *_io_info, H5S_sel_iter_t *iter, size_t nel
     size_t        vec_size;              /* Vector length */
     size_t        ret_value = nelmts;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(_io_info);
@@ -751,7 +751,7 @@ H5D__compound_opt_read(size_t nelmts, H5S_sel_iter_t *iter, const H5D_type_info_
     size_t   vec_size;            /* Vector length */
     herr_t   ret_value = SUCCEED; /* Return value		*/
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(nelmts > 0);
@@ -875,7 +875,7 @@ H5D__compound_opt_write(size_t nelmts, const H5D_type_info_t *type_info)
     size_t   src_stride, dst_stride; /* Strides through source & destination datatypes */
     size_t   i;                      /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(nelmts > 0);

--- a/src/H5Dselect.c
+++ b/src/H5Dselect.c
@@ -97,7 +97,7 @@ H5D__select_io(const H5D_io_info_t *io_info, size_t elmt_size, size_t nelmts, H5
     ssize_t         tmp_file_len;           /* Temporary number of bytes in file sequence */
     herr_t          ret_value = SUCCEED;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(io_info);

--- a/src/H5Dsingle.c
+++ b/src/H5Dsingle.c
@@ -116,7 +116,7 @@ static herr_t
 H5D__single_idx_init(const H5D_chk_idx_info_t *idx_info, const H5S_t H5_ATTR_UNUSED *space,
                      haddr_t H5_ATTR_UNUSED dset_ohdr_addr)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(idx_info);
@@ -154,7 +154,7 @@ H5D__single_idx_init(const H5D_chk_idx_info_t *idx_info, const H5S_t H5_ATTR_UNU
 static herr_t
 H5D__single_idx_create(const H5D_chk_idx_info_t *idx_info)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(idx_info);
@@ -188,7 +188,7 @@ H5D__single_idx_create(const H5D_chk_idx_info_t *idx_info)
 static hbool_t
 H5D__single_idx_is_space_alloc(const H5O_storage_chunk_t *storage)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(storage);
@@ -212,7 +212,7 @@ H5D__single_idx_insert(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -258,7 +258,7 @@ done:
 static herr_t
 H5D__single_idx_get_addr(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -302,7 +302,7 @@ H5D__single_idx_iterate(const H5D_chk_idx_info_t *idx_info, H5D_chunk_cb_func_t 
     H5D_chunk_rec_t chunk_rec;      /* generic chunk record  */
     int             ret_value = -1; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -351,7 +351,7 @@ H5D__single_idx_remove(const H5D_chk_idx_info_t *idx_info, H5D_chunk_common_ud_t
     hsize_t nbytes;              /* Size of all chunks */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -392,7 +392,7 @@ H5D__single_idx_delete(const H5D_chk_idx_info_t *idx_info)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(idx_info);
@@ -426,7 +426,7 @@ H5D__single_idx_copy_setup(const H5D_chk_idx_info_t H5_ATTR_NDEBUG_UNUSED *idx_i
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(idx_info_src);
@@ -471,7 +471,7 @@ done:
 static herr_t
 H5D__single_idx_size(const H5D_chk_idx_info_t H5_ATTR_UNUSED *idx_info, hsize_t *index_size)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(index_size);
@@ -495,7 +495,7 @@ H5D__single_idx_size(const H5D_chk_idx_info_t H5_ATTR_UNUSED *idx_info, hsize_t 
 static herr_t
 H5D__single_idx_reset(H5O_storage_chunk_t *storage, hbool_t reset_addr)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(storage);
@@ -521,7 +521,7 @@ H5D__single_idx_reset(H5O_storage_chunk_t *storage, hbool_t reset_addr)
 static herr_t
 H5D__single_idx_dump(const H5O_storage_chunk_t *storage, FILE *stream)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(storage);

--- a/src/H5Dvirtual.c
+++ b/src/H5Dvirtual.c
@@ -896,7 +896,7 @@ H5D__virtual_open_source_dset(const H5D_t *vdset, H5O_storage_virtual_ent_t *vir
     hbool_t src_file_open = FALSE;   /* Whether we have opened and need to close src_file */
     herr_t  ret_value     = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(vdset);
@@ -988,7 +988,7 @@ H5D__virtual_reset_source_dset(H5O_storage_virtual_ent_t *    virtual_ent,
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(source_dset);
@@ -1070,7 +1070,7 @@ H5D__virtual_str_append(const char *src, size_t src_len, char **p, char **buf, s
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(src);
@@ -1262,7 +1262,7 @@ H5D__virtual_copy_parsed_name(H5O_storage_virtual_name_seg_t **dst, H5O_storage_
     H5O_storage_virtual_name_seg_t **p_dst     = &tmp_dst;
     herr_t                           ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(dst);
@@ -1347,7 +1347,7 @@ H5D__virtual_build_source_name(char *source_name, const H5O_storage_virtual_name
     char * tmp_name  = NULL;    /* Name buffer */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(source_name);
@@ -1937,7 +1937,7 @@ H5D__virtual_init_all(const H5D_t *dset)
     size_t                 i, j;
     herr_t                 ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(dset);
@@ -2342,7 +2342,7 @@ H5D__virtual_is_data_cached(const H5D_shared_t *shared_dset)
     size_t                       i, j;              /* Local index variables */
     hbool_t                      ret_value = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(shared_dset);
@@ -2398,7 +2398,7 @@ H5D__virtual_pre_io(H5D_io_info_t *io_info, H5O_storage_virtual_t *storage, H5S_
     size_t   i, j, k;             /* Local index variables */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(storage);
@@ -2654,7 +2654,7 @@ H5D__virtual_post_io(H5O_storage_virtual_t *storage)
     size_t i, j;                /* Local index variables */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(storage);
@@ -2704,7 +2704,7 @@ H5D__virtual_read_one(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, 
     H5S_t *projected_src_space = NULL;    /* File space for selection in a single source dataset */
     herr_t ret_value           = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(source_dset);
 
@@ -2767,7 +2767,7 @@ H5D__virtual_read(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsiz
     size_t                 i, j;                /* Local index variables */
     herr_t                 ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(io_info);
@@ -2894,7 +2894,7 @@ H5D__virtual_write_one(H5D_io_info_t *io_info, const H5D_type_info_t *type_info,
     H5S_t *projected_src_space = NULL;    /* File space for selection in a single source dataset */
     herr_t ret_value           = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(source_dset);
 
@@ -2958,7 +2958,7 @@ H5D__virtual_write(H5D_io_info_t *io_info, const H5D_type_info_t *type_info, hsi
     size_t                 i, j;                /* Local index variables */
     herr_t                 ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(io_info);
@@ -3031,7 +3031,7 @@ H5D__virtual_flush(H5D_t *dset)
     size_t                 i, j;                /* Local index variables */
     herr_t                 ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(dset);
@@ -3151,7 +3151,7 @@ H5D__virtual_refresh_source_dset(H5D_t **dset)
     H5VL_object_t *vol_obj   = NULL;            /* VOL object stored with the ID */
     herr_t         ret_value = SUCCEED;         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(dset && *dset);

--- a/src/H5E.c
+++ b/src/H5E.c
@@ -282,7 +282,7 @@ H5E_term_package(void)
 static herr_t
 H5E__set_default_auto(H5E_t *stk)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #ifndef H5_NO_DEPRECATED_SYMBOLS
 #ifdef H5_USE_16_API_DEFAULT
@@ -372,7 +372,7 @@ H5E__get_stack(void)
 static herr_t
 H5E__free_class(H5E_cls_t *cls)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(cls);
@@ -443,7 +443,7 @@ H5E__register_class(const char *cls_name, const char *lib_name, const char *vers
     H5E_cls_t *cls       = NULL; /* Pointer to error class */
     H5E_cls_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(cls_name);
@@ -525,7 +525,7 @@ H5E__unregister_class(H5E_cls_t *cls, void H5_ATTR_UNUSED **request)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(cls);
@@ -594,7 +594,7 @@ H5E__get_class_name(const H5E_cls_t *cls, char *name, size_t size)
 {
     ssize_t len = -1; /* Length of error class's name */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(cls);
@@ -634,7 +634,7 @@ H5E__close_msg_cb(void *obj_ptr, hid_t obj_id, void *udata)
     H5E_cls_t *cls       = (H5E_cls_t *)udata;
     int        ret_value = H5_ITER_CONT; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(err_msg);
@@ -698,7 +698,7 @@ done:
 static herr_t
 H5E__close_msg(H5E_msg_t *err, void H5_ATTR_UNUSED **request)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(err);
@@ -775,7 +775,7 @@ H5E__create_msg(H5E_cls_t *cls, H5E_type_t msg_type, const char *msg_str)
     H5E_msg_t *msg       = NULL; /* Pointer to new error message */
     H5E_msg_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(cls);
@@ -931,7 +931,7 @@ H5E__get_current_stack(void)
     unsigned u;                  /* Local index variable */
     H5E_t *  ret_value = NULL;   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get a pointer to the current error stack */
     if (NULL == (current_stack = H5E__get_my_stack())) /*lint !e506 !e774 Make lint 'constant value Boolean'
@@ -1050,7 +1050,7 @@ H5E__set_current_stack(H5E_t *estack)
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(estack);
@@ -1148,7 +1148,7 @@ done:
 static herr_t
 H5E__close_stack(H5E_t *estack, void H5_ATTR_UNUSED **request)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(estack);
@@ -1224,7 +1224,7 @@ done:
 static ssize_t
 H5E__get_num(const H5E_t *estack)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(estack);
 
@@ -1444,7 +1444,7 @@ H5E__print2(hid_t err_stack, FILE *stream)
     H5E_t *estack;              /* Error stack to operate on */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Need to check for errors */
     if (err_stack == H5E_DEFAULT) {
@@ -1755,7 +1755,7 @@ H5E__append_stack(H5E_t *dst_stack, const H5E_t *src_stack)
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(dst_stack);

--- a/src/H5EA.c
+++ b/src/H5EA.c
@@ -120,7 +120,7 @@ H5EA__new(H5F_t *f, haddr_t ea_addr, hbool_t from_open, void *ctx_udata)
     H5EA_hdr_t *hdr       = NULL; /* The extensible array header information */
     H5EA_t *    ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(f);
@@ -339,7 +339,7 @@ H5EA__lookup_elmt(const H5EA_t *ea, hsize_t idx, hbool_t will_extend, unsigned t
     hbool_t           hdr_dirty          = FALSE;              /* Whether the array header changed */
     herr_t            ret_value          = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(ea);

--- a/src/H5EAcache.c
+++ b/src/H5EAcache.c
@@ -226,7 +226,7 @@ H5EA__cache_hdr_get_initial_load_size(void *_udata, size_t *image_len)
 {
     H5EA_hdr_cache_ud_t *udata = (H5EA_hdr_cache_ud_t *)_udata; /* User data for callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(udata);
@@ -260,7 +260,7 @@ H5EA__cache_hdr_verify_chksum(const void *_image, size_t len, void H5_ATTR_UNUSE
     uint32_t       computed_chksum;                 /* Computed metadata checksum value */
     htri_t         ret_value = TRUE;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -297,7 +297,7 @@ H5EA__cache_hdr_deserialize(const void *_image, size_t len, void *_udata, hbool_
     uint32_t             stored_chksum;                   /* Stored metadata checksum value */
     void *               ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -418,7 +418,7 @@ H5EA__cache_hdr_image_len(const void *_thing, size_t *image_len)
 {
     const H5EA_hdr_t *hdr = (const H5EA_hdr_t *)_thing; /* Pointer to the object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(hdr);
@@ -449,7 +449,7 @@ H5EA__cache_hdr_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_UNUSED le
     uint8_t *   image = (uint8_t *)_image;    /* Pointer into raw data buffer */
     uint32_t    metadata_chksum;              /* Computed metadata checksum value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check arguments */
     HDassert(f);
@@ -519,7 +519,7 @@ H5EA__cache_hdr_notify(H5AC_notify_action_t action, void *_thing)
     H5EA_hdr_t *hdr       = (H5EA_hdr_t *)_thing; /* Pointer to the object */
     herr_t      ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(hdr);
@@ -599,7 +599,7 @@ H5EA__cache_hdr_free_icr(void *thing)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(thing);
@@ -630,7 +630,7 @@ H5EA__cache_iblock_get_initial_load_size(void *_udata, size_t *image_len)
     H5EA_hdr_t *  hdr = (H5EA_hdr_t *)_udata; /* User data for callback */
     H5EA_iblock_t iblock;                     /* Fake index block for computing size */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(hdr);
@@ -670,7 +670,7 @@ H5EA__cache_iblock_verify_chksum(const void *_image, size_t len, void H5_ATTR_UN
     uint32_t       computed_chksum;                 /* Computed metadata checksum value */
     htri_t         ret_value = TRUE;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -708,7 +708,7 @@ H5EA__cache_iblock_deserialize(const void *_image, size_t len, void *_udata, hbo
     size_t         u;                                /* Local index variable */
     void *         ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -809,7 +809,7 @@ H5EA__cache_iblock_image_len(const void *_thing, size_t *image_len)
 {
     const H5EA_iblock_t *iblock = (const H5EA_iblock_t *)_thing; /* Pointer to the object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(iblock);
@@ -841,7 +841,7 @@ H5EA__cache_iblock_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_UNUSED
     uint32_t       metadata_chksum;                  /* Computed metadata checksum value */
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(f);
@@ -925,7 +925,7 @@ H5EA__cache_iblock_notify(H5AC_notify_action_t action, void *_thing)
     H5EA_iblock_t *iblock    = (H5EA_iblock_t *)_thing; /* Pointer to the object */
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(iblock);
@@ -1000,7 +1000,7 @@ H5EA__cache_iblock_free_icr(void *thing)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(thing);
@@ -1031,7 +1031,7 @@ H5EA__cache_sblock_get_initial_load_size(void *_udata, size_t *image_len)
     H5EA_sblock_cache_ud_t *udata = (H5EA_sblock_cache_ud_t *)_udata; /* User data */
     H5EA_sblock_t           sblock; /* Fake super block for computing size */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(udata);
@@ -1090,7 +1090,7 @@ H5EA__cache_sblock_verify_chksum(const void *_image, size_t len, void H5_ATTR_UN
     uint32_t       computed_chksum;                 /* Computed metadata checksum value */
     htri_t         ret_value = TRUE;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -1128,7 +1128,7 @@ H5EA__cache_sblock_deserialize(const void *_image, size_t len, void *_udata, hbo
     size_t                  u;        /* Local index variable */
     void *                  ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(udata);
@@ -1226,7 +1226,7 @@ H5EA__cache_sblock_image_len(const void *_thing, size_t *image_len)
 {
     const H5EA_sblock_t *sblock = (const H5EA_sblock_t *)_thing; /* Pointer to the object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(sblock);
@@ -1258,7 +1258,7 @@ H5EA__cache_sblock_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_UNUSED
     uint32_t       metadata_chksum;                  /* Computed metadata checksum value */
     size_t         u;                                /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check arguments */
     HDassert(f);
@@ -1329,7 +1329,7 @@ H5EA__cache_sblock_notify(H5AC_notify_action_t action, void *_thing)
     H5EA_sblock_t *sblock    = (H5EA_sblock_t *)_thing; /* Pointer to the object */
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(sblock);
@@ -1425,7 +1425,7 @@ H5EA__cache_sblock_free_icr(void *thing)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(thing);
@@ -1456,7 +1456,7 @@ H5EA__cache_dblock_get_initial_load_size(void *_udata, size_t *image_len)
     H5EA_dblock_cache_ud_t *udata = (H5EA_dblock_cache_ud_t *)_udata; /* User data */
     H5EA_dblock_t           dblock;                                   /* Fake data block for computing size */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(udata);
@@ -1516,7 +1516,7 @@ H5EA__cache_dblock_verify_chksum(const void *_image, size_t len, void H5_ATTR_UN
     uint32_t       computed_chksum;                 /* Computed metadata checksum value */
     htri_t         ret_value = TRUE;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -1652,7 +1652,7 @@ H5EA__cache_dblock_image_len(const void *_thing, size_t *image_len)
 {
     const H5EA_dblock_t *dblock = (const H5EA_dblock_t *)_thing; /* Pointer to the object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(dblock);
@@ -1687,7 +1687,7 @@ H5EA__cache_dblock_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_UNUSED
     uint32_t       metadata_chksum;                  /* Computed metadata checksum value */
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(f);
@@ -1755,7 +1755,7 @@ H5EA__cache_dblock_notify(H5AC_notify_action_t action, void *_thing)
     H5EA_dblock_t *dblock    = (H5EA_dblock_t *)_thing; /* Pointer to the object */
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(dblock);
@@ -1850,7 +1850,7 @@ H5EA__cache_dblock_free_icr(void *thing)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(thing);
@@ -1897,7 +1897,7 @@ H5EA__cache_dblock_fsf_size(const void *_thing, hsize_t *fsf_size)
 {
     const H5EA_dblock_t *dblock = (const H5EA_dblock_t *)_thing; /* Pointer to the object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(dblock);
@@ -1927,7 +1927,7 @@ H5EA__cache_dblk_page_get_initial_load_size(void *_udata, size_t *image_len)
 {
     H5EA_dblk_page_cache_ud_t *udata = (H5EA_dblk_page_cache_ud_t *)_udata; /* User data */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(udata);
@@ -1961,7 +1961,7 @@ H5EA__cache_dblk_page_verify_chksum(const void *_image, size_t len, void H5_ATTR
     uint32_t       computed_chksum;                 /* Computed metadata checksum value */
     htri_t         ret_value = TRUE;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -1998,7 +1998,7 @@ H5EA__cache_dblk_page_deserialize(const void *_image, size_t len, void *_udata, 
     uint32_t       stored_chksum;                   /* Stored metadata checksum value */
     void *         ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(udata);
@@ -2066,7 +2066,7 @@ H5EA__cache_dblk_page_image_len(const void *_thing, size_t *image_len)
 {
     const H5EA_dblk_page_t *dblk_page = (const H5EA_dblk_page_t *)_thing; /* Pointer to the object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(dblk_page);
@@ -2099,7 +2099,7 @@ H5EA__cache_dblk_page_serialize(const H5F_t H5_ATTR_NDEBUG_UNUSED *f, void *_ima
     uint32_t          metadata_chksum;                        /* Computed metadata checksum value */
     herr_t            ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(f);
@@ -2148,7 +2148,7 @@ H5EA__cache_dblk_page_notify(H5AC_notify_action_t action, void *_thing)
     H5EA_dblk_page_t *dblk_page = (H5EA_dblk_page_t *)_thing; /* Pointer to the object */
     herr_t            ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(dblk_page);
@@ -2244,7 +2244,7 @@ H5EA__cache_dblk_page_free_icr(void *thing)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(thing);

--- a/src/H5EAtest.c
+++ b/src/H5EAtest.c
@@ -126,7 +126,7 @@ H5EA__test_crt_context(void *_udata)
     H5EA__ctx_cb_t *  udata     = (H5EA__ctx_cb_t *)_udata; /* User data for context */
     void *            ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate new context structure */
     if (NULL == (ctx = H5FL_MALLOC(H5EA__test_ctx_t)))
@@ -162,7 +162,7 @@ H5EA__test_dst_context(void *_ctx)
 {
     H5EA__test_ctx_t *ctx = (H5EA__test_ctx_t *)_ctx; /* Callback context to destroy */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(H5EA__TEST_BOGUS_VAL == ctx->bogus);
@@ -191,7 +191,7 @@ H5EA__test_fill(void *nat_blk, size_t nelmts)
 {
     uint64_t fill_val = H5EA_TEST_FILL; /* Value to fill elements with */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(nat_blk);
@@ -222,7 +222,7 @@ H5EA__test_encode(void *raw, const void *_elmt, size_t nelmts, void *_ctx)
     const uint64_t *  elmt      = (const uint64_t *)_elmt;  /* Convenience pointer to native elements */
     herr_t            ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(raw);
@@ -274,7 +274,7 @@ H5EA__test_decode(const void *_raw, void *_elmt, size_t nelmts, void H5_ATTR_NDE
     uint64_t *     elmt = (uint64_t *)_elmt;          /* Convenience pointer to native elements */
     const uint8_t *raw  = (const uint8_t *)_raw;      /* Convenience pointer to raw elements */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(raw);
@@ -315,7 +315,7 @@ H5EA__test_debug(FILE *stream, int indent, int fwidth, hsize_t idx, const void *
 {
     char temp_str[128]; /* Temporary string, for formatting */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(stream);
@@ -347,7 +347,7 @@ H5EA__test_crt_dbg_context(H5F_t H5_ATTR_UNUSED *f, haddr_t H5_ATTR_UNUSED obj_a
     H5EA__ctx_cb_t *ctx; /* Context for callbacks */
     void *          ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate new context structure */
     if (NULL == (ctx = H5FL_MALLOC(H5EA__ctx_cb_t)))
@@ -378,7 +378,7 @@ H5EA__test_dst_dbg_context(void *_ctx)
 {
     H5EA__ctx_cb_t *ctx = (H5EA__ctx_cb_t *)_ctx; /* Callback context to destroy */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(_ctx);
 

--- a/src/H5ESint.c
+++ b/src/H5ESint.c
@@ -192,7 +192,7 @@ H5ES__close_cb(void *_es, void H5_ATTR_UNUSED **rt)
     H5ES_t *es        = (H5ES_t *)_es; /* The event set to close */
     herr_t  ret_value = SUCCEED;       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(es);
@@ -261,7 +261,7 @@ H5ES__insert(H5ES_t *es, H5VL_t *connector, void *request_token, const char *app
     hbool_t       ev_inserted = FALSE;   /* Flag to indicate that event is in active list */
     herr_t        ret_value   = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(es);
@@ -447,7 +447,7 @@ H5ES__get_requests_cb(H5ES_event_t *ev, void *_ctx)
     H5ES_get_requests_ctx_t *ctx       = (H5ES_get_requests_ctx_t *)_ctx; /* Callback context */
     int                      ret_value = H5_ITER_CONT;                    /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ev);
@@ -523,7 +523,7 @@ done:
 static herr_t
 H5ES__handle_fail(H5ES_t *es, H5ES_event_t *ev)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(es);
@@ -561,7 +561,7 @@ H5ES__op_complete(H5ES_t *es, H5ES_event_t *ev, H5VL_request_status_t ev_status)
     hid_t                        err_stack_id = H5I_INVALID_HID; /* Error stack for failed operation */
     herr_t                       ret_value    = SUCCEED;         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(es);
@@ -657,7 +657,7 @@ H5ES__wait_cb(H5ES_event_t *ev, void *_ctx)
     uint64_t start_time = 0, elapsed_time = 0; /* Start and elapsed times for waiting on an operation */
     int      ret_value = H5_ITER_CONT;         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(ev);
@@ -777,7 +777,7 @@ H5ES__cancel_cb(H5ES_event_t *ev, void *_ctx)
     H5VL_request_status_t ev_status = H5VL_REQUEST_STATUS_SUCCEED; /* Status from event's operation */
     int                   ret_value = H5_ITER_CONT;                /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(ev);
@@ -885,7 +885,7 @@ H5ES__get_err_info_cb(H5ES_event_t *ev, void *_ctx)
     H5ES_gei_ctx_t *             ctx       = (H5ES_gei_ctx_t *)_ctx; /* Callback context */
     int                          ret_value = H5_ITER_CONT;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(ev);

--- a/src/H5Eint.c
+++ b/src/H5Eint.c
@@ -190,7 +190,7 @@ H5E__walk1_cb(int n, H5E_error1_t *err_desc, void *client_data)
     unsigned     have_desc = 1; /* Flag to indicate whether the error has a "real" description */
     herr_t       ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(err_desc);
@@ -313,7 +313,7 @@ H5E__walk2_cb(unsigned n, const H5E_error2_t *err_desc, void *client_data)
     unsigned     have_desc = 1; /* Flag to indicate whether the error has a "real" description */
     herr_t       ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(err_desc);
@@ -807,7 +807,7 @@ H5E__clear_entries(H5E_t *estack, size_t nentries)
     unsigned      u;                   /* Local index variable */
     herr_t        ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(estack);

--- a/src/H5F.c
+++ b/src/H5F.c
@@ -202,7 +202,7 @@ H5F__get_all_count_cb(void H5_ATTR_UNUSED *obj_ptr, hid_t H5_ATTR_UNUSED obj_id,
     H5F_trav_obj_cnt_t *udata     = (H5F_trav_obj_cnt_t *)key;
     int                 ret_value = H5_ITER_CONT; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     udata->obj_count++;
 
@@ -309,7 +309,7 @@ H5F__get_all_ids_cb(void H5_ATTR_UNUSED *obj_ptr, hid_t obj_id, void *key)
     H5F_trav_obj_ids_t *udata     = (H5F_trav_obj_ids_t *)key;
     int                 ret_value = H5_ITER_CONT; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (udata->obj_count >= udata->max_objs)
         HGOTO_DONE(H5_ITER_STOP);
@@ -524,7 +524,7 @@ H5F__post_open_api_common(H5VL_object_t *vol_obj, void **token_ptr)
     uint64_t supported;           /* Whether 'post open' operation is supported by VOL connector */
     herr_t   ret_value = SUCCEED; /* Return value     */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check for 'post open' callback */
     supported = 0;
@@ -563,7 +563,7 @@ H5F__create_api_common(const char *filename, unsigned flags, hid_t fcpl_id, hid_
     H5VL_connector_prop_t connector_prop;              /* Property for VOL connector ID & info     */
     hid_t                 ret_value = H5I_INVALID_HID; /* Return value                             */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check/fix arguments */
     if (!filename || !*filename)
@@ -757,7 +757,7 @@ H5F__open_api_common(const char *filename, unsigned flags, hid_t fapl_id, void *
     H5VL_connector_prop_t connector_prop;              /* Property for VOL connector ID & info     */
     hid_t                 ret_value = H5I_INVALID_HID; /* Return value                             */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (!filename || !*filename)
@@ -934,7 +934,7 @@ H5F__flush_api_common(hid_t object_id, H5F_scope_t scope, void **token_ptr, H5VL
     H5VL_file_specific_args_t vol_cb_args;            /* Arguments to VOL callback */
     herr_t                    ret_value = SUCCEED;    /* Return value     */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get the type of object we're flushing + sanity check */
     obj_type = H5I_get_type(object_id);
@@ -1418,7 +1418,7 @@ H5F__reopen_api_common(hid_t file_id, void **token_ptr)
     void *                    reopen_file = NULL;            /* Pointer to the re-opened file object */
     hid_t                     ret_value   = H5I_INVALID_HID; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get the file object */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))

--- a/src/H5FA.c
+++ b/src/H5FA.c
@@ -109,7 +109,7 @@ H5FA__new(H5F_t *f, haddr_t fa_addr, hbool_t from_open, void *ctx_udata)
     H5FA_hdr_t *hdr       = NULL; /* The fixed array header information */
     H5FA_t *    ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(f);

--- a/src/H5FAcache.c
+++ b/src/H5FAcache.c
@@ -172,7 +172,7 @@ H5FA__cache_hdr_get_initial_load_size(void *_udata, size_t *image_len)
 {
     H5FA_hdr_cache_ud_t *udata = (H5FA_hdr_cache_ud_t *)_udata; /* User data for callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(udata);
@@ -206,7 +206,7 @@ H5FA__cache_hdr_verify_chksum(const void *_image, size_t len, void H5_ATTR_UNUSE
     uint32_t       computed_chksum;                 /* Computed metadata checksum value */
     htri_t         ret_value = TRUE;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -244,7 +244,7 @@ H5FA__cache_hdr_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED len
     uint32_t             stored_chksum;                   /* Stored metadata checksum value */
     void *               ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(udata);
@@ -350,7 +350,7 @@ H5FA__cache_hdr_image_len(const void *_thing, size_t *image_len)
 {
     const H5FA_hdr_t *hdr = (const H5FA_hdr_t *)_thing; /* Pointer to the object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(hdr);
@@ -381,7 +381,7 @@ H5FA__cache_hdr_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_UNUSED le
     uint8_t *   image = (uint8_t *)_image;    /* Pointer into raw data buffer */
     uint32_t    metadata_chksum;              /* Computed metadata checksum value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(f);
@@ -441,7 +441,7 @@ H5FA__cache_hdr_notify(H5AC_notify_action_t action, void *_thing)
     H5FA_hdr_t *hdr       = (H5FA_hdr_t *)_thing; /* Pointer to the object */
     herr_t      ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(hdr);
@@ -522,7 +522,7 @@ H5FA__cache_hdr_free_icr(void *thing)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(thing);
@@ -554,7 +554,7 @@ H5FA__cache_dblock_get_initial_load_size(void *_udata, size_t *image_len)
     H5FA_dblock_t           dblock;                                   /* Fake data block for computing size */
     size_t                  dblk_page_nelmts;                         /* # of elements per data block page */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(udata);
@@ -608,7 +608,7 @@ H5FA__cache_dblock_verify_chksum(const void *_image, size_t len, void H5_ATTR_UN
     uint32_t       computed_chksum;                 /* Computed metadata checksum value */
     htri_t         ret_value = TRUE;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -646,7 +646,7 @@ H5FA__cache_dblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED 
     haddr_t                 arr_addr; /* Address of array header in the file */
     void *                  ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(udata);
@@ -740,7 +740,7 @@ H5FA__cache_dblock_image_len(const void *_thing, size_t *image_len)
 {
     const H5FA_dblock_t *dblock = (const H5FA_dblock_t *)_thing; /* Pointer to the object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(dblock);
@@ -775,7 +775,7 @@ H5FA__cache_dblock_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_UNUSED
     uint32_t       metadata_chksum;                  /* Computed metadata checksum value */
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(f);
@@ -847,7 +847,7 @@ H5FA__cache_dblock_notify(H5AC_notify_action_t action, void *_thing)
     H5FA_dblock_t *dblock    = (H5FA_dblock_t *)_thing;
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(dblock);
@@ -922,7 +922,7 @@ H5FA__cache_dblock_free_icr(void *_thing)
     H5FA_dblock_t *dblock    = (H5FA_dblock_t *)_thing; /* Pointer to the object */
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(dblock);
@@ -969,7 +969,7 @@ H5FA__cache_dblock_fsf_size(const void *_thing, hsize_t *fsf_size)
 {
     const H5FA_dblock_t *dblock = (const H5FA_dblock_t *)_thing; /* Pointer to the object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(dblock);
@@ -999,7 +999,7 @@ H5FA__cache_dblk_page_get_initial_load_size(void *_udata, size_t *image_len)
 {
     H5FA_dblk_page_cache_ud_t *udata = (H5FA_dblk_page_cache_ud_t *)_udata; /* User data */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(udata);
@@ -1034,7 +1034,7 @@ H5FA__cache_dblk_page_verify_chksum(const void *_image, size_t len, void H5_ATTR
     uint32_t       computed_chksum;                 /* Computed metadata checksum value */
     htri_t         ret_value = TRUE;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -1072,7 +1072,7 @@ H5FA__cache_dblk_page_deserialize(const void *_image, size_t len, void *_udata, 
     void *         ret_value = NULL;
 
     /* Sanity check */
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(udata);
     HDassert(udata->hdr);
@@ -1140,7 +1140,7 @@ H5FA__cache_dblk_page_image_len(const void *_thing, size_t *image_len)
 {
     const H5FA_dblk_page_t *dblk_page = (const H5FA_dblk_page_t *)_thing; /* Pointer to the object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(dblk_page);
@@ -1173,7 +1173,7 @@ H5FA__cache_dblk_page_serialize(const H5F_t H5_ATTR_NDEBUG_UNUSED *f, void *_ima
     uint32_t          metadata_chksum;                        /* Computed metadata checksum value */
     herr_t            ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);
@@ -1222,7 +1222,7 @@ H5FA__cache_dblk_page_notify(H5AC_notify_action_t action, void *_thing)
     H5FA_dblk_page_t *dblk_page = (H5FA_dblk_page_t *)_thing; /* Pointer to the object */
     herr_t            ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(dblk_page);
@@ -1285,7 +1285,7 @@ H5FA__cache_dblk_page_free_icr(void *thing)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(thing);

--- a/src/H5FAtest.c
+++ b/src/H5FAtest.c
@@ -118,7 +118,7 @@ H5FA__test_crt_context(void H5_ATTR_UNUSED *udata)
     H5FA__test_ctx_t *ctx; /* Context for callbacks */
     void *            ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate new context structure */
     if (NULL == (ctx = H5FL_MALLOC(H5FA__test_ctx_t)))
@@ -151,7 +151,7 @@ H5FA__test_dst_context(void *_ctx)
 {
     H5FA__test_ctx_t *ctx = (H5FA__test_ctx_t *)_ctx; /* Callback context to destroy */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(H5FA__TEST_BOGUS_VAL == ctx->bogus);
@@ -179,7 +179,7 @@ H5FA__test_fill(void *nat_blk, size_t nelmts)
 {
     uint64_t fill_val = H5FA_TEST_FILL; /* Value to fill elements with */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(nat_blk);
@@ -210,7 +210,7 @@ H5FA__test_encode(void *raw, const void *_elmt, size_t nelmts, void H5_ATTR_UNUS
 #endif
     const uint64_t *elmt = (const uint64_t *)_elmt; /* Convenience pointer to native elements */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(raw);
@@ -255,7 +255,7 @@ H5FA__test_decode(const void *_raw, void *_elmt, size_t nelmts, void H5_ATTR_UNU
     uint64_t *     elmt = (uint64_t *)_elmt;     /* Convenience pointer to native elements */
     const uint8_t *raw  = (const uint8_t *)_raw; /* Convenience pointer to raw elements */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(raw);
@@ -296,7 +296,7 @@ H5FA__test_debug(FILE *stream, int indent, int fwidth, hsize_t idx, const void *
 {
     char temp_str[128]; /* Temporary string, for formatting */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(stream);
@@ -329,7 +329,7 @@ H5FA__test_crt_dbg_context(H5F_t H5_ATTR_UNUSED *f, haddr_t H5_ATTR_UNUSED obj_a
     H5FA__test_ctx_t *ctx; /* Context for callbacks */
     void *            ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate new context structure */
     if (NULL == (ctx = H5FL_MALLOC(H5FA__test_ctx_t)))

--- a/src/H5FD.c
+++ b/src/H5FD.c
@@ -167,7 +167,7 @@ H5FD__free_cls(H5FD_class_t *cls, void H5_ATTR_UNUSED **request)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(cls);
@@ -507,7 +507,7 @@ H5FD__sb_decode(H5FD_t *file, const char *name, const uint8_t *buf)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(file);
@@ -1007,7 +1007,7 @@ H5FD__query(const H5FD_t *file, unsigned long *flags /*out*/)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(file);

--- a/src/H5FDcore.c
+++ b/src/H5FDcore.c
@@ -223,7 +223,7 @@ H5FD__core_add_dirty_region(H5FD_core_t *file, haddr_t start, haddr_t end)
     hbool_t             create_new_node = TRUE;
     herr_t              ret_value       = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
     HDassert(file->dirty_list);
@@ -322,7 +322,7 @@ H5FD__core_destroy_dirty_list(H5FD_core_t *file)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
 
@@ -360,7 +360,7 @@ H5FD__core_write_to_bstore(H5FD_core_t *file, haddr_t addr, size_t size)
     HDoff_t offset    = (HDoff_t)addr;     /* Offset to write at */
     herr_t  ret_value = SUCCEED;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
 
@@ -501,7 +501,7 @@ H5FD_core_init(void)
 static herr_t
 H5FD__core_term(void)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Reset VFL ID */
     H5FD_CORE_g = 0;
@@ -702,7 +702,7 @@ H5FD__core_fapl_get(H5FD_t *_file)
     H5FD_core_fapl_t *fa;               /* Core VFD info */
     void *            ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (NULL == (fa = (H5FD_core_fapl_t *)H5MM_calloc(sizeof(H5FD_core_fapl_t))))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed")
@@ -749,7 +749,7 @@ H5FD__core_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
     H5FD_file_image_info_t file_image_info;
     H5FD_t *               ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (!name || !*name)
@@ -1005,7 +1005,7 @@ H5FD__core_close(H5FD_t *_file)
     H5FD_core_t *file      = (H5FD_core_t *)_file;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Flush any changed buffers */
     if (H5FD__core_flush(_file, (hid_t)-1, TRUE) < 0)
@@ -1062,7 +1062,7 @@ H5FD__core_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
     const H5FD_core_t *f2        = (const H5FD_core_t *)_f2;
     int                ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (f1->fd >= 0 && f2->fd >= 0) {
         /* Compare low level file information for backing store */
@@ -1145,7 +1145,7 @@ H5FD__core_query(const H5FD_t *_file, unsigned long *flags /* out */)
 {
     const H5FD_core_t *file = (const H5FD_core_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* clang-format off */
     /* Set the VFL feature flags that this driver supports */
@@ -1188,7 +1188,7 @@ H5FD__core_get_eoa(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_core_t *file = (const H5FD_core_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(file->eoa)
 } /* end H5FD__core_get_eoa() */
@@ -1213,7 +1213,7 @@ H5FD__core_set_eoa(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t addr)
     H5FD_core_t *file      = (H5FD_core_t *)_file;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (ADDR_OVERFLOW(addr))
         HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "address overflow")
@@ -1245,7 +1245,7 @@ H5FD__core_get_eof(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_core_t *file = (const H5FD_core_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(file->eof)
 } /* end H5FD__core_get_eof() */
@@ -1268,7 +1268,7 @@ H5FD__core_get_handle(H5FD_t *_file, hid_t fapl, void **file_handle)
     H5FD_core_t *file      = (H5FD_core_t *)_file; /* core VFD info */
     herr_t       ret_value = SUCCEED;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     if (!file_handle)
@@ -1332,7 +1332,7 @@ H5FD__core_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UNU
     H5FD_core_t *file      = (H5FD_core_t *)_file;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file && file->pub.cls);
     HDassert(buf);
@@ -1391,7 +1391,7 @@ H5FD__core_write(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UN
     H5FD_core_t *file      = (H5FD_core_t *)_file;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file && file->pub.cls);
     HDassert(buf);
@@ -1476,7 +1476,7 @@ H5FD__core_flush(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t H5_ATTR_UN
     H5FD_core_t *file      = (H5FD_core_t *)_file;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Write to backing store */
     if (file->dirty && file->fd >= 0 && file->backing_store) {
@@ -1560,7 +1560,7 @@ H5FD__core_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t closing
     size_t       new_eof;             /* New size of memory buffer */
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
 
@@ -1661,7 +1661,7 @@ H5FD__core_lock(H5FD_t *_file, hbool_t rw)
     int          lock_flags;                  /* file locking flags       */
     herr_t       ret_value = SUCCEED;         /* Return value             */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
 
@@ -1706,7 +1706,7 @@ H5FD__core_unlock(H5FD_t *_file)
     H5FD_core_t *file      = (H5FD_core_t *)_file; /* VFD file struct */
     herr_t       ret_value = SUCCEED;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
 
@@ -1742,7 +1742,7 @@ H5FD__core_delete(const char *filename, hid_t fapl_id)
     H5P_genplist_t *        plist;               /* Property list pointer */
     herr_t                  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(filename);
 

--- a/src/H5FDdirect.c
+++ b/src/H5FDdirect.c
@@ -246,7 +246,7 @@ done:
 static herr_t
 H5FD__direct_term(void)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Reset VFL ID */
     H5FD_DIRECT_g = 0;
@@ -348,7 +348,7 @@ H5FD__direct_populate_config(size_t boundary, size_t block_size, size_t cbuf_siz
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(fa_out);
 
@@ -403,7 +403,7 @@ H5FD__direct_fapl_get(H5FD_t *_file)
     H5FD_direct_t *file      = (H5FD_direct_t *)_file;
     void *         ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set return value */
     ret_value = H5FD__direct_fapl_copy(&(file->fa));
@@ -431,7 +431,7 @@ H5FD__direct_fapl_copy(const void *_old_fa)
     const H5FD_direct_fapl_t *old_fa = (const H5FD_direct_fapl_t *)_old_fa;
     H5FD_direct_fapl_t *      new_fa = H5MM_calloc(sizeof(H5FD_direct_fapl_t));
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(new_fa);
 
@@ -474,7 +474,7 @@ H5FD__direct_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxad
     void *          buf1, *buf2;
     H5FD_t *        ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check on file offsets */
     HDassert(sizeof(HDoff_t) >= sizeof(size_t));
@@ -628,7 +628,7 @@ H5FD__direct_close(H5FD_t *_file)
     H5FD_direct_t *file      = (H5FD_direct_t *)_file;
     herr_t         ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (HDclose(file->fd) < 0)
         HSYS_GOTO_ERROR(H5E_IO, H5E_CANTCLOSEFILE, FAIL, "unable to close file")
@@ -662,7 +662,7 @@ H5FD__direct_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
     const H5FD_direct_t *f2        = (const H5FD_direct_t *)_f2;
     int                  ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #ifdef H5_HAVE_WIN32_API
     if (f1->fileindexhi < f2->fileindexhi)
@@ -721,7 +721,7 @@ done:
 static herr_t
 H5FD__direct_query(const H5FD_t H5_ATTR_UNUSED *_f, unsigned long *flags /* out */)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set the VFL feature flags that this driver supports */
     if (flags) {
@@ -758,7 +758,7 @@ H5FD__direct_get_eoa(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_direct_t *file = (const H5FD_direct_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(file->eoa)
 }
@@ -784,7 +784,7 @@ H5FD__direct_set_eoa(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t addr
 {
     H5FD_direct_t *file = (H5FD_direct_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     file->eoa = addr;
 
@@ -814,7 +814,7 @@ H5FD__direct_get_eof(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_direct_t *file = (const H5FD_direct_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(file->eof)
 }
@@ -837,7 +837,7 @@ H5FD__direct_get_handle(H5FD_t *_file, hid_t H5_ATTR_UNUSED fapl, void **file_ha
     H5FD_direct_t *file      = (H5FD_direct_t *)_file;
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (!file_handle)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "file handle not valid")
@@ -881,7 +881,7 @@ H5FD__direct_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_U
     size_t         copy_size = size; /* Size remaining to read when using copy buffer */
     size_t         copy_offset;      /* Offset into copy buffer of the requested data */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file && file->pub.cls);
     HDassert(buf);
@@ -1064,7 +1064,7 @@ H5FD__direct_write(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_
     size_t         copy_size = size; /* Size remaining to write when using copy buffer */
     size_t         copy_offset;      /* Offset into copy buffer of the data to write */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file && file->pub.cls);
     HDassert(buf);
@@ -1278,7 +1278,7 @@ H5FD__direct_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t H5_AT
     H5FD_direct_t *file      = (H5FD_direct_t *)_file;
     herr_t         ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
 
@@ -1342,7 +1342,7 @@ H5FD__direct_lock(H5FD_t *_file, hbool_t rw)
     int            lock_flags;                    /* file locking flags   */
     herr_t         ret_value = SUCCEED;           /* Return value         */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
 
@@ -1382,7 +1382,7 @@ H5FD__direct_unlock(H5FD_t *_file)
     H5FD_direct_t *file      = (H5FD_direct_t *)_file; /* VFD file struct */
     herr_t         ret_value = SUCCEED;                /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
 
@@ -1415,7 +1415,7 @@ H5FD__direct_delete(const char *filename, hid_t H5_ATTR_UNUSED fapl_id)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(filename);
 

--- a/src/H5FDfamily.c
+++ b/src/H5FDfamily.c
@@ -171,7 +171,7 @@ H5FD__family_get_default_config(H5FD_family_fapl_t *fa_out)
     H5P_genplist_t *plist;
     herr_t          ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(fa_out);
 
@@ -225,7 +225,7 @@ H5FD__family_get_default_printf_filename(const char *old_filename)
     char *      tmp_buffer       = NULL;
     char *      ret_value        = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(old_filename);
 
@@ -315,7 +315,7 @@ H5FD_family_init(void)
 static herr_t
 H5FD__family_term(void)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Reset VFL ID */
     H5FD_FAMILY_g = 0;
@@ -441,7 +441,7 @@ H5FD__family_fapl_get(H5FD_t *_file)
     H5P_genplist_t *    plist;            /* Property list pointer */
     void *              ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (NULL == (fa = (H5FD_family_fapl_t *)H5MM_calloc(sizeof(H5FD_family_fapl_t))))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed")
@@ -484,7 +484,7 @@ H5FD__family_fapl_copy(const void *_old_fa)
     H5P_genplist_t *          plist;            /* Property list pointer */
     void *                    ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (NULL == (new_fa = (H5FD_family_fapl_t *)H5MM_malloc(sizeof(H5FD_family_fapl_t))))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed")
@@ -534,7 +534,7 @@ H5FD__family_fapl_free(void *_fa)
     H5FD_family_fapl_t *fa        = (H5FD_family_fapl_t *)_fa;
     herr_t              ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (H5I_dec_ref(fa->memb_fapl_id) < 0)
         HGOTO_ERROR(H5E_VFL, H5E_CANTDEC, FAIL, "can't close driver ID")
@@ -562,7 +562,7 @@ done:
 static hsize_t
 H5FD__family_sb_size(H5FD_t H5_ATTR_UNUSED *_file)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* 8 bytes field for the size of member file size field should be
      * enough for now. */
@@ -592,7 +592,7 @@ H5FD__family_sb_encode(H5FD_t *_file, char *name /*out*/, unsigned char *buf /*o
 {
     H5FD_family_t *file = (H5FD_family_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Name and version number */
     HDstrncpy(name, "NCSAfami", (size_t)9);
@@ -636,7 +636,7 @@ H5FD__family_sb_decode(H5FD_t *_file, const char H5_ATTR_UNUSED *name, const uns
     uint64_t       msize;
     herr_t         ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Read member file size. Skip name template for now although it's saved. */
     UINT64DECODE(buf, msize);
@@ -700,7 +700,7 @@ H5FD__family_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxad
     unsigned       t_flags        = flags & ~H5F_ACC_CREAT;
     H5FD_t *       ret_value      = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (!name || !*name)
@@ -891,7 +891,7 @@ H5FD__family_close(H5FD_t *_file)
     unsigned       u;                   /* Local index variable */
     herr_t         ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Close as many members as possible. Use private function here to avoid clearing
      * the error stack. We need the error message to indicate wrong member file size. */
@@ -941,7 +941,7 @@ H5FD__family_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
     const H5FD_family_t *f2        = (const H5FD_family_t *)_f2;
     int                  ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(f1->nmembs >= 1 && f1->memb[0]);
     HDassert(f2->nmembs >= 1 && f2->memb[0]);
@@ -970,7 +970,7 @@ H5FD__family_query(const H5FD_t *_file, unsigned long *flags /* out */)
 {
     const H5FD_family_t *file = (const H5FD_family_t *)_file; /* Family VFD info */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set the VFL feature flags that this driver supports */
     if (flags) {
@@ -1010,7 +1010,7 @@ H5FD__family_get_eoa(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_family_t *file = (const H5FD_family_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(file->eoa)
 }
@@ -1045,7 +1045,7 @@ H5FD__family_set_eoa(H5FD_t *_file, H5FD_mem_t type, haddr_t abs_eoa)
     unsigned       u;                   /* Local index variable */
     herr_t         ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate space for the member name buffer */
     if (NULL == (memb_name = (char *)H5MM_malloc(H5FD_FAM_MEMB_NAME_BUF_SIZE)))
@@ -1131,7 +1131,7 @@ H5FD__family_get_eof(const H5FD_t *_file, H5FD_mem_t type)
     int                  i;                       /* Local index variable */
     haddr_t              ret_value = HADDR_UNDEF; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /*
      * Find the last member that has a non-zero EOF and break out of the loop
@@ -1182,7 +1182,7 @@ H5FD__family_get_handle(H5FD_t *_file, hid_t fapl, void **file_handle)
     int             memb;
     herr_t          ret_value = FAIL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get the plist structure and family offset */
     if (NULL == (plist = H5P_object_verify(fapl, H5P_FILE_ACCESS)))
@@ -1230,7 +1230,7 @@ H5FD__family_read(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, s
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Get the member data transfer property list. If the transfer property
@@ -1295,7 +1295,7 @@ H5FD__family_write(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, 
     H5P_genplist_t *     plist;               /* Property list pointer */
     herr_t               ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Get the member data transfer property list. If the transfer property
@@ -1352,7 +1352,7 @@ H5FD__family_flush(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t closing)
     unsigned       u, nerrors = 0;
     herr_t         ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     for (u = 0; u < file->nmembs; u++)
         if (file->memb[u] && H5FD_flush(file->memb[u], closing) < 0)
@@ -1386,7 +1386,7 @@ H5FD__family_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t closi
     unsigned       u, nerrors = 0;
     herr_t         ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     for (u = 0; u < file->nmembs; u++)
         if (file->memb[u] && H5FD_truncate(file->memb[u], closing) < 0)
@@ -1420,7 +1420,7 @@ H5FD__family_lock(H5FD_t *_file, hbool_t rw)
     unsigned       u;                             /* Local index variable */
     herr_t         ret_value = SUCCEED;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Place the lock on all the member files */
     for (u = 0; u < file->nmembs; u++)
@@ -1464,7 +1464,7 @@ H5FD__family_unlock(H5FD_t *_file)
     unsigned       u;                             /* Local index variable */
     herr_t         ret_value = SUCCEED;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Remove the lock on the member files */
     for (u = 0; u < file->nmembs; u++)
@@ -1499,7 +1499,7 @@ H5FD__family_delete(const char *filename, hid_t fapl_id)
     herr_t                    delete_error = FAIL;
     herr_t                    ret_value    = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(filename);
 

--- a/src/H5FDhdfs.c
+++ b/src/H5FDhdfs.c
@@ -385,7 +385,7 @@ done:
 static herr_t
 H5FD__hdfs_term(void)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #if HDFS_DEBUG
     HDfprintf(stdout, "called %s.\n", __func__);
@@ -419,7 +419,7 @@ H5FD__hdfs_handle_open(const char *path, const char *namenode_name, const int32_
     hdfs_t *            handle    = NULL;
     hdfs_t *            ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if HDFS_DEBUG
     HDfprintf(stdout, "called %s.\n", __func__);
@@ -504,7 +504,7 @@ H5FD__hdfs_handle_close(hdfs_t *handle)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if HDFS_DEBUG
     HDfprintf(stdout, "called %s.\n", __func__);
@@ -556,7 +556,7 @@ H5FD__hdfs_validate_config(const H5FD_hdfs_fapl_t *fa)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(fa != NULL);
 
@@ -684,7 +684,7 @@ H5FD__hdfs_fapl_get(H5FD_t *_file)
     H5FD_hdfs_fapl_t *fa        = NULL;
     void *            ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     fa = (H5FD_hdfs_fapl_t *)H5MM_calloc(sizeof(H5FD_hdfs_fapl_t));
     if (fa == NULL)
@@ -723,7 +723,7 @@ H5FD__hdfs_fapl_copy(const void *_old_fa)
     H5FD_hdfs_fapl_t *      new_fa    = NULL;
     void *                  ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     new_fa = (H5FD_hdfs_fapl_t *)H5MM_malloc(sizeof(H5FD_hdfs_fapl_t));
     if (new_fa == NULL)
@@ -756,7 +756,7 @@ H5FD__hdfs_fapl_free(void *_fa)
 {
     H5FD_hdfs_fapl_t *fa = (H5FD_hdfs_fapl_t *)_fa;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(fa != NULL); /* sanity check */
 
@@ -793,7 +793,7 @@ hdfs__reset_stats(H5FD_hdfs_t *file)
     unsigned i         = 0;
     herr_t   ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if HDFS_DEBUG
     HDfprintf(stdout, "called %s.\n", __func__);
@@ -851,7 +851,7 @@ H5FD__hdfs_open(const char *path, unsigned flags, hid_t fapl_id, haddr_t maxaddr
     hdfs_t *         handle    = NULL;
     H5FD_hdfs_fapl_t fa;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if HDFS_DEBUG
     HDfprintf(stdout, "called %s.\n", __func__);
@@ -983,7 +983,7 @@ hdfs__fprint_stats(FILE *stream, const H5FD_hdfs_t *file)
     unsigned           suffix_i     = 0;
     const char         suffixes[]   = {' ', 'K', 'M', 'G', 'T', 'P'};
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (stream == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "file stream cannot be null")
@@ -1189,7 +1189,7 @@ H5FD__hdfs_close(H5FD_t *_file)
     H5FD_hdfs_t *file      = (H5FD_hdfs_t *)_file;
     herr_t       ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if HDFS_DEBUG
     HDfprintf(stdout, "called %s.\n", __func__);
@@ -1245,7 +1245,7 @@ H5FD__hdfs_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
     hdfsFileInfo *     finfo1    = NULL;
     hdfsFileInfo *     finfo2    = NULL;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #if HDFS_DEBUG
     HDfprintf(stdout, "called %s.\n", __func__);
@@ -1318,7 +1318,7 @@ done:
 static herr_t
 H5FD__hdfs_query(const H5FD_t H5_ATTR_UNUSED *_file, unsigned long *flags)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #if HDFS_DEBUG
     HDfprintf(stdout, "called %s.\n", __func__);
@@ -1356,7 +1356,7 @@ H5FD__hdfs_get_eoa(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_hdfs_t *file = (const H5FD_hdfs_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #if HDFS_DEBUG
     HDfprintf(stdout, "called %s.\n", __func__);
@@ -1387,7 +1387,7 @@ H5FD__hdfs_set_eoa(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t addr)
 {
     H5FD_hdfs_t *file = (H5FD_hdfs_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #if HDFS_DEBUG
     HDfprintf(stdout, "called %s.\n", __func__);
@@ -1421,7 +1421,7 @@ H5FD__hdfs_get_eof(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_hdfs_t *file = (const H5FD_hdfs_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #if HDFS_DEBUG
     HDfprintf(stdout, "called %s.\n", __func__);
@@ -1456,7 +1456,7 @@ H5FD__hdfs_get_handle(H5FD_t *_file, hid_t H5_ATTR_UNUSED fapl, void **file_hand
     H5FD_hdfs_t *file      = (H5FD_hdfs_t *)_file;
     herr_t       ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if HDFS_DEBUG
     HDfprintf(stdout, "called %s.\n", __func__);
@@ -1506,7 +1506,7 @@ H5FD__hdfs_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UNU
     unsigned       bin_i = 0;
 #endif /* HDFS_STATS */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if HDFS_DEBUG
     HDfprintf(stdout, "called %s.\n", __func__);
@@ -1578,7 +1578,7 @@ H5FD__hdfs_write(H5FD_t H5_ATTR_UNUSED *_file, H5FD_mem_t H5_ATTR_UNUSED type, h
 {
     herr_t ret_value = FAIL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if HDFS_DEBUG
     HDfprintf(stdout, "called %s.\n", __func__);
@@ -1616,7 +1616,7 @@ H5FD__hdfs_truncate(H5FD_t H5_ATTR_UNUSED *_file, hid_t H5_ATTR_UNUSED dxpl_id,
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if HDFS_DEBUG
     HDfprintf(stdout, "called %s.\n", __func__);

--- a/src/H5FDint.c
+++ b/src/H5FDint.c
@@ -2171,7 +2171,7 @@ H5FD__vsrt_tmp_cmp(const void *element_1, const void *element_2)
     haddr_t addr_2    = ((const H5FD_vsrt_tmp_t *)element_2)->addr;
     int     ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(H5F_addr_defined(addr_1));
@@ -2482,7 +2482,7 @@ H5FD__get_driver_cb(void *obj, hid_t id, void *_op_data)
     H5FD_class_t *        cls       = (H5FD_class_t *)obj;
     int                   ret_value = H5_ITER_CONT; /* Callback return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (H5FD_GET_DRIVER_BY_NAME == op_data->key.kind) {
         if (0 == HDstrcmp(cls->name, op_data->key.u.name)) {

--- a/src/H5FDlog.c
+++ b/src/H5FDlog.c
@@ -283,7 +283,7 @@ H5FD_log_init(void)
 static herr_t
 H5FD__log_term(void)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Reset VFL ID */
     H5FD_LOG_g = 0;
@@ -364,7 +364,7 @@ H5FD__log_fapl_get(H5FD_t *_file)
     H5FD_log_t *file      = (H5FD_log_t *)_file;
     void *      ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set return value */
     ret_value = H5FD__log_fapl_copy(&(file->fa));
@@ -392,7 +392,7 @@ H5FD__log_fapl_copy(const void *_old_fa)
     H5FD_log_fapl_t *      new_fa    = NULL; /* New FAPL info */
     void *                 ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(old_fa);
 
@@ -439,7 +439,7 @@ H5FD__log_fapl_free(void *_fa)
 {
     H5FD_log_fapl_t *fa = (H5FD_log_fapl_t *)_fa;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Free the fapl information */
     if (fa->logfile)
@@ -481,7 +481,7 @@ H5FD__log_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr)
     h5_stat_t  sb;
     H5FD_t *   ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check on file offsets */
     HDcompile_assert(sizeof(HDoff_t) >= sizeof(size_t));
@@ -675,7 +675,7 @@ H5FD__log_close(H5FD_t *_file)
     H5_timer_t  close_timer;         /* Timer for close() call */
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(file);
@@ -833,7 +833,7 @@ H5FD__log_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
     const H5FD_log_t *f2        = (const H5FD_log_t *)_f2;
     int               ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #ifdef H5_HAVE_WIN32_API
     if (f1->dwVolumeSerialNumber < f2->dwVolumeSerialNumber)
@@ -896,7 +896,7 @@ H5FD__log_query(const H5FD_t *_file, unsigned long *flags /* out */)
 {
     const H5FD_log_t *file = (const H5FD_log_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set the VFL feature flags that this driver supports */
     if (flags) {
@@ -940,7 +940,7 @@ H5FD__log_alloc(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_id, hs
     haddr_t     addr;
     haddr_t     ret_value = HADDR_UNDEF; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Compute the address for the block to allocate */
     addr = file->eoa;
@@ -985,7 +985,7 @@ H5FD__log_free(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_id, had
 {
     H5FD_log_t *file = (H5FD_log_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (file->fa.flags != 0) {
         /* Reset the flavor of the information in the file */
@@ -1024,7 +1024,7 @@ H5FD__log_get_eoa(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_log_t *file = (const H5FD_log_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(file->eoa)
 } /* end H5FD__log_get_eoa() */
@@ -1048,7 +1048,7 @@ H5FD__log_set_eoa(H5FD_t *_file, H5FD_mem_t type, haddr_t addr)
 {
     H5FD_log_t *file = (H5FD_log_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (file->fa.flags != 0) {
         /* Check for increasing file size */
@@ -1115,7 +1115,7 @@ H5FD__log_get_eof(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_log_t *file = (const H5FD_log_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(file->eof)
 } /* end H5FD__log_get_eof() */
@@ -1138,7 +1138,7 @@ H5FD__log_get_handle(H5FD_t *_file, hid_t H5_ATTR_UNUSED fapl, void **file_handl
     H5FD_log_t *file      = (H5FD_log_t *)_file;
     herr_t      ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (!file_handle)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "file handle not valid")
@@ -1177,7 +1177,7 @@ H5FD__log_read(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_id, had
     HDoff_t       offset    = (HDoff_t)addr;
     herr_t        ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file && file->pub.cls);
     HDassert(buf);
@@ -1391,7 +1391,7 @@ H5FD__log_write(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_id, ha
     HDoff_t       offset    = (HDoff_t)addr;
     herr_t        ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file && file->pub.cls);
     HDassert(size > 0);
@@ -1602,7 +1602,7 @@ H5FD__log_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t H5_ATTR_
     H5FD_log_t *file      = (H5FD_log_t *)_file;
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
 
@@ -1710,7 +1710,7 @@ H5FD__log_lock(H5FD_t *_file, hbool_t rw)
     int         lock_flags;                 /* file locking flags       */
     herr_t      ret_value = SUCCEED;        /* Return value             */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(file);
@@ -1751,7 +1751,7 @@ H5FD__log_unlock(H5FD_t *_file)
     H5FD_log_t *file      = (H5FD_log_t *)_file; /* VFD file struct          */
     herr_t      ret_value = SUCCEED;             /* Return value             */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
 
@@ -1784,7 +1784,7 @@ H5FD__log_delete(const char *filename, hid_t H5_ATTR_UNUSED fapl_id)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(filename);
 

--- a/src/H5FDmirror.c
+++ b/src/H5FDmirror.c
@@ -252,7 +252,7 @@ done:
 static herr_t
 H5FD__mirror_term(void)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Reset VFL ID */
     H5FD_MIRROR_g = 0;
@@ -1111,7 +1111,7 @@ H5FD__mirror_verify_reply(H5FD_mirror_t *file)
     ssize_t                         read_ret  = 0;
     herr_t                          ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     LOG_OP_CALL(__func__);
 
@@ -1166,7 +1166,7 @@ H5FD__mirror_fapl_get(H5FD_t *_file)
     H5FD_mirror_fapl_t *fa        = NULL;
     void *              ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     LOG_OP_CALL(__func__);
 
@@ -1202,7 +1202,7 @@ H5FD__mirror_fapl_copy(const void *_old_fa)
     H5FD_mirror_fapl_t *      new_fa    = NULL;
     void *                    ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     LOG_OP_CALL(__func__);
 
@@ -1234,7 +1234,7 @@ H5FD__mirror_fapl_free(void *_fa)
 {
     H5FD_mirror_fapl_t *fa = (H5FD_mirror_fapl_t *)_fa;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     LOG_OP_CALL(__func__);
 
@@ -1352,7 +1352,7 @@ H5FD__mirror_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxad
     H5FD_mirror_xmit_open_t *open_xmit = NULL;
     H5FD_t *                 ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     LOG_OP_CALL(__func__);
 
@@ -1477,7 +1477,7 @@ H5FD__mirror_close(H5FD_t *_file)
     int            xmit_encoded = 0; /* monitor point of failure */
     herr_t         ret_value    = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     LOG_OP_CALL(__func__);
 
@@ -1549,7 +1549,7 @@ done:
 static herr_t
 H5FD__mirror_query(const H5FD_t H5_ATTR_UNUSED *_file, unsigned long *flags)
 {
-    FUNC_ENTER_STATIC_NOERR;
+    FUNC_ENTER_PACKAGE_NOERR;
 
     LOG_OP_CALL(__func__);
 
@@ -1586,7 +1586,7 @@ H5FD__mirror_get_eoa(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_mirror_t *file = (const H5FD_mirror_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     LOG_OP_CALL(__func__);
 
@@ -1613,7 +1613,7 @@ H5FD__mirror_set_eoa(H5FD_t *_file, H5FD_mem_t type, haddr_t addr)
     H5FD_mirror_t *        file      = (H5FD_mirror_t *)_file;
     herr_t                 ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     LOG_OP_CALL(__func__);
 
@@ -1668,7 +1668,7 @@ H5FD__mirror_get_eof(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_mirror_t *file = (const H5FD_mirror_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     LOG_OP_CALL(__func__);
 
@@ -1689,7 +1689,7 @@ static herr_t
 H5FD__mirror_read(H5FD_t H5_ATTR_UNUSED *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UNUSED fapl_id,
                   haddr_t H5_ATTR_UNUSED addr, size_t H5_ATTR_UNUSED size, void H5_ATTR_UNUSED *buf)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     LOG_OP_CALL(__func__);
 
@@ -1722,7 +1722,7 @@ H5FD__mirror_write(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_id,
     H5FD_mirror_t *          file      = (H5FD_mirror_t *)_file;
     herr_t                   ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     LOG_OP_CALL(__func__);
 
@@ -1785,7 +1785,7 @@ H5FD__mirror_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t H5_AT
     H5FD_mirror_t *file      = (H5FD_mirror_t *)_file;
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     LOG_OP_CALL(__func__);
 
@@ -1833,7 +1833,7 @@ H5FD__mirror_lock(H5FD_t *_file, hbool_t rw)
     H5FD_mirror_t *         file      = (H5FD_mirror_t *)_file;
     herr_t                  ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     LOG_OP_CALL(__func__);
 
@@ -1880,7 +1880,7 @@ H5FD__mirror_unlock(H5FD_t *_file)
     H5FD_mirror_t *file      = (H5FD_mirror_t *)_file;
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     LOG_OP_CALL(__func__);
 

--- a/src/H5FDmpio.c
+++ b/src/H5FDmpio.c
@@ -189,7 +189,7 @@ static int H5FD_mpio_debug_rank_s = -1;
 static void
 H5FD__mpio_parse_debug_str(const char *s)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(s);
@@ -328,7 +328,7 @@ done:
 static herr_t
 H5FD__mpio_term(void)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Terminate MPI if the driver initialized it */
     if (H5FD_mpi_self_initialized) {
@@ -851,7 +851,7 @@ H5FD__mpio_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t H5_ATTR
     int     mpi_code;         /* MPI return code */
     H5FD_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get a pointer to the fapl */
     if (NULL == (plist = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
@@ -993,7 +993,7 @@ H5FD__mpio_close(H5FD_t *_file)
     int    mpi_code;            /* MPI return code */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #ifdef H5FDmpio_DEBUG
     if (H5FD_mpio_debug_t_flag)
@@ -1038,7 +1038,7 @@ done:
 static herr_t
 H5FD__mpio_query(const H5FD_t H5_ATTR_UNUSED *_file, unsigned long *flags /* out */)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set the VFL feature flags that this driver supports */
     if (flags) {
@@ -1073,7 +1073,7 @@ H5FD__mpio_get_eoa(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_mpio_t *file = (const H5FD_mpio_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(file);
@@ -1101,7 +1101,7 @@ H5FD__mpio_set_eoa(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t addr)
 {
     H5FD_mpio_t *file = (H5FD_mpio_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(file);
@@ -1143,7 +1143,7 @@ H5FD__mpio_get_eof(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_mpio_t *file = (const H5FD_mpio_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(file);
@@ -1170,7 +1170,7 @@ H5FD__mpio_get_handle(H5FD_t *_file, hid_t H5_ATTR_UNUSED fapl, void **file_hand
     H5FD_mpio_t *file      = (H5FD_mpio_t *)_file;
     herr_t       ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (!file_handle)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "file handle not valid")
@@ -1232,7 +1232,7 @@ H5FD__mpio_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UNU
     int    mpi_code; /* MPI return code */
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #ifdef H5FDmpio_DEBUG
     if (H5FD_mpio_debug_t_flag)
@@ -1502,7 +1502,7 @@ H5FD__mpio_write(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_id, h
     int    mpi_code; /* MPI return code */
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #ifdef H5FDmpio_DEBUG
     if (H5FD_mpio_debug_t_flag)
@@ -1717,7 +1717,7 @@ H5FD__mpio_vector_build_types(uint32_t count, H5FD_mem_t types[], haddr_t addrs[
     int           mpi_code; /* MPI return code */
     herr_t        ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(s_sizes);
@@ -2095,7 +2095,7 @@ H5FD__mpio_read_vector(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, uint32_t cou
 #endif
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #ifdef H5FDmpio_DEBUG
     if (H5FD_mpio_debug_t_flag)
@@ -2487,7 +2487,7 @@ H5FD__mpio_write_vector(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, uint32_t co
     haddr_t max_addr  = 0;
     herr_t  ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #ifdef H5FDmpio_DEBUG
     if (H5FD_mpio_debug_t_flag)
@@ -2745,7 +2745,7 @@ H5FD__mpio_flush(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t closing)
     int    mpi_code; /* mpi return code */
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #ifdef H5FDmpio_DEBUG
     if (H5FD_mpio_debug_t_flag)
@@ -2802,7 +2802,7 @@ H5FD__mpio_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t H5_ATTR
 #endif
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #ifdef H5FDmpio_DEBUG
     if (H5FD_mpio_debug_t_flag)
@@ -2902,7 +2902,7 @@ H5FD__mpio_delete(const char *filename, hid_t fapl_id)
     int             mpi_code;            /* MPI return code */
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(filename);
 

--- a/src/H5FDros3.c
+++ b/src/H5FDros3.c
@@ -347,7 +347,7 @@ done:
 static herr_t
 H5FD__ros3_term(void)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #if ROS3_DEBUG
     HDfprintf(stdout, "H5FD__ros3_term() called.\n");
@@ -427,7 +427,7 @@ H5FD__ros3_validate_config(const H5FD_ros3_fapl_t *fa)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(fa != NULL);
 
@@ -515,7 +515,7 @@ H5FD__ros3_fapl_get(H5FD_t *_file)
     H5FD_ros3_fapl_t *fa        = NULL;
     void *            ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     fa = (H5FD_ros3_fapl_t *)H5MM_calloc(sizeof(H5FD_ros3_fapl_t));
     if (fa == NULL)
@@ -556,7 +556,7 @@ H5FD__ros3_fapl_copy(const void *_old_fa)
     H5FD_ros3_fapl_t *      new_fa    = NULL;
     void *                  ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     new_fa = (H5FD_ros3_fapl_t *)H5MM_malloc(sizeof(H5FD_ros3_fapl_t));
     if (new_fa == NULL)
@@ -590,7 +590,7 @@ H5FD__ros3_fapl_free(void *_fa)
 {
     H5FD_ros3_fapl_t *fa = (H5FD_ros3_fapl_t *)_fa;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(fa != NULL); /* sanity check */
 
@@ -627,7 +627,7 @@ ros3_reset_stats(H5FD_ros3_t *file)
     unsigned i         = 0;
     herr_t   ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if ROS3_DEBUG
     HDprintf("ros3_reset_stats() called\n");
@@ -695,7 +695,7 @@ H5FD__ros3_open(const char *url, unsigned flags, hid_t fapl_id, haddr_t maxaddr)
     H5FD_ros3_fapl_t fa;
     H5FD_t *         ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if ROS3_DEBUG
     HDfprintf(stdout, "H5FD__ros3_open() called.\n");
@@ -852,7 +852,7 @@ ros3_fprint_stats(FILE *stream, const H5FD_ros3_t *file)
     unsigned           suffix_i     = 0;
     const char         suffixes[]   = {' ', 'K', 'M', 'G', 'T', 'P'};
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (stream == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "file stream cannot be null");
@@ -1080,7 +1080,7 @@ H5FD__ros3_close(H5FD_t H5_ATTR_UNUSED *_file)
     H5FD_ros3_t *file      = (H5FD_ros3_t *)_file;
     herr_t       ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if ROS3_DEBUG
     HDfprintf(stdout, "H5FD__ros3_close() called.\n");
@@ -1149,7 +1149,7 @@ H5FD__ros3_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
     const parsed_url_t *purl2     = NULL;
     int                 ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #if ROS3_DEBUG
     HDfprintf(stdout, "H5FD__ros3_cmp() called.\n");
@@ -1261,7 +1261,7 @@ done:
 static herr_t
 H5FD__ros3_query(const H5FD_t H5_ATTR_UNUSED *_file, unsigned long *flags)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #if ROS3_DEBUG
     HDfprintf(stdout, "H5FD__ros3_query() called.\n");
@@ -1301,7 +1301,7 @@ H5FD__ros3_get_eoa(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_ros3_t *file = (const H5FD_ros3_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #if ROS3_DEBUG
     HDfprintf(stdout, "H5FD__ros3_get_eoa() called.\n");
@@ -1332,7 +1332,7 @@ H5FD__ros3_set_eoa(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t addr)
 {
     H5FD_ros3_t *file = (H5FD_ros3_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #if ROS3_DEBUG
     HDfprintf(stdout, "H5FD__ros3_set_eoa() called.\n");
@@ -1366,7 +1366,7 @@ H5FD__ros3_get_eof(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_ros3_t *file = (const H5FD_ros3_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #if ROS3_DEBUG
     HDfprintf(stdout, "H5FD__ros3_get_eof() called.\n");
@@ -1398,7 +1398,7 @@ H5FD__ros3_get_handle(H5FD_t *_file, hid_t H5_ATTR_UNUSED fapl, void **file_hand
     H5FD_ros3_t *file      = (H5FD_ros3_t *)_file;
     herr_t       ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if ROS3_DEBUG
     HDfprintf(stdout, "H5FD__ros3_get_handle() called.\n");
@@ -1448,7 +1448,7 @@ H5FD__ros3_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UNU
     unsigned       bin_i = 0;
 #endif /* ROS3_STATS */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if ROS3_DEBUG
     HDfprintf(stdout, "H5FD__ros3_read() called.\n");
@@ -1518,7 +1518,7 @@ H5FD__ros3_write(H5FD_t H5_ATTR_UNUSED *_file, H5FD_mem_t H5_ATTR_UNUSED type, h
 {
     herr_t ret_value = FAIL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if ROS3_DEBUG
     HDfprintf(stdout, "H5FD__ros3_write() called.\n");
@@ -1556,7 +1556,7 @@ H5FD__ros3_truncate(H5FD_t H5_ATTR_UNUSED *_file, hid_t H5_ATTR_UNUSED dxpl_id,
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if ROS3_DEBUG
     HDfprintf(stdout, "H5FD__ros3_truncate() called.\n");

--- a/src/H5FDs3comms.c
+++ b/src/H5FDs3comms.c
@@ -1935,7 +1935,7 @@ H5FD__s3comms_load_aws_creds_from_file(FILE *file, const char *profile_name, cha
     int      found_setting = 0;
     char *   line_buffer   = &(buffer[0]);
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #if S3COMMS_DEBUG
     HDfprintf(stdout, "called load_aws_creds_from_file.\n");

--- a/src/H5FDsec2.c
+++ b/src/H5FDsec2.c
@@ -243,7 +243,7 @@ H5FD_sec2_init(void)
 static herr_t
 H5FD__sec2_term(void)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Reset VFL ID */
     H5FD_SEC2_g = 0;
@@ -311,7 +311,7 @@ H5FD__sec2_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
     H5P_genplist_t *plist;            /* Property list pointer */
     H5FD_t *        ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check on file offsets */
     HDcompile_assert(sizeof(HDoff_t) >= sizeof(size_t));
@@ -433,7 +433,7 @@ H5FD__sec2_close(H5FD_t *_file)
     H5FD_sec2_t *file      = (H5FD_sec2_t *)_file;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(file);
@@ -471,7 +471,7 @@ H5FD__sec2_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
     const H5FD_sec2_t *f2        = (const H5FD_sec2_t *)_f2;
     int                ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #ifdef H5_HAVE_WIN32_API
     if (f1->dwVolumeSerialNumber < f2->dwVolumeSerialNumber)
@@ -532,7 +532,7 @@ H5FD__sec2_query(const H5FD_t *_file, unsigned long *flags /* out */)
 {
     const H5FD_sec2_t *file = (const H5FD_sec2_t *)_file; /* sec2 VFD info */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set the VFL feature flags that this driver supports */
     /* Notice: the Mirror VFD Writer currently uses only the Sec2 driver as
@@ -581,7 +581,7 @@ H5FD__sec2_get_eoa(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_sec2_t *file = (const H5FD_sec2_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(file->eoa)
 } /* end H5FD__sec2_get_eoa() */
@@ -605,7 +605,7 @@ H5FD__sec2_set_eoa(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t addr)
 {
     H5FD_sec2_t *file = (H5FD_sec2_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     file->eoa = addr;
 
@@ -632,7 +632,7 @@ H5FD__sec2_get_eof(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
 {
     const H5FD_sec2_t *file = (const H5FD_sec2_t *)_file;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(file->eof)
 } /* end H5FD__sec2_get_eof() */
@@ -655,7 +655,7 @@ H5FD__sec2_get_handle(H5FD_t *_file, hid_t H5_ATTR_UNUSED fapl, void **file_hand
     H5FD_sec2_t *file      = (H5FD_sec2_t *)_file;
     herr_t       ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (!file_handle)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "file handle not valid")
@@ -690,7 +690,7 @@ H5FD__sec2_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UNU
     HDoff_t      offset    = (HDoff_t)addr;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file && file->pub.cls);
     HDassert(buf);
@@ -798,7 +798,7 @@ H5FD__sec2_write(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UN
     HDoff_t      offset    = (HDoff_t)addr;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file && file->pub.cls);
     HDassert(buf);
@@ -900,7 +900,7 @@ H5FD__sec2_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t H5_ATTR
     H5FD_sec2_t *file      = (H5FD_sec2_t *)_file;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
 
@@ -970,7 +970,7 @@ H5FD__sec2_lock(H5FD_t *_file, hbool_t rw)
     int          lock_flags;                  /* file locking flags       */
     herr_t       ret_value = SUCCEED;         /* Return value             */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
 
@@ -1010,7 +1010,7 @@ H5FD__sec2_unlock(H5FD_t *_file)
     H5FD_sec2_t *file      = (H5FD_sec2_t *)_file; /* VFD file struct          */
     herr_t       ret_value = SUCCEED;              /* Return value             */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(file);
 
@@ -1043,7 +1043,7 @@ H5FD__sec2_delete(const char *filename, hid_t H5_ATTR_UNUSED fapl_id)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(filename);
 
@@ -1081,7 +1081,7 @@ H5FD__sec2_ctl(H5FD_t *_file, uint64_t op_code, uint64_t flags, const void H5_AT
     H5FD_sec2_t *file      = (H5FD_sec2_t *)_file;
     herr_t       ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(file);

--- a/src/H5FDspace.c
+++ b/src/H5FDspace.c
@@ -94,7 +94,7 @@ H5FD__extend(H5FD_t *file, H5FD_mem_t type, hsize_t size)
     haddr_t eoa;                     /* Address of end-of-allocated space */
     haddr_t ret_value = HADDR_UNDEF; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(file);

--- a/src/H5FDsplitter.c
+++ b/src/H5FDsplitter.c
@@ -224,7 +224,7 @@ H5FD_splitter_init(void)
 static herr_t
 H5FD__splitter_term(void)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -249,7 +249,7 @@ H5FD__copy_plist(hid_t fapl_id, hid_t *id_out_ptr)
     int             ret_value = 0;
     H5P_genplist_t *plist_ptr = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -402,7 +402,7 @@ H5FD__splitter_populate_config(H5FD_splitter_vfd_config_t *vfd_config, H5FD_spli
     hbool_t         free_config = FALSE;
     herr_t          ret_value   = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(fapl_out);
 
@@ -521,7 +521,7 @@ H5FD__splitter_get_default_wo_path(char *new_path, size_t new_path_len, const ch
     char *      file_extension   = NULL;
     herr_t      ret_value        = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(new_path);
     HDassert(base_filename);
@@ -573,7 +573,7 @@ H5FD__splitter_flush(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t closin
     H5FD_splitter_t *file      = (H5FD_splitter_t *)_file;
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -608,7 +608,7 @@ H5FD__splitter_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR
     H5FD_splitter_t *file      = (H5FD_splitter_t *)_file;
     herr_t           ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -648,7 +648,7 @@ H5FD__splitter_write(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr
     H5P_genplist_t * plist_ptr = NULL;
     herr_t           ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -684,7 +684,7 @@ H5FD__splitter_fapl_get(H5FD_t *_file)
     H5FD_splitter_t *file      = (H5FD_splitter_t *)_file;
     void *           ret_value = NULL;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -709,7 +709,7 @@ H5FD__splitter_fapl_copy(const void *_old_fa)
     H5FD_splitter_fapl_t *      new_fa_ptr = NULL;
     void *                      ret_value  = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -753,7 +753,7 @@ H5FD__splitter_fapl_free(void *_fapl)
     H5FD_splitter_fapl_t *fapl      = (H5FD_splitter_fapl_t *)_fapl;
     herr_t                ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -792,7 +792,7 @@ H5FD__splitter_open(const char *name, unsigned flags, hid_t splitter_fapl_id, ha
     H5P_genplist_t *            plist_ptr    = NULL;
     H5FD_t *                    ret_value    = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -903,7 +903,7 @@ H5FD__splitter_close(H5FD_t *_file)
     H5FD_splitter_t *file      = (H5FD_splitter_t *)_file;
     herr_t           ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -954,7 +954,7 @@ H5FD__splitter_get_eoa(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
     const H5FD_splitter_t *file      = (const H5FD_splitter_t *)_file;
     haddr_t                ret_value = HADDR_UNDEF;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -985,7 +985,7 @@ H5FD__splitter_set_eoa(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t ad
     H5FD_splitter_t *file      = (H5FD_splitter_t *)_file;
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__)
 
@@ -1022,7 +1022,7 @@ H5FD__splitter_get_eof(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
     const H5FD_splitter_t *file      = (const H5FD_splitter_t *)_file;
     haddr_t                ret_value = HADDR_UNDEF; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -1051,7 +1051,7 @@ H5FD__splitter_truncate(H5FD_t *_file, hid_t dxpl_id, hbool_t closing)
     H5FD_splitter_t *file      = (H5FD_splitter_t *)_file;
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -1089,7 +1089,7 @@ H5FD__splitter_sb_size(H5FD_t *_file)
     H5FD_splitter_t *file      = (H5FD_splitter_t *)_file;
     hsize_t          ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -1117,7 +1117,7 @@ H5FD__splitter_sb_encode(H5FD_t *_file, char *name /*out*/, unsigned char *buf /
     H5FD_splitter_t *file      = (H5FD_splitter_t *)_file;
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -1148,7 +1148,7 @@ H5FD__splitter_sb_decode(H5FD_t *_file, const char *name, const unsigned char *b
     H5FD_splitter_t *file      = (H5FD_splitter_t *)_file;
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -1179,7 +1179,7 @@ H5FD__splitter_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
     const H5FD_splitter_t *f2        = (const H5FD_splitter_t *)_f2;
     herr_t                 ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -1206,7 +1206,7 @@ H5FD__splitter_get_handle(H5FD_t *_file, hid_t H5_ATTR_UNUSED fapl, void **file_
     H5FD_splitter_t *file      = (H5FD_splitter_t *)_file;
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -1237,7 +1237,7 @@ H5FD__splitter_lock(H5FD_t *_file, hbool_t rw)
     H5FD_splitter_t *file      = (H5FD_splitter_t *)_file; /* VFD file struct */
     herr_t           ret_value = SUCCEED;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -1270,7 +1270,7 @@ H5FD__splitter_unlock(H5FD_t *_file)
     H5FD_splitter_t *file      = (H5FD_splitter_t *)_file; /* VFD file struct */
     herr_t           ret_value = SUCCEED;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -1317,7 +1317,7 @@ H5FD__splitter_ctl(H5FD_t *_file, uint64_t op_code, uint64_t flags, const void *
     H5FD_splitter_t *file      = (H5FD_splitter_t *)_file;
     herr_t           ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(file);
@@ -1361,7 +1361,7 @@ H5FD__splitter_query(const H5FD_t *_file, unsigned long *flags /* out */)
     const H5FD_splitter_t *file      = (const H5FD_splitter_t *)_file;
     herr_t                 ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -1398,7 +1398,7 @@ H5FD__splitter_alloc(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, hsize_t size
     H5FD_splitter_t *file      = (H5FD_splitter_t *)_file; /* VFD file struct */
     haddr_t          ret_value = HADDR_UNDEF;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -1432,7 +1432,7 @@ H5FD__splitter_get_type_map(const H5FD_t *_file, H5FD_mem_t *type_map)
     const H5FD_splitter_t *file      = (const H5FD_splitter_t *)_file;
     herr_t                 ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -1462,7 +1462,7 @@ H5FD__splitter_free(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr,
     H5FD_splitter_t *file      = (H5FD_splitter_t *)_file; /* VFD file struct */
     herr_t           ret_value = SUCCEED;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 
@@ -1497,7 +1497,7 @@ H5FD__splitter_delete(const char *filename, hid_t fapl_id)
     H5P_genplist_t *            plist;
     herr_t                      ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(filename);
 
@@ -1561,7 +1561,7 @@ H5FD__splitter_log_error(const H5FD_splitter_t *file, const char *atfunc, const 
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 

--- a/src/H5FL.c
+++ b/src/H5FL.c
@@ -232,7 +232,7 @@ H5FL__malloc(size_t mem_size)
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Attempt to allocate the memory requested */
     if (NULL == (ret_value = H5MM_malloc(mem_size))) {
@@ -269,7 +269,7 @@ H5FL__reg_init(H5FL_reg_head_t *head)
     H5FL_reg_gc_node_t *new_node;            /* Pointer to the node for the new list to garbage collect */
     herr_t              ret_value = SUCCEED; /* return value*/
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate a new garbage collection node */
     if (NULL == (new_node = (H5FL_reg_gc_node_t *)H5MM_malloc(sizeof(H5FL_reg_gc_node_t))))
@@ -513,7 +513,7 @@ H5FL__reg_gc_list(H5FL_reg_head_t *head)
 {
     H5FL_reg_node_t *free_list; /* Pointer to nodes in free list being garbage collected */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* For each free list being garbage collected, walk through the nodes and free them */
     free_list = head->list;
@@ -562,7 +562,7 @@ H5FL__reg_gc(void)
     H5FL_reg_gc_node_t *gc_node;             /* Pointer into the list of things to garbage collect */
     herr_t              ret_value = SUCCEED; /* return value*/
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Walk through all the free lists, free()'ing the nodes */
     gc_node = H5FL_reg_gc_head.first;
@@ -612,7 +612,7 @@ H5FL__reg_term(void)
 {
     H5FL_reg_gc_node_t *left; /* pointer to garbage collection lists with work left */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Free the nodes on the garbage collection list, keeping nodes with allocations outstanding */
     left = NULL;
@@ -672,7 +672,7 @@ H5FL__blk_find_list(H5FL_blk_node_t **head, size_t size)
 {
     H5FL_blk_node_t *temp = NULL; /* Temp. pointer to node in the native list */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Find the correct free list */
     temp = *head;
@@ -730,7 +730,7 @@ H5FL__blk_create_list(H5FL_blk_node_t **head, size_t size)
 {
     H5FL_blk_node_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate room for the new free list node */
     if (NULL == (ret_value = H5FL_CALLOC(H5FL_blk_node_t)))
@@ -772,7 +772,7 @@ H5FL__blk_init(H5FL_blk_head_t *head)
     H5FL_blk_gc_node_t *new_node;            /* Pointer to the node for the new list to garbage collect */
     herr_t              ret_value = SUCCEED; /* return value*/
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate a new garbage collection node */
     if (NULL == (new_node = (H5FL_blk_gc_node_t *)H5MM_malloc(sizeof(H5FL_blk_gc_node_t))))
@@ -1180,7 +1180,7 @@ H5FL__blk_gc_list(H5FL_blk_head_t *head)
 {
     H5FL_blk_node_t *blk_head; /* Temp. ptr to the free list page node */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Loop through all the nodes in the block free list queue */
     blk_head = head->head;
@@ -1269,7 +1269,7 @@ H5FL__blk_gc(void)
     H5FL_blk_gc_node_t *gc_node;             /* Pointer into the list of things to garbage collect */
     herr_t              ret_value = SUCCEED; /* return value*/
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Walk through all the free lists, free()'ing the nodes */
     gc_node = H5FL_blk_gc_head.first;
@@ -1313,7 +1313,7 @@ H5FL__blk_term(void)
 {
     H5FL_blk_gc_node_t *left; /* pointer to garbage collection lists with work left */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Free the nodes on the garbage collection list, keeping nodes with allocations outstanding */
     left = NULL;
@@ -1372,7 +1372,7 @@ H5FL__arr_init(H5FL_arr_head_t *head)
     size_t              u;                   /* Local index variable */
     herr_t              ret_value = SUCCEED; /* return value*/
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate a new garbage collection node */
     if (NULL == (new_node = (H5FL_gc_arr_node_t *)H5MM_malloc(sizeof(H5FL_gc_arr_node_t))))
@@ -1748,7 +1748,7 @@ H5FL__arr_gc_list(H5FL_arr_head_t *head)
 {
     unsigned u; /* Counter for array of free lists */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Walk through the array of free lists */
     for (u = 0; u < (unsigned)head->maxelem; u++) {
@@ -1811,7 +1811,7 @@ H5FL__arr_gc(void)
     H5FL_gc_arr_node_t *gc_arr_node;         /* Pointer into the list of things to garbage collect */
     herr_t              ret_value = SUCCEED; /* return value*/
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Walk through all the free lists, free()'ing the nodes */
     gc_arr_node = H5FL_arr_gc_head.first;
@@ -1855,7 +1855,7 @@ H5FL__arr_term(void)
 {
     H5FL_gc_arr_node_t *left; /* pointer to garbage collection lists with work left */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Free the nodes on the garbage collection list, keeping nodes with allocations outstanding */
     left = NULL;
@@ -2302,7 +2302,7 @@ H5FL__fac_gc_list(H5FL_fac_head_t *head)
 {
     H5FL_fac_node_t *free_list; /* Pointer to nodes in free list being garbage collected */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* For each free list being garbage collected, walk through the nodes and free them */
     free_list = head->list;
@@ -2448,7 +2448,7 @@ done:
 static int
 H5FL__fac_term_all(void)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Free the nodes on the garbage collection list */
     while (H5FL_fac_gc_head.first != NULL) {

--- a/src/H5FS.c
+++ b/src/H5FS.c
@@ -1074,7 +1074,7 @@ H5FS__sinfo_free_sect_cb(void *_sect, void H5_ATTR_UNUSED *key, void *op_data)
     H5FS_section_info_t *sect  = (H5FS_section_info_t *)_sect;  /* Section to free */
     const H5FS_sinfo_t * sinfo = (const H5FS_sinfo_t *)op_data; /* Free space manager for section */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(sect);
     HDassert(sinfo);
@@ -1102,7 +1102,7 @@ H5FS__sinfo_free_node_cb(void *item, void H5_ATTR_UNUSED *key, void *op_data)
 {
     H5FS_node_t *fspace_node = (H5FS_node_t *)item; /* Temporary pointer to free space list node */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(fspace_node);
     HDassert(op_data);

--- a/src/H5FScache.c
+++ b/src/H5FScache.c
@@ -158,7 +158,7 @@ H5FS__cache_hdr_get_initial_load_size(void *_udata, size_t *image_len)
 {
     H5FS_hdr_cache_ud_t *udata = (H5FS_hdr_cache_ud_t *)_udata; /* User-data for metadata cache callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(udata);
@@ -192,7 +192,7 @@ H5FS__cache_hdr_verify_chksum(const void *_image, size_t len, void H5_ATTR_UNUSE
     uint32_t       computed_chksum;                 /* Computed metadata checksum value */
     htri_t         ret_value = TRUE;                /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -233,7 +233,7 @@ H5FS__cache_hdr_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED len
     unsigned             nclasses;                               /* Number of section classes */
     H5FS_t *             ret_value = NULL;                       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -340,7 +340,7 @@ H5FS__cache_hdr_image_len(const void *_thing, size_t *image_len)
 {
     const H5FS_t *fspace = (const H5FS_t *)_thing; /* Pointer to the object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(fspace);
@@ -390,7 +390,7 @@ H5FS__cache_hdr_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5_AT
     H5AC_ring_t orig_ring = H5AC_RING_INV;    /* Original ring value */
     herr_t      ret_value = SUCCEED;          /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);
@@ -688,7 +688,7 @@ H5FS__cache_hdr_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG_UN
     uint32_t metadata_chksum;            /* Computed metadata checksum value */
     herr_t   ret_value = SUCCEED;        /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(f);
@@ -852,7 +852,7 @@ H5FS__cache_hdr_free_icr(void *_thing)
     H5FS_t *fspace    = (H5FS_t *)_thing; /* Pointer to the object */
     herr_t  ret_value = SUCCEED;          /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(fspace);
@@ -890,7 +890,7 @@ H5FS__cache_sinfo_get_initial_load_size(void *_udata, size_t *image_len)
     const H5FS_t *         fspace;                                  /* free space manager */
     H5FS_sinfo_cache_ud_t *udata = (H5FS_sinfo_cache_ud_t *)_udata; /* User data for callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(udata);
@@ -970,7 +970,7 @@ H5FS__cache_sinfo_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED l
     uint32_t               stored_chksum;                           /* Stored metadata checksum  */
     void *                 ret_value = NULL;                        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(image);
@@ -1121,7 +1121,7 @@ H5FS__cache_sinfo_image_len(const void *_thing, size_t *image_len)
 {
     const H5FS_sinfo_t *sinfo = (const H5FS_sinfo_t *)_thing; /* Pointer to the object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(sinfo);
@@ -1163,7 +1163,7 @@ H5FS__cache_sinfo_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5_
     haddr_t       sinfo_addr;                     /* Address for section info */
     herr_t        ret_value = SUCCEED;            /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -1248,7 +1248,7 @@ H5FS__cache_sinfo_serialize(const H5F_t *f, void *_image, size_t len, void *_thi
     unsigned       bin;                              /* Current bin we are on */
     herr_t         ret_value = SUCCEED;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -1392,7 +1392,7 @@ H5FS__cache_sinfo_free_icr(void *_thing)
     H5FS_sinfo_t *sinfo     = (H5FS_sinfo_t *)_thing; /* Pointer to the object */
     herr_t        ret_value = SUCCEED;                /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(sinfo);
@@ -1431,7 +1431,7 @@ H5FS__sinfo_serialize_sect_cb(void *_item, void H5_ATTR_UNUSED *key, void *_udat
     H5FS_iter_ud_t *      udata     = (H5FS_iter_ud_t *)_udata;     /* Callback info */
     herr_t                ret_value = SUCCEED;                      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sect);
@@ -1485,7 +1485,7 @@ H5FS__sinfo_serialize_node_cb(void *_item, void H5_ATTR_UNUSED *key, void *_udat
     H5FS_iter_ud_t *udata       = (H5FS_iter_ud_t *)_udata; /* Callback info */
     herr_t          ret_value   = SUCCEED;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(fspace_node);

--- a/src/H5FSsection.c
+++ b/src/H5FSsection.c
@@ -197,7 +197,7 @@ H5FS__sinfo_lock(H5F_t *f, H5FS_t *fspace, unsigned accmode)
     H5FS_sinfo_cache_ud_t cache_udata;         /* User-data for cache callback */
     herr_t                ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #ifdef H5FS_SINFO_DEBUG
     HDfprintf(stderr,
@@ -333,7 +333,7 @@ H5FS__sinfo_unlock(H5F_t *f, H5FS_t *fspace, hbool_t modified)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 #ifdef H5FS_SINFO_DEBUG
     HDfprintf(stderr,
               "%s: Called, modified = %d, fspace->addr = %" PRIuHADDR ", fspace->sect_addr = %" PRIuHADDR
@@ -529,7 +529,7 @@ done:
 static herr_t
 H5FS__sect_serialize_size(H5FS_t *fspace)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments. */
     HDassert(fspace);
@@ -585,7 +585,7 @@ H5FS__sect_increase(H5FS_t *fspace, const H5FS_section_class_t *cls, unsigned fl
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(fspace);
@@ -640,7 +640,7 @@ H5FS__sect_decrease(H5FS_t *fspace, const H5FS_section_class_t *cls)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(fspace);
@@ -692,7 +692,7 @@ H5FS__size_node_decr(H5FS_sinfo_t *sinfo, unsigned bin, H5FS_node_t *fspace_node
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sinfo);
@@ -779,7 +779,7 @@ H5FS__sect_unlink_size(H5FS_sinfo_t *sinfo, const H5FS_section_class_t *cls, H5F
     unsigned             bin;                 /* Bin to put the free space section in */
     herr_t               ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sinfo);
@@ -829,7 +829,7 @@ H5FS__sect_unlink_rest(H5FS_t *fspace, const H5FS_section_class_t *cls, H5FS_sec
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(fspace);
@@ -875,7 +875,7 @@ H5FS__sect_remove_real(H5FS_t *fspace, H5FS_section_info_t *sect)
     const H5FS_section_class_t *cls;                 /* Class of section */
     herr_t                      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(fspace);
@@ -960,7 +960,7 @@ H5FS__sect_link_size(H5FS_sinfo_t *sinfo, const H5FS_section_class_t *cls, H5FS_
     unsigned     bin;                       /* Bin to put the free space section in */
     herr_t       ret_value = SUCCEED;       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sinfo);
@@ -1058,7 +1058,7 @@ H5FS__sect_link_rest(H5FS_t *fspace, const H5FS_section_class_t *cls, H5FS_secti
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(fspace);
@@ -1105,7 +1105,7 @@ H5FS__sect_link(H5FS_t *fspace, H5FS_section_info_t *sect, unsigned flags)
     const H5FS_section_class_t *cls;                 /* Class of section */
     herr_t                      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(fspace);
@@ -1150,7 +1150,7 @@ H5FS__sect_merge(H5FS_t *fspace, H5FS_section_info_t **sect, void *op_data)
     htri_t                status;              /* Status value */
     herr_t                ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(fspace);
@@ -1642,7 +1642,7 @@ H5FS__sect_find_node(H5FS_t *fspace, hsize_t request, H5FS_section_info_t **node
     const H5FS_section_class_t *cls; /* Class of section */
     hsize_t                     alignment;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(fspace);
@@ -1848,7 +1848,7 @@ H5FS__iterate_sect_cb(void *_item, void H5_ATTR_UNUSED *key, void *_udata)
     H5FS_iter_ud_t *     udata     = (H5FS_iter_ud_t *)_udata;     /* Callback info */
     herr_t               ret_value = SUCCEED;                      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sect_info);
@@ -1883,7 +1883,7 @@ H5FS__iterate_node_cb(void *_item, void H5_ATTR_UNUSED *key, void *_udata)
     H5FS_iter_ud_t *udata       = (H5FS_iter_ud_t *)_udata; /* Callback info */
     herr_t          ret_value   = SUCCEED;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(fspace_node);

--- a/src/H5Faccum.c
+++ b/src/H5Faccum.c
@@ -273,7 +273,7 @@ H5F__accum_adjust(H5F_meta_accum_t *accum, H5FD_t *file, H5F_accum_adjust_t adju
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(accum);
     HDassert(file);

--- a/src/H5Fefc.c
+++ b/src/H5Fefc.c
@@ -445,7 +445,7 @@ H5F__efc_release_real(H5F_efc_t *efc)
     H5F_efc_ent_t *prev_ent  = NULL;    /* Previous EFC entry */
     herr_t         ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(efc);
@@ -586,7 +586,7 @@ H5F__efc_remove_ent(H5F_efc_t *efc, H5F_efc_ent_t *ent)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(efc);
@@ -652,7 +652,7 @@ H5F__efc_try_close_tag1(H5F_shared_t *sf, H5F_shared_t **tail)
     H5F_efc_ent_t *ent = NULL; /* EFC entry */
     H5F_shared_t * esf;        /* Convenience pointer to ent->file->shared */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(sf);
@@ -725,7 +725,7 @@ H5F__efc_try_close_tag2(H5F_shared_t *sf, H5F_shared_t **tail)
     H5F_efc_ent_t *ent = NULL; /* EFC entry */
     H5F_shared_t * esf;        /* Convenience pointer to ent->file->shared */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(sf);

--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -207,7 +207,7 @@ H5F__close_cb(H5VL_object_t *file_vol_obj, void **request)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(file_vol_obj);
@@ -273,7 +273,7 @@ H5F__set_vol_conn(H5F_t *file)
     void *                new_connector_info = NULL;    /* Copy of connector info */
     herr_t                ret_value          = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(file);
@@ -525,7 +525,7 @@ H5F__get_objects(const H5F_t *f, unsigned types, size_t max_nobjs, hid_t *obj_id
     H5F_olist_t olist;               /* Structure to hold search results */
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(obj_id_count_ptr);
@@ -627,7 +627,7 @@ H5F__get_objects_cb(void *obj_ptr, hid_t obj_id, void *key)
     hbool_t      add_obj   = FALSE;
     int          ret_value = H5_ITER_CONT; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(obj_ptr);
     HDassert(olist);
@@ -739,7 +739,7 @@ H5F__build_name(const char *prefix, const char *file_name, char **full_name /*ou
     size_t fname_len;           /* Length of external link file name */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     prefix_len = HDstrlen(prefix);
     fname_len  = HDstrlen(file_name);
@@ -775,7 +775,7 @@ H5F__getenv_prefix_name(char **env_prefix /*in,out*/)
     char *strret;           /* Pointer to next separator */
     char *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set return value now */
     ret_value = *env_prefix;
@@ -1086,7 +1086,7 @@ H5F__new(H5F_shared_t *shared, unsigned flags, hid_t fcpl_id, hid_t fapl_id, H5F
     H5F_t *f         = NULL;
     H5F_t *ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (NULL == (f = H5FL_CALLOC(H5F_t)))
         HGOTO_ERROR(H5E_FILE, H5E_NOSPACE, NULL, "can't allocate top file structure")
@@ -1354,7 +1354,7 @@ H5F__dest(H5F_t *f, hbool_t flush)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);
@@ -1649,7 +1649,7 @@ H5F__check_if_using_file_locks(H5P_genplist_t *fapl, hbool_t *use_file_locking)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Make sure the out parameter has a value */
     *use_file_locking = TRUE;
@@ -2130,7 +2130,7 @@ H5F__flush_phase1(H5F_t *f)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check arguments */
     HDassert(f);
@@ -2167,7 +2167,7 @@ H5F__flush_phase2(H5F_t *f, hbool_t closing)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check arguments */
     HDassert(f);
@@ -2659,7 +2659,7 @@ H5F__build_actual_name(const H5F_t *f, const H5P_genplist_t *fapl, const char *n
 #endif                          /* H5_HAVE_SYMLINK */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);

--- a/src/H5Fmount.c
+++ b/src/H5Fmount.c
@@ -440,7 +440,7 @@ H5F__mount_count_ids_recurse(H5F_t *f, unsigned *nopen_files, unsigned *nopen_ob
 {
     unsigned u; /* Local index value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(f);
@@ -523,7 +523,7 @@ H5F__flush_mounts_recurse(H5F_t *f)
     unsigned u;                   /* Index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);

--- a/src/H5Fsuper.c
+++ b/src/H5Fsuper.c
@@ -91,7 +91,7 @@ H5F__super_ext_create(H5F_t *f, H5O_loc_t *ext_ptr)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);
@@ -241,7 +241,7 @@ H5F__update_super_ext_driver_msg(H5F_t *f)
     H5F_super_t *sblock;              /* Pointer to the super block */
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);

--- a/src/H5Fsuper_cache.c
+++ b/src/H5Fsuper_cache.c
@@ -152,7 +152,7 @@ H5F__superblock_prefix_decode(H5F_super_t *sblock, const uint8_t **image_ref,
     const uint8_t *image     = (const uint8_t *)*image_ref; /* Pointer into raw data buffer */
     htri_t         ret_value = SUCCEED;                     /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(sblock);
@@ -231,7 +231,7 @@ H5F__drvrinfo_prefix_decode(H5O_drvinfo_t *drvrinfo, char *drv_name, const uint8
     unsigned       drv_vers;                            /* Version of driver info block */
     herr_t         ret_value = SUCCEED;                 /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(drvrinfo);
@@ -298,7 +298,7 @@ done:
 static herr_t
 H5F__cache_superblock_get_initial_load_size(void H5_ATTR_UNUSED *_udata, size_t *image_len)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image_len);
@@ -331,7 +331,7 @@ H5F__cache_superblock_get_final_load_size(const void *_image, size_t H5_ATTR_NDE
     H5F_super_t                sblock;                                      /* Temporary file superblock */
     htri_t                     ret_value = SUCCEED;                         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -377,7 +377,7 @@ H5F__cache_superblock_verify_chksum(const void *_image, size_t len, void *_udata
     uint32_t                   computed_chksum;  /* Computed metadata checksum value */
     htri_t                     ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -418,7 +418,7 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
     const uint8_t *            image     = _image; /* Pointer into raw data buffer */
     H5F_super_t *              ret_value = NULL;   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -606,7 +606,7 @@ H5F__cache_superblock_image_len(const void *_thing, size_t *image_len)
 {
     const H5F_super_t *sblock = (const H5F_super_t *)_thing; /* Pointer to the object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(sblock);
@@ -640,7 +640,7 @@ H5F__cache_superblock_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_UNU
     haddr_t      rel_eof;                        /* Relative EOF for file */
     herr_t       ret_value = SUCCEED;            /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);
@@ -779,7 +779,7 @@ H5F__cache_superblock_free_icr(void *_thing)
     H5F_super_t *sblock    = (H5F_super_t *)_thing; /* Pointer to the object */
     herr_t       ret_value = SUCCEED;               /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(sblock);
@@ -809,7 +809,7 @@ done:
 static herr_t
 H5F__cache_drvrinfo_get_initial_load_size(void H5_ATTR_UNUSED *_udata, size_t *image_len)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image_len);
@@ -841,7 +841,7 @@ H5F__cache_drvrinfo_get_final_load_size(const void *_image, size_t H5_ATTR_NDEBU
     H5O_drvinfo_t            drvrinfo;                                  /* Driver info */
     herr_t                   ret_value = SUCCEED;                       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -884,7 +884,7 @@ H5F__cache_drvrinfo_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED
     char                     drv_name[9];                                 /* Name of driver */
     H5O_drvinfo_t *          ret_value = NULL;                            /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(image);
@@ -938,7 +938,7 @@ H5F__cache_drvrinfo_image_len(const void *_thing, size_t *image_len)
 {
     const H5O_drvinfo_t *drvinfo = (const H5O_drvinfo_t *)_thing; /* Pointer to the object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(drvinfo);
@@ -973,7 +973,7 @@ H5F__cache_drvrinfo_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBU
     uint8_t *      dbuf;                              /* Pointer to beginning of driver info */
     herr_t         ret_value = SUCCEED;               /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(f);
@@ -1031,7 +1031,7 @@ H5F__cache_drvrinfo_free_icr(void *_thing)
 {
     H5O_drvinfo_t *drvinfo = (H5O_drvinfo_t *)_thing; /* Pointer to the object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(drvinfo);

--- a/src/H5G.c
+++ b/src/H5G.c
@@ -152,7 +152,7 @@ H5G__create_api_common(hid_t loc_id, const char *name, hid_t lcpl_id, hid_t gcpl
     H5VL_loc_params_t loc_params;                     /* Location parameters for object access */
     hid_t             ret_value = H5I_INVALID_HID;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (!name)
@@ -382,7 +382,7 @@ H5G__open_api_common(hid_t loc_id, const char *name, hid_t gapl_id, void **token
     H5VL_loc_params_t loc_params;                     /* Location parameters for object access */
     hid_t             ret_value = H5I_INVALID_HID;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     if (!name)
@@ -549,7 +549,7 @@ H5G__get_info_api_common(hid_t loc_id, H5G_info_t *group_info /*out*/, void **to
     H5I_type_t            id_type;                    /* Type of ID */
     herr_t                ret_value = SUCCEED;        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     id_type = H5I_get_type(loc_id);
@@ -658,7 +658,7 @@ H5G__get_info_by_name_api_common(hid_t loc_id, const char *name, H5G_info_t *gro
     H5VL_group_get_args_t vol_cb_args;                /* Arguments to VOL callback */
     herr_t                ret_value = SUCCEED;        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     if (!group_info)
@@ -767,7 +767,7 @@ H5G__get_info_by_idx_api_common(hid_t loc_id, const char *group_name, H5_index_t
     H5VL_group_get_args_t vol_cb_args;                /* Arguments to VOL callback */
     herr_t                ret_value = SUCCEED;        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     if (!group_info)

--- a/src/H5Gbtree2.c
+++ b/src/H5Gbtree2.c
@@ -149,7 +149,7 @@ H5G__dense_fh_name_cmp(const void *obj, size_t obj_len, void *_udata)
     H5O_link_t *     lnk;                               /* Pointer to link created from heap object */
     herr_t           ret_value = SUCCEED;               /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Decode link information */
     if (NULL == (lnk = (H5O_link_t *)H5O_msg_decode(udata->f, NULL, H5O_LINK_ID, obj_len,
@@ -191,7 +191,7 @@ H5G__dense_btree2_name_store(void *_nrecord, const void *_udata)
     const H5G_bt2_ud_ins_t *  udata   = (const H5G_bt2_ud_ins_t *)_udata;
     H5G_dense_bt2_name_rec_t *nrecord = (H5G_dense_bt2_name_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Copy user information info native record */
     nrecord->hash = udata->common.name_hash;
@@ -221,7 +221,7 @@ H5G__dense_btree2_name_compare(const void *_bt2_udata, const void *_bt2_rec, int
     const H5G_dense_bt2_name_rec_t *bt2_rec   = (const H5G_dense_bt2_name_rec_t *)_bt2_rec;
     herr_t                          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(bt2_udata);
@@ -278,7 +278,7 @@ H5G__dense_btree2_name_encode(uint8_t *raw, const void *_nrecord, void H5_ATTR_U
 {
     const H5G_dense_bt2_name_rec_t *nrecord = (const H5G_dense_bt2_name_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Encode the record's fields */
     UINT32ENCODE(raw, nrecord->hash)
@@ -305,7 +305,7 @@ H5G__dense_btree2_name_decode(const uint8_t *raw, void *_nrecord, void H5_ATTR_U
 {
     H5G_dense_bt2_name_rec_t *nrecord = (H5G_dense_bt2_name_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Decode the record's fields */
     UINT32DECODE(raw, nrecord->hash)
@@ -334,7 +334,7 @@ H5G__dense_btree2_name_debug(FILE *stream, int indent, int fwidth, const void *_
     const H5G_dense_bt2_name_rec_t *nrecord = (const H5G_dense_bt2_name_rec_t *)_nrecord;
     unsigned                        u; /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDfprintf(stream, "%*s%-*s {%x, ", indent, "", fwidth, "Record:", (unsigned)nrecord->hash);
     for (u = 0; u < H5G_DENSE_FHEAP_ID_LEN; u++)
@@ -362,7 +362,7 @@ H5G__dense_btree2_corder_store(void *_nrecord, const void *_udata)
     const H5G_bt2_ud_ins_t *    udata   = (const H5G_bt2_ud_ins_t *)_udata;
     H5G_dense_bt2_corder_rec_t *nrecord = (H5G_dense_bt2_corder_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Copy user information info native record */
     nrecord->corder = udata->common.corder;
@@ -391,7 +391,7 @@ H5G__dense_btree2_corder_compare(const void *_bt2_udata, const void *_bt2_rec, i
     const H5G_bt2_ud_common_t *       bt2_udata = (const H5G_bt2_ud_common_t *)_bt2_udata;
     const H5G_dense_bt2_corder_rec_t *bt2_rec   = (const H5G_dense_bt2_corder_rec_t *)_bt2_rec;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(bt2_udata);
@@ -426,7 +426,7 @@ H5G__dense_btree2_corder_encode(uint8_t *raw, const void *_nrecord, void H5_ATTR
 {
     const H5G_dense_bt2_corder_rec_t *nrecord = (const H5G_dense_bt2_corder_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Encode the record's fields */
     INT64ENCODE(raw, nrecord->corder)
@@ -453,7 +453,7 @@ H5G__dense_btree2_corder_decode(const uint8_t *raw, void *_nrecord, void H5_ATTR
 {
     H5G_dense_bt2_corder_rec_t *nrecord = (H5G_dense_bt2_corder_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Decode the record's fields */
     INT64DECODE(raw, nrecord->corder)
@@ -482,7 +482,7 @@ H5G__dense_btree2_corder_debug(FILE *stream, int indent, int fwidth, const void 
     const H5G_dense_bt2_corder_rec_t *nrecord = (const H5G_dense_bt2_corder_rec_t *)_nrecord;
     unsigned                          u; /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDfprintf(stream, "%*s%-*s {%llu, ", indent, "", fwidth, "Record:", (unsigned long long)nrecord->corder);
     for (u = 0; u < H5G_DENSE_FHEAP_ID_LEN; u++)

--- a/src/H5Gcache.c
+++ b/src/H5Gcache.c
@@ -118,7 +118,7 @@ H5G__cache_node_get_initial_load_size(void *_udata, size_t *image_len)
 {
     H5F_t *f = (H5F_t *)_udata; /* User data for callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(f);
@@ -160,7 +160,7 @@ H5G__cache_node_deserialize(const void *_image, size_t len, void *_udata, hbool_
     const uint8_t *image_end = image + len - 1;         /* Pointer to end of image buffer */
     void *         ret_value = NULL;                    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(image);
@@ -224,7 +224,7 @@ H5G__cache_node_image_len(const void *_thing, size_t *image_len)
 {
     const H5G_node_t *sym = (const H5G_node_t *)_thing; /* Pointer to object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(sym);
@@ -260,7 +260,7 @@ H5G__cache_node_serialize(const H5F_t *f, void *_image, size_t len, void *_thing
     uint8_t *   image     = (uint8_t *)_image;    /* Pointer into raw data buffer */
     herr_t      ret_value = SUCCEED;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -317,7 +317,7 @@ H5G__cache_node_free_icr(void *_thing)
     H5G_node_t *sym       = (H5G_node_t *)_thing; /* Pointer to the object */
     herr_t      ret_value = SUCCEED;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(sym);

--- a/src/H5Gcompact.c
+++ b/src/H5Gcompact.c
@@ -83,7 +83,7 @@ H5G__compact_build_table_cb(const void *_mesg, unsigned H5_ATTR_UNUSED idx, void
     H5G_iter_bt_t *   udata     = (H5G_iter_bt_t *)_udata;   /* 'User data' passed in */
     herr_t            ret_value = H5_ITER_CONT;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(lnk);
@@ -121,7 +121,7 @@ H5G__compact_build_table(const H5O_loc_t *oloc, const H5O_linfo_t *linfo, H5_ind
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(oloc);
@@ -266,7 +266,7 @@ H5G__compact_remove_common_cb(const void *_mesg, unsigned H5_ATTR_UNUSED idx, vo
     H5G_iter_rm_t *   udata     = (H5G_iter_rm_t *)_udata;   /* 'User data' passed in */
     herr_t            ret_value = H5_ITER_CONT;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(lnk);
@@ -435,7 +435,7 @@ H5G__compact_lookup_cb(const void *_mesg, unsigned H5_ATTR_UNUSED idx, void *_ud
     H5G_iter_lkp_t *  udata     = (H5G_iter_lkp_t *)_udata;  /* 'User data' passed in */
     herr_t            ret_value = H5_ITER_CONT;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(lnk);

--- a/src/H5Gdense.c
+++ b/src/H5Gdense.c
@@ -458,7 +458,7 @@ H5G__dense_lookup_cb(const void *_lnk, void *_user_lnk)
     H5O_link_t *      user_lnk  = (H5O_link_t *)_user_lnk;  /* User data from v2 B-tree link lookup */
     herr_t            ret_value = SUCCEED;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -555,7 +555,7 @@ H5G__dense_lookup_by_idx_fh_cb(const void *obj, size_t obj_len, void *_udata)
     H5O_link_t *     tmp_lnk   = NULL;                      /* Temporary pointer to link */
     herr_t           ret_value = SUCCEED;                   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Decode link information & keep a copy */
     if (NULL == (tmp_lnk = (H5O_link_t *)H5O_msg_decode(udata->f, NULL, H5O_LINK_ID, obj_len,
@@ -594,7 +594,7 @@ H5G__dense_lookup_by_idx_bt2_cb(const void *_record, void *_bt2_udata)
     H5G_fh_ud_lbi_t                 fh_udata;                 /* User data for fractal heap 'op' callback */
     int                             ret_value = H5_ITER_CONT; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Prepare user data for callback */
     /* down */
@@ -736,7 +736,7 @@ H5G__dense_build_table_cb(const H5O_link_t *lnk, void *_udata)
     H5G_dense_bt_ud_t *udata     = (H5G_dense_bt_ud_t *)_udata; /* 'User data' passed in */
     herr_t             ret_value = H5_ITER_CONT;                /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(lnk);
@@ -834,7 +834,7 @@ H5G__dense_iterate_fh_cb(const void *obj, size_t obj_len, void *_udata)
     H5G_fh_ud_it_t *udata     = (H5G_fh_ud_it_t *)_udata; /* User data for fractal heap 'op' callback */
     herr_t          ret_value = SUCCEED;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Decode link information & keep a copy */
     /* (we make a copy instead of calling the user/library callback directly in
@@ -870,7 +870,7 @@ H5G__dense_iterate_bt2_cb(const void *_record, void *_bt2_udata)
     H5G_bt2_ud_it_t *               bt2_udata = (H5G_bt2_ud_it_t *)_bt2_udata; /* User data for callback */
     herr_t                          ret_value = H5_ITER_CONT;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check for skipping links */
     if (bt2_udata->skip > 0)
@@ -1038,7 +1038,7 @@ H5G__dense_get_name_by_idx_fh_cb(const void *obj, size_t obj_len, void *_udata)
     H5O_link_t *      lnk;                                /* Pointer to link created from heap object */
     herr_t            ret_value = SUCCEED;                /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Decode link information */
     if (NULL == (lnk = (H5O_link_t *)H5O_msg_decode(udata->f, NULL, H5O_LINK_ID, obj_len,
@@ -1082,7 +1082,7 @@ H5G__dense_get_name_by_idx_bt2_cb(const void *_record, void *_bt2_udata)
     H5G_fh_ud_gnbi_t                fh_udata;            /* User data for fractal heap 'op' callback */
     herr_t                          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Prepare user data for callback */
     /* down */
@@ -1236,7 +1236,7 @@ H5G__dense_remove_fh_cb(const void *obj, size_t obj_len, void *_udata)
     H5B2_t *        bt2       = NULL;                     /* v2 B-tree handle for index */
     herr_t          ret_value = SUCCEED;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Decode link information */
     if (NULL == (lnk = (H5O_link_t *)H5O_msg_decode(udata->f, NULL, H5O_LINK_ID, obj_len,
@@ -1301,7 +1301,7 @@ H5G__dense_remove_bt2_cb(const void *_record, void *_bt2_udata)
     H5G_fh_ud_rm_t                  fh_udata;            /* User data for fractal heap 'op' callback */
     herr_t                          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Set up the user data for fractal heap 'op' callback */
     fh_udata.f               = bt2_udata->common.f;
@@ -1403,7 +1403,7 @@ H5G__dense_remove_by_idx_fh_cb(const void *obj, size_t obj_len, void *_udata)
     H5G_fh_ud_rmbi_t *udata     = (H5G_fh_ud_rmbi_t *)_udata; /* User data for fractal heap 'op' callback */
     herr_t            ret_value = SUCCEED;                    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Decode link information */
     if (NULL == (udata->lnk = (H5O_link_t *)H5O_msg_decode(udata->f, NULL, H5O_LINK_ID, obj_len,
@@ -1437,7 +1437,7 @@ H5G__dense_remove_by_idx_bt2_cb(const void *_record, void *_bt2_udata)
     const uint8_t *    heap_id;             /* Heap ID for link */
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Determine the index being used */
     if (bt2_udata->idx_type == H5_INDEX_NAME) {

--- a/src/H5Gdeprec.c
+++ b/src/H5Gdeprec.c
@@ -1009,7 +1009,7 @@ H5G__get_objinfo_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char *name, 
     H5G_trav_goi_t *udata     = (H5G_trav_goi_t *)_udata; /* User data passed in */
     herr_t          ret_value = SUCCEED;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name in this group resolved to a valid link */
     if (lnk == NULL && obj_loc == NULL)

--- a/src/H5Gint.c
+++ b/src/H5Gint.c
@@ -214,7 +214,7 @@ H5G__close_cb(H5VL_object_t *grp_vol_obj, void **request)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(grp_vol_obj);
@@ -531,7 +531,7 @@ H5G__open_oid(H5G_t *grp)
     hbool_t obj_opened = FALSE;
     herr_t  ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(grp);
@@ -841,7 +841,7 @@ H5G__iterate_cb(const H5O_link_t *lnk, void *_udata)
     H5G_iter_appcall_ud_t *udata     = (H5G_iter_appcall_ud_t *)_udata; /* User data for callback */
     herr_t                 ret_value = H5_ITER_ERROR;                   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(lnk);
@@ -949,7 +949,7 @@ done:
 static herr_t
 H5G__free_visit_visited(void *item, void H5_ATTR_UNUSED *key, void H5_ATTR_UNUSED *operator_data /*in,out*/)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     item = H5FL_FREE(H5_obj_t, item);
 
@@ -983,7 +983,7 @@ H5G__visit_cb(const H5O_link_t *lnk, void *_udata)
     size_t len_needed;                          /* Length of path string needed */
     herr_t ret_value = H5_ITER_CONT;            /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(lnk);

--- a/src/H5Glink.c
+++ b/src/H5Glink.c
@@ -95,7 +95,7 @@ static int H5G__link_cmp_corder_dec(const void *lnk1, const void *lnk2);
 static int
 H5G__link_cmp_name_inc(const void *lnk1, const void *lnk2)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(HDstrcmp(((const H5O_link_t *)lnk1)->name, ((const H5O_link_t *)lnk2)->name))
 } /* end H5G__link_cmp_name_inc() */
@@ -120,7 +120,7 @@ H5G__link_cmp_name_inc(const void *lnk1, const void *lnk2)
 static int
 H5G__link_cmp_name_dec(const void *lnk1, const void *lnk2)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(HDstrcmp(((const H5O_link_t *)lnk2)->name, ((const H5O_link_t *)lnk1)->name))
 } /* end H5G__link_cmp_name_dec() */
@@ -146,7 +146,7 @@ H5G__link_cmp_corder_inc(const void *lnk1, const void *lnk2)
 {
     int ret_value = -1; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (((const H5O_link_t *)lnk1)->corder < ((const H5O_link_t *)lnk2)->corder)
         ret_value = -1;
@@ -179,7 +179,7 @@ H5G__link_cmp_corder_dec(const void *lnk1, const void *lnk2)
 {
     int ret_value = -1; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (((const H5O_link_t *)lnk1)->corder < ((const H5O_link_t *)lnk2)->corder)
         ret_value = 1;

--- a/src/H5Gloc.c
+++ b/src/H5Gloc.c
@@ -389,7 +389,7 @@ H5G__loc_find_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char *name,
     H5G_loc_fnd_t *udata     = (H5G_loc_fnd_t *)_udata; /* User data passed in */
     herr_t         ret_value = SUCCEED;                 /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name in this group resolved to a valid object */
     if (obj_loc == NULL)
@@ -467,7 +467,7 @@ H5G__loc_find_by_idx_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_
     hbool_t        obj_exists    = FALSE;           /* Whether the object exists (unused) */
     herr_t         ret_value     = SUCCEED;         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name in this group resolved to a valid link */
     if (obj_loc == NULL)
@@ -613,7 +613,7 @@ H5G__loc_exists_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_ATTR_
     hbool_t *exists    = (hbool_t *)_udata; /* User data passed in */
     herr_t   ret_value = SUCCEED;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name in this group resolved to a valid object */
     if (obj_loc == NULL)
@@ -685,7 +685,7 @@ H5G__loc_addr_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_ATTR_UN
     haddr_t *udata     = (haddr_t *)_udata; /* User data passed in */
     herr_t   ret_value = SUCCEED;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name in this group resolved to a valid link */
     if (obj_loc == NULL)
@@ -755,7 +755,7 @@ H5G__loc_info_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_ATTR_UN
     H5G_loc_info_t *udata     = (H5G_loc_info_t *)_udata; /* User data passed in */
     herr_t          ret_value = SUCCEED;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name in this group resolved to a valid link */
     if (obj_loc == NULL)
@@ -831,7 +831,7 @@ H5G__loc_native_info_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_
     H5G_loc_native_info_t *udata     = (H5G_loc_native_info_t *)_udata; /* User data passed in */
     herr_t                 ret_value = SUCCEED;                         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name in this group resolved to a valid link */
     if (obj_loc == NULL)
@@ -909,7 +909,7 @@ H5G__loc_set_comment_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_
     htri_t        exists;                         /* Whether a "comment" message already exists */
     herr_t        ret_value = SUCCEED;            /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name in this group resolved to a valid link */
     if (obj_loc == NULL)
@@ -998,7 +998,7 @@ H5G__loc_get_comment_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_
     H5O_name_t    comment;                        /* Object header "comment" message */
     herr_t        ret_value = SUCCEED;            /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name in this group resolved to a valid link */
     if (obj_loc == NULL)

--- a/src/H5Gname.c
+++ b/src/H5Gname.c
@@ -212,7 +212,7 @@ H5G__common_path(const H5RS_str_t *fullpath_r, const H5RS_str_t *prefix_r)
     size_t      nchars1, nchars2;  /* Number of characters in components */
     htri_t      ret_value = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Get component of each name */
     fullpath = H5RS_get_str(fullpath_r);
@@ -273,7 +273,7 @@ H5G__build_fullpath(const char *prefix, const char *name)
 {
     H5RS_str_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(prefix);
@@ -597,7 +597,7 @@ H5G__name_move_path(H5RS_str_t **path_r_ptr, const char *full_suffix, const char
     size_t      full_suffix_len;     /* Length of full suffix */
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(path_r_ptr && *path_r_ptr);
@@ -690,7 +690,7 @@ H5G__name_replace_cb(void *obj_ptr, hid_t obj_id, void *key)
     hbool_t obj_in_child = FALSE;    /* Flag to indicate that the object is in the child mount hier. */
     herr_t  ret_value    = SUCCEED;  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(obj_ptr);
 
@@ -1086,7 +1086,7 @@ H5G__get_name_by_addr_cb(hid_t gid, const char *path, const H5L_info2_t *linfo, 
     hbool_t          obj_found = FALSE;                 /* Object at 'path' found */
     herr_t           ret_value = H5_ITER_CONT;          /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(path);

--- a/src/H5Gnode.c
+++ b/src/H5Gnode.c
@@ -139,7 +139,7 @@ H5FL_SEQ_DEFINE(H5G_entry_t);
 static H5UC_t *
 H5G__node_get_shared(const H5F_t *f, const void H5_ATTR_UNUSED *_udata)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(f);
 
@@ -164,7 +164,7 @@ H5G__node_decode_key(const H5B_shared_t *shared, const uint8_t *raw, void *_key)
 {
     H5G_node_key_t *key = (H5G_node_key_t *)_key;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(shared);
     HDassert(raw);
@@ -192,7 +192,7 @@ H5G__node_encode_key(const H5B_shared_t *shared, uint8_t *raw, const void *_key)
 {
     const H5G_node_key_t *key = (const H5G_node_key_t *)_key;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(shared);
     HDassert(raw);
@@ -221,7 +221,7 @@ H5G__node_debug_key(FILE *stream, int indent, int fwidth, const void *_key, cons
     const H5G_node_key_t * key   = (const H5G_node_key_t *)_key;
     const H5G_bt_common_t *udata = (const H5G_bt_common_t *)_udata;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(key);
 
@@ -300,7 +300,7 @@ H5G__node_create(H5F_t *f, H5B_ins_t H5_ATTR_UNUSED op, void *_lt_key, void H5_A
     H5G_node_t *    sym       = NULL;
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -370,7 +370,7 @@ H5G__node_cmp2(void *_lt_key, void *_udata, void *_rt_key)
     const char *     s1, *s2;
     int              ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(udata && udata->heap);
@@ -423,7 +423,7 @@ H5G__node_cmp3(void *_lt_key, void *_udata, void *_rt_key)
     const char *     s;
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(udata && udata->heap);
@@ -481,7 +481,7 @@ H5G__node_found(H5F_t *f, haddr_t addr, const void H5_ATTR_UNUSED *_lt_key, hboo
     const char *  s;
     herr_t        ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -579,7 +579,7 @@ H5G__node_insert(H5F_t *f, haddr_t addr, void H5_ATTR_UNUSED *_lt_key, hbool_t H
     H5G_entry_t     ent;                /* Entry to insert in node */
     H5B_ins_t       ret_value = H5B_INS_ERROR;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -737,7 +737,7 @@ H5G__node_remove(H5F_t *f, haddr_t addr, void H5_ATTR_NDEBUG_UNUSED *_lt_key /*i
     int             cmp       = 1;
     H5B_ins_t       ret_value = H5B_INS_ERROR;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(f);

--- a/src/H5Gobj.c
+++ b/src/H5Gobj.c
@@ -358,7 +358,7 @@ H5G__obj_compact_to_dense_cb(const void *_mesg, unsigned H5_ATTR_UNUSED idx, voi
     H5G_obj_oh_it_ud1_t *udata     = (H5G_obj_oh_it_ud1_t *)_udata; /* 'User data' passed in */
     herr_t               ret_value = H5_ITER_CONT;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(lnk);
@@ -391,7 +391,7 @@ H5G__obj_stab_to_new_cb(const H5O_link_t *lnk, void *_udata)
     H5G_obj_stab_it_ud1_t *udata     = (H5G_obj_stab_it_ud1_t *)_udata; /* 'User data' passed in */
     herr_t                 ret_value = H5_ITER_CONT;                    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(lnk);
@@ -835,7 +835,7 @@ H5G__obj_remove_update_linfo(const H5O_loc_t *oloc, H5O_linfo_t *linfo)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(oloc);

--- a/src/H5Goh.c
+++ b/src/H5Goh.c
@@ -97,7 +97,7 @@ H5O__group_get_copy_file_udata(void)
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate space for the 'copy file' user data for copying groups.
      * Currently this is only a ginfo, so there is no specific struct type for
@@ -127,7 +127,7 @@ H5O__group_free_copy_file_udata(void *_udata)
 {
     H5G_copy_file_ud_t *udata = (H5G_copy_file_ud_t *)_udata;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(udata);
@@ -165,7 +165,7 @@ H5O__group_isa(const H5O_t *oh)
     htri_t linfo_exists;     /* Whether the 'linfo' message is in the object header */
     htri_t ret_value = FAIL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(oh);
 
@@ -200,7 +200,7 @@ H5O__group_open(const H5G_loc_t *obj_loc, H5I_type_t *opened_type)
     H5G_t *grp       = NULL; /* Group opened */
     void * ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(obj_loc);
 
@@ -240,7 +240,7 @@ H5O__group_create(H5F_t *f, void *_crt_info, H5G_loc_t *obj_loc)
     H5G_t *           grp       = NULL;                          /* New group created */
     void *            ret_value = NULL;                          /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -287,7 +287,7 @@ H5O__group_get_oloc(hid_t obj_id)
     H5G_t *    grp;              /* Group opened */
     H5O_loc_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get the group */
     if (NULL == (grp = (H5G_t *)H5VL_object(obj_id)))
@@ -323,7 +323,7 @@ H5O__group_bh_info(const H5O_loc_t *loc, H5O_t *oh, H5_ih_info_t *bh_info)
     H5B2_t *bt2_corder = NULL;    /* v2 B-tree handle for creation order index */
     herr_t  ret_value  = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(loc);

--- a/src/H5Gstab.c
+++ b/src/H5Gstab.c
@@ -681,7 +681,7 @@ H5G__stab_get_name_by_idx_cb(const H5G_entry_t *ent, void *_udata)
     const char *      name;                /* Pointer to name string in heap */
     herr_t            ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(ent);
@@ -808,7 +808,7 @@ H5G__stab_lookup_cb(const H5G_entry_t *ent, void *_udata)
     H5G_stab_fnd_ud_t *udata     = (H5G_stab_fnd_ud_t *)_udata; /* 'User data' passed in */
     herr_t             ret_value = SUCCEED;                     /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check for setting link info */
     if (udata->lnk)
@@ -901,7 +901,7 @@ H5G__stab_lookup_by_idx_cb(const H5G_entry_t *ent, void *_udata)
     const char *     name;                /* Pointer to name string in heap */
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(ent);

--- a/src/H5Gtest.c
+++ b/src/H5Gtest.c
@@ -721,7 +721,7 @@ H5G__verify_cached_stabs_test_cb(H5F_t *f, const void H5_ATTR_UNUSED *_lt_key, h
     unsigned    i;
     int         ret_value = H5_ITER_CONT;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(f);

--- a/src/H5Gtraverse.c
+++ b/src/H5Gtraverse.c
@@ -111,7 +111,7 @@ H5G__traverse_slink_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc, const char H5_ATTR_UNU
     H5G_trav_slink_t *udata     = (H5G_trav_slink_t *)_udata; /* User data passed in */
     herr_t            ret_value = SUCCEED;                    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check for dangling soft link */
     if (obj_loc == NULL) {
@@ -163,7 +163,7 @@ H5G__traverse_ud(const H5G_loc_t *grp_loc /*in,out*/, const H5O_link_t *lnk, H5G
     hid_t              cur_grp   = (-1);
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(grp_loc);
@@ -284,7 +284,7 @@ H5G__traverse_slink(const H5G_loc_t *grp_loc, const H5O_link_t *lnk, H5G_loc_t *
     hbool_t          tmp_grp_loc_set = FALSE;   /* Flag to indicate that tmp group location is initialized */
     herr_t           ret_value       = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(grp_loc);
@@ -475,7 +475,7 @@ H5G__traverse_real(const H5G_loc_t *_loc, const char *name, unsigned target, H5G
     hbool_t       last_comp = FALSE; /* Flag to indicate that a component is the last component in the name */
     herr_t        ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check parameters */
     HDassert(_loc);

--- a/src/H5HFbtree2.c
+++ b/src/H5HFbtree2.c
@@ -192,7 +192,7 @@ H5HF__huge_bt2_crt_context(void *_f)
     H5HF_huge_bt2_ctx_t *ctx;              /* Callback context structure */
     void *               ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);
@@ -232,7 +232,7 @@ H5HF__huge_bt2_dst_context(void *_ctx)
 {
     H5HF_huge_bt2_ctx_t *ctx = (H5HF_huge_bt2_ctx_t *)_ctx; /* Callback context structure */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -317,7 +317,7 @@ done:
 static herr_t
 H5HF__huge_bt2_indir_store(void *nrecord, const void *udata)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     *(H5HF_huge_bt2_indir_rec_t *)nrecord = *(const H5HF_huge_bt2_indir_rec_t *)udata;
 
@@ -341,7 +341,7 @@ H5HF__huge_bt2_indir_store(void *nrecord, const void *udata)
 static herr_t
 H5HF__huge_bt2_indir_compare(const void *_rec1, const void *_rec2, int *result)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     *result = (int)(((const H5HF_huge_bt2_indir_rec_t *)_rec1)->id -
                     ((const H5HF_huge_bt2_indir_rec_t *)_rec2)->id);
@@ -368,7 +368,7 @@ H5HF__huge_bt2_indir_encode(uint8_t *raw, const void *_nrecord, void *_ctx)
     H5HF_huge_bt2_ctx_t *            ctx     = (H5HF_huge_bt2_ctx_t *)_ctx; /* Callback context structure */
     const H5HF_huge_bt2_indir_rec_t *nrecord = (const H5HF_huge_bt2_indir_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -400,7 +400,7 @@ H5HF__huge_bt2_indir_decode(const uint8_t *raw, void *_nrecord, void *_ctx)
     H5HF_huge_bt2_ctx_t *      ctx     = (H5HF_huge_bt2_ctx_t *)_ctx; /* Callback context structure */
     H5HF_huge_bt2_indir_rec_t *nrecord = (H5HF_huge_bt2_indir_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -432,7 +432,7 @@ H5HF__huge_bt2_indir_debug(FILE *stream, int indent, int fwidth, const void *_nr
 {
     const H5HF_huge_bt2_indir_rec_t *nrecord = (const H5HF_huge_bt2_indir_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDfprintf(stream, "%*s%-*s {%" PRIuHADDR ", %" PRIuHSIZE ", %" PRIuHSIZE "}\n", indent, "", fwidth,
               "Record:", nrecord->addr, nrecord->len, nrecord->id);
@@ -515,7 +515,7 @@ done:
 static herr_t
 H5HF__huge_bt2_filt_indir_store(void *nrecord, const void *udata)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     *(H5HF_huge_bt2_filt_indir_rec_t *)nrecord = *(const H5HF_huge_bt2_filt_indir_rec_t *)udata;
 
@@ -539,7 +539,7 @@ H5HF__huge_bt2_filt_indir_store(void *nrecord, const void *udata)
 static herr_t
 H5HF__huge_bt2_filt_indir_compare(const void *_rec1, const void *_rec2, int *result)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     *result = (int)(((const H5HF_huge_bt2_filt_indir_rec_t *)_rec1)->id -
                     ((const H5HF_huge_bt2_filt_indir_rec_t *)_rec2)->id);
@@ -566,7 +566,7 @@ H5HF__huge_bt2_filt_indir_encode(uint8_t *raw, const void *_nrecord, void *_ctx)
     H5HF_huge_bt2_ctx_t *                 ctx = (H5HF_huge_bt2_ctx_t *)_ctx; /* Callback context structure */
     const H5HF_huge_bt2_filt_indir_rec_t *nrecord = (const H5HF_huge_bt2_filt_indir_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -600,7 +600,7 @@ H5HF__huge_bt2_filt_indir_decode(const uint8_t *raw, void *_nrecord, void *_ctx)
     H5HF_huge_bt2_ctx_t *           ctx     = (H5HF_huge_bt2_ctx_t *)_ctx; /* Callback context structure */
     H5HF_huge_bt2_filt_indir_rec_t *nrecord = (H5HF_huge_bt2_filt_indir_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -634,7 +634,7 @@ H5HF__huge_bt2_filt_indir_debug(FILE *stream, int indent, int fwidth, const void
 {
     const H5HF_huge_bt2_filt_indir_rec_t *nrecord = (const H5HF_huge_bt2_filt_indir_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDfprintf(stream, "%*s%-*s {%" PRIuHADDR ", %" PRIuHSIZE ", %x, %" PRIuHSIZE ", %" PRIuHSIZE "}\n",
               indent, "", fwidth, "Record:", nrecord->addr, nrecord->len, nrecord->filter_mask,
@@ -693,7 +693,7 @@ done:
 static herr_t
 H5HF__huge_bt2_dir_store(void *nrecord, const void *udata)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     *(H5HF_huge_bt2_dir_rec_t *)nrecord = *(const H5HF_huge_bt2_dir_rec_t *)udata;
 
@@ -720,7 +720,7 @@ H5HF__huge_bt2_dir_compare(const void *_rec1, const void *_rec2, int *result)
     const H5HF_huge_bt2_dir_rec_t *rec1 = (const H5HF_huge_bt2_dir_rec_t *)_rec1;
     const H5HF_huge_bt2_dir_rec_t *rec2 = (const H5HF_huge_bt2_dir_rec_t *)_rec2;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (rec1->addr < rec2->addr)
         *result = -1;
@@ -755,7 +755,7 @@ H5HF__huge_bt2_dir_encode(uint8_t *raw, const void *_nrecord, void *_ctx)
     H5HF_huge_bt2_ctx_t *          ctx     = (H5HF_huge_bt2_ctx_t *)_ctx; /* Callback context structure */
     const H5HF_huge_bt2_dir_rec_t *nrecord = (const H5HF_huge_bt2_dir_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -786,7 +786,7 @@ H5HF__huge_bt2_dir_decode(const uint8_t *raw, void *_nrecord, void *_ctx)
     H5HF_huge_bt2_ctx_t *    ctx     = (H5HF_huge_bt2_ctx_t *)_ctx; /* Callback context structure */
     H5HF_huge_bt2_dir_rec_t *nrecord = (H5HF_huge_bt2_dir_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -817,7 +817,7 @@ H5HF__huge_bt2_dir_debug(FILE *stream, int indent, int fwidth, const void *_nrec
 {
     const H5HF_huge_bt2_dir_rec_t *nrecord = (const H5HF_huge_bt2_dir_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDfprintf(stream, "%*s%-*s {%" PRIuHADDR ", %" PRIuHSIZE "}\n", indent, "", fwidth,
               "Record:", nrecord->addr, nrecord->len);
@@ -900,7 +900,7 @@ done:
 static herr_t
 H5HF__huge_bt2_filt_dir_store(void *nrecord, const void *udata)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     *(H5HF_huge_bt2_filt_dir_rec_t *)nrecord = *(const H5HF_huge_bt2_filt_dir_rec_t *)udata;
 
@@ -927,7 +927,7 @@ H5HF__huge_bt2_filt_dir_compare(const void *_rec1, const void *_rec2, int *resul
     const H5HF_huge_bt2_filt_dir_rec_t *rec1 = (const H5HF_huge_bt2_filt_dir_rec_t *)_rec1;
     const H5HF_huge_bt2_filt_dir_rec_t *rec2 = (const H5HF_huge_bt2_filt_dir_rec_t *)_rec2;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (rec1->addr < rec2->addr)
         *result = -1;
@@ -962,7 +962,7 @@ H5HF__huge_bt2_filt_dir_encode(uint8_t *raw, const void *_nrecord, void *_ctx)
     H5HF_huge_bt2_ctx_t *               ctx = (H5HF_huge_bt2_ctx_t *)_ctx; /* Callback context structure */
     const H5HF_huge_bt2_filt_dir_rec_t *nrecord = (const H5HF_huge_bt2_filt_dir_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -995,7 +995,7 @@ H5HF__huge_bt2_filt_dir_decode(const uint8_t *raw, void *_nrecord, void *_ctx)
     H5HF_huge_bt2_ctx_t *         ctx     = (H5HF_huge_bt2_ctx_t *)_ctx; /* Callback context structure */
     H5HF_huge_bt2_filt_dir_rec_t *nrecord = (H5HF_huge_bt2_filt_dir_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -1028,7 +1028,7 @@ H5HF__huge_bt2_filt_dir_debug(FILE *stream, int indent, int fwidth, const void *
 {
     const H5HF_huge_bt2_filt_dir_rec_t *nrecord = (const H5HF_huge_bt2_filt_dir_rec_t *)_nrecord;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDfprintf(stream, "%*s%-*s {%" PRIuHADDR ", %" PRIuHSIZE ", %x, %" PRIuHSIZE "}\n", indent, "", fwidth,
               "Record:", nrecord->addr, nrecord->len, nrecord->filter_mask, nrecord->obj_size);

--- a/src/H5HFcache.c
+++ b/src/H5HFcache.c
@@ -202,7 +202,7 @@ H5HF__hdr_prefix_decode(H5HF_hdr_t *hdr, const uint8_t **image_ref)
     const uint8_t *image     = *image_ref; /* Pointer into into supplied image */
     herr_t         ret_value = SUCCEED;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(hdr);
@@ -245,7 +245,7 @@ done:
 static herr_t
 H5HF__dtable_decode(H5F_t *f, const uint8_t **pp, H5HF_dtable_t *dtable)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(f);
@@ -293,7 +293,7 @@ H5HF__dtable_decode(H5F_t *f, const uint8_t **pp, H5HF_dtable_t *dtable)
 static herr_t
 H5HF__dtable_encode(H5F_t *f, uint8_t **pp, const H5HF_dtable_t *dtable)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(f);
@@ -349,7 +349,7 @@ H5HF__cache_hdr_get_initial_load_size(void *_udata, size_t *image_len)
     H5HF_hdr_cache_ud_t *udata = (H5HF_hdr_cache_ud_t *)_udata; /* Pointer to user data */
     H5HF_hdr_t           dummy_hdr;                             /* Dummy header -- to compute size */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(udata);
@@ -389,7 +389,7 @@ H5HF__cache_hdr_get_final_load_size(const void *_image, size_t H5_ATTR_NDEBUG_UN
     H5HF_hdr_cache_ud_t *udata     = (H5HF_hdr_cache_ud_t *)_udata; /* User data for callback */
     herr_t               ret_value = SUCCEED;                       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(image);
@@ -433,7 +433,7 @@ H5HF__cache_hdr_verify_chksum(const void *_image, size_t len, void H5_ATTR_UNUSE
     uint32_t       computed_chksum;                 /* Computed metadata checksum value */
     htri_t         ret_value = TRUE;                /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -473,7 +473,7 @@ H5HF__cache_hdr_deserialize(const void *_image, size_t len, void *_udata, hbool_
     uint8_t              heap_flags;                            /* Status flags for heap */
     void *               ret_value = NULL;                      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(image);
@@ -603,7 +603,7 @@ H5HF__cache_hdr_image_len(const void *_thing, size_t *image_len)
 {
     const H5HF_hdr_t *hdr = (const H5HF_hdr_t *)_thing; /* Fractal heap info */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(hdr);
@@ -644,7 +644,7 @@ H5HF__cache_hdr_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t len,
     H5HF_hdr_t *hdr       = (H5HF_hdr_t *)_thing; /* Fractal heap info */
     herr_t      ret_value = SUCCEED;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -731,7 +731,7 @@ H5HF__cache_hdr_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG_UN
     uint32_t    metadata_chksum;              /* Computed metadata checksum value */
     herr_t      ret_value = SUCCEED;          /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -843,7 +843,7 @@ H5HF__cache_hdr_free_icr(void *_thing)
     H5HF_hdr_t *hdr       = (H5HF_hdr_t *)_thing; /* Fractal heap info */
     herr_t      ret_value = SUCCEED;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(hdr);
@@ -877,7 +877,7 @@ H5HF__cache_iblock_get_initial_load_size(void *_udata, size_t *image_len)
 {
     H5HF_iblock_cache_ud_t *udata = (H5HF_iblock_cache_ud_t *)_udata; /* User data for callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(udata);
@@ -912,7 +912,7 @@ H5HF__cache_iblock_verify_chksum(const void *_image, size_t len, void H5_ATTR_UN
     uint32_t       computed_chksum;                 /* Computed metadata checksum value */
     htri_t         ret_value = TRUE;                /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -959,7 +959,7 @@ H5HF__cache_iblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED 
     unsigned                u;                /* Local index variable */
     void *                  ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(image);
@@ -1140,7 +1140,7 @@ H5HF__cache_iblock_image_len(const void *_thing, size_t *image_len)
 {
     const H5HF_indirect_t *iblock = (const H5HF_indirect_t *)_thing; /* Indirect block info */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(iblock);
@@ -1181,7 +1181,7 @@ H5HF__cache_iblock_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5
     H5HF_indirect_t *iblock    = (H5HF_indirect_t *)_thing; /* Indirect block info */
     herr_t           ret_value = SUCCEED;                   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -1309,7 +1309,7 @@ H5HF__cache_iblock_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG
     size_t   u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(f);
@@ -1420,7 +1420,7 @@ H5HF__cache_iblock_notify(H5AC_notify_action_t action, void *_thing)
     H5HF_indirect_t *iblock    = (H5HF_indirect_t *)_thing; /* Indirect block info */
     herr_t           ret_value = SUCCEED;                   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(iblock);
@@ -1519,7 +1519,7 @@ H5HF__cache_iblock_free_icr(void *thing)
     H5HF_indirect_t *iblock    = (H5HF_indirect_t *)thing; /* Fractal heap indirect block to free */
     herr_t           ret_value = SUCCEED;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(iblock);
@@ -1557,7 +1557,7 @@ H5HF__cache_dblock_get_initial_load_size(void *_udata, size_t *image_len)
     const H5HF_parent_t *         par_info; /* Pointer to parent information */
     const H5HF_hdr_t *            hdr;      /* Shared fractal heap information */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(udata);
@@ -1612,7 +1612,7 @@ H5HF__cache_dblock_verify_chksum(const void *_image, size_t len, void *_udata)
     uint8_t *               chk_p;            /* Pointer to the area for validating checksum */
     htri_t                  ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(image);
@@ -1742,7 +1742,7 @@ H5HF__cache_dblock_deserialize(const void *_image, size_t len, void *_udata, hbo
     haddr_t                 heap_addr;                                /* Address of heap header in the file */
     void *                  ret_value = NULL;                         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(image);
@@ -1918,7 +1918,7 @@ H5HF__cache_dblock_image_len(const void *_thing, size_t *image_len)
     const H5HF_hdr_t *   hdr;                                    /* Shared fractal heap information */
     size_t               size;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(dblock);
@@ -2060,7 +2060,7 @@ H5HF__cache_dblock_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t le
     unsigned         dblock_flags = 0;
     herr_t           ret_value    = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -2424,7 +2424,7 @@ H5HF__cache_dblock_serialize(const H5F_t H5_ATTR_NDEBUG_UNUSED *f, void *image,
     H5HF_direct_t *dblock    = (H5HF_direct_t *)_thing; /* Direct block info */
     herr_t         ret_value = SUCCEED;                 /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(f);
@@ -2475,7 +2475,7 @@ H5HF__cache_dblock_notify(H5AC_notify_action_t action, void *_thing)
     H5HF_direct_t *dblock    = (H5HF_direct_t *)_thing; /* Fractal heap direct block */
     herr_t         ret_value = SUCCEED;                 /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(dblock);
@@ -2544,7 +2544,7 @@ H5HF__cache_dblock_free_icr(void *_thing)
     H5HF_direct_t *dblock    = (H5HF_direct_t *)_thing; /* Fractal heap direct block */
     herr_t         ret_value = SUCCEED;                 /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(dblock);
@@ -2579,7 +2579,7 @@ H5HF__cache_dblock_fsf_size(const void *_thing, hsize_t *fsf_size)
 {
     const H5HF_direct_t *dblock = (const H5HF_direct_t *)_thing; /* Fractal heap direct block */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(dblock);
@@ -2666,7 +2666,7 @@ H5HF__cache_verify_hdr_descendants_clean(H5F_t *f, H5HF_hdr_t *hdr, hbool_t *fd_
     unsigned hdr_status = 0;       /* Header cache entry status */
     herr_t   ret_value  = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -3030,7 +3030,7 @@ H5HF__cache_verify_iblock_descendants_clean(H5F_t *f, haddr_t fd_parent_addr, H5
     hbool_t has_iblocks = FALSE;
     herr_t  ret_value   = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -3149,7 +3149,7 @@ H5HF__cache_verify_iblocks_dblocks_clean(H5F_t *f, haddr_t fd_parent_addr, H5HF_
     haddr_t  iblock_addr;
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -3314,7 +3314,7 @@ H5HF__cache_verify_descendant_iblocks_clean(H5F_t *f, haddr_t fd_parent_addr, H5
     haddr_t  iblock_addr;
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);

--- a/src/H5HFdbg.c
+++ b/src/H5HFdbg.c
@@ -175,7 +175,7 @@ done:
 static herr_t
 H5HF__dtable_debug(const H5HF_dtable_t *dtable, FILE *stream, int indent, int fwidth)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /*
      * Check arguments.

--- a/src/H5HFhdr.c
+++ b/src/H5HFhdr.c
@@ -148,7 +148,7 @@ H5HF__hdr_compute_free_space(H5HF_hdr_t *hdr, unsigned iblock_row)
     unsigned curr_row;            /* Current row in block */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /*
      * Check arguments.

--- a/src/H5HFhuge.c
+++ b/src/H5HFhuge.c
@@ -96,7 +96,7 @@ H5HF__huge_bt2_create(H5HF_hdr_t *hdr)
     H5B2_create_t bt2_cparam;          /* v2 B-tree creation parameters */
     herr_t        ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -246,7 +246,7 @@ H5HF__huge_new_id(H5HF_hdr_t *hdr)
     hsize_t new_id;        /* New object's ID */
     hsize_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -670,7 +670,7 @@ H5HF__huge_op_real(H5HF_hdr_t *hdr, const uint8_t *id, hbool_t is_read, H5HF_ope
     unsigned filter_mask = 0;       /* Filter mask for object (only used for filtered objects) */
     herr_t   ret_value   = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.

--- a/src/H5HFiblock.c
+++ b/src/H5HFiblock.c
@@ -99,7 +99,7 @@ H5HF__iblock_pin(H5HF_indirect_t *iblock)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(iblock);
@@ -164,7 +164,7 @@ H5HF__iblock_unpin(H5HF_indirect_t *iblock)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(iblock);
@@ -679,7 +679,7 @@ H5HF__man_iblock_root_halve(H5HF_indirect_t *iblock)
     unsigned    u;                   /* Local index variable */
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(iblock);
@@ -809,7 +809,7 @@ H5HF__man_iblock_root_revert(H5HF_indirect_t *root_iblock)
     size_t         dblock_size;         /* Direct block's size */
     herr_t         ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.

--- a/src/H5HFman.c
+++ b/src/H5HFman.c
@@ -306,7 +306,7 @@ H5HF__man_op_real(H5HF_hdr_t *hdr, const uint8_t *id, H5HF_operator_t op, void *
     uint8_t *p;                         /* Temporary pointer to obj info in block */
     herr_t   ret_value = SUCCEED;       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.

--- a/src/H5HFsection.c
+++ b/src/H5HFsection.c
@@ -295,7 +295,7 @@ H5FS__sect_init_cls(H5FS_section_class_t *cls, H5HF_hdr_t *hdr)
     H5HF_sect_private_t *cls_prvt;            /* Pointer to class private info */
     herr_t               ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(cls);
@@ -336,7 +336,7 @@ H5FS__sect_term_cls(H5FS_section_class_t *cls)
     H5HF_sect_private_t *cls_prvt;            /* Pointer to class private info */
     herr_t               ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(cls);
@@ -375,7 +375,7 @@ H5FS__sect_node_new(unsigned sect_type, haddr_t sect_addr, hsize_t sect_size, H5
     H5HF_free_section_t *new_sect;         /* New section */
     H5HF_free_section_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(H5F_addr_defined(sect_addr));
@@ -419,7 +419,7 @@ H5HF__sect_node_free(H5HF_free_section_t *sect, H5HF_indirect_t *iblock)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(sect);
 
@@ -507,7 +507,7 @@ H5HF__sect_single_locate_parent(H5HF_hdr_t *hdr, hbool_t refresh, H5HF_free_sect
     hbool_t          did_protect;         /* Whether we protected the indirect block or not */
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -713,7 +713,7 @@ H5HF__sect_single_full_dblock(H5HF_hdr_t *hdr, H5HF_free_section_t *sect)
     size_t  dblock_overhead;     /* Direct block's overhead */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sect);
@@ -776,7 +776,7 @@ H5HF__sect_single_add(H5FS_section_info_t **_sect, unsigned *flags, void *_udata
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Don't need to check section if we are deserializing, because it should
      *  have already been checked when it was first added
@@ -828,7 +828,7 @@ H5HF__sect_single_deserialize(const H5FS_section_class_t H5_ATTR_UNUSED *cls,
     H5HF_free_section_t *new_sect;         /* New section */
     H5FS_section_info_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(H5F_addr_defined(sect_addr));
@@ -870,7 +870,7 @@ H5HF__sect_single_can_merge(const H5FS_section_info_t *_sect1, const H5FS_sectio
     const H5HF_free_section_t *sect2 = (const H5HF_free_section_t *)_sect2; /* Fractal heap free section */
     htri_t                     ret_value = FALSE;                           /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments. */
     HDassert(sect1);
@@ -915,7 +915,7 @@ H5HF__sect_single_merge(H5FS_section_info_t **_sect1, H5FS_section_info_t *_sect
     H5HF_hdr_t *          hdr       = udata->hdr;                     /* Fractal heap header */
     herr_t                ret_value = SUCCEED;                        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sect1);
@@ -971,7 +971,7 @@ H5HF__sect_single_can_shrink(const H5FS_section_info_t *_sect, void *_udata)
     H5HF_hdr_t *               hdr       = udata->hdr;                         /* Fractal heap header */
     htri_t                     ret_value = FALSE;                              /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments. */
     HDassert(sect);
@@ -1028,7 +1028,7 @@ H5HF__sect_single_shrink(H5FS_section_info_t **_sect, void *_udata)
     size_t                dblock_size;                           /* Section's direct block's size */
     herr_t                ret_value = SUCCEED;                   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sect);
@@ -1126,7 +1126,7 @@ H5HF__sect_single_valid(const H5FS_section_class_t H5_ATTR_UNUSED *cls, const H5
 {
     const H5HF_free_section_t *sect = (const H5HF_free_section_t *)_sect; /* Pointer to section to check */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments. */
     HDassert(sect);
@@ -1215,7 +1215,7 @@ H5HF__sect_row_create(haddr_t sect_off, hsize_t sect_size, hbool_t is_first, uns
     H5HF_free_section_t *sect      = NULL; /* 'Row' section created */
     H5HF_free_section_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sect_size);
@@ -1260,7 +1260,7 @@ H5HF__sect_row_from_single(H5HF_hdr_t *hdr, H5HF_free_section_t *sect, H5HF_dire
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -1425,7 +1425,7 @@ H5HF__sect_row_first(H5HF_hdr_t *hdr, H5HF_free_section_t *sect)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(hdr);
@@ -1499,7 +1499,7 @@ H5HF__sect_row_parent_removed(H5HF_free_section_t *sect)
     unsigned u;                   /* Local index value */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(sect);
@@ -1553,7 +1553,7 @@ H5HF__sect_row_init_cls(H5FS_section_class_t *cls, void *_udata)
     H5HF_hdr_t *hdr       = (H5HF_hdr_t *)_udata; /* Fractal heap header */
     herr_t      ret_value = SUCCEED;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(cls);
@@ -1595,7 +1595,7 @@ H5HF__sect_row_term_cls(H5FS_section_class_t *cls)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(cls);
@@ -1629,7 +1629,7 @@ H5HF__sect_row_serialize(const H5FS_section_class_t *cls, const H5FS_section_inf
     const H5HF_free_section_t *sect      = (const H5HF_free_section_t *)_sect;
     herr_t                     ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(cls);
@@ -1672,7 +1672,7 @@ H5HF__sect_row_deserialize(const H5FS_section_class_t *cls, const uint8_t *buf, 
     H5HF_hdr_t *         hdr;              /* Fractal heap header */
     H5FS_section_info_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(cls);
@@ -1715,7 +1715,7 @@ H5HF__sect_row_can_merge(const H5FS_section_info_t *_sect1, const H5FS_section_i
     H5HF_free_section_t *      top_indir_sect1, *top_indir_sect2; /* Top indirect section for each row */
     htri_t                     ret_value = FALSE;                 /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments. */
     HDassert(sect1);
@@ -1771,7 +1771,7 @@ H5HF__sect_row_merge(H5FS_section_info_t **_sect1, H5FS_section_info_t *_sect2, 
     H5HF_hdr_t *          hdr       = udata->hdr;                     /* Fractal heap header */
     herr_t                ret_value = SUCCEED;                        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sect1);
@@ -1825,7 +1825,7 @@ H5HF__sect_row_can_shrink(const H5FS_section_info_t *_sect, void H5_ATTR_UNUSED 
     H5HF_hdr_t *               hdr       = udata->hdr;                         /* Fractal heap header */
     htri_t                     ret_value = FALSE;                              /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments. */
     HDassert(sect);
@@ -1862,7 +1862,7 @@ H5HF__sect_row_shrink(H5FS_section_info_t **_sect, void *_udata)
     H5HF_hdr_t *          hdr       = udata->hdr;                   /* Fractal heap header */
     herr_t                ret_value = SUCCEED;                      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sect);
@@ -1902,7 +1902,7 @@ H5HF__sect_row_free_real(H5HF_free_section_t *sect)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(sect);
 
@@ -1934,7 +1934,7 @@ H5HF__sect_row_free(H5FS_section_info_t *_sect)
     H5HF_free_section_t *sect      = (H5HF_free_section_t *)_sect; /* Pointer to section to free */
     herr_t               ret_value = SUCCEED;                      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(sect);
     HDassert(sect->u.row.under);
@@ -1973,7 +1973,7 @@ H5HF__sect_row_valid(const H5FS_section_class_t *cls, const H5FS_section_info_t 
     const H5HF_free_section_t *indir_sect;    /* Pointer to underlying indirect section */
     unsigned H5_ATTR_NDEBUG_UNUSED indir_idx; /* Index of row in underlying indirect section's row array */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Basic sanity check */
     HDassert(cls);
@@ -2029,7 +2029,7 @@ H5HF__sect_row_debug(const H5FS_section_info_t *_sect, FILE *stream, int indent,
 {
     const H5HF_free_section_t *sect = (const H5HF_free_section_t *)_sect; /* Section to dump info */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments. */
     HDassert(sect);
@@ -2067,7 +2067,7 @@ H5HF__sect_indirect_iblock_off(const H5HF_free_section_t *sect)
 {
     hsize_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /*
      * Check arguments.
@@ -2097,7 +2097,7 @@ H5HF__sect_indirect_top(H5HF_free_section_t *sect)
 {
     H5HF_free_section_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /*
      * Check arguments.
@@ -2132,7 +2132,7 @@ H5HF__sect_indirect_init_cls(H5FS_section_class_t *cls, void *_udata)
     H5HF_hdr_t *hdr       = (H5HF_hdr_t *)_udata; /* Fractal heap header */
     herr_t      ret_value = SUCCEED;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(cls);
@@ -2168,7 +2168,7 @@ H5HF__sect_indirect_term_cls(H5FS_section_class_t *cls)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(cls);
@@ -2201,7 +2201,7 @@ H5HF__sect_indirect_new(H5HF_hdr_t *hdr, haddr_t sect_off, hsize_t sect_size, H5
     H5HF_free_section_t *sect      = NULL; /* 'Indirect' free space section to add */
     H5HF_free_section_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -2268,7 +2268,7 @@ H5HF__sect_indirect_for_row(H5HF_hdr_t *hdr, H5HF_indirect_t *iblock, H5HF_free_
     H5HF_free_section_t *sect      = NULL; /* 'Indirect' free space section to add */
     H5HF_free_section_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -2340,7 +2340,7 @@ H5HF__sect_indirect_init_rows(H5HF_hdr_t *hdr, H5HF_free_section_t *sect, hbool_
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -2658,7 +2658,7 @@ H5HF__sect_indirect_decr(H5HF_free_section_t *sect)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -2710,7 +2710,7 @@ H5HF__sect_indirect_revive_row(H5HF_hdr_t *hdr, H5HF_free_section_t *sect)
     hbool_t          did_protect;         /* Whether we protected the indirect block or not */
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -2754,7 +2754,7 @@ H5HF__sect_indirect_revive(H5HF_hdr_t *hdr, H5HF_free_section_t *sect, H5HF_indi
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -2819,7 +2819,7 @@ H5HF__sect_indirect_reduce_row(H5HF_hdr_t *hdr, H5HF_free_section_t *row_sect, h
     H5HF_free_section_t *peer_sect = NULL;    /* Peer indirect section */
     herr_t               ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -3085,7 +3085,7 @@ H5HF__sect_indirect_reduce(H5HF_hdr_t *hdr, H5HF_free_section_t *sect, unsigned 
     H5HF_free_section_t *peer_sect = NULL;    /* Peer indirect section */
     herr_t               ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -3315,7 +3315,7 @@ H5HF__sect_indirect_is_first(H5HF_free_section_t *sect)
 {
     hbool_t ret_value = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(sect);
@@ -3348,7 +3348,7 @@ H5HF__sect_indirect_first(H5HF_hdr_t *hdr, H5HF_free_section_t *sect)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(hdr);
@@ -3396,7 +3396,7 @@ done:
 static H5HF_indirect_t *
 H5HF__sect_indirect_get_iblock(H5HF_free_section_t *sect)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /*
      * Check arguments.
@@ -3437,7 +3437,7 @@ H5HF__sect_indirect_merge_row(H5HF_hdr_t *hdr, H5HF_free_section_t *row_sect1, H
     unsigned             u;                      /* Local index variable */
     herr_t               ret_value = SUCCEED;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check parameters */
     HDassert(hdr);
@@ -3679,7 +3679,7 @@ H5HF__sect_indirect_build_parent(H5HF_hdr_t *hdr, H5HF_free_section_t *sect)
     unsigned             par_entry;           /* Entry within parent indirect section */
     herr_t               ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check parameters */
     HDassert(hdr);
@@ -3757,7 +3757,7 @@ H5HF__sect_indirect_shrink(H5HF_hdr_t *hdr, H5HF_free_section_t *sect)
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check parameters */
     HDassert(hdr);
@@ -3812,7 +3812,7 @@ H5HF__sect_indirect_serialize(H5HF_hdr_t *hdr, const H5HF_free_section_t *sect, 
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(hdr);
@@ -3877,7 +3877,7 @@ H5HF__sect_indirect_deserialize(H5HF_hdr_t *hdr, const uint8_t *buf, haddr_t sec
     unsigned             end_col;          /* End column in indirect block */
     H5FS_section_info_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(hdr);
@@ -3946,7 +3946,7 @@ H5HF__sect_indirect_free(H5HF_free_section_t *sect)
     H5HF_indirect_t *iblock    = NULL;    /* Indirect block for section */
     herr_t           ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(sect);
 
@@ -3993,7 +3993,7 @@ H5HF__sect_indirect_valid(const H5HF_hdr_t *hdr, const H5HF_free_section_t *sect
     unsigned end_entry;   /* Entry for last block covered */
     unsigned u;           /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check arguments */
     HDassert(hdr);
@@ -4090,7 +4090,7 @@ H5HF__sect_indirect_valid(const H5HF_hdr_t *hdr, const H5HF_free_section_t *sect
 static herr_t
 H5HF__sect_indirect_debug(const H5HF_free_section_t *sect, FILE *stream, int indent, int fwidth)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments. */
     HDassert(sect);

--- a/src/H5HFspace.c
+++ b/src/H5HFspace.c
@@ -241,7 +241,7 @@ H5HF__space_revert_root_cb(H5FS_section_info_t *_sect, void H5_ATTR_UNUSED *_uda
     H5HF_free_section_t *sect      = (H5HF_free_section_t *)_sect; /* Section to dump info */
     herr_t               ret_value = SUCCEED;                      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -323,7 +323,7 @@ H5HF__space_create_root_cb(H5FS_section_info_t *_sect, void *_udata)
     H5HF_indirect_t *    root_iblock = (H5HF_indirect_t *)_udata;    /* User data for callback */
     herr_t               ret_value   = SUCCEED;                      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.

--- a/src/H5HFtiny.c
+++ b/src/H5HFtiny.c
@@ -234,7 +234,7 @@ H5HF__tiny_op_real(H5HF_hdr_t *hdr, const uint8_t *id, H5HF_operator_t op, void 
     size_t enc_obj_size;        /* Encoded object size */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.

--- a/src/H5HG.c
+++ b/src/H5HG.c
@@ -129,7 +129,7 @@ H5HG__create(H5F_t *f, size_t size)
     size_t       n;
     haddr_t      ret_value = HADDR_UNDEF; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(f);
@@ -288,7 +288,7 @@ H5HG__alloc(H5F_t *f, H5HG_heap_t *heap, size_t size, unsigned *heap_flags_ptr)
     size_t   need      = H5HG_SIZEOF_OBJHDR(f) + H5HG_ALIGN(size);
     size_t   ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(heap);

--- a/src/H5HGcache.c
+++ b/src/H5HGcache.c
@@ -114,7 +114,7 @@ H5HG__hdr_deserialize(H5HG_heap_t *heap, const uint8_t *image, const H5F_t *f)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(heap);
@@ -161,7 +161,7 @@ done:
 static herr_t
 H5HG__cache_heap_get_initial_load_size(void H5_ATTR_UNUSED *_udata, size_t *image_len)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(image_len);
@@ -193,7 +193,7 @@ H5HG__cache_heap_get_final_load_size(const void *image, size_t H5_ATTR_NDEBUG_UN
     H5HG_heap_t heap;                /* Global heap */
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(image);
@@ -238,7 +238,7 @@ H5HG__cache_heap_deserialize(const void *_image, size_t len, void *_udata, hbool
     size_t       nalloc;                 /* Number of objects allocated */
     void *       ret_value = NULL;       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(_image);
@@ -382,7 +382,7 @@ H5HG__cache_heap_image_len(const void *_thing, size_t *image_len)
 {
     const H5HG_heap_t *heap = (const H5HG_heap_t *)_thing;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(heap);
@@ -417,7 +417,7 @@ H5HG__cache_heap_serialize(const H5F_t H5_ATTR_NDEBUG_UNUSED *f, void *image, si
 {
     H5HG_heap_t *heap = (H5HG_heap_t *)_thing;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(f);
     HDassert(image);
@@ -456,7 +456,7 @@ H5HG__cache_heap_free_icr(void *_thing)
     H5HG_heap_t *heap      = (H5HG_heap_t *)_thing;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(heap);

--- a/src/H5HL.c
+++ b/src/H5HL.c
@@ -195,7 +195,7 @@ H5HL__minimize_heap_space(H5F_t *f, H5HL_t *heap)
     size_t new_heap_size = heap->dblk_size; /* New size of heap */
     herr_t ret_value     = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(f);
@@ -468,7 +468,7 @@ H5HL__remove_free(H5HL_t *heap, H5HL_free_t *fl)
 {
     H5HL_free_t *ret_value = NULL;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (fl->prev)
         fl->prev->next = fl->next;
@@ -501,7 +501,7 @@ H5HL__dirty(H5HL_t *heap)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(heap);

--- a/src/H5HLcache.c
+++ b/src/H5HLcache.c
@@ -153,7 +153,7 @@ H5HL__hdr_deserialize(H5HL_t *heap, const uint8_t *image, H5HL_cache_prfx_ud_t *
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(heap);
@@ -210,7 +210,7 @@ H5HL__fl_deserialize(H5HL_t *heap)
     hsize_t      free_block;              /* Offset of free block */
     herr_t       ret_value = SUCCEED;     /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(heap);
@@ -278,7 +278,7 @@ H5HL__fl_serialize(const H5HL_t *heap)
 {
     H5HL_free_t *fl; /* Pointer to heap free list node */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check arguments */
     HDassert(heap);
@@ -319,7 +319,7 @@ H5HL__fl_serialize(const H5HL_t *heap)
 static herr_t
 H5HL__cache_prefix_get_initial_load_size(void H5_ATTR_UNUSED *_udata, size_t *image_len)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(image_len);
@@ -353,7 +353,7 @@ H5HL__cache_prefix_get_final_load_size(const void *_image, size_t H5_ATTR_NDEBUG
     H5HL_t                heap;                                   /* Local heap */
     herr_t                ret_value = SUCCEED;                    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(image);
@@ -404,7 +404,7 @@ H5HL__cache_prefix_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED 
     H5HL_cache_prfx_ud_t *udata     = (H5HL_cache_prfx_ud_t *)_udata; /* User data for callback */
     void *                ret_value = NULL;                           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -496,7 +496,7 @@ H5HL__cache_prefix_image_len(const void *_thing, size_t *image_len)
 {
     const H5HL_prfx_t *prfx = (const H5HL_prfx_t *)_thing; /* Pointer to local heap prefix to query */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(prfx);
@@ -541,7 +541,7 @@ H5HL__cache_prefix_serialize(const H5_ATTR_NDEBUG_UNUSED H5F_t *f, void *_image,
     uint8_t *    image = (uint8_t *)_image;    /* Pointer into image buffer */
     size_t       buf_size;                     /* expected size of the image buffer */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(f);
@@ -638,7 +638,7 @@ H5HL__cache_prefix_free_icr(void *_thing)
     H5HL_prfx_t *prfx      = (H5HL_prfx_t *)_thing; /* Pointer to local heap prefix to query */
     herr_t       ret_value = SUCCEED;               /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(prfx);
@@ -674,7 +674,7 @@ H5HL__cache_datablock_get_initial_load_size(void *_udata, size_t *image_len)
 {
     H5HL_t *heap = (H5HL_t *)_udata; /* User data for callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(heap);
@@ -709,7 +709,7 @@ H5HL__cache_datablock_deserialize(const void *image, size_t len, void *_udata, h
     H5HL_t *     heap      = (H5HL_t *)_udata; /* User data for callback */
     void *       ret_value = NULL;             /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -768,7 +768,7 @@ H5HL__cache_datablock_image_len(const void *_thing, size_t *image_len)
 {
     const H5HL_dblk_t *dblk = (const H5HL_dblk_t *)_thing; /* Pointer to the local heap data block */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(dblk);
@@ -804,7 +804,7 @@ H5HL__cache_datablock_serialize(const H5F_t H5_ATTR_NDEBUG_UNUSED *f, void *imag
     H5HL_t *     heap;                         /* Pointer to the local heap */
     H5HL_dblk_t *dblk = (H5HL_dblk_t *)_thing; /* Pointer to the local heap data block */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(f);
@@ -849,7 +849,7 @@ H5HL__cache_datablock_notify(H5C_notify_action_t action, void *_thing)
     H5HL_dblk_t *dblk      = (H5HL_dblk_t *)_thing; /* Pointer to the local heap data block */
     herr_t       ret_value = SUCCEED;               /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(dblk);
@@ -921,7 +921,7 @@ H5HL__cache_datablock_free_icr(void *_thing)
     H5HL_dblk_t *dblk      = (H5HL_dblk_t *)_thing; /* Pointer to the local heap data block */
     herr_t       ret_value = SUCCEED;               /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(dblk);

--- a/src/H5I.c
+++ b/src/H5I.c
@@ -707,7 +707,7 @@ H5I__search_cb(void *obj, hid_t id, void *_udata)
     herr_t           cb_ret_val;                        /* User callback return value */
     int              ret_value = H5_ITER_ERROR;         /* Callback return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     cb_ret_val = (*udata->app_cb)(obj, id, udata->app_key);
 
@@ -795,7 +795,7 @@ H5I__iterate_pub_cb(void H5_ATTR_UNUSED *obj, hid_t id, void *_udata)
     herr_t                cb_ret_val = FAIL;                           /* User callback return value */
     int                   ret_value  = H5_ITER_ERROR;                  /* Callback return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Invoke the callback */
     cb_ret_val = (*udata->op)(id, udata->op_data);

--- a/src/H5Idbg.c
+++ b/src/H5Idbg.c
@@ -80,7 +80,7 @@ H5I__id_dump_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
     const H5G_name_t *path   = NULL;                   /* Path to file object */
     const void *      object = NULL;                   /* Pointer to VOL connector object */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDfprintf(stderr, "         id = %" PRIdHID "\n", info->id);
     HDfprintf(stderr, "         count = %u\n", info->count);

--- a/src/H5Iint.c
+++ b/src/H5Iint.c
@@ -258,7 +258,7 @@ H5I__unwrap(void *object, H5I_type_t type)
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(object);
@@ -370,7 +370,7 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
     H5I_clear_type_ud_t *udata = (H5I_clear_type_ud_t *)_udata; /* udata struct */
     hbool_t              mark  = FALSE;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(info);
@@ -876,7 +876,7 @@ H5I__remove_verify(hid_t id, H5I_type_t type)
 {
     void *ret_value = NULL; /*return value            */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Argument checking will be performed by H5I_remove() */
 
@@ -908,7 +908,7 @@ H5I__remove_common(H5I_type_info_t *type_info, hid_t id)
     H5I_id_info_t *info      = NULL; /* Pointer to the current ID */
     void *         ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(type_info);
@@ -1002,7 +1002,7 @@ H5I__dec_ref(hid_t id, void **request)
     H5I_id_info_t *info      = NULL; /* Pointer to the ID */
     int            ret_value = 0;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(id >= 0);
@@ -1099,7 +1099,7 @@ H5I__dec_app_ref(hid_t id, void **request)
 {
     int ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(id >= 0);
@@ -1214,7 +1214,7 @@ H5I__dec_app_ref_always_close(hid_t id, void **request)
 {
     int ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(id >= 0);
@@ -1385,7 +1385,7 @@ H5I__inc_type_ref(H5I_type_t type)
     H5I_type_info_t *type_info = NULL; /* Pointer to the type */
     int              ret_value = -1;   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(type > 0 && (int)type < H5I_next_type_g);
@@ -1471,7 +1471,7 @@ H5I__get_type_ref(H5I_type_t type)
     H5I_type_info_t *type_info = NULL; /* Pointer to the type  */
     int              ret_value = -1;   /* Return value         */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(type >= 0);
@@ -1507,7 +1507,7 @@ H5I__iterate_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
     H5I_iterate_ud_t *udata     = (H5I_iterate_ud_t *)_udata; /* User data for callback */
     int               ret_value = H5_ITER_CONT;               /* Callback return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Only invoke the callback function if this ID is visible externally and
      * its reference count is positive.
@@ -1705,7 +1705,7 @@ H5I__find_id_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
     const void *     object    = NULL;
     int              ret_value = H5_ITER_CONT; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(info);

--- a/src/H5L.c
+++ b/src/H5L.c
@@ -304,7 +304,7 @@ H5L__create_soft_api_common(const char *link_target, hid_t link_loc_id, const ch
     H5VL_loc_params_t       loc_params;               /* Location parameters for object access */
     herr_t                  ret_value = SUCCEED;      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (link_loc_id == H5L_SAME_LOC)
@@ -446,7 +446,7 @@ H5L__create_hard_api_common(hid_t cur_loc_id, const char *cur_name, hid_t link_l
     H5VL_loc_params_t       link_loc_params;     /* Location parameters for link_loc_id object access */
     herr_t                  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (cur_loc_id == H5L_SAME_LOC && link_loc_id == H5L_SAME_LOC)
@@ -817,7 +817,7 @@ H5L__delete_api_common(hid_t loc_id, const char *name, hid_t lapl_id, void **tok
     H5VL_loc_params_t         loc_params;             /* Location parameters for object access */
     herr_t                    ret_value = SUCCEED;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     /* name is verified in H5VL_setup_name_args() */
@@ -933,7 +933,7 @@ H5L__delete_by_idx_api_common(hid_t loc_id, const char *group_name, H5_index_t i
     H5VL_loc_params_t         loc_params;             /* Location parameters for object access */
     herr_t                    ret_value = SUCCEED;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (!group_name || !*group_name)
@@ -1188,7 +1188,7 @@ H5L__exists_api_common(hid_t loc_id, const char *name, hbool_t *exists, hid_t la
     H5VL_loc_params_t         loc_params;             /* Location parameters for object access */
     herr_t                    ret_value = SUCCEED;    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     /* name is verified in H5VL_setup_name_args() */
@@ -1629,7 +1629,7 @@ H5L__iterate_api_common(hid_t group_id, H5_index_t idx_type, H5_iter_order_t ord
     H5I_type_t                id_type;                  /* Type of ID */
     herr_t                    ret_value = H5_ITER_CONT; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     id_type = H5I_get_type(group_id);

--- a/src/H5Ldeprec.c
+++ b/src/H5Ldeprec.c
@@ -93,7 +93,7 @@ H5L__iterate2_shim(hid_t group_id, const char *name, const H5L_info2_t *linfo2, 
     H5L_info1_t      linfo;
     herr_t           ret_value = H5_ITER_CONT;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Copy the new-style members into the old-style struct */
     if (linfo2) {

--- a/src/H5Lexternal.c
+++ b/src/H5Lexternal.c
@@ -122,7 +122,7 @@ H5L__extern_traverse(const char H5_ATTR_UNUSED *link_name, hid_t cur_group, cons
     char *             elink_prefix = NULL;                         /* Pointer to elink prefix */
     hid_t              ret_value    = H5I_INVALID_HID;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(p);
@@ -281,7 +281,7 @@ H5L__extern_query(const char H5_ATTR_UNUSED *link_name, const void *_udata, size
     const uint8_t *udata     = (const uint8_t *)_udata; /* Pointer to external link buffer */
     ssize_t        ret_value = SUCCEED;                 /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check external link version & flags */
     if (((*udata >> 4) & 0x0F) != H5L_EXT_VERSION)

--- a/src/H5Lint.c
+++ b/src/H5Lint.c
@@ -267,7 +267,7 @@ H5L__find_class_idx(H5L_type_t id)
     size_t i;                /* Local index variable */
     int    ret_value = FAIL; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     for (i = 0; i < H5L_table_used_g; i++)
         if (H5L_table_g[i].id == id)
@@ -544,7 +544,7 @@ H5L__link_cb(H5G_loc_t *grp_loc /*in*/, const char *name, const H5O_link_t H5_AT
     hbool_t obj_created   = FALSE;   /* Whether an object was created (through a hard link) */
     herr_t  ret_value     = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name in this group resolved to a valid location */
     /* (which is not what we want) */
@@ -708,7 +708,7 @@ H5L__create_real(const H5G_loc_t *link_loc, const char *link_name, H5G_name_t *o
     H5L_trav_cr_t   udata;                              /* User data for callback */
     herr_t          ret_value = SUCCEED;                /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(link_loc);
@@ -958,7 +958,7 @@ H5L__get_val_real(const H5O_link_t *lnk, void *buf, size_t size)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(lnk);
@@ -1015,7 +1015,7 @@ H5L__get_val_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char *name, cons
     H5L_trav_gv_t *udata     = (H5L_trav_gv_t *)_udata; /* User data passed in */
     herr_t         ret_value = SUCCEED;                 /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name in this group resolved to a valid link */
     if (lnk == NULL)
@@ -1099,7 +1099,7 @@ H5L__get_val_by_idx_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_A
     hbool_t          lnk_copied = FALSE;                /* Whether the link was copied */
     herr_t           ret_value  = SUCCEED;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name of the group resolved to a valid object */
     if (obj_loc == NULL)
@@ -1187,7 +1187,7 @@ H5L__delete_cb(H5G_loc_t *grp_loc /*in*/, const char *name, const H5O_link_t *ln
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the group resolved to a valid link */
     if (grp_loc == NULL)
@@ -1277,7 +1277,7 @@ H5L__delete_by_idx_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_AT
     H5L_trav_gvbi_t *udata     = (H5L_trav_gvbi_t *)_udata; /* User data passed in */
     herr_t           ret_value = SUCCEED;                   /* Return value */
 
-    FUNC_ENTER_STATIC_TAG((obj_loc) ? (obj_loc->oloc->addr) : HADDR_UNDEF)
+    FUNC_ENTER_PACKAGE_TAG((obj_loc) ? (obj_loc->oloc->addr) : HADDR_UNDEF)
 
     /* Check if the name of the group resolved to a valid object */
     if (obj_loc == NULL)
@@ -1361,7 +1361,7 @@ H5L__move_dest_cb(H5G_loc_t *grp_loc /*in*/, const char *name, const H5O_link_t 
     hbool_t         temp_loc_init = FALSE;
     herr_t          ret_value     = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Make sure an object with this name doesn't already exist */
     if (obj_loc != NULL)
@@ -1472,7 +1472,7 @@ H5L__move_cb(H5G_loc_t *grp_loc /*in*/, const char *name, const H5O_link_t *lnk,
     hbool_t        link_copied = FALSE;             /* Has udata_out.lnk been allocated? */
     herr_t         ret_value   = SUCCEED;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name in this group resolved to a valid link */
     if (obj_loc == NULL)
@@ -1662,7 +1662,7 @@ H5L__exists_final_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_ATT
 {
     H5L_trav_le_t *udata = (H5L_trav_le_t *)_udata; /* User data passed in */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check if the name in this group resolved to a valid link */
     *udata->exists = (hbool_t)(lnk != NULL);
@@ -1695,7 +1695,7 @@ H5L__exists_inter_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_ATT
     H5L_trav_le_t *udata     = (H5L_trav_le_t *)_udata; /* User data passed in */
     herr_t         ret_value = SUCCEED;                 /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name in this group resolved to a valid link */
     if (lnk != NULL) {
@@ -1859,7 +1859,7 @@ H5L__get_info_cb(H5G_loc_t *grp_loc /*in*/, const char H5_ATTR_UNUSED *name, con
     H5L_trav_gi_t *udata     = (H5L_trav_gi_t *)_udata; /* User data passed in */
     herr_t         ret_value = SUCCEED;                 /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name in this group resolved to a valid link */
     if (lnk == NULL)
@@ -1930,7 +1930,7 @@ H5L__get_info_by_idx_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_
     hbool_t          lnk_copied = FALSE;                /* Whether the link was copied */
     herr_t           ret_value  = SUCCEED;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name of the group resolved to a valid object */
     if (obj_loc == NULL)
@@ -2016,7 +2016,7 @@ H5L__get_name_by_idx_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_
     H5L_trav_gnbi_t *udata     = (H5L_trav_gnbi_t *)_udata; /* User data passed in */
     herr_t           ret_value = SUCCEED;                   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the name of the group resolved to a valid object */
     if (obj_loc == NULL)

--- a/src/H5M.c
+++ b/src/H5M.c
@@ -168,7 +168,7 @@ H5M__close_cb(H5VL_object_t *map_vol_obj, void **request)
     H5VL_optional_args_t vol_cb_args;         /* Arguments to VOL callback */
     herr_t               ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(map_vol_obj);
@@ -214,7 +214,7 @@ H5M__create_api_common(hid_t loc_id, const char *name, hid_t key_type_id, hid_t 
     H5VL_map_args_t      map_args;                    /* Arguments for map operations */
     hid_t                ret_value = H5I_INVALID_HID; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (!name)
@@ -466,7 +466,7 @@ H5M__open_api_common(hid_t loc_id, const char *name, hid_t mapl_id, void **token
     H5VL_map_args_t      map_args;                    /* Arguments for map operations */
     hid_t                ret_value = H5I_INVALID_HID; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     if (!name)
@@ -935,7 +935,7 @@ H5M__put_api_common(hid_t map_id, hid_t key_mem_type_id, const void *key, hid_t 
     H5VL_map_args_t      map_args;                    /* Arguments for map operations */
     herr_t               ret_value = SUCCEED;         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (key_mem_type_id < 0)
@@ -1070,7 +1070,7 @@ H5M__get_api_common(hid_t map_id, hid_t key_mem_type_id, const void *key, hid_t 
     H5VL_map_args_t      map_args;                    /* Arguments for map operations */
     herr_t               ret_value = SUCCEED;         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (key_mem_type_id < 0)

--- a/src/H5MF.c
+++ b/src/H5MF.c
@@ -385,7 +385,7 @@ H5MF__create_fstype(H5F_t *f, H5F_mem_page_t type)
     H5AC_ring_t                 fsm_ring;                  /* Ring of FSM */
     herr_t                      ret_value = SUCCEED;       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -511,7 +511,7 @@ H5MF__delete_fstype(H5F_t *f, H5F_mem_page_t type)
     haddr_t     tmp_fs_addr;               /* Temporary holder for free space manager address */
     herr_t      ret_value = SUCCEED;       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -579,7 +579,7 @@ H5MF__close_fstype(H5F_t *f, H5F_mem_page_t type)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -888,7 +888,7 @@ H5MF__alloc_pagefs(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size)
     H5MF_free_section_t *node      = NULL;        /* Free space section pointer */
     haddr_t              ret_value = HADDR_UNDEF; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #ifdef H5MF_ALLOC_DEBUG
     HDfprintf(stderr, "%s: alloc_type = %u, size = %" PRIuHSIZE "\n", __func__, (unsigned)alloc_type, size);
@@ -1583,7 +1583,7 @@ H5MF__close_delete_fstype(H5F_t *f, H5F_mem_page_t type)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 #ifdef H5MF_ALLOC_DEBUG
     HDfprintf(stderr, "%s: Entering\n", __func__);
 #endif /* H5MF_ALLOC_DEBUG */
@@ -1754,7 +1754,7 @@ H5MF__close_aggrfs(H5F_t *f)
     H5FD_mem_t  type;                        /* Memory type for iteration */
     herr_t      ret_value = SUCCEED;         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 #ifdef H5MF_ALLOC_DEBUG
     HDfprintf(stderr, "%s: Entering\n", __func__);
 #endif /* H5MF_ALLOC_DEBUG */
@@ -1920,7 +1920,7 @@ H5MF__close_pagefs(H5F_t *f)
     H5O_fsinfo_t   fsinfo;                      /* File space info message */
     herr_t         ret_value = SUCCEED;         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 #ifdef H5MF_ALLOC_DEBUG
     HDfprintf(stderr, "%s: Entering\n", __func__);
 #endif /* H5MF_ALLOC_DEBUG */
@@ -2099,7 +2099,7 @@ H5MF__close_shrink_eoa(H5F_t *f)
     H5MF_sect_ud_t udata;               /* User data for callback */
     herr_t         ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -2466,7 +2466,7 @@ H5MF__sects_cb(H5FS_section_info_t *_sect, void *_udata)
     H5MF_free_section_t *sect  = (H5MF_free_section_t *)_sect;
     H5MF_sect_iter_ud_t *udata = (H5MF_sect_iter_ud_t *)_udata;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (udata->sect_idx < udata->sect_count) {
         udata->sects[udata->sect_idx].addr = sect->sect_info.addr;
@@ -2495,7 +2495,7 @@ H5MF__get_free_sects(H5F_t *f, H5FS_t *fspace, H5MF_sect_iter_ud_t *sect_udata, 
     hsize_t hnums     = 0;       /* # of sections */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -3340,7 +3340,7 @@ static herr_t
 H5MF__continue_alloc_fsm(H5F_shared_t *f_sh, H5FS_t *sm_hdr_fspace, H5FS_t *sm_sinfo_fspace,
                          H5FS_t *lg_hdr_fspace, H5FS_t *lg_sinfo_fspace, hbool_t *continue_alloc_fsm)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(f_sh);
@@ -3392,7 +3392,7 @@ H5MF__fsm_type_is_self_referential(H5F_shared_t *f_sh, H5F_mem_page_t fsm_type)
     H5F_mem_page_t lg_fssinfo_fsm;
     hbool_t        result = FALSE;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(f_sh);
@@ -3445,7 +3445,7 @@ H5MF__fsm_is_self_referential(H5F_shared_t *f_sh, H5FS_t *fspace)
     H5F_mem_page_t sm_fssinfo_fsm;
     hbool_t        result = FALSE;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(f_sh);

--- a/src/H5MFaggr.c
+++ b/src/H5MFaggr.c
@@ -149,7 +149,7 @@ H5MF__aggr_alloc(H5F_t *f, H5F_blk_aggr_t *aggr, H5F_blk_aggr_t *other_aggr, H5F
     haddr_t eoa           = HADDR_UNDEF; /* Initial EOA for the file */
     haddr_t ret_value     = HADDR_UNDEF; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 #ifdef H5MF_AGGR_DEBUG
     HDfprintf(stderr, "%s: type = %u, size = %" PRIuHSIZE "\n", __func__, (unsigned)type, size);
 #endif /* H5MF_AGGR_DEBUG */
@@ -713,7 +713,7 @@ done:
         H5FD_mem_t alloc_type;          /* Type of file memory to work with */
         herr_t     ret_value = SUCCEED; /* Return value */
 
-        FUNC_ENTER_STATIC
+        FUNC_ENTER_PACKAGE
 
         /* Check args */
         HDassert(f);
@@ -838,7 +838,7 @@ done:
         haddr_t eoa       = HADDR_UNDEF; /* EOA for the file */
         htri_t  ret_value = FALSE;       /* Return value */
 
-        FUNC_ENTER_STATIC
+        FUNC_ENTER_PACKAGE
 
         /* Sanity check */
         HDassert(f);
@@ -876,7 +876,7 @@ done:
     {
         herr_t ret_value = SUCCEED; /* Return value */
 
-        FUNC_ENTER_STATIC
+        FUNC_ENTER_PACKAGE
 
         /* Sanity check */
         HDassert(f);

--- a/src/H5MFdbg.c
+++ b/src/H5MFdbg.c
@@ -95,7 +95,7 @@ H5MF__sects_debug_cb(H5FS_section_info_t *_sect, void *_udata)
     H5MF_debug_iter_ud_t *udata     = (H5MF_debug_iter_ud_t *)_udata; /* User data for callbacks */
     herr_t                ret_value = SUCCEED;                        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.

--- a/src/H5MFsection.c
+++ b/src/H5MFsection.c
@@ -265,7 +265,7 @@ H5MF__sect_deserialize(const H5FS_section_class_t *cls, const uint8_t H5_ATTR_UN
     H5MF_free_section_t *sect;             /* New section */
     H5FS_section_info_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(cls);
@@ -307,7 +307,7 @@ H5MF__sect_valid(const H5FS_section_class_t H5_ATTR_UNUSED *cls, const H5FS_sect
     const H5MF_free_section_t *sect = (const H5MF_free_section_t *)_sect; /* File free section */
 #endif                                                                    /* NDEBUG */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments. */
     HDassert(sect);
@@ -333,7 +333,7 @@ H5MF__sect_split(H5FS_section_info_t *sect, hsize_t frag_size)
 {
     H5MF_free_section_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate space for new section */
     if (NULL == (ret_value = H5MF__sect_new(sect->type, sect->addr, frag_size)))
@@ -374,7 +374,7 @@ H5MF__sect_simple_can_merge(const H5FS_section_info_t *_sect1, const H5FS_sectio
     const H5MF_free_section_t *sect2     = (const H5MF_free_section_t *)_sect2; /* File free section */
     htri_t                     ret_value = FAIL;                                /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments. */
     HDassert(sect1);
@@ -411,7 +411,7 @@ H5MF__sect_simple_merge(H5FS_section_info_t **_sect1, H5FS_section_info_t *_sect
     H5MF_free_section_t * sect2     = (H5MF_free_section_t *)_sect2;  /* File free section */
     herr_t                ret_value = SUCCEED;                        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sect1);
@@ -453,7 +453,7 @@ H5MF__sect_simple_can_shrink(const H5FS_section_info_t *_sect, void *_udata)
     haddr_t                    end;              /* End of section to extend */
     htri_t                     ret_value = FAIL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sect);
@@ -557,7 +557,7 @@ H5MF__sect_simple_shrink(H5FS_section_info_t **_sect, void *_udata)
     H5MF_sect_ud_t *      udata     = (H5MF_sect_ud_t *)_udata;      /* User data for callback */
     herr_t                ret_value = SUCCEED;                       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sect);
@@ -625,7 +625,7 @@ H5MF__sect_small_add(H5FS_section_info_t **_sect, unsigned *flags, void *_udata)
     hsize_t               rem, prem;
     herr_t                ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #ifdef H5MF_ALLOC_DEBUG_MORE
     HDfprintf(stderr, "%s: Entering, section {%" PRIuHADDR ", %" PRIuHSIZE "}\n", __func__,
@@ -688,7 +688,7 @@ H5MF__sect_small_can_merge(const H5FS_section_info_t *_sect1, const H5FS_section
     H5MF_sect_ud_t *           udata     = (H5MF_sect_ud_t *)_udata;            /* User data for callback */
     htri_t                     ret_value = FALSE;                               /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments. */
     HDassert(sect1);
@@ -735,7 +735,7 @@ H5MF__sect_small_merge(H5FS_section_info_t **_sect1, H5FS_section_info_t *_sect2
     H5MF_sect_ud_t *      udata     = (H5MF_sect_ud_t *)_udata;       /* User data for callback */
     herr_t                ret_value = SUCCEED;                        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sect1);
@@ -798,7 +798,7 @@ H5MF__sect_large_can_merge(const H5FS_section_info_t *_sect1, const H5FS_section
     const H5MF_free_section_t *sect2     = (const H5MF_free_section_t *)_sect2; /* File free section */
     htri_t                     ret_value = FALSE;                               /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments. */
     HDassert(sect1);
@@ -836,7 +836,7 @@ H5MF__sect_large_merge(H5FS_section_info_t **_sect1, H5FS_section_info_t *_sect2
     H5MF_free_section_t * sect2     = (H5MF_free_section_t *)_sect2;  /* File free section */
     herr_t                ret_value = SUCCEED;                        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sect1);
@@ -877,7 +877,7 @@ H5MF__sect_large_can_shrink(const H5FS_section_info_t *_sect, void *_udata)
     haddr_t                    end;               /* End of section to extend */
     htri_t                     ret_value = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sect);
@@ -930,7 +930,7 @@ H5MF__sect_large_shrink(H5FS_section_info_t **_sect, void *_udata)
     hsize_t               frag_size = 0;                             /* Fragment size */
     herr_t                ret_value = SUCCEED;                       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(sect);

--- a/src/H5O.c
+++ b/src/H5O.c
@@ -106,7 +106,7 @@ H5O__open_api_common(hid_t loc_id, const char *name, hid_t lapl_id, void **token
     H5VL_loc_params_t loc_params;
     hid_t             ret_value = H5I_INVALID_HID;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
 
@@ -234,7 +234,7 @@ H5O__open_by_idx_api_common(hid_t loc_id, const char *group_name, H5_index_t idx
     H5VL_loc_params_t loc_params;
     hid_t             ret_value = H5I_INVALID_HID;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     /* group_name, idx_type, order are checked in H5VL_setup_idx-args() */
@@ -425,7 +425,7 @@ H5O__copy_api_common(hid_t src_loc_id, const char *src_name, hid_t dst_loc_id, c
 
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (!src_name || !*src_name)
@@ -621,7 +621,7 @@ H5O__flush_api_common(hid_t obj_id, void **token_ptr, H5VL_object_t **_vol_obj_p
     H5VL_loc_params_t           loc_params;           /* Location parameters for object access */
     herr_t                      ret_value = SUCCEED;  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Setup and check args */
     if (H5VL_setup_loc_args(obj_id, vol_obj_ptr, &loc_params) < 0)
@@ -727,7 +727,7 @@ H5O__refresh_api_common(hid_t oid, void **token_ptr, H5VL_object_t **_vol_obj_pt
     H5VL_loc_params_t           loc_params;           /* Location parameters for object access */
     herr_t                      ret_value = SUCCEED;  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Setup and check args */
     if (H5VL_setup_loc_args(oid, vol_obj_ptr, &loc_params) < 0)
@@ -1160,7 +1160,7 @@ H5O__get_info_by_name_api_common(hid_t loc_id, const char *name, H5O_info2_t *oi
     H5VL_loc_params_t      loc_params;                /* Location parameters for object access */
     herr_t                 ret_value = SUCCEED;       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     if (!oinfo)
@@ -1941,7 +1941,7 @@ H5O__close_check_type(hid_t object_id)
 {
     htri_t ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check for closeable object */
     switch (H5I_get_type(object_id)) {

--- a/src/H5Oainfo.c
+++ b/src/H5Oainfo.c
@@ -103,7 +103,7 @@ H5O__ainfo_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNUS
     unsigned char flags;            /* Flags for encoding attribute info */
     void *        ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -173,7 +173,7 @@ H5O__ainfo_encode(H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, uint8_t *p, c
     const H5O_ainfo_t *ainfo = (const H5O_ainfo_t *)_mesg;
     unsigned char      flags; /* Flags for encoding attribute info */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -228,7 +228,7 @@ H5O__ainfo_copy(const void *_mesg, void *_dest)
     H5O_ainfo_t *      dest      = (H5O_ainfo_t *)_dest;
     void *             ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(ainfo);
@@ -266,7 +266,7 @@ H5O__ainfo_size(const H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, const voi
     const H5O_ainfo_t *ainfo     = (const H5O_ainfo_t *)_mesg;
     size_t             ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set return value */
     ret_value =
@@ -297,7 +297,7 @@ H5O__ainfo_size(const H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, const voi
 static herr_t
 H5O__ainfo_free(void *mesg)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(mesg);
 
@@ -326,7 +326,7 @@ H5O__ainfo_delete(H5F_t *f, H5O_t H5_ATTR_NDEBUG_UNUSED *open_oh, void *_mesg)
     H5O_ainfo_t *ainfo     = (H5O_ainfo_t *)_mesg;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -361,7 +361,7 @@ static herr_t
 H5O__ainfo_pre_copy_file(H5F_t H5_ATTR_UNUSED *file_src, const void H5_ATTR_UNUSED *native_src,
                          hbool_t *deleted, const H5O_copy_t *cpy_info, void H5_ATTR_UNUSED *udata)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(deleted);
@@ -398,7 +398,7 @@ H5O__ainfo_copy_file(H5F_t H5_ATTR_NDEBUG_UNUSED *file_src, void *mesg_src, H5F_
     H5O_ainfo_t *ainfo_dst = NULL;
     void *       ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(file_src);
@@ -461,7 +461,7 @@ H5O__ainfo_post_copy_file(const H5O_loc_t *src_oloc, const void *mesg_src, H5O_l
     const H5O_ainfo_t *ainfo_src = (const H5O_ainfo_t *)mesg_src;
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(ainfo_src);
 
@@ -491,7 +491,7 @@ H5O__ainfo_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int i
 {
     const H5O_ainfo_t *ainfo = (const H5O_ainfo_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);

--- a/src/H5Oalloc.c
+++ b/src/H5Oalloc.c
@@ -106,7 +106,7 @@ H5O__add_gap(H5F_t H5_ATTR_NDEBUG_UNUSED *f, H5O_t *oh, unsigned chunkno, hbool_
     size_t  u;                   /* Local index variable */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(oh);
@@ -229,7 +229,7 @@ H5O__eliminate_gap(H5O_t *oh, hbool_t *chk_dirtied, H5O_mesg_t *mesg, uint8_t *g
     uint8_t *move_start, *move_end; /* Pointers to area of messages to move */
     hbool_t  null_before_gap;       /* Flag whether the null message is before the gap or not */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(oh);
@@ -329,7 +329,7 @@ H5O__alloc_null(H5F_t *f, H5O_t *oh, size_t null_idx, const H5O_msg_class_t *new
     H5O_mesg_t *       alloc_msg;           /* Pointer to null message to allocate out of */
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(oh);
@@ -507,7 +507,7 @@ H5O__alloc_extend_chunk(H5F_t *f, H5O_t *oh, unsigned chunkno, size_t size, size
     size_t             u;                         /* Local index variable */
     htri_t             ret_value = TRUE;          /* return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f != NULL);
@@ -723,7 +723,7 @@ H5O__alloc_find_best_nonnull(const H5F_t *f, const H5O_t *oh, size_t *size, H5O_
     size_t      multi_size; /* Size of all the messages in the last chunk */
     unsigned    u;          /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(f);
@@ -1153,7 +1153,7 @@ H5O__alloc_new_chunk(H5F_t *f, H5O_t *oh, size_t size, size_t *new_idx)
     H5O_msg_alloc_info_t found_msg;           /* Best fit non-null message */
     herr_t               ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(oh);
@@ -1200,7 +1200,7 @@ H5O__alloc_find_best_null(const H5O_t *oh, size_t size, size_t *mesg_idx)
     size_t  idx;        /* Index of message which fits allocation */
     ssize_t found_null; /* Best fit null message         */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(oh);
@@ -1431,7 +1431,7 @@ H5O__move_cont(H5F_t *f, H5O_t *oh, unsigned cont_u)
     hbool_t            chk_dirtied = FALSE; /* Flags for unprotecting chunk */
     htri_t             ret_value   = TRUE;  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
     HDassert(f);
@@ -1603,7 +1603,7 @@ H5O__move_msgs_forward(H5F_t *f, H5O_t *oh)
     hbool_t            did_packing = FALSE;         /* Whether any messages were packed */
     htri_t             ret_value   = FAIL;          /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(oh);
@@ -1976,7 +1976,7 @@ H5O__merge_null(H5F_t *f, H5O_t *oh)
     hbool_t did_merging = FALSE; /* Whether any messages were merged */
     htri_t  ret_value   = FAIL;  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(oh != NULL);
@@ -2124,7 +2124,7 @@ H5O__remove_empty_chunks(H5F_t *f, H5O_t *oh)
     hbool_t did_deleting = FALSE; /* Whether any chunks were deleted */
     htri_t  ret_value    = FAIL;  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(oh != NULL);
@@ -2383,7 +2383,7 @@ H5O__alloc_shrink_chunk(H5F_t *f, H5O_t *oh, unsigned chunkno)
     size_t             u;                         /* Index */
     herr_t             ret_value = SUCCEED;       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);

--- a/src/H5Oattr.c
+++ b/src/H5Oattr.c
@@ -129,7 +129,7 @@ H5O__attr_decode(H5F_t *f, H5O_t *open_oh, unsigned H5_ATTR_UNUSED mesg_flags, u
     unsigned      flags     = 0;    /* Attribute flags */
     H5A_t *       ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -295,7 +295,7 @@ H5O__attr_encode(H5F_t *f, uint8_t *p, const void *mesg)
     unsigned     flags     = 0;   /* Attribute flags */
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -397,7 +397,7 @@ H5O__attr_copy(const void *_src, void *_dst)
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(_src);
@@ -433,7 +433,7 @@ H5O__attr_size(const H5F_t H5_ATTR_UNUSED *f, const void *_mesg)
     size_t       name_len;
     size_t       ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(attr);
 
@@ -509,7 +509,7 @@ H5O__attr_free(void *mesg)
     H5A_t *attr      = (H5A_t *)mesg;
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(mesg);
 
@@ -616,7 +616,7 @@ H5O__attr_pre_copy_file(H5F_t H5_ATTR_UNUSED *file_src, const void *native_src, 
     const H5A_t *attr_src  = (const H5A_t *)native_src; /* Source attribute */
     herr_t       ret_value = SUCCEED;                   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(deleted);
@@ -659,7 +659,7 @@ H5O__attr_copy_file(H5F_t *file_src, const H5O_msg_class_t H5_ATTR_UNUSED *mesg_
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(native_src);
@@ -702,7 +702,7 @@ H5O__attr_post_copy_file(const H5O_loc_t *src_oloc, const void *mesg_src, H5O_lo
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (H5A__attr_post_copy_file(src_oloc, (const H5A_t *)mesg_src, dst_oloc, (H5A_t *)mesg_dst, cpy_info) <
         0)
@@ -729,7 +729,7 @@ H5O__attr_get_crt_index(const void *_mesg, H5O_msg_crt_idx_t *crt_idx /*out*/)
 {
     const H5A_t *attr = (const H5A_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(attr);
     HDassert(crt_idx);
@@ -757,7 +757,7 @@ H5O__attr_set_crt_index(void *_mesg, H5O_msg_crt_idx_t crt_idx)
 {
     H5A_t *attr = (H5A_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(attr);
 
@@ -793,7 +793,7 @@ H5O__attr_debug(H5F_t *f, const void *_mesg, FILE *stream, int indent, int fwidt
     char         buf[128];            /* Temporary string buffer */
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);

--- a/src/H5Oattribute.c
+++ b/src/H5Oattribute.c
@@ -162,7 +162,7 @@ H5O__attr_to_dense_cb(H5O_t *oh, H5O_mesg_t *mesg /*in,out*/, unsigned H5_ATTR_U
     H5A_t *         attr      = (H5A_t *)mesg->native;    /* Pointer to attribute to insert */
     herr_t          ret_value = H5_ITER_CONT;             /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(oh);
@@ -402,7 +402,7 @@ H5O__attr_open_cb(H5O_t *oh, H5O_mesg_t *mesg /*in,out*/, unsigned sequence,
     H5O_iter_opn_t *udata     = (H5O_iter_opn_t *)_udata; /* Operator user data */
     herr_t          ret_value = H5_ITER_CONT;             /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(oh);
@@ -545,7 +545,7 @@ H5O__attr_open_by_idx_cb(const H5A_t *attr, void *_ret_attr)
     H5A_t **ret_attr  = (H5A_t **)_ret_attr; /* 'User data' passed in */
     herr_t  ret_value = H5_ITER_STOP;        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(attr);
@@ -652,7 +652,7 @@ H5O__attr_find_opened_attr(const H5O_loc_t *loc, H5A_t **attr, const char *name_
     size_t        num_open_attr;       /* Number of opened attributes */
     htri_t        ret_value = FALSE;   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get file serial number for the location of attribute */
     if (H5F_get_fileno(loc->file, &loc_fnum) < 0)
@@ -803,7 +803,7 @@ H5O__attr_write_cb(H5O_t *oh, H5O_mesg_t *mesg /*in,out*/, unsigned H5_ATTR_UNUS
     hbool_t            chk_dirtied = FALSE;                    /* Flag for unprotecting chunk */
     herr_t             ret_value   = H5_ITER_CONT;             /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(oh);
@@ -959,7 +959,7 @@ H5O__attr_rename_chk_cb(H5O_t H5_ATTR_UNUSED *oh, H5O_mesg_t *mesg /*in,out*/,
     H5O_iter_ren_t *udata     = (H5O_iter_ren_t *)_udata; /* Operator user data */
     herr_t          ret_value = H5_ITER_CONT;             /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(oh);
@@ -1005,7 +1005,7 @@ H5O__attr_rename_mod_cb(H5O_t *oh, H5O_mesg_t *mesg /*in,out*/, unsigned H5_ATTR
     hbool_t            chk_dirtied = FALSE;                    /* Flag for unprotecting chunk */
     herr_t             ret_value   = H5_ITER_CONT;             /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(oh);
@@ -1344,7 +1344,7 @@ H5O__attr_remove_update(const H5O_loc_t *loc, H5O_t *oh, H5O_ainfo_t *ainfo)
     H5A_attr_table_t atable    = {0, NULL}; /* Table of attributes */
     herr_t           ret_value = SUCCEED;   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(loc);
@@ -1464,7 +1464,7 @@ H5O__attr_remove_cb(H5O_t *oh, H5O_mesg_t *mesg /*in,out*/, unsigned H5_ATTR_UNU
     H5O_iter_rm_t *udata     = (H5O_iter_rm_t *)_udata; /* Operator user data */
     herr_t         ret_value = H5_ITER_CONT;            /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(oh);
@@ -1735,7 +1735,7 @@ H5O__attr_exists_cb(H5O_t H5_ATTR_UNUSED *oh, H5O_mesg_t *mesg /*in,out*/, unsig
     H5O_iter_xst_t *udata     = (H5O_iter_xst_t *)_udata; /* Operator user data */
     herr_t          ret_value = H5_ITER_CONT;             /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(mesg);

--- a/src/H5Obogus.c
+++ b/src/H5Obogus.c
@@ -112,7 +112,7 @@ H5O__bogus_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNUS
     H5O_bogus_t *mesg = NULL;
     void *       ret_value; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -155,7 +155,7 @@ static herr_t
 H5O__bogus_encode(H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_shared, uint8_t *p,
                   const void H5_ATTR_UNUSED *mesg)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -189,7 +189,7 @@ static size_t
 H5O__bogus_size(const H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_shared,
                 const void H5_ATTR_UNUSED *mesg)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(4)
 } /* end H5O__bogus_size() */
@@ -211,7 +211,7 @@ H5O__bogus_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int i
 {
     const H5O_bogus_t *mesg = (const H5O_bogus_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);

--- a/src/H5Obtreek.c
+++ b/src/H5Obtreek.c
@@ -80,7 +80,7 @@ H5O__btreek_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsig
     H5O_btreek_t *mesg;             /* Native message */
     void *        ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);
@@ -124,7 +124,7 @@ H5O__btreek_encode(H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_share
 {
     const H5O_btreek_t *mesg = (const H5O_btreek_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(f);
@@ -161,7 +161,7 @@ H5O__btreek_copy(const void *_mesg, void *_dest)
     H5O_btreek_t *      dest      = (H5O_btreek_t *)_dest;
     void *              ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(mesg);
@@ -200,7 +200,7 @@ H5O__btreek_size(const H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_s
 {
     size_t ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(f);
@@ -230,7 +230,7 @@ H5O__btreek_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int 
 {
     const H5O_btreek_t *mesg = (const H5O_btreek_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(f);

--- a/src/H5Ocache.c
+++ b/src/H5Ocache.c
@@ -159,7 +159,7 @@ H5FL_SEQ_DEFINE(H5O_cont_t);
 static herr_t
 H5O__cache_get_initial_load_size(void H5_ATTR_UNUSED *_udata, size_t *image_len)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image_len);
@@ -190,7 +190,7 @@ H5O__cache_get_final_load_size(const void *image, size_t H5_ATTR_NDEBUG_UNUSED i
     H5O_cache_ud_t *udata     = (H5O_cache_ud_t *)_udata; /* User data for callback */
     herr_t          ret_value = SUCCEED;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -233,7 +233,7 @@ H5O__cache_verify_chksum(const void *_image, size_t len, void *_udata)
     H5O_cache_ud_t *udata     = (H5O_cache_ud_t *)_udata; /* User data for callback */
     htri_t          ret_value = TRUE;                     /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -293,7 +293,7 @@ H5O__cache_deserialize(const void *image, size_t len, void *_udata, hbool_t *dir
     H5O_cache_ud_t *udata     = (H5O_cache_ud_t *)_udata; /* User data for callback */
     void *          ret_value = NULL;                     /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -372,7 +372,7 @@ H5O__cache_image_len(const void *_thing, size_t *image_len)
 {
     const H5O_t *oh = (const H5O_t *)_thing; /* Object header to query */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(oh);
@@ -407,7 +407,7 @@ H5O__cache_serialize(const H5F_t *f, void *image, size_t len, void *_thing)
     uint8_t *chunk_image;          /* Pointer to object header prefix buffer */
     herr_t   ret_value = SUCCEED;  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(f);
@@ -547,7 +547,7 @@ H5O__cache_notify(H5AC_notify_action_t action, void *_thing)
     H5O_t *oh        = (H5O_t *)_thing;
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -631,7 +631,7 @@ H5O__cache_free_icr(void *_thing)
     H5O_t *oh        = (H5O_t *)_thing; /* Object header to destroy */
     herr_t ret_value = SUCCEED;         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(oh);
@@ -666,7 +666,7 @@ H5O__cache_chk_get_initial_load_size(void *_udata, size_t *image_len)
 {
     const H5O_chk_cache_ud_t *udata = (const H5O_chk_cache_ud_t *)_udata; /* User data for callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(udata);
@@ -700,7 +700,7 @@ H5O__cache_chk_verify_chksum(const void *_image, size_t len, void *_udata)
     H5O_chk_cache_ud_t *udata     = (H5O_chk_cache_ud_t *)_udata; /* User data for callback */
     htri_t              ret_value = TRUE;                         /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -742,7 +742,7 @@ H5O__cache_chk_deserialize(const void *image, size_t len, void *_udata, hbool_t 
     H5O_chk_cache_ud_t *udata     = (H5O_chk_cache_ud_t *)_udata; /* User data for callback */
     void *              ret_value = NULL;                         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -819,7 +819,7 @@ H5O__cache_chk_image_len(const void *_thing, size_t *image_len)
 {
     const H5O_chunk_proxy_t *chk_proxy = (const H5O_chunk_proxy_t *)_thing; /* Chunk proxy to query */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(chk_proxy);
@@ -855,7 +855,7 @@ H5O__cache_chk_serialize(const H5F_t *f, void *image, size_t len, void *_thing)
     H5O_chunk_proxy_t *chk_proxy = (H5O_chunk_proxy_t *)_thing; /* Object header chunk to serialize */
     herr_t             ret_value = SUCCEED;                     /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(f);
@@ -897,7 +897,7 @@ H5O__cache_chk_notify(H5AC_notify_action_t action, void *_thing)
     H5O_chunk_proxy_t *chk_proxy = (H5O_chunk_proxy_t *)_thing;
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -1028,7 +1028,7 @@ H5O__cache_chk_free_icr(void *_thing)
     H5O_chunk_proxy_t *chk_proxy = (H5O_chunk_proxy_t *)_thing; /* Object header chunk proxy to release */
     herr_t             ret_value = SUCCEED;                     /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(chk_proxy);
@@ -1063,7 +1063,7 @@ H5O__add_cont_msg(H5O_cont_msgs_t *cont_msg_info, const H5O_cont_t *cont)
     size_t contno;              /* Continuation message index */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(cont_msg_info);
@@ -1110,7 +1110,7 @@ H5O__prefix_deserialize(const uint8_t *_image, H5O_cache_ud_t *udata)
     H5O_t *        oh        = NULL;                    /* Object header read in */
     herr_t         ret_value = SUCCEED;                 /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -1289,7 +1289,7 @@ H5O__chunk_deserialize(H5O_t *oh, haddr_t addr, size_t chunk_size, const uint8_t
         FALSE; /* Whether any messages were modified when the object header was deserialized */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(oh);
@@ -1629,7 +1629,7 @@ H5O__chunk_serialize(const H5F_t *f, H5O_t *oh, unsigned chunkno)
     unsigned    u;                   /* Local index variable */
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(f);

--- a/src/H5Ocache_image.c
+++ b/src/H5Ocache_image.c
@@ -97,7 +97,7 @@ H5O__mdci_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNUSE
     H5O_mdci_t *mesg;             /* Native message        */
     void *      ret_value = NULL; /* Return value          */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);
@@ -140,7 +140,7 @@ H5O__mdci_encode(H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, uint8_t *p, co
 {
     const H5O_mdci_t *mesg = (const H5O_mdci_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(f);
@@ -176,7 +176,7 @@ H5O__mdci_copy(const void *_mesg, void *_dest)
     H5O_mdci_t *      dest      = (H5O_mdci_t *)_dest;
     void *            ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(mesg);
@@ -214,7 +214,7 @@ H5O__mdci_size(const H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, const void
 {
     size_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set return value */
     ret_value = (size_t)(1 +                  /* Version number           */
@@ -241,7 +241,7 @@ H5O__mdci_size(const H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, const void
 static herr_t
 H5O__mdci_free(void *mesg)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(mesg);
 
@@ -269,7 +269,7 @@ H5O__mdci_delete(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, void *_mesg)
     haddr_t     final_eoa;           /* For sanity check */
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -317,7 +317,7 @@ H5O__mdci_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int in
 {
     const H5O_mdci_t *mdci = (const H5O_mdci_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);

--- a/src/H5Ocont.c
+++ b/src/H5Ocont.c
@@ -90,7 +90,7 @@ H5O__cont_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNUSE
     H5O_cont_t *cont      = NULL;
     void *      ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -129,7 +129,7 @@ H5O__cont_encode(H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, uint8_t *p, co
 {
     const H5O_cont_t *cont = (const H5O_cont_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -166,7 +166,7 @@ H5O__cont_size(const H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, const void
 {
     size_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set return value */
     ret_value = (size_t)(H5F_SIZEOF_ADDR(f) + /* Continuation header address */
@@ -190,7 +190,7 @@ H5O__cont_size(const H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, const void
 static herr_t
 H5O__cont_free(void *mesg)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(mesg);
 
@@ -217,7 +217,7 @@ H5O__cont_delete(H5F_t *f, H5O_t *open_oh, void *_mesg)
     H5O_cont_t *mesg      = (H5O_cont_t *)_mesg;
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -249,7 +249,7 @@ H5O__cont_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int in
 {
     const H5O_cont_t *cont = (const H5O_cont_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);

--- a/src/H5Ocopy.c
+++ b/src/H5Ocopy.c
@@ -222,7 +222,7 @@ H5O__copy_header_real(const H5O_loc_t *oloc_src, H5O_loc_t *oloc_dst /*out*/, H5
     size_t                 msghdr_size;
     herr_t                 ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC_TAG(oloc_src->addr)
+    FUNC_ENTER_PACKAGE_TAG(oloc_src->addr)
 
     HDassert(oloc_src);
     HDassert(oloc_src->file);
@@ -904,7 +904,7 @@ H5O__copy_free_addrmap_cb(void *_item, void H5_ATTR_UNUSED *key, void H5_ATTR_UN
 {
     H5O_addr_map_t *item = (H5O_addr_map_t *)_item;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(item);
 
@@ -943,7 +943,7 @@ H5O__copy_header(const H5O_loc_t *oloc_src, H5O_loc_t *oloc_dst /*out */, hid_t 
     unsigned                     cpy_option = 0; /* Copy options */
     herr_t                       ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(oloc_src);
@@ -1040,7 +1040,7 @@ H5O__copy_obj(H5G_loc_t *src_loc, H5G_loc_t *dst_loc, const char *dst_name, hid_
     hbool_t    entry_inserted = FALSE;   /* Flag to indicate that the new entry was inserted into a group */
     herr_t     ret_value      = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(src_loc);
     HDassert(src_loc->oloc->file);
@@ -1098,7 +1098,7 @@ H5O__copy_free_comm_dt_cb(void *item, void *_key, void H5_ATTR_UNUSED *_op_data)
     haddr_t *                      addr = (haddr_t *)item;
     H5O_copy_search_comm_dt_key_t *key  = (H5O_copy_search_comm_dt_key_t *)_key;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(addr);
     HDassert(key);
@@ -1133,7 +1133,7 @@ H5O__copy_comm_dt_cmp(const void *_key1, const void *_key2)
     const H5O_copy_search_comm_dt_key_t *key2      = (const H5O_copy_search_comm_dt_key_t *)_key2;
     int                                  ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check fileno.  It is unlikely to be different so check if they are equal
      * first so only one comparison needs to be made. */
@@ -1176,7 +1176,7 @@ H5O__copy_search_comm_dt_attr_cb(const H5A_t *attr, void *_udata)
     hbool_t                        obj_inserted = FALSE;   /* Object inserted into skip list */
     herr_t                         ret_value    = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(attr);
@@ -1256,7 +1256,7 @@ H5O__copy_search_comm_dt_check(H5O_loc_t *obj_oloc, H5O_copy_search_comm_dt_ud_t
     const H5O_obj_class_t *        obj_class = NULL;     /* Type of object */
     herr_t                         ret_value = SUCCEED;  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(obj_oloc);
@@ -1375,7 +1375,7 @@ H5O__copy_search_comm_dt_cb(hid_t H5_ATTR_UNUSED group, const char *name, const 
     hbool_t    obj_found = FALSE;               /* Object at 'name' found */
     herr_t     ret_value = H5_ITER_CONT;        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(name);
@@ -1436,7 +1436,7 @@ H5O__copy_search_comm_dt(H5F_t *file_src, H5O_t *oh_src, H5O_loc_t *oloc_dst /*i
     H5O_copy_search_comm_dt_ud_t   udata;                       /* Group iteration user data */
     herr_t                         ret_value = FALSE;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(oh_src);
@@ -1601,7 +1601,7 @@ H5O__copy_insert_comm_dt(H5F_t *file_src, H5O_t *oh_src, H5O_loc_t *oloc_dst, H5
     haddr_t *                      addr      = NULL;    /* Destination object address */
     herr_t                         ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(oh_src);

--- a/src/H5Ocopy_ref.c
+++ b/src/H5Ocopy_ref.c
@@ -97,7 +97,7 @@ H5O__copy_obj_by_ref(H5O_loc_t *src_oloc, H5O_loc_t *dst_oloc, H5G_loc_t *dst_ro
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(src_oloc);
     HDassert(dst_oloc);
@@ -161,7 +161,7 @@ H5O__copy_expand_ref_object1(H5O_loc_t *src_oloc, const void *buf_src, H5O_loc_t
     size_t              token_size = H5F_SIZEOF_ADDR(src_oloc->file);
     herr_t              ret_value  = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Making equivalent references in the destination file */
     for (i = 0; i < ref_count; i++) {
@@ -221,7 +221,7 @@ H5O__copy_expand_ref_region1(H5O_loc_t *src_oloc, const void *buf_src, H5O_loc_t
     size_t                 i; /* Local index variable */
     herr_t                 ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Making equivalent references in the destination file */
     for (i = 0; i < ref_count; i++) {
@@ -305,7 +305,7 @@ H5O__copy_expand_ref_object2(H5O_loc_t *src_oloc, hid_t tid_src, const H5T_t *dt
     const unsigned char zeros[H5R_REF_BUF_SIZE] = {0};
     herr_t              ret_value               = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Create datatype ID for src datatype. */
     if ((tid_src == H5I_INVALID_HID) && (tid_src = H5I_register(H5I_DATATYPE, dt_src, FALSE)) < 0)

--- a/src/H5Odeprec.c
+++ b/src/H5Odeprec.c
@@ -91,7 +91,7 @@ static herr_t H5O__get_info_old(H5VL_object_t *vol_obj, H5VL_loc_params_t *loc_p
 static herr_t
 H5O__reset_info1(H5O_info1_t *oinfo)
 {
-    FUNC_ENTER_STATIC_NOERR;
+    FUNC_ENTER_PACKAGE_NOERR;
 
     /* Reset the passed-in info struct */
     HDmemset(oinfo, 0, sizeof(H5O_info1_t));
@@ -124,7 +124,7 @@ H5O__iterate1_adapter(hid_t obj_id, const char *name, const H5O_info2_t *oinfo2,
     unsigned              nat_fields;               /* Fields for native query */
     herr_t                ret_value = H5_ITER_CONT; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(oinfo2);
@@ -223,7 +223,7 @@ H5O__get_info_old(H5VL_object_t *vol_obj, H5VL_loc_params_t *loc_params, H5O_inf
     unsigned nat_fields;          /* Fields for native query */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(vol_obj);

--- a/src/H5Odrvinfo.c
+++ b/src/H5Odrvinfo.c
@@ -82,7 +82,7 @@ H5O__drvinfo_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh,
     H5O_drvinfo_t *mesg;             /* Native message */
     void *         ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);
@@ -139,7 +139,7 @@ H5O__drvinfo_encode(H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_shar
 {
     const H5O_drvinfo_t *mesg = (const H5O_drvinfo_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(f);
@@ -178,7 +178,7 @@ H5O__drvinfo_copy(const void *_mesg, void *_dest)
     H5O_drvinfo_t *      dest      = (H5O_drvinfo_t *)_dest;
     void *               ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(mesg);
@@ -225,7 +225,7 @@ H5O__drvinfo_size(const H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_
     const H5O_drvinfo_t *mesg      = (const H5O_drvinfo_t *)_mesg;
     size_t               ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(f);
@@ -257,7 +257,7 @@ H5O__drvinfo_reset(void *_mesg)
 {
     H5O_drvinfo_t *mesg = (H5O_drvinfo_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(mesg);
@@ -285,7 +285,7 @@ H5O__drvinfo_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int
 {
     const H5O_drvinfo_t *mesg = (const H5O_drvinfo_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(f);

--- a/src/H5Odtype.c
+++ b/src/H5Odtype.c
@@ -131,7 +131,7 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
     size_t   z;
     htri_t   ret_value = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(pp && *pp);
@@ -614,7 +614,7 @@ H5O__dtype_encode_helper(uint8_t **pp, const H5T_t *dt)
     size_t   n, z;
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(pp && *pp);
@@ -1124,7 +1124,7 @@ H5O__dtype_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
     H5T_t *dt        = NULL;
     void * ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(p);
@@ -1167,7 +1167,7 @@ H5O__dtype_encode(H5F_t H5_ATTR_UNUSED *f, uint8_t *p, const void *mesg)
     const H5T_t *dt        = (const H5T_t *)mesg;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -1206,7 +1206,7 @@ H5O__dtype_copy(const void *_src, void *_dst)
     H5T_t *      dst;
     void *       ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(src);
@@ -1252,7 +1252,7 @@ H5O__dtype_size(const H5F_t *f, const void *_mesg)
     unsigned     u;             /* Local index variable */
     size_t       ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(f);
     HDassert(dt);
@@ -1380,7 +1380,7 @@ H5O__dtype_reset(void *_mesg)
 {
     H5T_t *dt = (H5T_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (dt)
         H5T__free(dt);
@@ -1405,7 +1405,7 @@ H5O__dtype_free(void *mesg)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(mesg);
@@ -1436,7 +1436,7 @@ H5O__dtype_set_share(void *_mesg /*in,out*/, const H5O_shared_t *sh)
     H5T_t *dt        = (H5T_t *)_mesg;
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(dt);
     HDassert(sh);
@@ -1492,7 +1492,7 @@ H5O__dtype_can_share(const void *_mesg)
     htri_t       tri_ret;
     htri_t       ret_value = TRUE;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(mesg);
 
@@ -1535,7 +1535,7 @@ H5O__dtype_pre_copy_file(H5F_t *file_src, const void *mesg_src, hbool_t H5_ATTR_
     H5D_copy_file_ud_t *udata     = (H5D_copy_file_ud_t *)_udata; /* Dataset copying user data */
     herr_t              ret_value = SUCCEED;                      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(file_src);
@@ -1590,7 +1590,7 @@ H5O__dtype_copy_file(H5F_t H5_ATTR_UNUSED *file_src, const H5O_msg_class_t *mesg
     H5T_t *dst_mesg;         /* Destination datatype */
     void * ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Perform a normal copy of the object header message */
     if (NULL == (dst_mesg = (H5T_t *)H5O__dtype_copy(native_src, NULL)))
@@ -1630,7 +1630,7 @@ H5O__dtype_shared_post_copy_upd(const H5O_loc_t H5_ATTR_UNUSED *src_oloc, const 
     H5T_t *dt_dst    = (H5T_t *)mesg_dst; /* Destination datatype */
     herr_t ret_value = SUCCEED;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (dt_dst->sh_loc.type == H5O_SHARE_TYPE_COMMITTED) {
         HDassert(H5T_is_named(dt_dst));
@@ -1674,7 +1674,7 @@ H5O__dtype_debug(H5F_t *f, const void *mesg, FILE *stream, int indent, int fwidt
     unsigned     i;
     size_t       k;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);

--- a/src/H5Oefl.c
+++ b/src/H5Oefl.c
@@ -93,7 +93,7 @@ H5O__efl_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNUSED
     size_t      u;                /* Local index variable */
     void *      ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(f);
@@ -192,7 +192,7 @@ H5O__efl_encode(H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, uint8_t *p, con
     const H5O_efl_t *mesg = (const H5O_efl_t *)_mesg;
     size_t           u; /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -256,7 +256,7 @@ H5O__efl_copy(const void *_mesg, void *_dest)
     hbool_t          slot_allocated = FALSE; /* Flag to indicate that dynamic allocation has begun */
     void *           ret_value      = NULL;  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(mesg);
@@ -321,7 +321,7 @@ H5O__efl_size(const H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, const void 
     const H5O_efl_t *mesg      = (const H5O_efl_t *)_mesg;
     size_t           ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -357,7 +357,7 @@ H5O__efl_reset(void *_mesg)
     H5O_efl_t *mesg = (H5O_efl_t *)_mesg;
     size_t     u; /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(mesg);
@@ -439,7 +439,7 @@ H5O__efl_copy_file(H5F_t H5_ATTR_UNUSED *file_src, void *mesg_src, H5F_t *file_d
     size_t     idx, size, name_offset, heap_size;
     void *     ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC_TAG(H5AC__COPIED_TAG)
+    FUNC_ENTER_PACKAGE_TAG(H5AC__COPIED_TAG)
 
     /* check args */
     HDassert(efl_src);
@@ -520,7 +520,7 @@ H5O__efl_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int ind
     const H5O_efl_t *mesg = (const H5O_efl_t *)_mesg;
     size_t           u;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);

--- a/src/H5Ofill.c
+++ b/src/H5Ofill.c
@@ -200,7 +200,7 @@ H5O__fill_new_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh,
     const uint8_t *p_end     = p + p_size - 1; /* End of the p buffer */
     void *         ret_value = NULL;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(f);
     HDassert(p);
@@ -321,7 +321,7 @@ H5O__fill_old_decode(H5F_t *f, H5O_t *open_oh, unsigned H5_ATTR_UNUSED mesg_flag
     const uint8_t *p_end     = p + p_size - 1; /* End of the p buffer */
     void *         ret_value = NULL;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(f);
     HDassert(p);
@@ -399,7 +399,7 @@ H5O__fill_new_encode(H5F_t H5_ATTR_UNUSED *f, uint8_t *p, const void *_fill)
 {
     const H5O_fill_t *fill = (const H5O_fill_t *)_fill;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(f);
     HDassert(p);
@@ -495,7 +495,7 @@ H5O__fill_old_encode(H5F_t H5_ATTR_UNUSED *f, uint8_t *p, const void *_fill)
 {
     const H5O_fill_t *fill = (const H5O_fill_t *)_fill;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(f);
     HDassert(p);
@@ -531,7 +531,7 @@ H5O__fill_copy(const void *_src, void *_dst)
     H5O_fill_t *      dst       = (H5O_fill_t *)_dst;
     void *            ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(src);
 
@@ -649,7 +649,7 @@ H5O__fill_new_size(const H5F_t H5_ATTR_UNUSED *f, const void *_fill)
     const H5O_fill_t *fill      = (const H5O_fill_t *)_fill;
     size_t            ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(f);
     HDassert(fill);
@@ -695,7 +695,7 @@ H5O__fill_old_size(const H5F_t H5_ATTR_UNUSED *f, const void *_fill)
 {
     const H5O_fill_t *fill = (const H5O_fill_t *)_fill;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(fill);
 
@@ -784,7 +784,7 @@ H5O__fill_reset(void *_fill)
 {
     H5O_fill_t *fill = (H5O_fill_t *)_fill;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(fill);
 
@@ -814,7 +814,7 @@ H5O__fill_reset(void *_fill)
 static herr_t
 H5O__fill_free(void *fill)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(fill);
 
@@ -843,7 +843,7 @@ H5O__fill_pre_copy_file(H5F_t H5_ATTR_UNUSED *file_src, const void *mesg_src, hb
     const H5O_fill_t *fill_src  = (const H5O_fill_t *)mesg_src; /* Source fill value */
     herr_t            ret_value = SUCCEED;                      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(cpy_info);
@@ -876,7 +876,7 @@ H5O__fill_debug(H5F_t H5_ATTR_UNUSED *f, const void *_fill, FILE *stream, int in
     const H5O_fill_t *fill = (const H5O_fill_t *)_fill;
     H5D_fill_value_t  fill_status; /* Whether the fill value is defined */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(f);
     HDassert(fill);

--- a/src/H5Oflush.c
+++ b/src/H5Oflush.c
@@ -151,7 +151,7 @@ H5O__oh_tag(const H5O_loc_t *oloc, haddr_t *tag)
     H5O_t *oh        = NULL;    /* Object header */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(oloc);
@@ -290,7 +290,7 @@ H5O__refresh_metadata_close(H5O_loc_t *oloc, H5G_loc_t *obj_loc, hid_t oid)
     hbool_t corked    = FALSE;   /* Whether object's metadata is corked */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Make deep local copy of object's location information */
     if (obj_loc) {

--- a/src/H5Ofsinfo.c
+++ b/src/H5Ofsinfo.c
@@ -99,7 +99,7 @@ H5O__fsinfo_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNU
     const uint8_t *p_end     = p + p_size;
     void *         ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -215,7 +215,7 @@ H5O__fsinfo_encode(H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, uint8_t *p, 
     const H5O_fsinfo_t *fsinfo = (const H5O_fsinfo_t *)_mesg;
     H5F_mem_page_t      ptype; /* Memory type for iteration */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -260,7 +260,7 @@ H5O__fsinfo_copy(const void *_mesg, void *_dest)
     H5O_fsinfo_t *      dest      = (H5O_fsinfo_t *)_dest;
     void *              ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(fsinfo);
@@ -297,7 +297,7 @@ H5O__fsinfo_size(const H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, const vo
     const H5O_fsinfo_t *fsinfo    = (const H5O_fsinfo_t *)_mesg;
     size_t              ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     ret_value = 3                            /* Version, strategy & persist */
                 + (size_t)H5F_SIZEOF_SIZE(f) /* Free-space section threshold */
@@ -326,7 +326,7 @@ H5O__fsinfo_size(const H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, const vo
 static herr_t
 H5O__fsinfo_free(void *mesg)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(mesg);
 
@@ -352,7 +352,7 @@ H5O__fsinfo_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int 
     const H5O_fsinfo_t *fsinfo = (const H5O_fsinfo_t *)_mesg;
     H5F_mem_page_t      ptype; /* Free-space types for iteration */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);

--- a/src/H5Oginfo.c
+++ b/src/H5Oginfo.c
@@ -96,7 +96,7 @@ H5O__ginfo_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
     unsigned char flags;            /* Flags for encoding group info */
     void *        ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(p);
@@ -166,7 +166,7 @@ H5O__ginfo_encode(H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_shared
     const H5O_ginfo_t *ginfo = (const H5O_ginfo_t *)_mesg;
     unsigned char      flags = 0; /* Flags for encoding group info */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(p);
@@ -217,7 +217,7 @@ H5O__ginfo_copy(const void *_mesg, void *_dest)
     H5O_ginfo_t *      dest      = (H5O_ginfo_t *)_dest;
     void *             ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(ginfo);
@@ -256,7 +256,7 @@ H5O__ginfo_size(const H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_sh
     const H5O_ginfo_t *ginfo     = (const H5O_ginfo_t *)_mesg;
     size_t             ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set return value */
     ret_value = 1 +                                             /* Version */
@@ -288,7 +288,7 @@ H5O__ginfo_size(const H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_sh
 static herr_t
 H5O__ginfo_free(void *mesg)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(mesg);
 
@@ -314,7 +314,7 @@ H5O__ginfo_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int i
 {
     const H5O_ginfo_t *ginfo = (const H5O_ginfo_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);

--- a/src/H5Oint.c
+++ b/src/H5Oint.c
@@ -219,7 +219,7 @@ H5O__set_version(H5F_t *f, H5O_t *oh, uint8_t oh_flags, hbool_t store_msg_crt_id
     uint8_t version;             /* Message version */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     HDassert(f);
@@ -1601,7 +1601,7 @@ H5O__delete_oh(H5F_t *f, H5O_t *oh)
     unsigned    u;
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(f);
@@ -1675,7 +1675,7 @@ H5O__obj_type_real(const H5O_t *oh, H5O_type_t *obj_type)
 {
     const H5O_obj_class_t *obj_class; /* Class of object for header */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(oh);
@@ -1751,7 +1751,7 @@ H5O__obj_class_real(const H5O_t *oh)
     size_t                 i;                /* Local index variable */
     const H5O_obj_class_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(oh);
@@ -2100,7 +2100,7 @@ H5O__get_hdr_info_real(const H5O_t *oh, H5O_hdr_info_t *hdr)
     const H5O_chunk_t *curr_chunk; /* Pointer to current message being operated on */
     unsigned           u;          /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(oh);
@@ -2616,7 +2616,7 @@ done:
 static herr_t
 H5O__free_visit_visited(void *item, void H5_ATTR_UNUSED *key, void H5_ATTR_UNUSED *operator_data /*in,out*/)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     item = H5FL_FREE(H5_obj_t, item);
 
@@ -2646,7 +2646,7 @@ H5O__visit_cb(hid_t H5_ATTR_UNUSED group, const char *name, const H5L_info2_t *l
     hbool_t              obj_found = FALSE;                     /* Object at 'name' found */
     herr_t               ret_value = H5_ITER_CONT;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(name);
@@ -3080,7 +3080,7 @@ done:
 static herr_t
 H5O__reset_info2(H5O_info2_t *oinfo)
 {
-    FUNC_ENTER_STATIC_NOERR;
+    FUNC_ENTER_PACKAGE_NOERR;
 
     /* Reset the passed-in info struct */
     HDmemset(oinfo, 0, sizeof(H5O_info2_t));

--- a/src/H5Olayout.c
+++ b/src/H5Olayout.c
@@ -98,7 +98,7 @@ H5O__layout_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNU
     const uint8_t *p_end     = p + p_size - 1; /* End of the p buffer */
     void *         ret_value = NULL;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -599,7 +599,7 @@ H5O__layout_encode(H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, uint8_t *p, 
     unsigned            u;
     herr_t              ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -757,7 +757,7 @@ H5O__layout_copy(const void *_mesg, void *_dest)
     H5O_layout_t *      dest      = (H5O_layout_t *)_dest;
     void *              ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(mesg);
@@ -843,7 +843,7 @@ H5O__layout_size(const H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, const vo
     const H5O_layout_t *mesg      = (const H5O_layout_t *)_mesg;
     size_t              ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -875,7 +875,7 @@ H5O__layout_reset(void *_mesg)
     H5O_layout_t *mesg      = (H5O_layout_t *)_mesg;
     herr_t        ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (mesg) {
         /* Free the compact storage buffer */
@@ -912,7 +912,7 @@ H5O__layout_free(void *_mesg)
 {
     H5O_layout_t *mesg = (H5O_layout_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(mesg);
 
@@ -942,7 +942,7 @@ H5O__layout_delete(H5F_t *f, H5O_t *open_oh, void *_mesg)
     H5O_layout_t *mesg      = (H5O_layout_t *)_mesg;
     herr_t        ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -1004,7 +1004,7 @@ H5O__layout_pre_copy_file(H5F_t H5_ATTR_UNUSED *file_src, const void *mesg_src,
     const H5O_layout_t *layout_src = (const H5O_layout_t *)mesg_src; /* Source layout */
     herr_t              ret_value  = SUCCEED;                        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(cpy_info);
@@ -1044,7 +1044,7 @@ H5O__layout_copy_file(H5F_t *file_src, void *mesg_src, H5F_t *file_dst,
     hbool_t             copied     = FALSE; /* Whether the data was copied */
     void *              ret_value  = NULL;  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(file_src);
@@ -1146,7 +1146,7 @@ H5O__layout_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int 
     const H5O_layout_t *mesg = (const H5O_layout_t *)_mesg;
     size_t              u;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);

--- a/src/H5Olinfo.c
+++ b/src/H5Olinfo.c
@@ -112,7 +112,7 @@ H5O__linfo_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNUS
     unsigned char index_flags;      /* Flags for encoding link index info */
     void *        ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -183,7 +183,7 @@ H5O__linfo_encode(H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, uint8_t *p, c
     const H5O_linfo_t *linfo = (const H5O_linfo_t *)_mesg;
     unsigned char      index_flags; /* Flags for encoding link index info */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -238,7 +238,7 @@ H5O__linfo_copy(const void *_mesg, void *_dest)
     H5O_linfo_t *      dest      = (H5O_linfo_t *)_dest;
     void *             ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(linfo);
@@ -276,7 +276,7 @@ H5O__linfo_size(const H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, const voi
     const H5O_linfo_t *linfo     = (const H5O_linfo_t *)_mesg;
     size_t             ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set return value */
     ret_value =
@@ -306,7 +306,7 @@ H5O__linfo_size(const H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, const voi
 static herr_t
 H5O__linfo_free(void *mesg)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(mesg);
 
@@ -333,7 +333,7 @@ H5O__linfo_delete(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, void *_mesg)
     H5O_linfo_t *linfo     = (H5O_linfo_t *)_mesg;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -372,7 +372,7 @@ H5O__linfo_copy_file(H5F_t H5_ATTR_UNUSED *file_src, void *native_src, H5F_t *fi
     H5G_copy_file_ud_t *udata     = (H5G_copy_file_ud_t *)_udata;
     void *              ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC_TAG(H5AC__COPIED_TAG)
+    FUNC_ENTER_PACKAGE_TAG(H5AC__COPIED_TAG)
 
     /* check args */
     HDassert(linfo_src);
@@ -438,7 +438,7 @@ H5O__linfo_post_copy_file_cb(const H5O_link_t *src_lnk, void *_udata)
     hbool_t                  dst_lnk_init = FALSE;        /* Whether the destination link is initialized */
     herr_t                   ret_value    = H5_ITER_CONT; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(src_lnk);
@@ -488,7 +488,7 @@ H5O__linfo_post_copy_file(const H5O_loc_t *src_oloc, const void *mesg_src, H5O_l
     H5O_linfo_t *      linfo_dst = (H5O_linfo_t *)mesg_dst;
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(src_oloc && src_oloc->file);
@@ -539,7 +539,7 @@ H5O__linfo_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int i
 {
     const H5O_linfo_t *linfo = (const H5O_linfo_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);

--- a/src/H5Olink.c
+++ b/src/H5Olink.c
@@ -120,7 +120,7 @@ H5O__link_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNUSE
     const uint8_t *p_end     = p + p_size; /* End of the p buffer */
     void *         ret_value = NULL;       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -293,7 +293,7 @@ H5O__link_encode(H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, uint8_t *p, co
     uint64_t          len;        /* Length of a string in the message */
     unsigned char     link_flags; /* Flags for encoding link info */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -417,7 +417,7 @@ H5O__link_copy(const void *_mesg, void *_dest)
     H5O_link_t *      dest      = (H5O_link_t *)_dest;
     void *            ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(lnk);
@@ -484,7 +484,7 @@ H5O__link_size(const H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, const void
     size_t            name_size;     /* Size of encoded name length */
     size_t            ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDcompile_assert(sizeof(uint64_t) >= sizeof(size_t));
@@ -553,7 +553,7 @@ H5O__link_reset(void *_mesg)
 {
     H5O_link_t *lnk = (H5O_link_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (lnk) {
         /* Free information for link (but don't free link pointer) */
@@ -586,7 +586,7 @@ H5O__link_free(void *_mesg)
 {
     H5O_link_t *lnk = (H5O_link_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(lnk);
 
@@ -682,7 +682,7 @@ static herr_t
 H5O__link_pre_copy_file(H5F_t H5_ATTR_UNUSED *file_src, const void H5_ATTR_UNUSED *native_src,
                         hbool_t *deleted, const H5O_copy_t *cpy_info, void H5_ATTR_UNUSED *udata)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(deleted);
@@ -721,7 +721,7 @@ H5O__link_copy_file(H5F_t H5_ATTR_UNUSED *file_src, void *native_src, H5F_t H5_A
     H5O_link_t *link_src  = (H5O_link_t *)native_src;
     void *      ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(link_src);
@@ -761,7 +761,7 @@ H5O__link_post_copy_file(const H5O_loc_t *src_oloc, const void *mesg_src, H5O_lo
     H5O_link_t *      link_dst  = (H5O_link_t *)mesg_dst;
     herr_t            ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(link_src);
@@ -798,7 +798,7 @@ H5O__link_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int in
     const H5O_link_t *lnk       = (const H5O_link_t *)_mesg;
     herr_t            ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);

--- a/src/H5Omessage.c
+++ b/src/H5Omessage.c
@@ -579,7 +579,7 @@ H5O__msg_reset_real(const H5O_msg_class_t *type, void *native)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(type);
@@ -1020,7 +1020,7 @@ H5O__msg_remove_cb(H5O_t *oh, H5O_mesg_t *mesg /*in,out*/, unsigned sequence, un
     htri_t         try_remove = FALSE;                   /* Whether to try removing a message */
     herr_t         ret_value  = H5_ITER_CONT;            /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(mesg);
@@ -1882,7 +1882,7 @@ H5O__copy_mesg(H5F_t *f, H5O_t *oh, size_t idx, const H5O_msg_class_t *type, con
     hbool_t            chk_dirtied = FALSE;          /* Flag for unprotecting chunk */
     herr_t             ret_value   = SUCCEED;        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);

--- a/src/H5Omtime.c
+++ b/src/H5Omtime.c
@@ -120,7 +120,7 @@ H5O__mtime_new_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh,
     uint32_t tmp_time;         /* Temporary copy of the time */
     void *   ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -175,7 +175,7 @@ H5O__mtime_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
     int       i;                /* Local index variable */
     void *    ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -228,7 +228,7 @@ H5O__mtime_new_encode(H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_sh
 {
     const time_t *mesg = (const time_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -268,7 +268,7 @@ H5O__mtime_encode(H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_shared
     const time_t *mesg = (const time_t *)_mesg;
     struct tm *   tm;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -305,7 +305,7 @@ H5O__mtime_copy(const void *_mesg, void *_dest)
     time_t *      dest      = (time_t *)_dest;
     void *        ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(mesg);
@@ -343,7 +343,7 @@ static size_t
 H5O__mtime_new_size(const H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_shared,
                     const void H5_ATTR_UNUSED *mesg)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -373,7 +373,7 @@ static size_t
 H5O__mtime_size(const H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_shared,
                 const void H5_ATTR_UNUSED *mesg)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -397,7 +397,7 @@ H5O__mtime_size(const H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_sh
 static herr_t
 H5O__mtime_free(void *mesg)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(mesg);
 
@@ -425,7 +425,7 @@ H5O__mtime_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int i
     struct tm *   tm;
     char          buf[128];
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);

--- a/src/H5Oname.c
+++ b/src/H5Oname.c
@@ -84,7 +84,7 @@ H5O__name_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigne
     H5O_name_t *mesg;
     void *      ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -125,7 +125,7 @@ H5O__name_encode(H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_shared,
 {
     const H5O_name_t *mesg = (const H5O_name_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -160,7 +160,7 @@ H5O__name_copy(const void *_mesg, void *_dest)
     H5O_name_t *      dest      = (H5O_name_t *)_dest;
     void *            ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(mesg);
@@ -207,7 +207,7 @@ H5O__name_size(const H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_sha
     const H5O_name_t *mesg      = (const H5O_name_t *)_mesg;
     size_t            ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -236,7 +236,7 @@ H5O__name_reset(void *_mesg)
 {
     H5O_name_t *mesg = (H5O_name_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(mesg);
@@ -264,7 +264,7 @@ H5O__name_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int in
 {
     const H5O_name_t *mesg = (const H5O_name_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);

--- a/src/H5Opline.c
+++ b/src/H5Opline.c
@@ -122,7 +122,7 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
     const uint8_t *    p_end     = p + p_size - 1; /* End of the p buffer */
     void *             ret_value = NULL;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(p);
@@ -260,7 +260,7 @@ H5O__pline_encode(H5F_t H5_ATTR_UNUSED *f, uint8_t *p /*out*/, const void *mesg)
     const H5Z_filter_info_t *filter;                            /* Filter to encode */
     size_t                   i, j;                              /* Local index variables */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(p);
@@ -362,7 +362,7 @@ H5O__pline_copy(const void *_src, void *_dst /*out*/)
     size_t             i;                               /* Local index variable */
     H5O_pline_t *      ret_value = NULL;                /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate pipeline message, if not provided */
     if (!dst && NULL == (dst = H5FL_MALLOC(H5O_pline_t)))
@@ -453,7 +453,7 @@ H5O__pline_size(const H5F_t H5_ATTR_UNUSED *f, const void *mesg)
     size_t             i;                                 /* Local index variable */
     size_t             ret_value = 0;                     /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Message header */
     ret_value = (size_t)(1 +                                               /*version            */
@@ -515,7 +515,7 @@ H5O__pline_reset(void *mesg)
     H5O_pline_t *pline = (H5O_pline_t *)mesg; /* Pipeline message */
     size_t       i;                           /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* NOTE: This function can be called during error processing from
      *       other API calls so DO NOT ASSUME THAT ANY VALUES ARE SANE.
@@ -565,7 +565,7 @@ H5O__pline_reset(void *mesg)
 static herr_t
 H5O__pline_free(void *mesg)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(mesg);
 
@@ -597,7 +597,7 @@ H5O__pline_pre_copy_file(H5F_t H5_ATTR_UNUSED *file_src, const void *mesg_src,
     H5O_copy_file_ud_common_t *udata     = (H5O_copy_file_ud_common_t *)_udata; /* Object copying user data */
     herr_t                     ret_value = SUCCEED;                             /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(pline_src);
@@ -641,7 +641,7 @@ H5O__pline_debug(H5F_t H5_ATTR_UNUSED *f, const void *mesg, FILE *stream, int in
     const H5O_pline_t *pline = (const H5O_pline_t *)mesg;
     size_t             i, j;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);

--- a/src/H5Orefcount.c
+++ b/src/H5Orefcount.c
@@ -91,7 +91,7 @@ H5O__refcount_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh,
     H5O_refcount_t *refcount  = NULL; /* Reference count */
     void *          ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -136,7 +136,7 @@ H5O__refcount_encode(H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable_sha
 {
     const H5O_refcount_t *refcount = (const H5O_refcount_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -173,7 +173,7 @@ H5O__refcount_copy(const void *_mesg, void *_dest)
     H5O_refcount_t *      dest      = (H5O_refcount_t *)_dest;
     void *                ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(refcount);
@@ -211,7 +211,7 @@ H5O__refcount_size(const H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable
 {
     size_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set return value */
     ret_value = 1    /* Version */
@@ -235,7 +235,7 @@ H5O__refcount_size(const H5F_t H5_ATTR_UNUSED *f, hbool_t H5_ATTR_UNUSED disable
 static herr_t
 H5O__refcount_free(void *mesg)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(mesg);
 
@@ -263,7 +263,7 @@ H5O__refcount_pre_copy_file(H5F_t H5_ATTR_UNUSED *file_src, const void H5_ATTR_U
                             hbool_t *deleted, const H5O_copy_t H5_ATTR_UNUSED *cpy_info,
                             void H5_ATTR_UNUSED *udata)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(deleted);
@@ -294,7 +294,7 @@ H5O__refcount_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, in
 {
     const H5O_refcount_t *refcount = (const H5O_refcount_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);

--- a/src/H5Osdspace.c
+++ b/src/H5Osdspace.c
@@ -114,7 +114,7 @@ H5O__sdspace_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UN
     const uint8_t *p_end     = p + p_size - 1; /* End of the p buffer */
     void *         ret_value = NULL;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -233,7 +233,7 @@ H5O__sdspace_encode(H5F_t *f, uint8_t *p, const void *_mesg)
     unsigned            flags = 0;
     unsigned            u; /* Local counting variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -301,7 +301,7 @@ H5O__sdspace_copy(const void *_mesg, void *_dest)
     H5S_extent_t *      dest      = (H5S_extent_t *)_dest;
     void *              ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(mesg);
@@ -346,7 +346,7 @@ H5O__sdspace_size(const H5F_t *f, const void *_mesg)
     const H5S_extent_t *space     = (const H5S_extent_t *)_mesg;
     size_t              ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Basic information for all dataspace messages */
     ret_value = (size_t)(1 +                                                  /* Version */
@@ -382,7 +382,7 @@ H5O__sdspace_reset(void *_mesg)
 {
     H5S_extent_t *mesg = (H5S_extent_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     H5S__extent_release(mesg);
 
@@ -404,7 +404,7 @@ H5O__sdspace_reset(void *_mesg)
 static herr_t
 H5O__sdspace_free(void *mesg)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(mesg);
 
@@ -436,7 +436,7 @@ H5O__sdspace_pre_copy_file(H5F_t H5_ATTR_UNUSED *file_src, const void *mesg_src,
     H5D_copy_file_ud_t *udata            = (H5D_copy_file_ud_t *)_udata;   /* Dataset copying user data */
     herr_t              ret_value        = SUCCEED;                        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(file_src);
@@ -492,7 +492,7 @@ H5O__sdspace_debug(H5F_t H5_ATTR_UNUSED *f, const void *mesg, FILE *stream, int 
 {
     const H5S_extent_t *sdim = (const H5S_extent_t *)mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);

--- a/src/H5Oshared.c
+++ b/src/H5Oshared.c
@@ -108,7 +108,7 @@ H5O__shared_read(H5F_t *f, H5O_t *open_oh, unsigned *ioflags, const H5O_shared_t
     uint8_t mesg_buf[H5O_MESG_BUF_SIZE]; /* Buffer for deserializing messages */
     void *  ret_value = NULL;            /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -217,7 +217,7 @@ H5O__shared_link_adj(H5F_t *f, H5O_t *open_oh, const H5O_msg_class_t *type, H5O_
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);

--- a/src/H5Oshared.h
+++ b/src/H5Oshared.h
@@ -217,7 +217,7 @@ H5O_SHARED_DELETE(H5F_t *f, H5O_t *open_oh, void *_mesg)
     H5O_shared_t *sh_mesg   = (H5O_shared_t *)_mesg; /* Pointer to shared message portion of actual message */
     herr_t        ret_value = SUCCEED;               /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #ifndef H5O_SHARED_TYPE
 #error "Need to define H5O_SHARED_TYPE macro!"
@@ -268,7 +268,7 @@ H5O_SHARED_LINK(H5F_t *f, H5O_t *open_oh, void *_mesg)
     H5O_shared_t *sh_mesg   = (H5O_shared_t *)_mesg; /* Pointer to shared message portion of actual message */
     herr_t        ret_value = SUCCEED;               /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #ifndef H5O_SHARED_TYPE
 #error "Need to define H5O_SHARED_TYPE macro!"
@@ -319,7 +319,7 @@ H5O_SHARED_COPY_FILE(H5F_t *file_src, void *_native_src, H5F_t *file_dst, hbool_
     void *dst_mesg  = NULL; /* Destination message */
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #ifndef H5O_SHARED_TYPE
 #error "Need to define H5O_SHARED_TYPE macro!"

--- a/src/H5Oshmesg.c
+++ b/src/H5Oshmesg.c
@@ -77,7 +77,7 @@ H5O__shmesg_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNU
     H5O_shmesg_table_t *mesg;             /* Native message */
     void *              ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);
@@ -116,7 +116,7 @@ H5O__shmesg_encode(H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, uint8_t *p, 
 {
     const H5O_shmesg_table_t *mesg = (const H5O_shmesg_table_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(f);
@@ -152,7 +152,7 @@ H5O__shmesg_copy(const void *_mesg, void *_dest)
     H5O_shmesg_table_t *      dest      = (H5O_shmesg_table_t *)_dest;
     void *                    ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(mesg);
@@ -190,7 +190,7 @@ H5O__shmesg_size(const H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, const vo
 {
     size_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(f);
@@ -219,7 +219,7 @@ H5O__shmesg_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int 
 {
     const H5O_shmesg_table_t *mesg = (const H5O_shmesg_table_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(f);

--- a/src/H5Ostab.c
+++ b/src/H5Ostab.c
@@ -95,7 +95,7 @@ H5O__stab_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNUSE
     H5O_stab_t *stab      = NULL;
     void *      ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -135,7 +135,7 @@ H5O__stab_encode(H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, uint8_t *p, co
 {
     const H5O_stab_t *stab = (const H5O_stab_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);
@@ -171,7 +171,7 @@ H5O__stab_copy(const void *_mesg, void *_dest)
     H5O_stab_t *      dest      = (H5O_stab_t *)_dest;
     void *            ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(stab);
@@ -209,7 +209,7 @@ H5O__stab_size(const H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, const void
 {
     size_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set return value */
     ret_value = (size_t)(2 * H5F_SIZEOF_ADDR(f));
@@ -232,7 +232,7 @@ H5O__stab_size(const H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, const void
 static herr_t
 H5O__stab_free(void *mesg)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(mesg);
 
@@ -258,7 +258,7 @@ H5O__stab_delete(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, void *mesg)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(f);
@@ -297,7 +297,7 @@ H5O__stab_copy_file(H5F_t *file_src, void *native_src, H5F_t *file_dst,
     size_t              size_hint;        /* Local heap initial size */
     void *              ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(stab_src);
@@ -358,7 +358,7 @@ H5O__stab_post_copy_file(const H5O_loc_t *src_oloc, const void *mesg_src, H5O_lo
     H5G_bt_it_cpy_t   udata;               /* B-tree user data */
     herr_t            ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(stab_src);
@@ -403,7 +403,7 @@ H5O__stab_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int in
 {
     const H5O_stab_t *stab = (const H5O_stab_t *)_mesg;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(f);

--- a/src/H5Ounknown.c
+++ b/src/H5Ounknown.c
@@ -74,7 +74,7 @@ H5FL_DEFINE(H5O_unknown_t);
 static herr_t
 H5O__unknown_free(void *mesg)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(mesg);
 

--- a/src/H5P.c
+++ b/src/H5P.c
@@ -1122,7 +1122,7 @@ H5P__iterate_cb(H5P_genprop_t *prop, void *_udata)
     H5P_iter_ud_t *udata     = (H5P_iter_ud_t *)_udata; /* Pointer to user data */
     int            ret_value = 0;                       /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(prop);

--- a/src/H5PB.c
+++ b/src/H5PB.c
@@ -362,7 +362,7 @@ H5PB__flush_cb(void *item, void H5_ATTR_UNUSED *key, void *_op_data)
     H5F_shared_t *f_sh       = (H5F_shared_t *)_op_data;
     herr_t        ret_value  = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(page_entry);
@@ -428,7 +428,7 @@ H5PB__dest_cb(void *item, void H5_ATTR_UNUSED *key, void *_op_data)
     H5PB_entry_t *page_entry = (H5PB_entry_t *)item; /* Pointer to page entry node */
     H5PB_ud1_t *  op_data    = (H5PB_ud1_t *)_op_data;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checking */
     HDassert(page_entry);
@@ -1398,7 +1398,7 @@ H5PB__insert_entry(H5PB_t *page_buf, H5PB_entry_t *page_entry)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Insert entry in skip list */
     if (H5SL_insert(page_buf->slist_ptr, page_entry, &(page_entry->addr)) < 0)
@@ -1443,7 +1443,7 @@ H5PB__make_space(H5F_shared_t *f_sh, H5PB_t *page_buf, H5FD_mem_t inserted_type)
     H5PB_entry_t *page_entry;       /* Pointer to page eviction candidate */
     htri_t        ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f_sh);
@@ -1541,7 +1541,7 @@ H5PB__write_entry(H5F_shared_t *f_sh, H5PB_entry_t *page_entry)
     haddr_t eoa;                 /* Current EOA for the file */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f_sh);

--- a/src/H5PLpath.c
+++ b/src/H5PLpath.c
@@ -105,7 +105,7 @@ H5PL__insert_at(const char *path, unsigned int idx)
     char * path_copy = NULL;    /* copy of path string (for storing) */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args - Just assert on package functions */
     HDassert(path);
@@ -155,7 +155,7 @@ H5PL__make_space_at(unsigned int idx)
     unsigned u;                   /* iterator */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args - Just assert on package functions */
     HDassert(idx < H5PL_path_capacity_g);
@@ -186,7 +186,7 @@ H5PL__replace_at(const char *path, unsigned int idx)
     char * path_copy = NULL;    /* copy of path string (for storing) */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args - Just assert on package functions */
     HDassert(path);
@@ -348,7 +348,7 @@ H5PL__expand_path_table(void)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Update the capacity */
     H5PL_path_capacity_g += H5PL_PATH_CAPACITY_ADD;
@@ -610,7 +610,7 @@ H5PL__path_table_iterate_process_path(const char *plugin_path, H5PL_iterate_type
     struct dirent *dp        = NULL; /* Directory entry */
     herr_t         ret_value = H5_ITER_CONT;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(plugin_path);
     HDassert(iter_op);
@@ -701,7 +701,7 @@ H5PL__path_table_iterate_process_path(const char *plugin_path, H5PL_iterate_type
     char             service[2048];
     herr_t           ret_value = H5_ITER_CONT;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args - Just assert on package functions */
     HDassert(plugin_path);
@@ -841,7 +841,7 @@ H5PL__find_plugin_in_path(const H5PL_search_params_t *search_params, hbool_t *fo
     struct dirent *dp        = NULL; /* Directory entry */
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args - Just assert on package functions */
     HDassert(search_params);
@@ -922,7 +922,7 @@ H5PL__find_plugin_in_path(const H5PL_search_params_t *search_params, hbool_t *fo
     char             service[2048];
     herr_t           ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args - Just assert on package functions */
     HDassert(search_params);

--- a/src/H5PLplugin_cache.c
+++ b/src/H5PLplugin_cache.c
@@ -175,7 +175,7 @@ H5PL__expand_cache(void)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Update the capacity */
     H5PL_cache_capacity_g += H5PL_CACHE_CAPACITY_ADD;

--- a/src/H5Pdapl.c
+++ b/src/H5Pdapl.c
@@ -197,7 +197,7 @@ H5P__dacc_reg_prop(H5P_genclass_t *pclass)
     hsize_t        printf_gap   = H5D_ACS_VDS_PRINTF_GAP_DEF; /* Default VDS printf gap */
     herr_t         ret_value    = SUCCEED;                    /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Register the size of raw data chunk cache (elements) */
     if (H5P__register_real(pclass, H5D_ACS_DATA_CACHE_NUM_SLOTS_NAME, H5D_ACS_DATA_CACHE_NUM_SLOTS_SIZE,
@@ -266,7 +266,7 @@ static herr_t
 H5P__dapl_vds_file_pref_set(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *name,
                             size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(value);
@@ -290,7 +290,7 @@ static herr_t
 H5P__dapl_vds_file_pref_get(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *name,
                             size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(value);
@@ -320,7 +320,7 @@ H5P__dapl_vds_file_pref_enc(const void *value, void **_pp, size_t *size)
     uint64_t    enc_value;
     unsigned    enc_size;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDcompile_assert(sizeof(size_t) <= sizeof(uint64_t));
 
@@ -371,7 +371,7 @@ H5P__dapl_vds_file_pref_dec(const void **_pp, void *_value)
     unsigned        enc_size;  /* Size of encoded property */
     herr_t          ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(pp);
     HDassert(*pp);
@@ -414,7 +414,7 @@ static herr_t
 H5P__dapl_vds_file_pref_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *name,
                             size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(value);
 
@@ -434,7 +434,7 @@ H5P__dapl_vds_file_pref_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNU
 static herr_t
 H5P__dapl_vds_file_pref_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(value);
 
@@ -460,7 +460,7 @@ H5P__dapl_vds_file_pref_cmp(const void *value1, const void *value2, size_t H5_AT
     const char *pref2     = *(const char *const *)value2;
     int         ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (NULL == pref1 && NULL != pref2)
         HGOTO_DONE(1);
@@ -484,7 +484,7 @@ done:
 static herr_t
 H5P__dapl_vds_file_pref_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(value);
 
@@ -506,7 +506,7 @@ static herr_t
 H5P__dapl_efile_pref_set(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *name,
                          size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(value);
@@ -530,7 +530,7 @@ static herr_t
 H5P__dapl_efile_pref_get(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *name,
                          size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(value);
@@ -560,7 +560,7 @@ H5P__dapl_efile_pref_enc(const void *value, void **_pp, size_t *size)
     uint64_t    enc_value;
     unsigned    enc_size;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDcompile_assert(sizeof(size_t) <= sizeof(uint64_t));
 
@@ -611,7 +611,7 @@ H5P__dapl_efile_pref_dec(const void **_pp, void *_value)
     unsigned        enc_size;  /* Size of encoded property */
     herr_t          ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(pp);
     HDassert(*pp);
@@ -654,7 +654,7 @@ static herr_t
 H5P__dapl_efile_pref_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *name,
                          size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(value);
 
@@ -674,7 +674,7 @@ H5P__dapl_efile_pref_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED
 static herr_t
 H5P__dapl_efile_pref_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(value);
 
@@ -700,7 +700,7 @@ H5P__dapl_efile_pref_cmp(const void *value1, const void *value2, size_t H5_ATTR_
     const char *pref2     = *(const char *const *)value2;
     int         ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (NULL == pref1 && NULL != pref2)
         HGOTO_DONE(1);
@@ -724,7 +724,7 @@ done:
 static herr_t
 H5P__dapl_efile_pref_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(value);
 
@@ -870,7 +870,7 @@ H5P__encode_chunk_cache_nslots(const void *value, void **_pp, size_t *size)
     uint8_t **pp        = (uint8_t **)_pp;
     unsigned  enc_size; /* Size of encoded property */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDcompile_assert(sizeof(size_t) <= sizeof(uint64_t));
@@ -925,7 +925,7 @@ H5P__decode_chunk_cache_nslots(const void **_pp, void *_value)
     uint64_t        enc_value; /* Decoded property value */
     unsigned        enc_size;  /* Size of encoded property */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDcompile_assert(sizeof(size_t) <= sizeof(uint64_t));
@@ -970,7 +970,7 @@ H5P__encode_chunk_cache_nbytes(const void *value, void **_pp, size_t *size)
     uint8_t **pp        = (uint8_t **)_pp;
     unsigned  enc_size; /* Size of encoded property */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDcompile_assert(sizeof(size_t) <= sizeof(uint64_t));
@@ -1025,7 +1025,7 @@ H5P__decode_chunk_cache_nbytes(const void **_pp, void *_value)
     uint64_t        enc_value; /* Decoded property value */
     unsigned        enc_size;  /* Size of encoded property */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDcompile_assert(sizeof(size_t) <= sizeof(uint64_t));
@@ -1141,7 +1141,7 @@ H5P__dacc_vds_view_enc(const void *value, void **_pp, size_t *size)
     const H5D_vds_view_t *view = (const H5D_vds_view_t *)value; /* Create local alias for values */
     uint8_t **            pp   = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(view);
@@ -1173,7 +1173,7 @@ H5P__dacc_vds_view_dec(const void **_pp, void *_value)
     H5D_vds_view_t *view = (H5D_vds_view_t *)_value;
     const uint8_t **pp   = (const uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(pp);

--- a/src/H5Pdcpl.c
+++ b/src/H5Pdcpl.c
@@ -349,7 +349,7 @@ H5P__dcrt_reg_prop(H5P_genclass_t *pclass)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Register the storage layout property */
     if (H5P__register_real(pclass, H5D_CRT_LAYOUT_NAME, H5D_CRT_LAYOUT_SIZE, &H5D_def_layout_g, NULL,
@@ -410,7 +410,7 @@ H5P__dcrt_layout_set(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *na
     H5O_layout_t  new_layout;
     herr_t        ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -447,7 +447,7 @@ H5P__dcrt_layout_get(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *na
     H5O_layout_t  new_layout;
     herr_t        ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -488,7 +488,7 @@ H5P__dcrt_layout_enc(const void *value, void **_pp, size_t *size)
     size_t              u;                   /* Local index variable */
     herr_t              ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(layout);
@@ -622,7 +622,7 @@ H5P__dcrt_layout_dec(const void **_pp, void *value)
     const uint8_t **    pp        = (const uint8_t **)_pp;
     herr_t              ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(pp);
@@ -816,7 +816,7 @@ H5P__dcrt_layout_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *na
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -849,7 +849,7 @@ H5P__dcrt_layout_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED siz
     H5O_layout_t  new_layout;
     herr_t        ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(layout);
 
@@ -887,7 +887,7 @@ H5P__dcrt_layout_cmp(const void *_layout1, const void *_layout2, size_t H5_ATTR_
         *layout2                = (const H5O_layout_t *)_layout2;
     herr_t ret_value            = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(layout1);
@@ -1015,7 +1015,7 @@ H5P__dcrt_layout_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED si
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -1049,7 +1049,7 @@ H5P__dcrt_fill_value_set(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED
     H5O_fill_t  new_fill;
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -1086,7 +1086,7 @@ H5P__dcrt_fill_value_get(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED
     H5O_fill_t  new_fill;
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -1127,7 +1127,7 @@ H5P__dcrt_fill_value_enc(const void *value, void **_pp, size_t *size)
     uint64_t          enc_value;
     unsigned          enc_size = 0;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDcompile_assert(sizeof(size_t) <= sizeof(uint64_t));
@@ -1218,7 +1218,7 @@ H5P__dcrt_fill_value_dec(const void **_pp, void *_value)
     const uint8_t **pp        = (const uint8_t **)_pp;
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDcompile_assert(sizeof(size_t) <= sizeof(uint64_t));
     HDcompile_assert(sizeof(ssize_t) <= sizeof(int64_t));
@@ -1281,7 +1281,7 @@ H5P__dcrt_fill_value_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -1314,7 +1314,7 @@ H5P__dcrt_fill_value_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED
     H5O_fill_t  new_fill;
     herr_t      ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(fill);
 
@@ -1417,7 +1417,7 @@ H5P__dcrt_fill_value_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSE
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -1451,7 +1451,7 @@ H5P__dcrt_ext_file_list_set(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNU
     H5O_efl_t  new_efl;
     herr_t     ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -1488,7 +1488,7 @@ H5P__dcrt_ext_file_list_get(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNU
     H5O_efl_t  new_efl;
     herr_t     ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -1529,7 +1529,7 @@ H5P__dcrt_ext_file_list_enc(const void *value, void **_pp, size_t *size)
     unsigned         enc_size;
     uint64_t         enc_value;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(efl);
@@ -1614,7 +1614,7 @@ H5P__dcrt_ext_file_list_dec(const void **_pp, void *_value)
     uint64_t        enc_value;
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(pp);
@@ -1695,7 +1695,7 @@ H5P__dcrt_ext_file_list_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNU
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -1728,7 +1728,7 @@ H5P__dcrt_ext_file_list_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNU
     H5O_efl_t  new_efl;
     herr_t     ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(efl);
 
@@ -1767,7 +1767,7 @@ H5P__dcrt_ext_file_list_cmp(const void *_efl1, const void *_efl2, size_t H5_ATTR
     int    cmp_value;     /* Value from comparison */
     herr_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(efl1);
@@ -1847,7 +1847,7 @@ H5P__dcrt_ext_file_list_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UN
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -1878,7 +1878,7 @@ H5P__set_layout(H5P_genplist_t *plist, const H5O_layout_t *layout)
     unsigned alloc_time_state;    /* State of allocation time property */
     herr_t   ret_value = SUCCEED; /* return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get the allocation time state */
     if (H5P_get(plist, H5D_CRT_ALLOC_TIME_STATE_NAME, &alloc_time_state) < 0)
@@ -1949,7 +1949,7 @@ H5P__init_def_layout(void)
     const H5O_storage_chunk_t   def_store_chunk   = H5D_DEF_STORAGE_CHUNK_INIT;
     const H5O_storage_virtual_t def_store_virtual = H5D_DEF_STORAGE_VIRTUAL_INIT;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Initialize the default layout info for non-contigous layouts */
     H5D_def_layout_compact_g.storage.type      = H5D_COMPACT;

--- a/src/H5Pdxpl.c
+++ b/src/H5Pdxpl.c
@@ -295,7 +295,7 @@ H5P__dxfr_reg_prop(H5P_genclass_t *pclass)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Register the max. temp buffer size property */
     if (H5P__register_real(pclass, H5D_XFER_MAX_TEMP_BUF_NAME, H5D_XFER_MAX_TEMP_BUF_SIZE,
@@ -467,7 +467,7 @@ H5P__dxfr_bkgr_buf_type_enc(const void *value, void **_pp, size_t *size)
     const H5T_bkg_t *bkgr_buf_type = (const H5T_bkg_t *)value; /* Create local alias for values */
     uint8_t **       pp            = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(bkgr_buf_type);
@@ -504,7 +504,7 @@ H5P__dxfr_bkgr_buf_type_dec(const void **_pp, void *_value)
     H5T_bkg_t *     bkgr_buf_type = (H5T_bkg_t *)_value; /* Background buffer type */
     const uint8_t **pp            = (const uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(pp);
@@ -538,7 +538,7 @@ H5P__dxfr_btree_split_ratio_enc(const void *value, void **_pp, size_t *size)
     const double *btree_split_ratio = (const double *)value; /* Create local alias for values */
     uint8_t **    pp                = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(btree_split_ratio);
@@ -589,7 +589,7 @@ H5P__dxfr_btree_split_ratio_dec(const void **_pp, void *_value)
     const uint8_t **pp        = (const uint8_t **)_pp;
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(pp);
@@ -629,7 +629,7 @@ H5P__dxfr_xform_set(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *nam
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -661,7 +661,7 @@ H5P__dxfr_xform_get(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *nam
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -699,7 +699,7 @@ H5P__dxfr_xform_enc(const void *value, void **_pp, size_t *size)
     uint8_t **  pp        = (uint8_t **)_pp;
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDcompile_assert(sizeof(size_t) <= sizeof(uint64_t));
@@ -771,7 +771,7 @@ H5P__dxfr_xform_dec(const void **_pp, void *_value)
     uint64_t           enc_value;
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(pp);
@@ -816,7 +816,7 @@ H5P__dxfr_xform_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *nam
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(value);
 
@@ -846,7 +846,7 @@ H5P__dxfr_xform_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -882,7 +882,7 @@ H5P__dxfr_xform_cmp(const void *_xform1, const void *_xform2, size_t H5_ATTR_UNU
     const char *pexp1, *pexp2;                    /* Pointers to transform expressions */
     herr_t      ret_value = 0;                    /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(xform1);
@@ -936,7 +936,7 @@ H5P__dxfr_xform_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED siz
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(value);
 
@@ -1756,7 +1756,7 @@ H5P__dxfr_io_xfer_mode_enc(const void *value, void **_pp, size_t *size)
     const H5FD_mpio_xfer_t *xfer_mode = (const H5FD_mpio_xfer_t *)value; /* Create local alias for values */
     uint8_t **              pp        = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(xfer_mode);
@@ -1793,7 +1793,7 @@ H5P__dxfr_io_xfer_mode_dec(const void **_pp, void *_value)
     H5FD_mpio_xfer_t *xfer_mode = (H5FD_mpio_xfer_t *)_value; /* I/O transfer mode */
     const uint8_t **  pp        = (const uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(pp);
@@ -1828,7 +1828,7 @@ H5P__dxfr_mpio_collective_opt_enc(const void *value, void **_pp, size_t *size)
         (const H5FD_mpio_collective_opt_t *)value; /* Create local alias for values */
     uint8_t **pp = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(coll_opt);
@@ -1866,7 +1866,7 @@ H5P__dxfr_mpio_collective_opt_dec(const void **_pp, void *_value)
         (H5FD_mpio_collective_opt_t *)_value; /* MPI-I/O collective optimization mode */
     const uint8_t **pp = (const uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(pp);
@@ -1901,7 +1901,7 @@ H5P__dxfr_mpio_chunk_opt_hard_enc(const void *value, void **_pp, size_t *size)
         (const H5FD_mpio_chunk_opt_t *)value; /* Create local alias for values */
     uint8_t **pp = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(chunk_opt);
@@ -1938,7 +1938,7 @@ H5P__dxfr_mpio_chunk_opt_hard_dec(const void **_pp, void *_value)
     H5FD_mpio_chunk_opt_t *chunk_opt = (H5FD_mpio_chunk_opt_t *)_value; /* MPI-I/O chunk optimization mode */
     const uint8_t **       pp        = (const uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(pp);
@@ -2082,7 +2082,7 @@ H5P__dxfr_edc_enc(const void *value, void **_pp, size_t *size)
     const H5Z_EDC_t *check = (const H5Z_EDC_t *)value; /* Create local alias for values */
     uint8_t **       pp    = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(check);
@@ -2119,7 +2119,7 @@ H5P__dxfr_edc_dec(const void **_pp, void *_value)
     H5Z_EDC_t *     check = (H5Z_EDC_t *)_value; /* EDC property */
     const uint8_t **pp    = (const uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(pp);
@@ -2151,7 +2151,7 @@ H5P__dxfr_dset_io_hyp_sel_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_U
     H5S_t *new_space  = NULL;             /* New dataspace for property */
     herr_t ret_value  = SUCCEED;          /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* If there's a dataspace I/O selection set, copy it */
     if (orig_space) {
@@ -2192,7 +2192,7 @@ H5P__dxfr_dset_io_hyp_sel_cmp(const void *_space1, const void *_space2, size_t H
     const H5S_t *const *space2    = (const H5S_t *const *)_space2; /* Create local aliases for values */
     herr_t              ret_value = 0;                             /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(space1);
@@ -2249,7 +2249,7 @@ H5P__dxfr_dset_io_hyp_sel_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_
     H5S_t *space     = *(H5S_t **)_value; /* Dataspace for property */
     herr_t ret_value = SUCCEED;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Release any dataspace */
     if (space && H5S_close(space) < 0)

--- a/src/H5Pencdec.c
+++ b/src/H5Pencdec.c
@@ -319,7 +319,7 @@ H5P__encode_cb(H5P_genprop_t *prop, void *_udata)
     H5P_enc_iter_ud_t *udata     = (H5P_enc_iter_ud_t *)_udata; /* Pointer to user data */
     int                ret_value = H5_ITER_CONT;                /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(prop);

--- a/src/H5Pfapl.c
+++ b/src/H5Pfapl.c
@@ -549,7 +549,7 @@ H5P__facc_reg_prop(H5P_genclass_t *pclass)
         H5F_ACS_VOL_CONN_DEF;   /* Default VOL connector ID & info (initialized from a variable) */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Register the initial metadata cache resize configuration */
     if (H5P__register_real(pclass, H5F_ACS_META_CACHE_INIT_CONFIG_NAME, H5F_ACS_META_CACHE_INIT_CONFIG_SIZE,
@@ -849,7 +849,7 @@ H5P__facc_set_def_driver(void)
     hid_t       driver_id      = H5I_INVALID_HID; /* VFL driver ID */
     herr_t      ret_value      = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if VFL driver environment variable is set */
     driver_env_var = HDgetenv(HDF5_DRIVER);
@@ -944,7 +944,7 @@ H5P__facc_set_def_driver_check_predefined(const char *driver_name, hid_t *driver
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(driver_name);
     HDassert(driver_id);
@@ -1672,7 +1672,7 @@ H5P__file_driver_copy(void *value)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (value) {
         H5FD_driver_prop_t *info = (H5FD_driver_prop_t *)value; /* Driver ID & info struct */
@@ -1742,7 +1742,7 @@ H5P__file_driver_free(void *value)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (value) {
         H5FD_driver_prop_t *info = (H5FD_driver_prop_t *)value; /* Driver ID & info struct */
@@ -1785,7 +1785,7 @@ H5P__facc_file_driver_create(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNU
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Make copy of file driver */
     if (H5P__file_driver_copy(value) < 0)
@@ -1814,7 +1814,7 @@ H5P__facc_file_driver_set(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSE
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -1846,7 +1846,7 @@ H5P__facc_file_driver_get(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSE
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -1878,7 +1878,7 @@ H5P__facc_file_driver_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSE
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Free the file driver ID & info */
     if (H5P__file_driver_free(value) < 0)
@@ -1906,7 +1906,7 @@ H5P__facc_file_driver_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSE
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Make copy of file driver */
     if (H5P__file_driver_copy(value) < 0)
@@ -1941,7 +1941,7 @@ H5P__facc_file_driver_cmp(const void *_info1, const void *_info2, size_t H5_ATTR
     int           cmp_value;     /* Value from comparison */
     herr_t        ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(info1);
@@ -2008,7 +2008,7 @@ H5P__facc_file_driver_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUS
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Free the file driver */
     if (H5P__file_driver_free(value) < 0)
@@ -3420,7 +3420,7 @@ H5P__file_image_info_copy(void *value)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (value) {
         H5FD_file_image_info_t *info; /* Image info struct */
@@ -3494,7 +3494,7 @@ H5P__file_image_info_free(void *value)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (value) {
         H5FD_file_image_info_t *info; /* Image info struct */
@@ -3551,7 +3551,7 @@ H5P__facc_cache_image_config_cmp(const void *_config1, const void *_config2, siz
         (const H5AC_cache_image_config_t *)_config2; /* Create local aliases for values */
     int ret_value = 0;                               /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check for a property being set */
     if (config1 == NULL && config2 != NULL)
@@ -3605,7 +3605,7 @@ H5P__facc_cache_image_config_enc(const void *value, void **_pp, size_t *size)
         (const H5AC_cache_image_config_t *)value; /* Create local aliases for value */
     uint8_t **pp = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(value);
@@ -3652,7 +3652,7 @@ H5P__facc_cache_image_config_dec(const void **_pp, void *_value)
     unsigned                   enc_size;
     herr_t                     ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(pp);
@@ -3699,7 +3699,7 @@ H5P__facc_file_image_info_set(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_U
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -3731,7 +3731,7 @@ H5P__facc_file_image_info_get(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_U
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -3765,7 +3765,7 @@ H5P__facc_file_image_info_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_U
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Free the file image info */
     if (H5P__file_image_info_free(value) < 0)
@@ -3794,7 +3794,7 @@ H5P__facc_file_image_info_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_U
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Make copy of file image info */
     if (H5P__file_image_info_copy(value) < 0)
@@ -3827,7 +3827,7 @@ H5P__facc_file_image_info_cmp(const void *_info1, const void *_info2, size_t H5_
         *info2       = (const H5FD_file_image_info_t *)_info2;
     herr_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(info1);
@@ -3893,7 +3893,7 @@ H5P__facc_file_image_info_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Free the file image info */
     if (H5P__file_image_info_free(value) < 0)
@@ -3925,7 +3925,7 @@ H5P__facc_cache_config_cmp(const void *_config1, const void *_config2, size_t H5
         (const H5AC_cache_config_t *)_config2; /* Create local aliases for values */
     int ret_value = 0;                         /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check for a property being set */
     if (config1 == NULL && config2 != NULL)
@@ -4096,7 +4096,7 @@ H5P__facc_cache_config_enc(const void *value, void **_pp, size_t *size)
     unsigned  enc_size;  /* Size of encoded property */
     uint64_t  enc_value; /* Property to encode */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(value);
@@ -4241,7 +4241,7 @@ H5P__facc_cache_config_dec(const void **_pp, void *_value)
     uint64_t             enc_value;
     herr_t               ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(pp);
@@ -4373,7 +4373,7 @@ H5P__facc_fclose_degree_enc(const void *value, void **_pp, size_t *size)
         (const H5F_close_degree_t *)value; /* Create local alias for values */
     uint8_t **pp = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(fclose_degree);
@@ -4410,7 +4410,7 @@ H5P__facc_fclose_degree_dec(const void **_pp, void *_value)
     H5F_close_degree_t *fclose_degree = (H5F_close_degree_t *)_value; /* File close degree */
     const uint8_t **    pp            = (const uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(pp);
@@ -4444,7 +4444,7 @@ H5P__facc_multi_type_enc(const void *value, void **_pp, size_t *size)
     const H5FD_mem_t *type = (const H5FD_mem_t *)value; /* Create local alias for values */
     uint8_t **        pp   = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(type);
@@ -4481,7 +4481,7 @@ H5P__facc_multi_type_dec(const void **_pp, void *_value)
     H5FD_mem_t *    type = (H5FD_mem_t *)_value; /* File close degree */
     const uint8_t **pp   = (const uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(pp);
@@ -4514,7 +4514,7 @@ H5P__facc_libver_type_enc(const void *value, void **_pp, size_t *size)
     const H5F_libver_t *type = (const H5F_libver_t *)value; /* Create local alias for values */
     uint8_t **          pp   = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(type);
@@ -4550,7 +4550,7 @@ H5P__facc_libver_type_dec(const void **_pp, void *_value)
     H5F_libver_t *  type = (H5F_libver_t *)_value;
     const uint8_t **pp   = (const uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(pp);
@@ -4848,7 +4848,7 @@ H5P__facc_mdc_log_location_enc(const void *value, void **_pp, size_t *size)
     uint64_t    enc_value;
     unsigned    enc_size;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDcompile_assert(sizeof(size_t) <= sizeof(uint64_t));
 
@@ -4901,7 +4901,7 @@ H5P__facc_mdc_log_location_dec(const void **_pp, void *_value)
     unsigned        enc_size;  /* Size of encoded property */
     herr_t          ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(pp);
     HDassert(*pp);
@@ -4945,7 +4945,7 @@ static herr_t
 H5P__facc_mdc_log_location_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *name,
                                size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(value);
 
@@ -4966,7 +4966,7 @@ H5P__facc_mdc_log_location_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_
 static herr_t
 H5P__facc_mdc_log_location_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(value);
 
@@ -4993,7 +4993,7 @@ H5P__facc_mdc_log_location_cmp(const void *value1, const void *value2, size_t H5
     const char *pref2     = *(const char *const *)value2;
     int         ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (NULL == pref1 && NULL != pref2)
         HGOTO_DONE(1);
@@ -5019,7 +5019,7 @@ done:
 static herr_t
 H5P__facc_mdc_log_location_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(value);
 
@@ -5266,7 +5266,7 @@ H5P__decode_coll_md_read_flag_t(const void **_pp, void *_value)
     H5P_coll_md_read_flag_t *coll_md_read_flag = (H5P_coll_md_read_flag_t *)_value; /* File close degree */
     const uint8_t **         pp                = (const uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(pp);
@@ -5528,7 +5528,7 @@ H5P__facc_mpi_comm_set(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *
     MPI_Comm  comm_tmp  = MPI_COMM_NULL;
     herr_t    ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Make a copy of the MPI communicator */
     if (H5_mpi_comm_dup(*comm, &comm_tmp) < 0)
@@ -5562,7 +5562,7 @@ H5P__facc_mpi_comm_get(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *
     MPI_Comm  comm_tmp  = MPI_COMM_NULL;
     herr_t    ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Make a copy of the MPI communicator */
     if (H5_mpi_comm_dup(*comm, &comm_tmp) < 0)
@@ -5595,7 +5595,7 @@ H5P__facc_mpi_comm_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *
     MPI_Comm *comm      = (MPI_Comm *)value;
     herr_t    ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Free the MPI communicator */
     if (H5_mpi_comm_free(comm) < 0)
@@ -5622,7 +5622,7 @@ H5P__facc_mpi_comm_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED s
     MPI_Comm  comm_tmp  = MPI_COMM_NULL;
     herr_t    ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Make a copy of the MPI communicator */
     if (H5_mpi_comm_dup(*comm, &comm_tmp) < 0)
@@ -5658,7 +5658,7 @@ H5P__facc_mpi_comm_cmp(const void *_comm1, const void *_comm2, size_t H5_ATTR_UN
     const MPI_Comm *comm2     = (const MPI_Comm *)_comm2;
     int             ret_value = 0;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Compare the MPI communicators */
     if (H5_mpi_comm_cmp(*comm1, *comm2, &ret_value) < 0)
@@ -5684,7 +5684,7 @@ H5P__facc_mpi_comm_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED 
     MPI_Comm *comm      = (MPI_Comm *)value;
     herr_t    ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Free the MPI communicator */
     if (H5_mpi_comm_free(comm) < 0)
@@ -5712,7 +5712,7 @@ H5P__facc_mpi_info_set(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *
     MPI_Info  info_tmp  = MPI_INFO_NULL;
     herr_t    ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Make a copy of the MPI info object */
     if (H5_mpi_info_dup(*info, &info_tmp) < 0)
@@ -5746,7 +5746,7 @@ H5P__facc_mpi_info_get(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *
     MPI_Info  info_tmp  = MPI_INFO_NULL;
     herr_t    ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Make a copy of the MPI communicator */
     if (H5_mpi_info_dup(*info, &info_tmp) < 0)
@@ -5779,7 +5779,7 @@ H5P__facc_mpi_info_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *
     MPI_Info *info      = (MPI_Info *)value;
     herr_t    ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Free the MPI info object */
     if (H5_mpi_info_free(info) < 0)
@@ -5806,7 +5806,7 @@ H5P__facc_mpi_info_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED s
     MPI_Info  info_tmp  = MPI_INFO_NULL;
     herr_t    ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Make a copy of the MPI info object */
     if (H5_mpi_info_dup(*info, &info_tmp) < 0)
@@ -5842,7 +5842,7 @@ H5P__facc_mpi_info_cmp(const void *_info1, const void *_info2, size_t H5_ATTR_UN
     const MPI_Info *info2     = (const MPI_Info *)_info2;
     int             ret_value = 0;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Compare the MPI info objects */
     if (H5_mpi_info_cmp(*info1, *info2, &ret_value) < 0)
@@ -5868,7 +5868,7 @@ H5P__facc_mpi_info_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED 
     MPI_Info *info      = (MPI_Info *)value;
     herr_t    ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Free the MPI info object */
     if (H5_mpi_info_free(info) < 0)
@@ -6292,7 +6292,7 @@ H5P__facc_vol_create(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Make copy of the VOL connector */
     if (H5VL_conn_copy((H5VL_connector_prop_t *)value) < 0)
@@ -6318,7 +6318,7 @@ H5P__facc_vol_set(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *name,
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -6347,7 +6347,7 @@ H5P__facc_vol_get(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *name,
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -6376,7 +6376,7 @@ H5P__facc_vol_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *name,
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Free the VOL connector ID & info */
     if (H5VL_conn_free((H5VL_connector_prop_t *)value) < 0)
@@ -6401,7 +6401,7 @@ H5P__facc_vol_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size, 
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Make copy of VOL connector */
     if (H5VL_conn_copy((H5VL_connector_prop_t *)value) < 0)
@@ -6435,7 +6435,7 @@ H5P__facc_vol_cmp(const void *_info1, const void *_info2, size_t H5_ATTR_UNUSED 
     herr_t H5_ATTR_NDEBUG_UNUSED status;        /* Status from info comparison */
     int                          ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(info1);
@@ -6485,7 +6485,7 @@ H5P__facc_vol_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size,
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Free the VOL connector */
     if (H5VL_conn_free((H5VL_connector_prop_t *)value) < 0)

--- a/src/H5Pfcpl.c
+++ b/src/H5Pfcpl.c
@@ -212,7 +212,7 @@ H5P__fcrt_reg_prop(H5P_genclass_t *pclass)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Register the user block size */
     if (H5P__register_real(pclass, H5F_CRT_USER_BLOCK_NAME, H5F_CRT_USER_BLOCK_SIZE,
@@ -698,7 +698,7 @@ H5P__fcrt_btree_rank_enc(const void *value, void **_pp, size_t *size)
     const unsigned *btree_k = (const unsigned *)value; /* Create local alias for values */
     uint8_t **      pp      = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(btree_k);
@@ -747,7 +747,7 @@ H5P__fcrt_btree_rank_dec(const void **_pp, void *_value)
     unsigned        u;                   /* Local index variable */
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(pp);
@@ -985,7 +985,7 @@ H5P__fcrt_shmsg_index_types_enc(const void *value, void **_pp, size_t *size)
     const unsigned *type_flags = (const unsigned *)value; /* Create local alias for values */
     uint8_t **      pp         = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(type_flags);
@@ -1035,7 +1035,7 @@ H5P__fcrt_shmsg_index_types_dec(const void **_pp, void *_value)
     unsigned        u;                   /* Local index variable */
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(pp);
@@ -1076,7 +1076,7 @@ H5P__fcrt_shmsg_index_minsize_enc(const void *value, void **_pp, size_t *size)
     const unsigned *minsizes = (const unsigned *)value; /* Create local alias for values */
     uint8_t **      pp       = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(minsizes);
@@ -1126,7 +1126,7 @@ H5P__fcrt_shmsg_index_minsize_dec(const void **_pp, void *_value)
     unsigned        u;                   /* Local index variable */
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(pp);
@@ -1354,7 +1354,7 @@ H5P__fcrt_fspace_strategy_enc(const void *value, void **_pp, size_t *size)
         (const H5F_fspace_strategy_t *)value; /* Create local alias for values */
     uint8_t **pp = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(strategy);
@@ -1391,7 +1391,7 @@ H5P__fcrt_fspace_strategy_dec(const void **_pp, void *_value)
     H5F_fspace_strategy_t *strategy = (H5F_fspace_strategy_t *)_value; /* Free-space strategy */
     const uint8_t **       pp       = (const uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(pp);

--- a/src/H5Pfmpl.c
+++ b/src/H5Pfmpl.c
@@ -111,7 +111,7 @@ H5P__fmnt_reg_prop(H5P_genclass_t *pclass)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Register property of whether symlinks is local to file */
     if (H5P__register_real(pclass, H5F_MNT_SYM_LOCAL_NAME, H5F_MNT_SYM_LOCAL_SIZE, &H5F_def_local_g, NULL,

--- a/src/H5Pgcpl.c
+++ b/src/H5Pgcpl.c
@@ -120,7 +120,7 @@ H5P__gcrt_reg_prop(H5P_genclass_t *pclass)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Register group info property */
     if (H5P__register_real(pclass, H5G_CRT_GROUP_INFO_NAME, H5G_CRT_GROUP_INFO_SIZE, &H5G_def_ginfo_g, NULL,
@@ -532,7 +532,7 @@ H5P__gcrt_group_info_enc(const void *value, void **_pp, size_t *size)
     const H5O_ginfo_t *ginfo = (const H5O_ginfo_t *)value; /* Create local aliases for values */
     uint8_t **         pp    = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (NULL != *pp) {
         UINT32ENCODE(*pp, ginfo->lheap_size_hint)
@@ -569,7 +569,7 @@ H5P__gcrt_group_info_dec(const void **_pp, void *_value)
     const uint8_t **pp        = (const uint8_t **)_pp;
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set property to default value */
     HDmemset(ginfo, 0, sizeof(H5O_ginfo_t));
@@ -617,7 +617,7 @@ H5P__gcrt_link_info_enc(const void *value, void **_pp, size_t *size)
     const H5O_linfo_t *linfo = (const H5O_linfo_t *)value; /* Create local aliases for values */
     uint8_t **         pp    = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (NULL != *pp) {
         unsigned crt_order_flags = 0;
@@ -661,7 +661,7 @@ H5P__gcrt_link_info_dec(const void **_pp, void *_value)
     unsigned        enc_size;
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     enc_size = *(*pp)++;
     if (enc_size != sizeof(unsigned))

--- a/src/H5Pint.c
+++ b/src/H5Pint.c
@@ -704,7 +704,7 @@ H5P__close_class_cb(void *_pclass, void H5_ATTR_UNUSED **request)
     H5P_genclass_t *pclass    = (H5P_genclass_t *)_pclass; /* Property list class to close */
     herr_t          ret_value = SUCCEED;                   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(pclass);
@@ -735,7 +735,7 @@ H5P__close_list_cb(void *_plist, void H5_ATTR_UNUSED **request)
     H5P_genplist_t *plist     = (H5P_genplist_t *)_plist; /* Property list to close */
     herr_t          ret_value = SUCCEED;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(plist);
@@ -777,7 +777,7 @@ H5P__do_prop_cb1(H5SL_t *slist, H5P_genprop_t *prop, H5P_prp_cb1_t cb)
     H5P_genprop_t *pcopy     = NULL;    /* Copy of property to insert into skip list */
     herr_t         ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(slist);
@@ -1143,7 +1143,7 @@ H5P__dup_prop(H5P_genprop_t *oprop, H5P_prop_within_t type)
     H5P_genprop_t *prop      = NULL; /* Pointer to new property copied */
     H5P_genprop_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(oprop);
     HDassert(type != H5P_PROP_WITHIN_UNKNOWN);
@@ -1257,7 +1257,7 @@ H5P__create_prop(const char *name, size_t size, H5P_prop_within_t type, const vo
     H5P_genprop_t *prop      = NULL; /* Pointer to new property copied */
     H5P_genprop_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(name);
     HDassert((size > 0 && value != NULL) || (size == 0));
@@ -1434,7 +1434,7 @@ H5P__find_prop_pclass(H5P_genclass_t *pclass, const char *name)
 {
     H5P_genprop_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(pclass);
     HDassert(name);
@@ -1468,7 +1468,7 @@ done:
 static herr_t
 H5P__free_prop(H5P_genprop_t *prop)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(prop);
 
@@ -1511,7 +1511,7 @@ H5P__free_prop_cb(void *item, void H5_ATTR_UNUSED *key, void *op_data)
     H5P_genprop_t *tprop   = (H5P_genprop_t *)item; /* Temporary pointer to property */
     hbool_t        make_cb = *(hbool_t *)op_data;   /* Whether to make property 'close' callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(tprop);
 
@@ -1549,7 +1549,7 @@ H5P__free_del_name_cb(void *item, void H5_ATTR_UNUSED *key, void H5_ATTR_UNUSED 
 {
     char *del_name = (char *)item; /* Temporary pointer to deleted name */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(del_name);
 
@@ -1679,7 +1679,7 @@ H5P__open_class_path_cb(void *_obj, hid_t H5_ATTR_UNUSED id, void *_key)
     H5P_check_class_t *key       = (H5P_check_class_t *)_key; /* Pointer to key information for comparison */
     int                ret_value = 0;                         /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(obj);
     HDassert(H5I_GENPROP_CLS == H5I_get_type(id));
@@ -1834,7 +1834,7 @@ H5P__create(H5P_genclass_t *pclass)
     H5SL_t *        seen      = NULL; /* Skip list to hold names of properties already seen */
     H5P_genplist_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(pclass);
 
@@ -2775,7 +2775,7 @@ H5P__do_prop(H5P_genplist_t *plist, const char *name, H5P_do_plist_op_t plist_op
     H5P_genprop_t * prop;                /* Temporary property pointer */
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(plist);
@@ -2855,7 +2855,7 @@ H5P__poke_plist_cb(H5P_genplist_t H5_ATTR_NDEBUG_UNUSED *plist, const char H5_AT
     H5P_prop_set_ud_t *udata     = (H5P_prop_set_ud_t *)_udata; /* User data for callback */
     herr_t             ret_value = SUCCEED;                     /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(plist);
@@ -2902,7 +2902,7 @@ H5P__poke_pclass_cb(H5P_genplist_t *plist, const char H5_ATTR_NDEBUG_UNUSED *nam
     H5P_genprop_t *    pcopy     = NULL;    /* Copy of property to insert into skip list */
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(plist);
@@ -3008,7 +3008,7 @@ H5P__set_plist_cb(H5P_genplist_t *plist, const char *name, H5P_genprop_t *prop, 
     const void *       prp_value = NULL;                        /* Property value */
     herr_t             ret_value = SUCCEED;                     /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(plist);
@@ -3085,7 +3085,7 @@ H5P__set_pclass_cb(H5P_genplist_t *plist, const char *name, H5P_genprop_t *prop,
     const void *       prp_value = NULL;    /* Property value */
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(plist);
@@ -3608,7 +3608,7 @@ H5P__cmp_prop(const H5P_genprop_t *prop1, const H5P_genprop_t *prop2)
     int cmp_value;     /* Value from comparison */
     int ret_value = 0; /* return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(prop1);
     HDassert(prop2);
@@ -3869,7 +3869,7 @@ H5P__cmp_plist_cb(H5P_genprop_t *prop, void *_udata)
     htri_t              prop2_exist; /* Whether the property exists in the second property list */
     int                 ret_value = H5_ITER_CONT; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(prop);
@@ -4151,7 +4151,7 @@ H5P__iterate_plist_cb(void *_item, void *_key, void *_udata)
     H5P_iter_plist_ud_t *udata     = (H5P_iter_plist_ud_t *)_udata; /* Pointer to user data */
     int                  ret_value = H5_ITER_CONT;                  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(item);
@@ -4204,7 +4204,7 @@ H5P__iterate_plist_pclass_cb(void *_item, void *_key, void *_udata)
     H5P_iter_plist_ud_t *udata     = (H5P_iter_plist_ud_t *)_udata; /* Pointer to user data */
     int                  ret_value = H5_ITER_CONT;                  /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(item);
@@ -4362,7 +4362,7 @@ H5P__iterate_pclass_cb(void *_item, void H5_ATTR_NDEBUG_UNUSED *_key, void *_uda
     H5P_iter_pclass_ud_t *udata     = (H5P_iter_pclass_ud_t *)_udata; /* Pointer to user data */
     int                   ret_value = 0;                              /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(item);
@@ -4495,7 +4495,7 @@ H5P__peek_cb(H5P_genplist_t H5_ATTR_NDEBUG_UNUSED *plist, const char H5_ATTR_NDE
     H5P_prop_get_ud_t *udata     = (H5P_prop_get_ud_t *)_udata; /* User data for callback */
     herr_t             ret_value = SUCCEED;                     /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(plist);
@@ -4588,7 +4588,7 @@ H5P__get_cb(H5P_genplist_t *plist, const char *name, H5P_genprop_t *prop, void *
     void *             tmp_value = NULL;                        /* Temporary value for property */
     herr_t             ret_value = SUCCEED;                     /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(plist);
@@ -4702,7 +4702,7 @@ H5P__del_plist_cb(H5P_genplist_t *plist, const char *name, H5P_genprop_t *prop, 
     char * del_name  = NULL;    /* Pointer to deleted name */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(plist);
@@ -4771,7 +4771,7 @@ H5P__del_pclass_cb(H5P_genplist_t *plist, const char *name, H5P_genprop_t *prop,
     void * tmp_value = NULL;    /* Temporary value for property */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(plist);

--- a/src/H5Plapl.c
+++ b/src/H5Plapl.c
@@ -189,7 +189,7 @@ H5P__lacc_reg_prop(H5P_genclass_t *pclass)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Register property for number of links traversed */
     if (H5P__register_real(pclass, H5L_ACS_NLINKS_NAME, H5L_ACS_NLINKS_SIZE, &H5L_def_nlinks_g, NULL, NULL,
@@ -255,7 +255,7 @@ H5P__lacc_elink_fapl_set(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED
     hid_t  l_fapl_id;
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -297,7 +297,7 @@ H5P__lacc_elink_fapl_get(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED
     hid_t  l_fapl_id;
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -344,7 +344,7 @@ H5P__lacc_elink_fapl_enc(const void *value, void **_pp, size_t *size)
     size_t          fapl_size        = 0;       /* FAPL's encoded size */
     herr_t          ret_value        = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check for non-default FAPL */
     if (*elink_fapl != H5P_DEFAULT) {
@@ -413,7 +413,7 @@ H5P__lacc_elink_fapl_dec(const void **_pp, void *_value)
     hbool_t         non_default_fapl;    /* Whether the FAPL is non-default */
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(pp);
@@ -468,7 +468,7 @@ H5P__lacc_elink_fapl_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED
     hid_t  l_fapl_id;
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -503,7 +503,7 @@ H5P__lacc_elink_fapl_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED
     hid_t  l_fapl_id;
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -547,7 +547,7 @@ H5P__lacc_elink_fapl_cmp(const void *value1, const void *value2, size_t H5_ATTR_
     H5P_genplist_t *obj1, *obj2; /* Property lists to compare */
     int             ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check for comparison with default value */
     if (*fapl1 == 0 && *fapl2 > 0)
@@ -594,7 +594,7 @@ H5P__lacc_elink_fapl_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSE
     hid_t  l_fapl_id;
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -627,7 +627,7 @@ static herr_t
 H5P__lacc_elink_pref_set(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *name,
                          size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(value);
@@ -655,7 +655,7 @@ static herr_t
 H5P__lacc_elink_pref_get(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *name,
                          size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(value);
@@ -690,7 +690,7 @@ H5P__lacc_elink_pref_enc(const void *value, void **_pp, size_t *size)
     uint64_t    enc_value;
     unsigned    enc_size;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDcompile_assert(sizeof(size_t) <= sizeof(uint64_t));
 
@@ -746,7 +746,7 @@ H5P__lacc_elink_pref_dec(const void **_pp, void *_value)
     unsigned        enc_size;  /* Size of encoded property */
     herr_t          ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(pp);
     HDassert(*pp);
@@ -793,7 +793,7 @@ static herr_t
 H5P__lacc_elink_pref_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *name,
                          size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(value);
 
@@ -817,7 +817,7 @@ H5P__lacc_elink_pref_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED
 static herr_t
 H5P__lacc_elink_pref_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(value);
 
@@ -847,7 +847,7 @@ H5P__lacc_elink_pref_cmp(const void *value1, const void *value2, size_t H5_ATTR_
     const char *pref2     = *(const char *const *)value2;
     int         ret_value = 0;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (NULL == pref1 && NULL != pref2)
         HGOTO_DONE(1);
@@ -875,7 +875,7 @@ done:
 static herr_t
 H5P__lacc_elink_pref_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(value);
 

--- a/src/H5Plcpl.c
+++ b/src/H5Plcpl.c
@@ -112,7 +112,7 @@ H5P__lcrt_reg_prop(H5P_genclass_t *pclass)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Register create intermediate groups property */
     if (H5P__register_real(pclass, H5L_CRT_INTERMEDIATE_GROUP_NAME, H5L_CRT_INTERMEDIATE_GROUP_SIZE,

--- a/src/H5Pmapl.c
+++ b/src/H5Pmapl.c
@@ -112,7 +112,7 @@ H5P__macc_reg_prop(H5P_genclass_t *pclass)
         H5M_ACS_KEY_ALLOC_SIZE_DEF; /* Default key prefetch allocation size for iteration */
     herr_t ret_value = SUCCEED;     /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Register the key prefetch size for iteration */
     if (H5P__register_real(pclass, H5M_ACS_KEY_PREFETCH_SIZE_NAME, H5M_ACS_KEY_PREFETCH_SIZE_SIZE,

--- a/src/H5Pmcpl.c
+++ b/src/H5Pmcpl.c
@@ -98,7 +98,7 @@ H5P__mcrt_reg_prop(H5P_genclass_t H5_ATTR_UNUSED *pclass)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5P__mcrt_reg_prop() */

--- a/src/H5Pocpl.c
+++ b/src/H5Pocpl.c
@@ -154,7 +154,7 @@ H5P__ocrt_reg_prop(H5P_genclass_t *pclass)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Register max. compact attribute storage property */
     if (H5P__register_real(pclass, H5O_CRT_ATTR_MAX_COMPACT_NAME, H5O_CRT_ATTR_MAX_COMPACT_SIZE,
@@ -705,7 +705,7 @@ H5P__set_filter(H5P_genplist_t *plist, H5Z_filter_t filter, unsigned int flags, 
     htri_t      filter_avail;        /* Filter availability */
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if filter is already available */
     if ((filter_avail = H5Z_filter_avail(filter)) < 0)
@@ -1286,7 +1286,7 @@ H5P__ocrt_pipeline_set(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *
     H5O_pline_t  new_pline;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -1323,7 +1323,7 @@ H5P__ocrt_pipeline_get(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *
     H5O_pline_t  new_pline;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -1361,7 +1361,7 @@ H5P__ocrt_pipeline_enc(const void *value, void **_pp, size_t *size)
     uint8_t **         pp    = (uint8_t **)_pp;
     size_t             u; /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(pline);
     HDassert(size);
@@ -1457,7 +1457,7 @@ H5P__ocrt_pipeline_dec(const void **_pp, void *_value)
     size_t          u;                   /* Local index variable */
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDcompile_assert(sizeof(size_t) <= sizeof(uint64_t));
 
@@ -1545,7 +1545,7 @@ H5P__ocrt_pipeline_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -1578,7 +1578,7 @@ H5P__ocrt_pipeline_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED s
     H5O_pline_t  new_pline;
     herr_t       ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(pline);
@@ -1617,7 +1617,7 @@ H5P__ocrt_pipeline_cmp(const void *_pline1, const void *_pline2, size_t H5_ATTR_
     int    cmp_value;     /* Value from comparison */
     herr_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(pline1);
@@ -1709,7 +1709,7 @@ H5P__ocrt_pipeline_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED 
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);

--- a/src/H5Pocpypl.c
+++ b/src/H5Pocpypl.c
@@ -155,7 +155,7 @@ H5P__ocpy_reg_prop(H5P_genclass_t *pclass)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Register copy options property */
     if (H5P__register_real(pclass, H5O_CPY_OPTION_NAME, H5O_CPY_OPTION_SIZE, &H5O_def_ocpy_option_g, NULL,
@@ -197,7 +197,7 @@ done:
 static H5O_copy_dtype_merge_list_t *
 H5P__free_merge_comm_dtype_list(H5O_copy_dtype_merge_list_t *dt_list)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Free the list */
     while (dt_list) {
@@ -236,7 +236,7 @@ H5P__copy_merge_comm_dt_list(H5O_copy_dtype_merge_list_t **value)
                                 *tmp_dt_list            = NULL; /* temporary merge named datatype lists */
     herr_t ret_value                                    = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -299,7 +299,7 @@ H5P__ocpy_merge_comm_dt_list_set(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATT
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -331,7 +331,7 @@ H5P__ocpy_merge_comm_dt_list_get(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATT
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -367,7 +367,7 @@ H5P__ocpy_merge_comm_dt_list_enc(const void *value, void **_pp, size_t *size)
     const H5O_copy_dtype_merge_list_t *       dt_list; /* Pointer to merge named datatype list */
     size_t                                    len;     /* Length of path component */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(dt_list_ptr);
     HDassert(size);
@@ -427,7 +427,7 @@ H5P__ocpy_merge_comm_dt_list_dec(const void **_pp, void *_value)
     size_t len;                                       /* Length of path component */
     herr_t ret_value = SUCCEED;                       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(pp);
@@ -495,7 +495,7 @@ static herr_t
 H5P__ocpy_merge_comm_dt_list_del(hid_t H5_ATTR_UNUSED prop_id, const char H5_ATTR_UNUSED *name,
                                  size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(value);
@@ -524,7 +524,7 @@ H5P__ocpy_merge_comm_dt_list_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATT
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(value);
@@ -561,7 +561,7 @@ H5P__ocpy_merge_comm_dt_list_cmp(const void *_dt_list1, const void *_dt_list2, s
         *dt_list2    = *(H5O_copy_dtype_merge_list_t *const *)_dt_list2;
     herr_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(_dt_list1);
@@ -610,7 +610,7 @@ done:
 static herr_t
 H5P__ocpy_merge_comm_dt_list_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED size, void *value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(value);
 

--- a/src/H5Pstrcpl.c
+++ b/src/H5Pstrcpl.c
@@ -118,7 +118,7 @@ H5P__strcrt_reg_prop(H5P_genclass_t *pclass)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Register character encoding */
     if (H5P__register_real(pclass, H5P_STRCRT_CHAR_ENCODING_NAME, H5P_STRCRT_CHAR_ENCODING_SIZE,
@@ -220,7 +220,7 @@ H5P__strcrt_char_encoding_enc(const void *value, void **_pp, size_t *size)
     const H5T_cset_t *encoding = (const H5T_cset_t *)value; /* Create local alias for values */
     uint8_t **        pp       = (uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(encoding);
@@ -257,7 +257,7 @@ H5P__strcrt_char_encoding_dec(const void **_pp, void *_value)
     H5T_cset_t *    encoding = (H5T_cset_t *)_value; /* Character set encoding */
     const uint8_t **pp       = (const uint8_t **)_pp;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(pp);

--- a/src/H5R.c
+++ b/src/H5R.c
@@ -506,7 +506,7 @@ H5R__open_object_api_common(H5R_ref_t *ref_ptr, hid_t rapl_id, hid_t oapl_id, vo
     void *            opened_obj = NULL;              /* Opened object */
     hid_t             ret_value  = H5I_INVALID_HID;   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     if (ref_ptr == NULL)
@@ -648,7 +648,7 @@ H5R__open_region_api_common(H5R_ref_t *ref_ptr, hid_t rapl_id, hid_t oapl_id, vo
     hid_t                   space_id      = H5I_INVALID_HID; /* Dataspace ID */
     hid_t                   ret_value     = H5I_INVALID_HID; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     if (ref_ptr == NULL)
@@ -813,7 +813,7 @@ H5R__open_attr_api_common(H5R_ref_t *ref_ptr, hid_t rapl_id, hid_t aapl_id, void
     void *            opened_attr   = NULL;            /* Opened attribute */
     hid_t             ret_value     = H5I_INVALID_HID; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     if (ref_ptr == NULL)

--- a/src/H5RS.c
+++ b/src/H5RS.c
@@ -108,7 +108,7 @@ H5RS__xstrdup(H5RS_str_t *rs, const char *s)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(rs);
@@ -172,7 +172,7 @@ H5RS__prepare_for_append(H5RS_str_t *rs)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(rs);
@@ -224,7 +224,7 @@ H5RS__resize_for_append(H5RS_str_t *rs, size_t len)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(rs);

--- a/src/H5Rdeprec.c
+++ b/src/H5Rdeprec.c
@@ -97,7 +97,7 @@ H5R__decode_token_compat(H5VL_object_t *vol_obj, H5I_type_t type, H5R_type_t ref
     H5VL_file_get_args_t  vol_cb_args; /* Arguments to VOL callback */
     herr_t                ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
 #ifndef NDEBUG
     {
@@ -172,7 +172,7 @@ H5R__encode_token_region_compat(H5F_t *f, const H5O_token_t *obj_token, size_t t
     unsigned char *data      = NULL;
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(f);
     HDassert(obj_token);

--- a/src/H5Rint.c
+++ b/src/H5Rint.c
@@ -1054,7 +1054,7 @@ H5R__encode_obj_token(const H5O_token_t *obj_token, size_t token_size, unsigned 
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(nalloc);
 
@@ -1088,7 +1088,7 @@ H5R__decode_obj_token(const unsigned char *buf, size_t *nbytes, H5O_token_t *obj
     const uint8_t *p         = (const uint8_t *)buf;
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(buf);
     HDassert(nbytes);
@@ -1132,7 +1132,7 @@ H5R__encode_region(H5S_t *space, unsigned char *buf, size_t *nalloc)
     hssize_t buf_size  = 0;
     herr_t   ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(space);
     HDassert(nalloc);
@@ -1183,7 +1183,7 @@ H5R__decode_region(const unsigned char *buf, size_t *nbytes, H5S_t **space_ptr)
     H5S_t *        space;
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(buf);
     HDassert(nbytes);
@@ -1235,7 +1235,7 @@ H5R__encode_string(const char *string, unsigned char *buf, size_t *nalloc)
     size_t string_len, buf_size;
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(string);
     HDassert(nalloc);
@@ -1278,7 +1278,7 @@ H5R__decode_string(const unsigned char *buf, size_t *nbytes, char **string_ptr)
     char *         string    = NULL;
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(buf);
     HDassert(nbytes);

--- a/src/H5S.c
+++ b/src/H5S.c
@@ -217,7 +217,7 @@ H5S__close_cb(void *_space, void H5_ATTR_UNUSED **request)
     H5S_t *space     = (H5S_t *)_space; /* The dataspace to close */
     herr_t ret_value = SUCCEED;         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(space);
@@ -1151,7 +1151,7 @@ H5S__is_simple(const H5S_t *sdim)
 {
     htri_t ret_value = FAIL; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args and all the boring stuff. */
     HDassert(sdim);

--- a/src/H5SL.c
+++ b/src/H5SL.c
@@ -628,7 +628,7 @@ H5SL__new_node(void *item, const void *key, uint32_t hashval)
 {
     H5SL_node_t *ret_value = NULL; /* New skip list node */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate the node */
     if (NULL == (ret_value = (H5SL_node_t *)H5FL_MALLOC(H5SL_node_t)))
@@ -678,7 +678,7 @@ H5SL__insert_common(H5SL_t *slist, void *item, const void *key)
     uint32_t     hashval   = 0;    /* Hash value for key */
     H5SL_node_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(slist);
@@ -794,7 +794,7 @@ H5SL__release_common(H5SL_t *slist, H5SL_operator_t op, void *op_data)
     H5SL_node_t *node, *next_node; /* Pointers to skip list nodes */
     herr_t       ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(slist);
@@ -872,7 +872,7 @@ H5SL__close_common(H5SL_t *slist, H5SL_operator_t op, void *op_data)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(slist);

--- a/src/H5SM.c
+++ b/src/H5SM.c
@@ -257,7 +257,7 @@ H5SM__type_to_flag(unsigned type_id, unsigned *type_flag)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Translate the H5O type_id into an H5SM type flag */
     switch (type_id) {
@@ -451,7 +451,7 @@ H5SM__create_index(H5F_t *f, H5SM_index_header_t *header)
     H5B2_t *      bt2       = NULL; /* v2 B-tree handle for index */
     herr_t        ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(header);
@@ -554,7 +554,7 @@ H5SM__delete_index(H5F_t *f, H5SM_index_header_t *header, hbool_t delete_heap)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Determine whether index is a list or a B-tree. */
     if (header->index_type == H5SM_LIST) {
@@ -626,7 +626,7 @@ H5SM__create_list(H5F_t *f, H5SM_index_header_t *header)
     haddr_t      addr      = HADDR_UNDEF; /* Address of the list on disk */
     haddr_t      ret_value = HADDR_UNDEF; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(f);
     HDassert(header);
@@ -706,7 +706,7 @@ H5SM__convert_list_to_btree(H5F_t *f, H5SM_index_header_t *header, H5SM_list_t *
     void *          encoding_buf = NULL;
     herr_t          ret_value    = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(_list && *_list);
     HDassert(header);
@@ -808,7 +808,7 @@ H5SM__bt2_convert_to_list_op(const void *record, void *op_data)
     const H5SM_list_t *list    = (const H5SM_list_t *)op_data;
     size_t             mesg_idx; /* Index of message to modify */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(record);
@@ -848,7 +848,7 @@ H5SM__convert_btree_to_list(H5F_t *f, H5SM_index_header_t *header)
     haddr_t              btree_addr;
     herr_t               ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Remember the address of the old B-tree, but change the header over to be
      * a list..
@@ -908,7 +908,7 @@ H5SM__can_share_common(const H5F_t *f, unsigned type_id, const void *mesg)
 {
     htri_t ret_value = FAIL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check whether this message ought to be shared or not */
     /* If sharing is disabled in this file, don't share the message */
@@ -1186,7 +1186,7 @@ H5SM__incr_ref(void *record, void *_op_data, hbool_t *changed)
     H5SM_incr_ref_opdata *op_data   = (H5SM_incr_ref_opdata *)_op_data;
     herr_t                ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(record);
     HDassert(op_data);
@@ -1271,7 +1271,7 @@ H5SM__write_mesg(H5F_t *f, H5O_t *open_oh, H5SM_index_header_t *header, hbool_t 
     size_t               empty_pos    = SIZE_MAX; /* Empty entry in list */
     herr_t               ret_value    = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(header);
@@ -1664,7 +1664,7 @@ H5SM__find_in_list(const H5SM_list_t *list, const H5SM_mesg_key_t *key, size_t *
     size_t x;
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(list);
     /* Both key and empty_pos can be NULL, but not both! */
@@ -1729,7 +1729,7 @@ H5SM__decr_ref(void *record, void *op_data, hbool_t *changed)
 {
     H5SM_sohm_t *message = (H5SM_sohm_t *)record;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(record);
     HDassert(op_data);
@@ -1782,7 +1782,7 @@ H5SM__delete_from_index(H5F_t *f, H5O_t *open_oh, H5SM_index_header_t *header, c
     unsigned        type_id;             /* Message type to operate on */
     herr_t          ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);
@@ -2124,7 +2124,7 @@ H5SM__get_refcount_bt2_cb(const void *_record, void *_op_data)
     const H5SM_sohm_t *record  = (const H5SM_sohm_t *)_record; /* v2 B-tree record for message */
     H5SM_sohm_t *      op_data = (H5SM_sohm_t *)_op_data;      /* "op data" from v2 B-tree find */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /*
      * Check arguments.
@@ -2292,7 +2292,7 @@ H5SM__read_iter_op(H5O_t *oh, H5O_mesg_t *mesg /*in,out*/, unsigned sequence,
     H5SM_read_udata_t *udata     = (H5SM_read_udata_t *)_udata;
     herr_t             ret_value = H5_ITER_CONT;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.
@@ -2348,7 +2348,7 @@ H5SM__read_mesg_fh_cb(const void *obj, size_t obj_len, void *_udata)
     H5SM_read_udata_t *udata     = (H5SM_read_udata_t *)_udata;
     herr_t             ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate a buffer to hold the message */
     if (NULL == (udata->encoding_buf = H5MM_malloc(obj_len)))
@@ -2384,7 +2384,7 @@ H5SM__read_mesg(H5F_t *f, const H5SM_sohm_t *mesg, H5HF_t *fheap, H5O_t *open_oh
     H5O_t *           oh        = NULL; /* Object header for message in object header */
     herr_t            ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(f);
     HDassert(mesg);

--- a/src/H5SMbtree2.c
+++ b/src/H5SMbtree2.c
@@ -90,7 +90,7 @@ H5SM__bt2_crt_context(void *_f)
     H5SM_bt2_ctx_t *ctx;              /* Callback context structure */
     void *          ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(f);
@@ -127,7 +127,7 @@ H5SM__bt2_dst_context(void *_ctx)
 {
     H5SM_bt2_ctx_t *ctx = (H5SM_bt2_ctx_t *)_ctx; /* Callback context structure */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(ctx);
@@ -158,7 +158,7 @@ H5SM__bt2_store(void *native, const void *udata)
 {
     const H5SM_mesg_key_t *key = (const H5SM_mesg_key_t *)udata;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Copy the source message to the B-tree */
     *(H5SM_sohm_t *)native = key->message;
@@ -184,7 +184,7 @@ H5SM__bt2_debug(FILE *stream, int indent, int fwidth, const void *record, const 
 {
     const H5SM_sohm_t *sohm = (const H5SM_sohm_t *)record;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (sohm->location == H5SM_IN_HEAP)
         HDfprintf(stream, "%*s%-*s {%" PRIu64 ", %" PRIo32 ", %" PRIxHSIZE "}\n", indent, "", fwidth,

--- a/src/H5SMcache.c
+++ b/src/H5SMcache.c
@@ -132,7 +132,7 @@ H5SM__cache_table_get_initial_load_size(void *_udata, size_t *image_len)
 {
     const H5SM_table_cache_ud_t *udata = (const H5SM_table_cache_ud_t *)_udata; /* User data for callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(udata);
@@ -166,7 +166,7 @@ H5SM__cache_table_verify_chksum(const void *_image, size_t len, void H5_ATTR_UNU
     uint32_t       computed_chksum;                 /* Computed metadata checksum value */
     htri_t         ret_value = TRUE;                /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -208,7 +208,7 @@ H5SM__cache_table_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED l
     size_t                 u;                                       /* Counter variable for index headers */
     void *                 ret_value = NULL;                        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -321,7 +321,7 @@ H5SM__cache_table_image_len(const void *_thing, size_t *image_len)
     const H5SM_master_table_t *table =
         (const H5SM_master_table_t *)_thing; /* Shared message table to query */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(table);
@@ -356,7 +356,7 @@ H5SM__cache_table_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG_
     uint32_t             computed_chksum;                       /* Computed metadata checksum value */
     size_t               u;                                     /* Counter variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(f);
@@ -442,7 +442,7 @@ H5SM__cache_table_free_icr(void *_thing)
     H5SM_master_table_t *table     = (H5SM_master_table_t *)_thing; /* Shared message table to release */
     herr_t               ret_value = SUCCEED;                       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(table);
@@ -477,7 +477,7 @@ H5SM__cache_list_get_initial_load_size(void *_udata, size_t *image_len)
 {
     const H5SM_list_cache_ud_t *udata = (const H5SM_list_cache_ud_t *)_udata; /* User data for callback */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(udata);
@@ -514,7 +514,7 @@ H5SM__cache_list_verify_chksum(const void *_image, size_t H5_ATTR_UNUSED len, vo
     uint32_t              computed_chksum;  /* Computed metadata checksum value */
     htri_t                ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(image);
@@ -559,7 +559,7 @@ H5SM__cache_list_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED le
     size_t                u;                                      /* Counter variable for messages in list */
     void *                ret_value = NULL;                       /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(image);
@@ -636,7 +636,7 @@ H5SM__cache_list_image_len(const void *_thing, size_t *image_len)
 {
     const H5SM_list_t *list = (const H5SM_list_t *)_thing; /* Shared message list to query */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check arguments */
     HDassert(list);
@@ -675,7 +675,7 @@ H5SM__cache_list_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG_U
     size_t         u;                            /* Local index variable */
     herr_t         ret_value = SUCCEED;          /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(f);
@@ -746,7 +746,7 @@ H5SM__cache_list_free_icr(void *_thing)
     H5SM_list_t *list      = (H5SM_list_t *)_thing; /* Shared message list to release */
     herr_t       ret_value = SUCCEED;               /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(list);

--- a/src/H5SMmessage.c
+++ b/src/H5SMmessage.c
@@ -82,7 +82,7 @@ H5SM__compare_cb(const void *obj, size_t obj_len, void *_udata)
 {
     H5SM_compare_udata_t *udata = (H5SM_compare_udata_t *)_udata;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* If the encoding sizes are different, it's not the same object */
     if (udata->key->encoding_size > obj_len)
@@ -119,7 +119,7 @@ H5SM__compare_iter_op(H5O_t *oh, H5O_mesg_t *mesg /*in,out*/, unsigned sequence,
     H5SM_compare_udata_t *udata     = (H5SM_compare_udata_t *)_udata;
     herr_t                ret_value = H5_ITER_CONT;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /*
      * Check arguments.

--- a/src/H5Sall.c
+++ b/src/H5Sall.c
@@ -146,7 +146,7 @@ static const H5S_sel_iter_class_t H5S_sel_iter_all[1] = {{
 static herr_t
 H5S__all_iter_init(H5S_t H5_ATTR_UNUSED *space, H5S_sel_iter_t *iter)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space && H5S_SEL_ALL == H5S_GET_SELECT_TYPE(space));
@@ -180,7 +180,7 @@ H5S__all_iter_coords(const H5S_sel_iter_t *iter, hsize_t *coords)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(iter);
@@ -212,7 +212,7 @@ H5S__all_iter_block(const H5S_sel_iter_t *iter, hsize_t *start, hsize_t *end)
 {
     unsigned u; /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -247,7 +247,7 @@ H5S__all_iter_block(const H5S_sel_iter_t *iter, hsize_t *start, hsize_t *end)
 static hsize_t
 H5S__all_iter_nelmts(const H5S_sel_iter_t *iter)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -275,7 +275,7 @@ H5S__all_iter_nelmts(const H5S_sel_iter_t *iter)
 static htri_t
 H5S__all_iter_has_next_block(const H5S_sel_iter_t H5_ATTR_UNUSED *iter)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -304,7 +304,7 @@ H5S__all_iter_has_next_block(const H5S_sel_iter_t H5_ATTR_UNUSED *iter)
 static herr_t
 H5S__all_iter_next(H5S_sel_iter_t *iter, size_t nelem)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -337,7 +337,7 @@ H5S__all_iter_next(H5S_sel_iter_t *iter, size_t nelem)
 static herr_t
 H5S__all_iter_next_block(H5S_sel_iter_t H5_ATTR_UNUSED *iter)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -380,7 +380,7 @@ H5S__all_iter_get_seq_list(H5S_sel_iter_t *iter, size_t H5_ATTR_UNUSED maxseq, s
 {
     size_t elem_used; /* The number of elements used */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -434,7 +434,7 @@ H5S__all_iter_get_seq_list(H5S_sel_iter_t *iter, size_t H5_ATTR_UNUSED maxseq, s
 static herr_t
 H5S__all_iter_release(H5S_sel_iter_t H5_ATTR_UNUSED *iter)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -462,7 +462,7 @@ H5S__all_iter_release(H5S_sel_iter_t H5_ATTR_UNUSED *iter)
 static herr_t
 H5S__all_release(H5S_t *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space);
@@ -496,7 +496,7 @@ H5S__all_release(H5S_t *space)
 static herr_t
 H5S__all_copy(H5S_t *dst, const H5S_t H5_ATTR_UNUSED *src, hbool_t H5_ATTR_UNUSED share_selection)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(src);
     HDassert(dst);
@@ -530,7 +530,7 @@ H5S__all_copy(H5S_t *dst, const H5S_t H5_ATTR_UNUSED *src, hbool_t H5_ATTR_UNUSE
 static htri_t
 H5S__all_is_valid(const H5S_t H5_ATTR_UNUSED *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
 
@@ -559,7 +559,7 @@ H5S__all_is_valid(const H5S_t H5_ATTR_UNUSED *space)
 static hssize_t
 H5S__all_serial_size(H5S_t H5_ATTR_UNUSED *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
 
@@ -596,7 +596,7 @@ H5S__all_serialize(H5S_t *space, uint8_t **p)
 {
     uint8_t *pp = (*p); /* Local pointer for decoding */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space);
@@ -645,7 +645,7 @@ H5S__all_deserialize(H5S_t **space, const uint8_t **p)
                                    either *space or a newly allocated one */
     herr_t ret_value = SUCCEED; /* return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(p);
     HDassert(*p);
@@ -720,7 +720,7 @@ H5S__all_bounds(const H5S_t *space, hsize_t *start, hsize_t *end)
     unsigned rank; /* Dataspace rank */
     unsigned i;    /* index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
     HDassert(start);
@@ -761,7 +761,7 @@ H5S__all_bounds(const H5S_t *space, hsize_t *start, hsize_t *end)
 static herr_t
 H5S__all_offset(const H5S_t H5_ATTR_UNUSED *space, hsize_t *offset)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
     HDassert(offset);
@@ -796,7 +796,7 @@ H5S__all_offset(const H5S_t H5_ATTR_UNUSED *space, hsize_t *offset)
 static int
 H5S__all_unlim_dim(const H5S_t H5_ATTR_UNUSED *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(-1)
 } /* end H5S__all_unlim_dim() */
@@ -822,7 +822,7 @@ H5S__all_unlim_dim(const H5S_t H5_ATTR_UNUSED *space)
 static htri_t
 H5S__all_is_contiguous(const H5S_t H5_ATTR_UNUSED *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
 
@@ -850,7 +850,7 @@ H5S__all_is_contiguous(const H5S_t H5_ATTR_UNUSED *space)
 static htri_t
 H5S__all_is_single(const H5S_t H5_ATTR_UNUSED *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
 
@@ -879,7 +879,7 @@ H5S__all_is_single(const H5S_t H5_ATTR_UNUSED *space)
 static htri_t
 H5S__all_is_regular(H5S_t H5_ATTR_UNUSED *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space);
@@ -913,7 +913,7 @@ H5S__all_shape_same(H5S_t *space1, H5S_t *space2)
     int    space2_dim;       /* Current dimension in second dataspace */
     htri_t ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space1);
@@ -973,7 +973,7 @@ htri_t
 H5S__all_intersect_block(H5S_t H5_ATTR_UNUSED *space, const hsize_t H5_ATTR_UNUSED *start,
                          const hsize_t H5_ATTR_UNUSED *end)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(space);
@@ -1005,7 +1005,7 @@ H5S__all_intersect_block(H5S_t H5_ATTR_UNUSED *space, const hsize_t H5_ATTR_UNUS
 static herr_t
 H5S__all_adjust_u(H5S_t H5_ATTR_UNUSED *space, const hsize_t H5_ATTR_UNUSED *offset)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space);
@@ -1035,7 +1035,7 @@ H5S__all_adjust_u(H5S_t H5_ATTR_UNUSED *space, const hsize_t H5_ATTR_UNUSED *off
 static herr_t
 H5S__all_adjust_s(H5S_t H5_ATTR_UNUSED *space, const hssize_t H5_ATTR_UNUSED *offset)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space);
@@ -1060,7 +1060,7 @@ H5S__all_adjust_s(H5S_t H5_ATTR_UNUSED *space, const hssize_t H5_ATTR_UNUSED *of
 static herr_t
 H5S__all_project_scalar(const H5S_t H5_ATTR_UNUSED *space, hsize_t *offset)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space && H5S_SEL_ALL == H5S_GET_SELECT_TYPE(space));
@@ -1091,7 +1091,7 @@ H5S__all_project_simple(const H5S_t H5_ATTR_UNUSED *base_space, H5S_t *new_space
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(base_space && H5S_SEL_ALL == H5S_GET_SELECT_TYPE(base_space));

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -293,7 +293,7 @@ static uint64_t H5S_hyper_op_gen_g = 1;
 static herr_t
 H5S__hyper_print_spans_helper(FILE *f, const H5S_hyper_span_t *span, unsigned depth)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     while (span) {
         HDfprintf(f, "%s: %*sdepth=%u, span=%p, (%" PRIuHSIZE ", %" PRIuHSIZE "), next=%p\n", __func__,
@@ -313,7 +313,7 @@ H5S__hyper_print_spans_helper(FILE *f, const H5S_hyper_span_t *span, unsigned de
 static herr_t
 H5S__hyper_print_spans(FILE *f, const H5S_hyper_span_info_t *span_lst)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (span_lst != NULL) {
         HDfprintf(f, "%s: spans=%p, count=%u, bounds[0]={%" PRIuHSIZE ", %" PRIuHSIZE "}, head=%p\n",
@@ -328,7 +328,7 @@ H5S__hyper_print_spans(FILE *f, const H5S_hyper_span_info_t *span_lst)
 static herr_t
 H5S__space_print_spans(FILE *f, const H5S_t *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     H5S__hyper_print_spans(f, space->select.sel_info.hslab->span_lst);
 
@@ -340,7 +340,7 @@ H5S__hyper_print_diminfo_helper(FILE *f, const char *field, unsigned ndims, cons
 {
     unsigned u; /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (dinfo != NULL) {
         HDfprintf(f, "%s: %s: start=[", __func__, field);
@@ -365,7 +365,7 @@ H5S__hyper_print_diminfo_helper(FILE *f, const char *field, unsigned ndims, cons
 static herr_t
 H5S__hyper_print_diminfo(FILE *f, const H5S_t *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     H5S__hyper_print_diminfo_helper(f, "diminfo.opt", space->extent.rank,
                                     space->select.sel_info.hslab->diminfo.opt);
@@ -400,7 +400,7 @@ H5S__hyper_print_spans_dfs(FILE *f, const H5S_hyper_span_info_t *span_lst, unsig
     unsigned          num_elems = 0;
     unsigned          u, elem_idx;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* get the actual tail from head */
     cur_elem = span_lst->head;
@@ -469,7 +469,7 @@ H5S__hyper_print_space_dfs(FILE *f, const H5S_t *space)
     const unsigned         dims  = space->extent.rank;
     unsigned               u;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(hslab);
 
@@ -570,7 +570,7 @@ H5S__hyper_iter_init(H5S_t *space, H5S_sel_iter_t *iter)
     int      i;                   /* Index variable */
     herr_t   ret_value = SUCCEED; /* return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(space && H5S_SEL_HYPERSLABS == H5S_GET_SELECT_TYPE(space));
@@ -799,7 +799,7 @@ done:
 static herr_t
 H5S__hyper_iter_coords(const H5S_sel_iter_t *iter, hsize_t *coords)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -889,7 +889,7 @@ H5S__hyper_iter_block(const H5S_sel_iter_t *iter, hsize_t *start, hsize_t *end)
 {
     unsigned u; /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -932,7 +932,7 @@ H5S__hyper_iter_block(const H5S_sel_iter_t *iter, hsize_t *start, hsize_t *end)
 static hsize_t
 H5S__hyper_iter_nelmts(const H5S_sel_iter_t *iter)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -963,7 +963,7 @@ H5S__hyper_iter_has_next_block(const H5S_sel_iter_t *iter)
     unsigned u;                 /* Local index variable */
     htri_t   ret_value = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -1016,7 +1016,7 @@ H5S__hyper_iter_next(H5S_sel_iter_t *iter, size_t nelem)
     int      fast_dim; /* Rank of the fastest changing dimension for the dataspace */
     unsigned u;        /* Counters */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check for the special case of just one H5Sselect_hyperslab call made */
     /* (i.e. a regular hyperslab selection */
@@ -1225,7 +1225,7 @@ H5S__hyper_iter_next_block(H5S_sel_iter_t *iter)
     int      fast_dim; /* Rank of the fastest changing dimension for the dataspace */
     unsigned u;        /* Counters */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check for the special case of just one H5Sselect_hyperslab call made */
     /* (i.e. a regular hyperslab selection) */
@@ -1433,7 +1433,7 @@ H5S__hyper_iter_get_seq_list_gen(H5S_sel_iter_t *iter, size_t maxseq, size_t max
     int                curr_dim;          /* Current dimension being operated on */
     unsigned           u;                 /* Index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -1904,7 +1904,7 @@ H5S__hyper_iter_get_seq_list_opt(H5S_sel_iter_t *iter, size_t maxseq, size_t max
     size_t   elem_size;        /* Size of each element iterating over */
     unsigned u;                /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -2343,7 +2343,7 @@ H5S__hyper_iter_get_seq_list_single(H5S_sel_iter_t *iter, size_t maxseq, size_t 
     unsigned               skip_dim; /* Rank of the dimension to skip along */
     unsigned               u;        /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -2606,7 +2606,7 @@ H5S__hyper_iter_get_seq_list(H5S_sel_iter_t *iter, size_t maxseq, size_t maxelem
 {
     herr_t ret_value = FAIL; /* return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -2757,7 +2757,7 @@ H5S__hyper_iter_get_seq_list(H5S_sel_iter_t *iter, size_t maxseq, size_t maxelem
 static herr_t
 H5S__hyper_iter_release(H5S_sel_iter_t *iter)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -2795,7 +2795,7 @@ H5S__hyper_new_span(hsize_t low, hsize_t high, H5S_hyper_span_info_t *down, H5S_
 {
     H5S_hyper_span_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate a new span node */
     if (NULL == (ret_value = H5FL_MALLOC(H5S_hyper_span_t)))
@@ -2839,7 +2839,7 @@ H5S__hyper_new_span_info(unsigned rank)
 {
     H5S_hyper_span_info_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(rank > 0);
@@ -2886,7 +2886,7 @@ H5S__hyper_copy_span_helper(H5S_hyper_span_info_t *spans, unsigned rank, unsigne
     H5S_hyper_span_info_t *new_down;         /* New down span tree */
     H5S_hyper_span_info_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(spans);
@@ -2977,7 +2977,7 @@ H5S__hyper_copy_span(H5S_hyper_span_info_t *spans, unsigned rank)
     uint64_t               op_gen;           /* Operation generation value */
     H5S_hyper_span_info_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(spans);
@@ -3019,7 +3019,7 @@ H5S__hyper_cmp_spans(const H5S_hyper_span_info_t *span_info1, const H5S_hyper_sp
 {
     hbool_t ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check for redundant comparison (or both spans being NULL) */
     if (span_info1 != span_info2) {
@@ -3111,7 +3111,7 @@ done:
 static void
 H5S__hyper_free_span_info(H5S_hyper_span_info_t *span_info)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(span_info);
@@ -3167,7 +3167,7 @@ H5S__hyper_free_span_info(H5S_hyper_span_info_t *span_info)
 static void
 H5S__hyper_free_span(H5S_hyper_span_t *span)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(span);
@@ -3214,7 +3214,7 @@ H5S__hyper_copy(H5S_t *dst, const H5S_t *src, hbool_t share_selection)
     const H5S_hyper_sel_t *src_hslab;           /* Pointer to source hyperslab info */
     herr_t                 ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(src);
@@ -3284,7 +3284,7 @@ H5S__hyper_is_valid(const H5S_t *space)
     unsigned       u;                        /* Counter */
     htri_t         ret_value = TRUE;         /* return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
 
@@ -3339,7 +3339,7 @@ H5S__hyper_span_nblocks_helper(H5S_hyper_span_info_t *spans, unsigned op_info_i,
 {
     hsize_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(spans);
@@ -3403,7 +3403,7 @@ H5S__hyper_span_nblocks(H5S_hyper_span_info_t *spans)
 {
     hsize_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Count the number of elements in the span tree */
     if (spans != NULL) {
@@ -3444,7 +3444,7 @@ H5S__get_select_hyper_nblocks(const H5S_t *space, hbool_t app_ref)
 {
     hsize_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
     HDassert(space->select.sel_info.hslab->unlim_dim < 0);
@@ -3529,7 +3529,7 @@ H5S__hyper_get_enc_size_real(hsize_t max_size)
 {
     uint8_t ret_value = H5S_SELECT_INFO_ENC_SIZE_2;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (max_size > H5S_UINT32_MAX)
         ret_value = H5S_SELECT_INFO_ENC_SIZE_8;
@@ -3589,7 +3589,7 @@ H5S__hyper_get_version_enc_size(H5S_t *space, hsize_t block_count, uint32_t *ver
     unsigned     u;                          /* Local index variable */
     herr_t       ret_value = SUCCEED;        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get bounding box for the selection */
     HDmemset(bounds_end, 0, sizeof(bounds_end));
@@ -3736,7 +3736,7 @@ H5S__hyper_serial_size(H5S_t *space)
     uint8_t  enc_size;        /* Encoded size of hyperslab selection info */
     hssize_t ret_value = -1;  /* return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(space);
 
@@ -3832,7 +3832,7 @@ H5S__hyper_serialize_helper(const H5S_hyper_span_info_t *spans, hsize_t *start, 
     H5S_hyper_span_t *curr;      /* Pointer to current hyperslab span */
     uint8_t *         pp = (*p); /* Local pointer for decoding */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(spans);
@@ -3965,7 +3965,7 @@ H5S__hyper_serialize(H5S_t *space, uint8_t **p)
     uint8_t                enc_size;            /* Encoded size */
     herr_t                 ret_value = SUCCEED; /* return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(space);
@@ -4237,7 +4237,7 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p)
     unsigned       u;                   /* Local counting variable */
     herr_t         ret_value = FAIL;    /* return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(p);
@@ -4498,7 +4498,7 @@ H5S__hyper_span_blocklist(const H5S_hyper_span_info_t *spans, hsize_t start[], h
     const H5S_hyper_span_t *curr;                /* Pointer to current hyperslab span */
     herr_t                  ret_value = SUCCEED; /* return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(spans);
@@ -4596,7 +4596,7 @@ H5S__get_select_hyper_blocklist(H5S_t *space, hsize_t startblock, hsize_t numblo
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
     HDassert(buf);
@@ -4834,7 +4834,7 @@ H5S__hyper_bounds(const H5S_t *space, hsize_t *start, hsize_t *end)
     const hsize_t *low_bounds, *high_bounds; /* Pointers to the correct pair of low & high bounds */
     herr_t         ret_value = SUCCEED;      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(space);
@@ -4912,7 +4912,7 @@ H5S__hyper_offset(const H5S_t *space, hsize_t *offset)
     int             i;                   /* index variable */
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(space && space->extent.rank > 0);
     HDassert(offset);
@@ -5014,7 +5014,7 @@ done:
 static int
 H5S__hyper_unlim_dim(const H5S_t *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(space->select.sel_info.hslab->unlim_dim);
 } /* end H5S__hyper_unlim_dim() */
@@ -5044,7 +5044,7 @@ H5S__hyper_num_elem_non_unlim(const H5S_t *space, hsize_t *num_elem_non_unlim)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(space);
@@ -5086,7 +5086,7 @@ H5S__hyper_is_contiguous(const H5S_t *space)
     unsigned u;                 /* index variable */
     htri_t   ret_value = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
 
@@ -5271,7 +5271,7 @@ H5S__hyper_is_single(const H5S_t *space)
 {
     htri_t ret_value = TRUE; /* return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
 
@@ -5344,7 +5344,7 @@ H5S__hyper_is_regular(H5S_t *space)
 {
     htri_t ret_value = FAIL; /* return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space);
@@ -5396,7 +5396,7 @@ H5S__hyper_spans_shape_same_helper(const H5S_hyper_span_info_t *span_info1,
 {
     hbool_t ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(span_info1);
@@ -5506,7 +5506,7 @@ H5S__hyper_spans_shape_same(const H5S_hyper_span_info_t *span_info1, const H5S_h
     unsigned u;                        /* Local index variable */
     hbool_t  ret_value = TRUE;         /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(span_info1);
@@ -5601,7 +5601,7 @@ H5S__hyper_shape_same(H5S_t *space1, H5S_t *space2)
     unsigned space2_rank;      /* Number of dimensions of second dataspace */
     htri_t   ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(space1);
@@ -5737,7 +5737,7 @@ done:
 static herr_t
 H5S__hyper_release(H5S_t *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space && H5S_SEL_HYPERSLABS == H5S_GET_SELECT_TYPE(space));
@@ -5782,7 +5782,7 @@ H5S__hyper_coord_to_span(unsigned rank, const hsize_t *coords)
     H5S_hyper_span_info_t *down      = NULL; /* Pointer to new span tree for next level down */
     H5S_hyper_span_t *     ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(rank > 0);
     HDassert(coords);
@@ -5847,7 +5847,7 @@ H5S__hyper_add_span_element_helper(H5S_hyper_span_info_t *span_tree, unsigned ra
     H5S_hyper_span_t *tail_span;           /* Pointer to the tail span of one dimension */
     herr_t            ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(span_tree);
@@ -6188,7 +6188,7 @@ H5S__hyper_intersect_block_helper(H5S_hyper_span_info_t *spans, unsigned rank, c
 {
     hbool_t ret_value = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(spans);
@@ -6275,7 +6275,7 @@ H5S__hyper_intersect_block(H5S_t *space, const hsize_t *start, const hsize_t *en
 {
     htri_t ret_value = FAIL; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(space);
@@ -6406,7 +6406,7 @@ static void
 H5S__hyper_adjust_u_helper(H5S_hyper_span_info_t *spans, unsigned rank, const hsize_t *offset,
                            unsigned op_info_i, uint64_t op_gen)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(spans);
@@ -6471,7 +6471,7 @@ H5S__hyper_adjust_u(H5S_t *space, const hsize_t *offset)
     hbool_t  non_zero_offset = FALSE; /* Whether any offset is non-zero */
     unsigned u;                       /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(space);
@@ -6536,7 +6536,7 @@ H5S__hyper_project_scalar(const H5S_t *space, hsize_t *offset)
 {
     hsize_t block[H5S_MAX_RANK]; /* Block selected in base dataspace */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space && H5S_SEL_HYPERSLABS == H5S_GET_SELECT_TYPE(space));
@@ -6613,7 +6613,7 @@ H5S__hyper_project_simple_lower(const H5S_t *base_space, H5S_t *new_space)
     H5S_hyper_span_info_t *down;     /* Pointer to list of spans */
     unsigned               curr_dim; /* Current dimension being operated on */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(base_space && H5S_SEL_HYPERSLABS == H5S_GET_SELECT_TYPE(base_space));
@@ -6662,7 +6662,7 @@ H5S__hyper_project_simple_higher(const H5S_t *base_space, H5S_t *new_space)
     unsigned          u;                   /* Local index variable */
     herr_t            ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(base_space && H5S_SEL_HYPERSLABS == H5S_GET_SELECT_TYPE(base_space));
@@ -6760,7 +6760,7 @@ H5S__hyper_project_simple(const H5S_t *base_space, H5S_t *new_space, hsize_t *of
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(base_space && H5S_SEL_HYPERSLABS == H5S_GET_SELECT_TYPE(base_space));
@@ -6948,7 +6948,7 @@ static void
 H5S__hyper_adjust_s_helper(H5S_hyper_span_info_t *spans, unsigned rank, const hssize_t *offset,
                            unsigned op_info_i, uint64_t op_gen)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(spans);
@@ -7013,7 +7013,7 @@ H5S__hyper_adjust_s(H5S_t *space, const hssize_t *offset)
     hbool_t  non_zero_offset = FALSE; /* Whether any offset is non-zero */
     unsigned u;                       /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(space);
@@ -7191,7 +7191,7 @@ H5S__hyper_append_span(H5S_hyper_span_info_t **span_tree, unsigned ndims, hsize_
     H5S_hyper_span_t *new_span  = NULL;
     herr_t            ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(span_tree);
@@ -7350,7 +7350,7 @@ H5S__hyper_clip_spans(H5S_hyper_span_info_t *a_spans, H5S_hyper_span_info_t *b_s
     hbool_t need_b_not_a;        /* Whether to generate b_not_a list */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(a_spans);
@@ -7982,7 +7982,7 @@ H5S__hyper_merge_spans_helper(H5S_hyper_span_info_t *a_spans, H5S_hyper_span_inf
     H5S_hyper_span_info_t *merged_spans = NULL; /* Pointer to the merged span tree */
     H5S_hyper_span_info_t *ret_value    = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Make certain both 'a' & 'b' spans have down span trees or neither does */
     HDassert((a_spans != NULL && b_spans != NULL) || (a_spans == NULL && b_spans == NULL));
@@ -8310,7 +8310,7 @@ H5S__hyper_merge_spans(H5S_t *space, H5S_hyper_span_info_t *new_spans)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(space);
@@ -8364,7 +8364,7 @@ H5S__hyper_spans_nelem_helper(H5S_hyper_span_info_t *spans, unsigned op_info_i, 
 {
     hsize_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(spans);
@@ -8434,7 +8434,7 @@ H5S__hyper_spans_nelem(H5S_hyper_span_info_t *spans)
     uint64_t op_gen;        /* Operation generation value */
     hsize_t  ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(spans);
@@ -8478,7 +8478,7 @@ H5S__hyper_add_disjoint_spans(H5S_t *space, H5S_hyper_span_info_t *new_spans)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(space);
@@ -8533,7 +8533,7 @@ H5S__hyper_make_spans(unsigned rank, const hsize_t *start, const hsize_t *stride
     int                    i;                /* Counters */
     H5S_hyper_span_info_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(rank > 0);
@@ -8681,7 +8681,7 @@ H5S__hyper_update_diminfo(H5S_t *space, H5S_seloper_t op, const H5S_hyper_dim_t 
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space);
@@ -8898,7 +8898,7 @@ H5S__hyper_rebuild_helper(const H5S_hyper_span_info_t *spans, H5S_hyper_dim_t sp
     size_t                  spancount;        /* Number of spans encountered in this dimension */
     hbool_t                 ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(spans);
@@ -9051,7 +9051,7 @@ H5S__hyper_generate_spans(H5S_t *space)
     unsigned u;                        /* Local index variable */
     herr_t   ret_value = SUCCEED;      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(space);
     HDassert(H5S_GET_SELECT_TYPE(space) == H5S_SEL_HYPERSLABS);
@@ -9104,7 +9104,7 @@ H5S__check_spans_overlap(const H5S_hyper_span_info_t *spans1, const H5S_hyper_sp
 {
     hbool_t ret_value = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(spans1);
@@ -9202,7 +9202,7 @@ H5S__fill_in_new_space(H5S_t *space1, H5S_seloper_t op, H5S_hyper_span_info_t *s
     hbool_t is_result_new = FALSE;
     herr_t  ret_value     = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(space1);
     HDassert(space2_span_lst);
@@ -9481,7 +9481,7 @@ H5S__generate_hyperslab(H5S_t *space, H5S_seloper_t op, const hsize_t start[], c
     H5S_hyper_span_info_t *new_spans = NULL;    /* Span tree for new hyperslab */
     herr_t                 ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(space);
@@ -9571,7 +9571,7 @@ H5S__set_regular_hyperslab(H5S_t *space, const hsize_t start[], const hsize_t *a
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(space);
@@ -9672,7 +9672,7 @@ H5S__hyper_regular_and_single_block(H5S_t *space, const hsize_t start[], const h
     unsigned u;                     /* Local index variable */
     herr_t   ret_value = SUCCEED;   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(space);
@@ -10494,7 +10494,7 @@ H5S__fill_in_select(H5S_t *space1, H5S_seloper_t op, H5S_t *space2, H5S_t **resu
     hbool_t updated_spans;
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(space1);
@@ -10608,7 +10608,7 @@ H5S__combine_select(H5S_t *space1, H5S_seloper_t op, H5S_t *space2)
     H5S_t *new_space = NULL; /* New dataspace generated */
     H5S_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(space1);
@@ -10900,7 +10900,7 @@ H5S__hyper_proj_int_build_proj(H5S_hyper_project_intersect_ud_t *udata)
     H5S_hyper_span_info_t *copied_span_info = NULL;    /* Temporary span info pointer */
     herr_t                 ret_value        = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(udata->nelem > 0);
 
@@ -11348,7 +11348,7 @@ H5S__hyper_proj_int_iterate(const H5S_hyper_span_info_t *ss_span_info,
     unsigned                u;                   /* Local index variable */
     herr_t                  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check for non-overlapping bounds */
     check_intersect = TRUE;
@@ -11783,7 +11783,7 @@ done:
 static void
 H5S__hyper_get_clip_diminfo(hsize_t start, hsize_t stride, hsize_t *count, hsize_t *block, hsize_t clip_size)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check for selection outside clip size */
     if (start >= clip_size) {
@@ -11970,7 +11970,7 @@ H5S__hyper_get_clip_extent_real(const H5S_t *clip_space, hsize_t num_slices, hbo
     hsize_t                rem_slices;
     hsize_t                ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check parameters */
     HDassert(clip_space);

--- a/src/H5Smpio.c
+++ b/src/H5Smpio.c
@@ -121,7 +121,7 @@ H5S__mpio_all_type(const H5S_t *space, size_t elmt_size, MPI_Datatype *new_type,
     hsize_t  bigio_count;         /* Transition point to create derived type */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(space);
@@ -173,7 +173,7 @@ done:
 static herr_t
 H5S__mpio_none_type(MPI_Datatype *new_type, int *count, hbool_t *is_derived_type)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* fill in the return values */
     *new_type        = MPI_BYTE;
@@ -212,7 +212,7 @@ H5S__mpio_create_point_datatype(size_t elmt_size, hsize_t num_points, MPI_Aint *
     int     mpi_code;            /* MPI error code */
     herr_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Create an MPI datatype for an element */
     if (MPI_SUCCESS != (mpi_code = MPI_Type_contiguous((int)elmt_size, MPI_BYTE, &elmt_type)))
@@ -375,7 +375,7 @@ H5S__mpio_point_type(const H5S_t *space, size_t elmt_size, MPI_Datatype *new_typ
     hsize_t         u;                   /* Local index variable */
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(space);
@@ -513,7 +513,7 @@ H5S__mpio_permute_type(const H5S_t *space, size_t elmt_size, hsize_t **permute, 
     hsize_t        u;                     /* Local index variable */
     herr_t         ret_value = SUCCEED;   /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(space);
@@ -661,7 +661,7 @@ H5S__mpio_reg_hyper_type(const H5S_t *space, size_t elmt_size, MPI_Datatype *new
     int              mpi_code; /* MPI return code */
     herr_t           ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(space);
@@ -994,7 +994,7 @@ H5S__mpio_span_hyper_type(const H5S_t *space, size_t elmt_size, MPI_Datatype *ne
     int                     mpi_code;                     /* MPI return code */
     herr_t                  ret_value = SUCCEED;          /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(space);
@@ -1065,7 +1065,7 @@ H5S__release_datatype(H5S_mpio_mpitype_list_t *type_list)
     H5S_mpio_mpitype_node_t *curr;                /* Pointer to head of list */
     herr_t                   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(type_list);
@@ -1124,7 +1124,7 @@ H5S__obtain_datatype(H5S_hyper_span_info_t *spans, const hsize_t *down, size_t e
     int               mpi_code;            /* MPI return status code */
     herr_t            ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(spans);

--- a/src/H5Snone.c
+++ b/src/H5Snone.c
@@ -146,7 +146,7 @@ static const H5S_sel_iter_class_t H5S_sel_iter_none[1] = {{
 static herr_t
 H5S__none_iter_init(H5S_t H5_ATTR_UNUSED *space, H5S_sel_iter_t *iter)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space && H5S_SEL_NONE == H5S_GET_SELECT_TYPE(space));
@@ -174,7 +174,7 @@ H5S__none_iter_init(H5S_t H5_ATTR_UNUSED *space, H5S_sel_iter_t *iter)
 static herr_t
 H5S__none_iter_coords(const H5S_sel_iter_t H5_ATTR_UNUSED *iter, hsize_t H5_ATTR_UNUSED *coords)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -200,7 +200,7 @@ static herr_t
 H5S__none_iter_block(const H5S_sel_iter_t H5_ATTR_UNUSED *iter, hsize_t H5_ATTR_UNUSED *start,
                      hsize_t H5_ATTR_UNUSED *end)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -225,7 +225,7 @@ H5S__none_iter_block(const H5S_sel_iter_t H5_ATTR_UNUSED *iter, hsize_t H5_ATTR_
 static hsize_t
 H5S__none_iter_nelmts(const H5S_sel_iter_t H5_ATTR_UNUSED *iter)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -253,7 +253,7 @@ H5S__none_iter_nelmts(const H5S_sel_iter_t H5_ATTR_UNUSED *iter)
 static htri_t
 H5S__none_iter_has_next_block(const H5S_sel_iter_t H5_ATTR_UNUSED *iter)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -282,7 +282,7 @@ H5S__none_iter_has_next_block(const H5S_sel_iter_t H5_ATTR_UNUSED *iter)
 static herr_t
 H5S__none_iter_next(H5S_sel_iter_t H5_ATTR_UNUSED *iter, size_t H5_ATTR_UNUSED nelem)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -311,7 +311,7 @@ H5S__none_iter_next(H5S_sel_iter_t H5_ATTR_UNUSED *iter, size_t H5_ATTR_UNUSED n
 static herr_t
 H5S__none_iter_next_block(H5S_sel_iter_t H5_ATTR_UNUSED *iter)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -353,7 +353,7 @@ H5S__none_iter_get_seq_list(H5S_sel_iter_t H5_ATTR_UNUSED *iter, size_t H5_ATTR_
                             size_t H5_ATTR_UNUSED maxelem, size_t *nseq, size_t *nelem,
                             hsize_t H5_ATTR_UNUSED *off, size_t H5_ATTR_UNUSED *len)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -393,7 +393,7 @@ H5S__none_iter_get_seq_list(H5S_sel_iter_t H5_ATTR_UNUSED *iter, size_t H5_ATTR_
 static herr_t
 H5S__none_iter_release(H5S_sel_iter_t H5_ATTR_UNUSED *iter)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -421,7 +421,7 @@ H5S__none_iter_release(H5S_sel_iter_t H5_ATTR_UNUSED *iter)
 static herr_t
 H5S__none_release(H5S_t H5_ATTR_UNUSED *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space);
@@ -452,7 +452,7 @@ H5S__none_release(H5S_t H5_ATTR_UNUSED *space)
 static herr_t
 H5S__none_copy(H5S_t *dst, const H5S_t H5_ATTR_UNUSED *src, hbool_t H5_ATTR_UNUSED share_selection)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(src);
     HDassert(dst);
@@ -486,7 +486,7 @@ H5S__none_copy(H5S_t *dst, const H5S_t H5_ATTR_UNUSED *src, hbool_t H5_ATTR_UNUS
 static htri_t
 H5S__none_is_valid(const H5S_t H5_ATTR_UNUSED *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
 
@@ -515,7 +515,7 @@ H5S__none_is_valid(const H5S_t H5_ATTR_UNUSED *space)
 static hssize_t
 H5S__none_serial_size(H5S_t H5_ATTR_UNUSED *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
 
@@ -552,7 +552,7 @@ H5S__none_serialize(H5S_t *space, uint8_t **p)
 {
     uint8_t *pp = (*p); /* Local pointer for decoding */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space);
@@ -601,7 +601,7 @@ H5S__none_deserialize(H5S_t **space, const uint8_t **p)
     uint32_t version;             /* Version number */
     herr_t   ret_value = SUCCEED; /* return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(p);
     HDassert(*p);
@@ -673,7 +673,7 @@ static herr_t
 H5S__none_bounds(const H5S_t H5_ATTR_UNUSED *space, hsize_t H5_ATTR_UNUSED *start,
                  hsize_t H5_ATTR_UNUSED *end)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
     HDassert(start);
@@ -705,7 +705,7 @@ H5S__none_bounds(const H5S_t H5_ATTR_UNUSED *space, hsize_t H5_ATTR_UNUSED *star
 static herr_t
 H5S__none_offset(const H5S_t H5_ATTR_UNUSED *space, hsize_t H5_ATTR_UNUSED *offset)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
     HDassert(offset);
@@ -735,7 +735,7 @@ H5S__none_offset(const H5S_t H5_ATTR_UNUSED *space, hsize_t H5_ATTR_UNUSED *offs
 static int
 H5S__none_unlim_dim(const H5S_t H5_ATTR_UNUSED *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(-1)
 } /* end H5S__none_unlim_dim() */
@@ -761,7 +761,7 @@ H5S__none_unlim_dim(const H5S_t H5_ATTR_UNUSED *space)
 static htri_t
 H5S__none_is_contiguous(const H5S_t H5_ATTR_UNUSED *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
 
@@ -789,7 +789,7 @@ H5S__none_is_contiguous(const H5S_t H5_ATTR_UNUSED *space)
 static htri_t
 H5S__none_is_single(const H5S_t H5_ATTR_UNUSED *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
 
@@ -818,7 +818,7 @@ H5S__none_is_single(const H5S_t H5_ATTR_UNUSED *space)
 static htri_t
 H5S__none_is_regular(H5S_t H5_ATTR_UNUSED *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space);
@@ -848,7 +848,7 @@ H5S__none_is_regular(H5S_t H5_ATTR_UNUSED *space)
 static htri_t
 H5S__none_shape_same(H5S_t H5_ATTR_UNUSED *space1, H5S_t H5_ATTR_UNUSED *space2)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space1);
@@ -880,7 +880,7 @@ htri_t
 H5S__none_intersect_block(H5S_t H5_ATTR_UNUSED *space, const hsize_t H5_ATTR_UNUSED *start,
                           const hsize_t H5_ATTR_UNUSED *end)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(space);
@@ -912,7 +912,7 @@ H5S__none_intersect_block(H5S_t H5_ATTR_UNUSED *space, const hsize_t H5_ATTR_UNU
 static herr_t
 H5S__none_adjust_u(H5S_t H5_ATTR_UNUSED *space, const hsize_t H5_ATTR_UNUSED *offset)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space);
@@ -942,7 +942,7 @@ H5S__none_adjust_u(H5S_t H5_ATTR_UNUSED *space, const hsize_t H5_ATTR_UNUSED *of
 static herr_t
 H5S__none_adjust_s(H5S_t H5_ATTR_UNUSED *space, const hssize_t H5_ATTR_UNUSED *offset)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space);
@@ -966,7 +966,7 @@ H5S__none_adjust_s(H5S_t H5_ATTR_UNUSED *space, const hssize_t H5_ATTR_UNUSED *o
 static herr_t
 H5S__none_project_scalar(const H5S_t H5_ATTR_UNUSED *space, hsize_t H5_ATTR_UNUSED *offset)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space && H5S_SEL_NONE == H5S_GET_SELECT_TYPE(space));
@@ -994,7 +994,7 @@ H5S__none_project_simple(const H5S_t H5_ATTR_UNUSED *base_space, H5S_t *new_spac
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(base_space && H5S_SEL_NONE == H5S_GET_SELECT_TYPE(base_space));

--- a/src/H5Spoint.c
+++ b/src/H5Spoint.c
@@ -174,7 +174,7 @@ H5S__point_iter_init(H5S_t *space, H5S_sel_iter_t *iter)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(space && H5S_SEL_POINTS == H5S_GET_SELECT_TYPE(space));
@@ -225,7 +225,7 @@ done:
 static herr_t
 H5S__point_iter_coords(const H5S_sel_iter_t *iter, hsize_t *coords)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -253,7 +253,7 @@ H5S__point_iter_coords(const H5S_sel_iter_t *iter, hsize_t *coords)
 static herr_t
 H5S__point_iter_block(const H5S_sel_iter_t *iter, hsize_t *start, hsize_t *end)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -282,7 +282,7 @@ H5S__point_iter_block(const H5S_sel_iter_t *iter, hsize_t *start, hsize_t *end)
 static hsize_t
 H5S__point_iter_nelmts(const H5S_sel_iter_t *iter)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -312,7 +312,7 @@ H5S__point_iter_has_next_block(const H5S_sel_iter_t *iter)
 {
     htri_t ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -346,7 +346,7 @@ done:
 static herr_t
 H5S__point_iter_next(H5S_sel_iter_t *iter, size_t nelem)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -381,7 +381,7 @@ H5S__point_iter_next(H5S_sel_iter_t *iter, size_t nelem)
 static herr_t
 H5S__point_iter_next_block(H5S_sel_iter_t *iter)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -435,7 +435,7 @@ H5S__point_iter_get_seq_list(H5S_sel_iter_t *iter, size_t maxseq, size_t maxelem
     int             i;                   /* Local index variable */
     herr_t          ret_value = SUCCEED; /* return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -542,7 +542,7 @@ H5S__point_iter_get_seq_list(H5S_sel_iter_t *iter, size_t maxseq, size_t maxelem
 static herr_t
 H5S__point_iter_release(H5S_sel_iter_t *iter)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -580,7 +580,7 @@ H5S__point_add(H5S_t *space, H5S_seloper_t op, size_t num_elem, const hsize_t *c
     unsigned        u;                                          /* Counter */
     herr_t          ret_value = SUCCEED;                        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(space);
@@ -692,7 +692,7 @@ done:
 static herr_t
 H5S__point_release(H5S_t *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space);
@@ -804,7 +804,7 @@ H5S__copy_pnt_list(const H5S_pnt_list_t *src, unsigned rank)
     H5S_pnt_node_t *curr, *new_tail;  /* Point information nodes */
     H5S_pnt_list_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(src);
@@ -879,7 +879,7 @@ H5S__free_pnt_list(H5S_pnt_list_t *pnt_lst)
 {
     H5S_pnt_node_t *curr; /* Point information nodes */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(pnt_lst);
@@ -923,7 +923,7 @@ H5S__point_copy(H5S_t *dst, const H5S_t *src, hbool_t H5_ATTR_UNUSED share_selec
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(src);
@@ -964,7 +964,7 @@ H5S__point_is_valid(const H5S_t *space)
     unsigned u;                /* Counter */
     htri_t   ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
 
@@ -1063,7 +1063,7 @@ H5S__point_get_version_enc_size(const H5S_t *space, uint32_t *version, uint8_t *
     unsigned     u;                          /* Local index variable */
     herr_t       ret_value = SUCCEED;        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get bounding box for the selection */
     HDmemset(bounds_end, 0, sizeof(bounds_end));
@@ -1165,7 +1165,7 @@ H5S__point_serial_size(H5S_t *space)
     uint8_t  enc_size;       /* Encoded size of point selection info */
     hssize_t ret_value = -1; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(space);
 
@@ -1230,7 +1230,7 @@ H5S__point_serialize(H5S_t *space, uint8_t **p)
     uint8_t         enc_size;            /* Encoded size of point selection info */
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(space);
@@ -1366,7 +1366,7 @@ H5S__point_deserialize(H5S_t **space, const uint8_t **p)
     unsigned       i, j;                     /* local counting variables */
     herr_t         ret_value = SUCCEED;      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(p);
@@ -1519,7 +1519,7 @@ H5S__get_select_elem_pointlist(const H5S_t *space, hsize_t startpoint, hsize_t n
     H5S_pnt_node_t *node;                              /* Point node */
     unsigned        rank;                              /* Dataspace rank */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
     HDassert(buf);
@@ -1642,7 +1642,7 @@ H5S__point_bounds(const H5S_t *space, hsize_t *start, hsize_t *end)
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(space);
@@ -1700,7 +1700,7 @@ H5S__point_offset(const H5S_t *space, hsize_t *offset)
     int             i;                   /* index variable */
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(space);
     HDassert(offset);
@@ -1756,7 +1756,7 @@ done:
 static int
 H5S__point_unlim_dim(const H5S_t H5_ATTR_UNUSED *space)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(-1)
 } /* end H5S__point_unlim_dim() */
@@ -1787,7 +1787,7 @@ H5S__point_is_contiguous(const H5S_t *space)
 {
     htri_t ret_value = FAIL; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
 
@@ -1824,7 +1824,7 @@ H5S__point_is_single(const H5S_t *space)
 {
     htri_t ret_value = FAIL; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
 
@@ -1863,7 +1863,7 @@ H5S__point_is_regular(H5S_t *space)
 {
     htri_t ret_value = FAIL; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space);
@@ -1907,7 +1907,7 @@ H5S__point_shape_same(H5S_t *space1, H5S_t *space2)
     int             space2_dim;           /* Current dimension in second dataspace */
     htri_t          ret_value = TRUE;     /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(space1);
@@ -2008,7 +2008,7 @@ H5S__point_intersect_block(H5S_t *space, const hsize_t *start, const hsize_t *en
     H5S_pnt_node_t *pnt;               /* Point information node */
     htri_t          ret_value = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(space);
@@ -2064,7 +2064,7 @@ H5S__point_adjust_u(H5S_t *space, const hsize_t *offset)
     unsigned        rank;                    /* Dataspace rank */
     unsigned        u;                       /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
     HDassert(offset);
@@ -2131,7 +2131,7 @@ H5S__point_adjust_s(H5S_t *space, const hssize_t *offset)
     unsigned        rank;                    /* Dataspace rank */
     unsigned        u;                       /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(space);
     HDassert(offset);
@@ -2194,7 +2194,7 @@ H5S__point_project_scalar(const H5S_t *space, hsize_t *offset)
     const H5S_pnt_node_t *node;                /* Point node */
     herr_t                ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(space && H5S_SEL_POINTS == H5S_GET_SELECT_TYPE(space));
@@ -2238,7 +2238,7 @@ H5S__point_project_simple(const H5S_t *base_space, H5S_t *new_space, hsize_t *of
     unsigned              u;                   /* Local index variable */
     herr_t                ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(base_space && H5S_SEL_POINTS == H5S_GET_SELECT_TYPE(base_space));

--- a/src/H5Sselect.c
+++ b/src/H5Sselect.c
@@ -1222,7 +1222,7 @@ H5S__select_iter_block(const H5S_sel_iter_t *iter, hsize_t *start, hsize_t *end)
 {
     herr_t ret_value; /* return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -1300,7 +1300,7 @@ H5S__select_iter_has_next_block(const H5S_sel_iter_t *iter)
 {
     herr_t ret_value; /* return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);
@@ -1384,7 +1384,7 @@ H5S__select_iter_next_block(H5S_sel_iter_t *iter)
 {
     herr_t ret_value; /* return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
     HDassert(iter);

--- a/src/H5Stest.c
+++ b/src/H5Stest.c
@@ -173,7 +173,7 @@ H5S__check_spans_tail_ptr(const H5S_hyper_span_info_t *span_lst)
     H5S_hyper_span_t *actual_tail = NULL;
     htri_t            ret_value   = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(span_lst);
 
@@ -222,7 +222,7 @@ H5S__check_points_tail_ptr(const H5S_pnt_list_t *pnt_lst)
     H5S_pnt_node_t *actual_tail = NULL;
     htri_t          ret_value   = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(pnt_lst);
 
@@ -266,7 +266,7 @@ H5S__check_internal_consistency(const H5S_t *space)
     unsigned u;
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(space);

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -621,7 +621,7 @@ H5T__init_inf(void)
     size_t        u;                   /* Local index value        */
     herr_t        ret_value = SUCCEED; /* Return value             */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get the float datatype */
     if (NULL == (dst_p = (H5T_t *)H5I_object(H5T_NATIVE_FLOAT_g)))
@@ -1462,7 +1462,7 @@ H5T__unlock_cb(void *_dt, hid_t H5_ATTR_UNUSED id, void *_udata)
     H5T_t *dt = (H5T_t *)_dt;
     int *  n  = (int *)_udata;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(dt);
     HDassert(dt->shared);
@@ -1720,7 +1720,7 @@ H5T__close_cb(H5T_t *dt, void **request)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(dt);
@@ -2484,7 +2484,7 @@ H5T__register_int(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T
     H5T_conv_func_t conv_func;           /* Conversion function wrapper */
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(H5T_PERS_HARD == pers || H5T_PERS_SOFT == pers);
@@ -2535,7 +2535,7 @@ H5T__register(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_con
     int         i;                          /*counter                    */
     herr_t      ret_value = SUCCEED;        /*return value               */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(src);
@@ -2769,7 +2769,7 @@ H5T__unregister(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_c
     int         nprint = 0;    /*number of paths shut down   */
     int         i;             /*counter                     */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Remove matching entries from the soft list */
     if (H5T_PERS_DONTCARE == pers || H5T_PERS_SOFT == pers) {
@@ -3424,7 +3424,7 @@ H5T__initiate_copy(const H5T_t *old_dt)
     H5T_t *new_dt    = NULL; /* Copy of datatype */
     H5T_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Allocate space */
     if (NULL == (new_dt = H5FL_MALLOC(H5T_t)))
@@ -3477,7 +3477,7 @@ H5T__copy_transient(H5T_t *old_dt)
 {
     H5T_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Copy datatype, with correct method */
     if (NULL == (ret_value = H5T_copy(old_dt, H5T_COPY_TRANSIENT)))
@@ -3505,7 +3505,7 @@ H5T__copy_all(H5T_t *old_dt)
 {
     H5T_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Copy datatype, with correct method */
     if (NULL == (ret_value = H5T_copy(old_dt, H5T_COPY_ALL)))
@@ -3540,7 +3540,7 @@ H5T__complete_copy(H5T_t *new_dt, const H5T_t *old_dt, H5T_shared_t *reopened_fo
     unsigned i;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Update fields in the new struct, if we aren't sharing an already opened
      * committed datatype */
@@ -4239,7 +4239,7 @@ H5T__set_size(H5T_t *dt, size_t size)
     size_t prec, offset;
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(dt);
@@ -5021,7 +5021,7 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
     int         nprint    = 0;            /* lines of output printed */
     H5T_path_t *ret_value = NULL;         /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(src);
@@ -5405,7 +5405,7 @@ H5T__compiler_conv(H5T_t *src, H5T_t *dst)
     H5T_path_t *path;
     htri_t      ret_value = FAIL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Find it */
     if (NULL == (path = H5T_path_find(src, dst)))
@@ -5977,7 +5977,7 @@ H5T__detect_vlen_ref(const H5T_t *dt)
     unsigned u;                 /* Local index variable */
     hbool_t  ret_value = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     HDassert(dt);
@@ -6080,7 +6080,7 @@ H5T_is_vl_storage(const H5T_t *dt)
 static herr_t
 H5T__upgrade_version_cb(H5T_t *dt, void *op_value)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     HDassert(dt);

--- a/src/H5TS.c
+++ b/src/H5TS.c
@@ -158,7 +158,7 @@ static H5TS_key_t H5TS_tid_key;
 static void
 H5TS__key_destructor(void *key_val)
 {
-    FUNC_ENTER_STATIC_NAMECHECK_ONLY
+    FUNC_ENTER_PACKAGE_NAMECHECK_ONLY
 
     /* Use HDfree here instead of H5MM_xfree(), to avoid calling the H5CS routines */
     if (key_val != NULL)
@@ -373,7 +373,7 @@ H5TS__mutex_acquire(H5TS_mutex_t *mutex, unsigned int lock_count, hbool_t *acqui
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC_NAMECHECK_ONLY
+    FUNC_ENTER_PACKAGE_NAMECHECK_ONLY
 
 #ifdef H5_HAVE_WIN_THREADS
     EnterCriticalSection(&mutex->CriticalSection);

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -106,7 +106,7 @@ H5T__commit_api_common(hid_t loc_id, const char *name, hid_t type_id, hid_t lcpl
     H5VL_loc_params_t loc_params;                     /* Location parameters */
     herr_t            ret_value = SUCCEED;            /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (!name)
@@ -629,7 +629,7 @@ H5T__open_api_common(hid_t loc_id, const char *name, hid_t tapl_id, void **token
     H5VL_loc_params_t loc_params;
     hid_t             ret_value = H5I_INVALID_HID; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     if (!name)
@@ -1166,7 +1166,7 @@ H5T__open_oid(const H5G_loc_t *loc)
     H5T_t *dt        = NULL; /* Datatype from the file */
     H5T_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC_TAG(loc->oloc->addr)
+    FUNC_ENTER_PACKAGE_TAG(loc->oloc->addr)
 
     HDassert(loc);
 

--- a/src/H5Tcompound.c
+++ b/src/H5Tcompound.c
@@ -282,7 +282,7 @@ H5T__reopen_member_type(const H5T_t *dt, unsigned membno)
 {
     H5T_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(dt);
@@ -521,7 +521,7 @@ H5T__pack(const H5T_t *dt)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(dt);
 
@@ -596,7 +596,7 @@ H5T__is_packed(const H5T_t *dt)
 {
     htri_t ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(dt);
 

--- a/src/H5Tconv.c
+++ b/src/H5Tconv.c
@@ -1912,7 +1912,7 @@ H5T__conv_struct_free(H5T_conv_struct_t *priv)
     hid_t *  src_memb_id = priv->src_memb_id, *dst_memb_id = priv->dst_memb_id;
     unsigned i;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     for (i = 0; i < priv->src_nmembs; i++)
         if (src2dst[i] >= 0) {
@@ -1987,7 +1987,7 @@ H5T__conv_struct_init(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata)
     unsigned           i, j;
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     src_nmembs = src->shared->u.compnd.nmembs;
     dst_nmembs = dst->shared->u.compnd.nmembs;
@@ -2680,7 +2680,7 @@ H5T__conv_enum_init(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata)
     unsigned           i, j;                /*counters            */
     herr_t             ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     cdata->need_bkg = H5T_BKG_NO;
     if (NULL == (priv = (H5T_enum_struct_t *)(cdata->priv = H5MM_calloc(sizeof(*priv)))))
@@ -9437,7 +9437,7 @@ H5T__reverse_order(uint8_t *rev, uint8_t *s, size_t size, H5T_order_t order)
 {
     size_t i;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(s);
     HDassert(size);

--- a/src/H5Tenum.c
+++ b/src/H5Tenum.c
@@ -363,7 +363,7 @@ H5T__enum_nameof(const H5T_t *dt, const void *value, char *name /*out*/, size_t 
     hbool_t  alloc_name = FALSE; /* Whether name has been allocated */
     char *   ret_value  = NULL;  /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(dt && H5T_ENUM == dt->shared->type);
@@ -493,7 +493,7 @@ H5T__enum_valueof(const H5T_t *dt, const char *name, void *value /*out*/)
     H5T_t *  copied_dt = NULL;    /*do sorting in copied datatype */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(dt && H5T_ENUM == dt->shared->type);

--- a/src/H5Tnative.c
+++ b/src/H5Tnative.c
@@ -140,7 +140,7 @@ H5T__get_native_type(H5T_t *dtype, H5T_direction_t direction, size_t *struct_ali
     unsigned    u;                     /* Local index variable */
     H5T_t *     ret_value = NULL;      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(dtype);
 
@@ -566,7 +566,7 @@ H5T__get_native_integer(size_t prec, H5T_sign_t sign, H5T_direction_t direction,
     } match          = H5T_NATIVE_INT_MATCH_UNKNOWN;
     H5T_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (direction == H5T_DIR_DEFAULT || direction == H5T_DIR_ASCEND) {
         if (prec <= H5T_get_precision((H5T_t *)H5I_object(H5T_NATIVE_SCHAR_g))) {
@@ -723,7 +723,7 @@ H5T__get_native_float(size_t size, H5T_direction_t direction, size_t *struct_ali
     } match          = H5T_NATIVE_FLOAT_MATCH_UNKNOWN;
     H5T_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(size > 0);
 
@@ -831,7 +831,7 @@ H5T__get_native_bitfield(size_t prec, H5T_direction_t direction, size_t *struct_
     size_t native_size = 0;    /* Datatype size of the native type */
     H5T_t *ret_value   = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (direction == H5T_DIR_DEFAULT || direction == H5T_DIR_ASCEND) {
         if (prec <= H5T_get_precision((H5T_t *)H5I_object(H5T_NATIVE_B8_g))) {
@@ -920,7 +920,7 @@ static herr_t
 H5T__cmp_offset(size_t *comp_size, size_t *offset, size_t elem_size, size_t nelems, size_t align,
                 size_t *struct_align)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (offset && comp_size) {
         if (align > 1 && *comp_size % align) {

--- a/src/H5Toffset.c
+++ b/src/H5Toffset.c
@@ -230,7 +230,7 @@ H5T__set_offset(const H5T_t *dt, size_t offset)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(dt);

--- a/src/H5Toh.c
+++ b/src/H5Toh.c
@@ -92,7 +92,7 @@ H5O__dtype_isa(const H5O_t *oh)
 {
     htri_t ret_value = FAIL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(oh);
 
@@ -122,7 +122,7 @@ H5O__dtype_open(const H5G_loc_t *obj_loc, H5I_type_t *opened_type)
     H5T_t *type      = NULL; /* Datatype opened */
     void * ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(obj_loc);
 
@@ -161,7 +161,7 @@ H5O__dtype_create(H5F_t *f, void *_crt_info, H5G_loc_t *obj_loc)
     H5T_obj_create_t *crt_info  = (H5T_obj_create_t *)_crt_info; /* Named datatype creation parameters */
     void *            ret_value = NULL;                          /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(f);
@@ -205,7 +205,7 @@ H5O__dtype_get_oloc(hid_t obj_id)
     H5T_t *    dt        = NULL;
     H5O_loc_t *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get the datatype */
     if (NULL == (dt = (H5T_t *)H5I_object(obj_id)))

--- a/src/H5Torder.c
+++ b/src/H5Torder.c
@@ -228,7 +228,7 @@ H5T__set_order(H5T_t *dtype, H5T_order_t order)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (H5T_ENUM == dtype->shared->type && dtype->shared->u.enumer.nmembs > 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTSET, FAIL, "operation not allowed after enum members are defined")

--- a/src/H5Tprecis.c
+++ b/src/H5Tprecis.c
@@ -191,7 +191,7 @@ H5T__set_precision(const H5T_t *dt, size_t prec)
     size_t offset, size;
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(dt);

--- a/src/H5Tref.c
+++ b/src/H5Tref.c
@@ -362,7 +362,7 @@ H5T__ref_mem_isnull(const H5VL_object_t H5_ATTR_UNUSED *src_file, const void *sr
     const unsigned char zeros[H5T_REF_MEM_SIZE] = {0};
     herr_t              ret_value               = SUCCEED;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
     H5T_REF_LOG_DEBUG("");
 
     /* Check parameters */
@@ -388,7 +388,7 @@ H5T__ref_mem_setnull(H5VL_object_t H5_ATTR_UNUSED *dst_file, void *dst_buf, H5_A
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
     H5T_REF_LOG_DEBUG("");
 
     HDmemset(dst_buf, 0, H5T_REF_MEM_SIZE);
@@ -416,7 +416,7 @@ H5T__ref_mem_getsize(H5VL_object_t H5_ATTR_UNUSED *src_file, const void *src_buf
     unsigned flags     = 0; /* References flags */
     size_t   ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
     H5T_REF_LOG_DEBUG("");
 
     /* Sanity check */
@@ -536,7 +536,7 @@ H5T__ref_mem_read(H5VL_object_t H5_ATTR_UNUSED *src_file, const void *src_buf, s
     unsigned flags     = 0;       /* References flags */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
     H5T_REF_LOG_DEBUG("");
 
     /* Sanity check */
@@ -647,7 +647,7 @@ H5T__ref_mem_write(H5VL_object_t *src_file, const void *src_buf, size_t src_size
     H5R_ref_priv_t  tmp_ref; /* Temporary reference to decode into */
     herr_t          ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
     H5T_REF_LOG_DEBUG("");
 
     /* Sanity check */
@@ -760,7 +760,7 @@ H5T__ref_disk_isnull(const H5VL_object_t *src_file, const void *src_buf, hbool_t
     H5R_type_t     ref_type;
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
     H5T_REF_LOG_DEBUG("");
 
     /* Check parameters */
@@ -810,7 +810,7 @@ H5T__ref_disk_setnull(H5VL_object_t *dst_file, void *dst_buf, void *bg_buf)
     uint8_t *                 p_bg      = (uint8_t *)bg_buf;
     herr_t                    ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
     H5T_REF_LOG_DEBUG("");
 
     HDassert(dst_file);
@@ -865,7 +865,7 @@ H5T__ref_disk_getsize(H5VL_object_t H5_ATTR_UNUSED *src_file, const void *src_bu
     H5R_type_t     ref_type;
     size_t         ret_value = 0;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
     H5T_REF_LOG_DEBUG("");
 
     HDassert(src_buf);
@@ -914,7 +914,7 @@ H5T__ref_disk_read(H5VL_object_t *src_file, const void *src_buf, size_t H5_ATTR_
     size_t         blob_size = dst_size;
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
     H5T_REF_LOG_DEBUG("");
 
     HDassert(src_file);
@@ -960,7 +960,7 @@ H5T__ref_disk_write(H5VL_object_t H5_ATTR_UNUSED *src_file, const void *src_buf,
     uint8_t *      p_bg          = (uint8_t *)bg_buf;
     herr_t         ret_value     = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
     H5T_REF_LOG_DEBUG("");
 
     HDassert(src_buf);
@@ -1023,7 +1023,7 @@ H5T__ref_obj_disk_isnull(const H5VL_object_t *src_file, const void *src_buf, hbo
     haddr_t        addr;
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
     H5T_REF_LOG_DEBUG("");
 
     /* Check parameters */
@@ -1075,7 +1075,7 @@ H5T__ref_obj_disk_getsize(H5VL_object_t *src_file, const void H5_ATTR_UNUSED *sr
     H5F_t *src_f;
     size_t ret_value = 0;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
     H5T_REF_LOG_DEBUG("");
 
     HDassert(src_file);
@@ -1122,7 +1122,7 @@ H5T__ref_obj_disk_read(H5VL_object_t *src_file, const void *src_buf, size_t src_
     H5F_t *src_f;
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
     H5T_REF_LOG_DEBUG("");
 
     HDassert(src_file);
@@ -1175,7 +1175,7 @@ H5T__ref_dsetreg_disk_isnull(const H5VL_object_t *src_file, const void *src_buf,
     haddr_t        addr;
     herr_t         ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
     H5T_REF_LOG_DEBUG("");
 
     /* Check parameters */
@@ -1227,9 +1227,9 @@ H5T__ref_dsetreg_disk_getsize(H5VL_object_t H5_ATTR_UNUSED *src_file, const void
     size_t ret_value = sizeof(struct H5Tref_dsetreg);
 
 #ifndef NDEBUG
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 #else
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 #endif
     H5T_REF_LOG_DEBUG("");
 
@@ -1279,7 +1279,7 @@ H5T__ref_dsetreg_disk_read(H5VL_object_t *src_file, const void *src_buf, size_t 
     struct H5Tref_dsetreg *dst_reg   = (struct H5Tref_dsetreg *)dst_buf;
     herr_t                 ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
     H5T_REF_LOG_DEBUG("");
 
     HDassert(src_file);

--- a/src/H5Tvlen.c
+++ b/src/H5Tvlen.c
@@ -375,7 +375,7 @@ H5T__vlen_mem_seq_getlen(H5VL_object_t H5_ATTR_UNUSED *file, const void *_vl, si
     hvl_t vl; /* User's hvl_t information */
 #endif
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check parameter */
     HDassert(_vl);
@@ -413,7 +413,7 @@ H5T__vlen_mem_seq_getptr(void *_vl)
     hvl_t vl; /* User's hvl_t information */
 #endif
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check parameters, return result */
 #ifdef H5_NO_ALIGNMENT_RESTRICTIONS
@@ -449,7 +449,7 @@ H5T__vlen_mem_seq_isnull(const H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, hb
     hvl_t vl; /* User's hvl_t information */
 #endif
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check parameters */
     HDassert(_vl);
@@ -482,7 +482,7 @@ H5T__vlen_mem_seq_setnull(H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, void H5
 {
     hvl_t vl; /* Temporary hvl_t to use during operation */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check parameters */
     HDassert(_vl);
@@ -518,7 +518,7 @@ H5T__vlen_mem_seq_read(H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, void *buf,
     hvl_t vl; /* User's hvl_t information */
 #endif
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check parameters, copy data */
     HDassert(buf);
@@ -556,7 +556,7 @@ H5T__vlen_mem_seq_write(H5VL_object_t H5_ATTR_UNUSED *file, const H5T_vlen_alloc
     hvl_t  vl;                  /* Temporary hvl_t to use during operation */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check parameters */
     HDassert(_vl);
@@ -612,7 +612,7 @@ H5T__vlen_mem_str_getlen(H5VL_object_t H5_ATTR_UNUSED *file, const void *_vl, si
     const char *s = NULL; /* Pointer to the user's string information */
 #endif
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check parameters */
     HDassert(_vl);
@@ -647,7 +647,7 @@ H5T__vlen_mem_str_getptr(void *_vl)
     char *      s = NULL; /* Pointer to the user's string information */
 #endif
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check parameters */
 #ifdef H5_NO_ALIGNMENT_RESTRICTIONS
@@ -681,7 +681,7 @@ H5T__vlen_mem_str_isnull(const H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, hb
     char *s = NULL; /* Pointer to the user's string information */
 #endif
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
 #ifndef H5_NO_ALIGNMENT_RESTRICTIONS
     H5MM_memcpy(&s, _vl, sizeof(char *));
@@ -709,7 +709,7 @@ H5T__vlen_mem_str_setnull(H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, void H5
 {
     char *t = NULL; /* Pointer to temporary buffer allocated */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Set pointer in user's buffer with memcpy, to avoid alignment issues */
     H5MM_memcpy(_vl, &t, sizeof(char *));
@@ -738,7 +738,7 @@ H5T__vlen_mem_str_read(H5VL_object_t H5_ATTR_UNUSED *file, void *_vl, void *buf,
     char *s;        /* Pointer to the user's string information */
 #endif
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (len > 0) {
         /* check parameters */
@@ -776,7 +776,7 @@ H5T__vlen_mem_str_write(H5VL_object_t H5_ATTR_UNUSED *file, const H5T_vlen_alloc
     size_t len;                 /* Maximum length of the string to copy */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check parameters */
     HDassert(buf);
@@ -821,7 +821,7 @@ H5T__vlen_disk_getlen(H5VL_object_t H5_ATTR_UNUSED *file, const void *_vl, size_
 {
     const uint8_t *vl = (const uint8_t *)_vl; /* Pointer to the user's hvl_t information */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Check parameters */
     HDassert(vl);
@@ -852,7 +852,7 @@ H5T__vlen_disk_isnull(const H5VL_object_t *file, void *_vl, hbool_t *isnull)
     uint8_t *                 vl        = (uint8_t *)_vl; /* Pointer to the user's hvl_t information */
     herr_t                    ret_value = SUCCEED;        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check parameters */
     HDassert(file);
@@ -893,7 +893,7 @@ H5T__vlen_disk_setnull(H5VL_object_t *file, void *_vl, void *bg)
     uint8_t *                 vl        = (uint8_t *)_vl; /* Pointer to the user's hvl_t information */
     herr_t                    ret_value = SUCCEED;        /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check parameters */
     HDassert(file);
@@ -937,7 +937,7 @@ H5T__vlen_disk_read(H5VL_object_t *file, void *_vl, void *buf, size_t len)
     const uint8_t *vl        = (const uint8_t *)_vl; /* Pointer to the user's hvl_t information */
     herr_t         ret_value = SUCCEED;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check parameters */
     HDassert(file);
@@ -975,7 +975,7 @@ H5T__vlen_disk_write(H5VL_object_t *file, const H5T_vlen_alloc_info_t H5_ATTR_UN
     const uint8_t *bg        = (const uint8_t *)_bg; /* Pointer to the old data hvl_t */
     herr_t         ret_value = SUCCEED;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check parameters */
     HDassert(vl);
@@ -1016,7 +1016,7 @@ H5T__vlen_disk_delete(H5VL_object_t *file, const void *_vl)
     const uint8_t *vl        = (const uint8_t *)_vl; /* Pointer to the user's hvl_t information */
     herr_t         ret_value = SUCCEED;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check parameters */
     HDassert(file);

--- a/src/H5VLcallback.c
+++ b/src/H5VLcallback.c
@@ -346,7 +346,7 @@ H5VL__common_optional_op(hid_t id, H5I_type_t id_type, H5VL_reg_opt_oper_t reg_o
     hbool_t         vol_wrapper_set = FALSE;   /* Whether the VOL object wrapping context was set up */
     herr_t          ret_value       = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check ID type & get VOL object */
     if (NULL == (*vol_obj_ptr = (H5VL_object_t *)H5I_object_verify(id, id_type)))
@@ -987,7 +987,7 @@ H5VL__attr_create(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_cla
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->attr_cls.create)
@@ -1092,7 +1092,7 @@ H5VL__attr_open(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_class
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->attr_cls.open)
@@ -1192,7 +1192,7 @@ H5VL__attr_read(void *obj, const H5VL_class_t *cls, hid_t mem_type_id, void *buf
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->attr_cls.read)
@@ -1290,7 +1290,7 @@ H5VL__attr_write(void *obj, const H5VL_class_t *cls, hid_t mem_type_id, const vo
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->attr_cls.write)
@@ -1388,7 +1388,7 @@ H5VL__attr_get(void *obj, const H5VL_class_t *cls, H5VL_attr_get_args_t *args, h
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->attr_cls.get)
@@ -1488,7 +1488,7 @@ H5VL__attr_specific(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_c
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->attr_cls.specific)
@@ -1591,7 +1591,7 @@ H5VL__attr_optional(void *obj, const H5VL_class_t *cls, H5VL_optional_args_t *ar
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->attr_cls.optional)
@@ -1735,7 +1735,7 @@ H5VL__attr_close(void *obj, const H5VL_class_t *cls, hid_t dxpl_id, void **req)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->attr_cls.close)
@@ -1827,7 +1827,7 @@ H5VL__dataset_create(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->dataset_cls.create)
@@ -1934,7 +1934,7 @@ H5VL__dataset_open(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_cl
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->dataset_cls.open)
@@ -2035,7 +2035,7 @@ H5VL__dataset_read(void *obj, const H5VL_class_t *cls, hid_t mem_type_id, hid_t 
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->dataset_cls.read)
@@ -2137,7 +2137,7 @@ H5VL__dataset_write(void *obj, const H5VL_class_t *cls, hid_t mem_type_id, hid_t
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->dataset_cls.write)
@@ -2239,7 +2239,7 @@ H5VL__dataset_get(void *obj, const H5VL_class_t *cls, H5VL_dataset_get_args_t *a
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->dataset_cls.get)
@@ -2338,7 +2338,7 @@ H5VL__dataset_specific(void *obj, const H5VL_class_t *cls, H5VL_dataset_specific
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->dataset_cls.specific)
@@ -2438,7 +2438,7 @@ H5VL__dataset_optional(void *obj, const H5VL_class_t *cls, H5VL_optional_args_t 
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->dataset_cls.optional)
@@ -2579,7 +2579,7 @@ H5VL__dataset_close(void *obj, const H5VL_class_t *cls, hid_t dxpl_id, void **re
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(obj);
@@ -2688,7 +2688,7 @@ H5VL__datatype_commit(void *obj, const H5VL_loc_params_t *loc_params, const H5VL
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->datatype_cls.commit)
@@ -2793,7 +2793,7 @@ H5VL__datatype_open(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_c
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->datatype_cls.open)
@@ -2894,7 +2894,7 @@ H5VL__datatype_get(void *obj, const H5VL_class_t *cls, H5VL_datatype_get_args_t 
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->datatype_cls.get)
@@ -2993,7 +2993,7 @@ H5VL__datatype_specific(void *obj, const H5VL_class_t *cls, H5VL_datatype_specif
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->datatype_cls.specific)
@@ -3093,7 +3093,7 @@ H5VL__datatype_optional(void *obj, const H5VL_class_t *cls, H5VL_optional_args_t
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->datatype_cls.optional)
@@ -3282,7 +3282,7 @@ H5VL__datatype_close(void *obj, const H5VL_class_t *cls, hid_t dxpl_id, void **r
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->datatype_cls.close)
@@ -3383,7 +3383,7 @@ H5VL__file_create(const H5VL_class_t *cls, const char *name, unsigned flags, hid
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->file_cls.create)
@@ -3487,7 +3487,7 @@ H5VL__file_open(const H5VL_class_t *cls, const char *name, unsigned flags, hid_t
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->file_cls.open)
@@ -3533,7 +3533,7 @@ H5VL__file_open_find_connector_cb(H5PL_type_t plugin_type, const void *plugin_in
     hid_t                            fapl_id      = H5I_INVALID_HID;
     herr_t                           ret_value    = H5_ITER_CONT;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(udata);
     HDassert(udata->filename);
@@ -3747,7 +3747,7 @@ H5VL__file_get(void *obj, const H5VL_class_t *cls, H5VL_file_get_args_t *args, h
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->file_cls.get)
@@ -3845,7 +3845,7 @@ H5VL__file_specific(void *obj, const H5VL_class_t *cls, H5VL_file_specific_args_
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->file_cls.specific)
@@ -3977,7 +3977,7 @@ H5VL__file_optional(void *obj, const H5VL_class_t *cls, H5VL_optional_args_t *ar
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->file_cls.optional)
@@ -4118,7 +4118,7 @@ H5VL__file_close(void *obj, const H5VL_class_t *cls, hid_t dxpl_id, void **req)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(obj);
@@ -4220,7 +4220,7 @@ H5VL__group_create(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_cl
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->group_cls.create)
@@ -4324,7 +4324,7 @@ H5VL__group_open(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_clas
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->group_cls.open)
@@ -4424,7 +4424,7 @@ H5VL__group_get(void *obj, const H5VL_class_t *cls, H5VL_group_get_args_t *args,
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->group_cls.get)
@@ -4522,7 +4522,7 @@ H5VL__group_specific(void *obj, const H5VL_class_t *cls, H5VL_group_specific_arg
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->group_cls.specific)
@@ -4621,7 +4621,7 @@ H5VL__group_optional(void *obj, const H5VL_class_t *cls, H5VL_optional_args_t *a
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->group_cls.optional)
@@ -4769,7 +4769,7 @@ H5VL__group_close(void *obj, const H5VL_class_t *cls, hid_t dxpl_id, void **req)
     HDassert(obj);
     HDassert(cls);
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->group_cls.close)
@@ -4869,7 +4869,7 @@ H5VL__link_create(H5VL_link_create_args_t *args, void *obj, const H5VL_loc_param
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->link_cls.create)
@@ -4981,7 +4981,7 @@ H5VL__link_copy(void *src_obj, const H5VL_loc_params_t *loc_params1, void *dst_o
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->link_cls.copy)
@@ -5088,7 +5088,7 @@ H5VL__link_move(void *src_obj, const H5VL_loc_params_t *loc_params1, void *dst_o
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->link_cls.move)
@@ -5194,7 +5194,7 @@ H5VL__link_get(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_class_
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->link_cls.get)
@@ -5294,7 +5294,7 @@ H5VL__link_specific(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_c
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->link_cls.specific)
@@ -5398,7 +5398,7 @@ H5VL__link_optional(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_c
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->link_cls.optional)
@@ -5559,7 +5559,7 @@ H5VL__object_open(void *obj, const H5VL_loc_params_t *params, const H5VL_class_t
 {
     void *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->object_cls.open)
@@ -5661,7 +5661,7 @@ H5VL__object_copy(void *src_obj, const H5VL_loc_params_t *src_loc_params, const 
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->object_cls.copy)
@@ -5772,7 +5772,7 @@ H5VL__object_get(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_clas
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->object_cls.get)
@@ -5872,7 +5872,7 @@ H5VL__object_specific(void *obj, const H5VL_loc_params_t *loc_params, const H5VL
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->object_cls.specific)
@@ -5976,7 +5976,7 @@ H5VL__object_optional(void *obj, const H5VL_loc_params_t *loc_params, const H5VL
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->object_cls.optional)
@@ -6139,7 +6139,7 @@ H5VL__introspect_get_conn_cls(void *obj, const H5VL_class_t *cls, H5VL_get_conn_
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(obj);
@@ -6322,7 +6322,7 @@ H5VL__introspect_opt_query(void *obj, const H5VL_class_t *cls, H5VL_subclass_t s
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->introspect_cls.opt_query)
@@ -6420,7 +6420,7 @@ H5VL__request_wait(void *req, const H5VL_class_t *cls, uint64_t timeout, H5VL_re
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(req);
@@ -6524,7 +6524,7 @@ H5VL__request_notify(void *req, const H5VL_class_t *cls, H5VL_request_notify_t c
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(req);
@@ -6628,7 +6628,7 @@ H5VL__request_cancel(void *req, const H5VL_class_t *cls, H5VL_request_status_t *
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(req);
@@ -6730,7 +6730,7 @@ H5VL__request_specific(void *req, const H5VL_class_t *cls, H5VL_request_specific
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(req);
@@ -6835,7 +6835,7 @@ H5VL__request_optional(void *req, const H5VL_class_t *cls, H5VL_optional_args_t 
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(req);
@@ -6977,7 +6977,7 @@ H5VL__request_free(void *req, const H5VL_class_t *cls)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(req);
@@ -7078,7 +7078,7 @@ H5VL__blob_put(void *obj, const H5VL_class_t *cls, const void *buf, size_t size,
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(obj);
@@ -7176,7 +7176,7 @@ H5VL__blob_get(void *obj, const H5VL_class_t *cls, const void *blob_id, void *bu
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(obj);
@@ -7274,7 +7274,7 @@ H5VL__blob_specific(void *obj, const H5VL_class_t *cls, void *blob_id, H5VL_blob
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(obj);
@@ -7371,7 +7371,7 @@ H5VL__blob_optional(void *obj, const H5VL_class_t *cls, void *blob_id, H5VL_opti
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(obj);
@@ -7470,7 +7470,7 @@ H5VL__token_cmp(void *obj, const H5VL_class_t *cls, const H5O_token_t *token1, c
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(obj);
@@ -7591,7 +7591,7 @@ H5VL__token_to_str(void *obj, H5I_type_t obj_type, const H5VL_class_t *cls, cons
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(obj);
@@ -7698,7 +7698,7 @@ H5VL__token_from_str(void *obj, H5I_type_t obj_type, const H5VL_class_t *cls, co
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(obj);
@@ -7804,7 +7804,7 @@ H5VL__optional(void *obj, const H5VL_class_t *cls, H5VL_optional_args_t *args, h
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check if the corresponding VOL callback exists */
     if (NULL == cls->optional)

--- a/src/H5VLdyn_ops.c
+++ b/src/H5VLdyn_ops.c
@@ -116,7 +116,7 @@ H5FL_DEFINE_STATIC(H5VL_dyn_op_t);
 static void
 H5VL__release_dyn_op(H5VL_dyn_op_t *dyn_op)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     H5MM_xfree(dyn_op->op_name);
     H5FL_FREE(H5VL_dyn_op_t, dyn_op);
@@ -139,7 +139,7 @@ H5VL__term_opt_operation_cb(void *_item, void H5_ATTR_UNUSED *key, void H5_ATTR_
 {
     H5VL_dyn_op_t *item = (H5VL_dyn_op_t *)_item; /* Item to release */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Release the dynamically registered operation info */
     H5VL__release_dyn_op(item);

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -280,7 +280,7 @@ H5VL__free_cls(H5VL_class_t *cls, void H5_ATTR_UNUSED **request)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(cls);
@@ -318,7 +318,7 @@ H5VL__get_connector_cb(void *obj, hid_t id, void *_op_data)
     H5VL_class_t *           cls       = (H5VL_class_t *)obj;
     int                      ret_value = H5_ITER_CONT; /* Callback return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (H5VL_GET_CONNECTOR_BY_NAME == op_data->key.kind) {
         if (0 == HDstrcmp(cls->name, op_data->key.u.name)) {
@@ -498,7 +498,7 @@ H5VL__wrap_obj(void *obj, H5I_type_t obj_type)
     H5VL_wrap_ctx_t *vol_wrap_ctx = NULL; /* Object wrapping context */
     void *           ret_value    = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(obj);
@@ -541,7 +541,7 @@ H5VL__new_vol_obj(H5I_type_t type, void *object, H5VL_t *vol_connector, hbool_t 
     hbool_t        conn_rc_incr = FALSE; /* Whether the VOL connector refcount has been incremented */
     H5VL_object_t *ret_value    = NULL;  /* Return value                                 */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     HDassert(object);
@@ -1861,7 +1861,7 @@ H5VL__object(hid_t id, H5I_type_t obj_type)
     H5VL_object_t *vol_obj   = NULL;
     void *         ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get the underlying object */
     switch (obj_type) {
@@ -2229,7 +2229,7 @@ H5VL__free_vol_wrapper(H5VL_wrap_ctx_t *vol_wrap_ctx)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(vol_wrap_ctx);

--- a/src/H5VLnative.c
+++ b/src/H5VLnative.c
@@ -210,7 +210,7 @@ done:
 static herr_t
 H5VL__native_term(void)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Reset VOL ID */
     H5VL_NATIVE_ID_g = H5I_INVALID_HID;

--- a/src/H5VLnative_dataset.c
+++ b/src/H5VLnative_dataset.c
@@ -80,7 +80,7 @@ H5VL__native_dataset_io_setup(H5D_t *dset, hid_t dxpl_id, hid_t file_space_id, h
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(dset);

--- a/src/H5VM.c
+++ b/src/H5VM.c
@@ -64,7 +64,7 @@ static void
 H5VM__stride_optimize1(unsigned *np /*in,out*/, hsize_t *elmt_size /*in,out*/, const hsize_t *size,
                        hsize_t *stride1)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* This has to be true because if we optimize the dimensionality down to
      * zero we still must make one reference.
@@ -103,7 +103,7 @@ static void
 H5VM__stride_optimize2(unsigned *np /*in,out*/, hsize_t *elmt_size /*in,out*/, const hsize_t *size,
                        hsize_t *stride1, hsize_t *stride2)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* This has to be true because if we optimize the dimensionality down to
      * zero we still must make one reference.
@@ -792,7 +792,7 @@ H5VM__stride_copy2(hsize_t nelmts, hsize_t elmt_size, unsigned dst_n, const hsiz
     int            j; /* Local index variable */
     hbool_t        carry;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(elmt_size < SIZET_MAX);
     HDassert(dst_n > 0);

--- a/src/H5Z.c
+++ b/src/H5Z.c
@@ -452,7 +452,7 @@ H5Z__check_unregister(hid_t ocpl_id, H5Z_filter_t filter_id)
     H5P_genplist_t *plist;             /* Property list */
     htri_t          ret_value = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get the plist structure of object creation */
     if (NULL == (plist = H5P_object_verify(ocpl_id, H5P_OBJECT_CREATE)))
@@ -488,7 +488,7 @@ H5Z__check_unregister_group_cb(void *obj_ptr, hid_t H5_ATTR_UNUSED obj_id, void 
     htri_t        filter_in_pline = FALSE;
     int           ret_value       = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(obj_ptr);
 
@@ -538,7 +538,7 @@ H5Z__check_unregister_dset_cb(void *obj_ptr, hid_t H5_ATTR_UNUSED obj_id, void *
     htri_t        filter_in_pline = FALSE;
     int           ret_value       = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(obj_ptr);
 
@@ -585,7 +585,7 @@ H5Z__flush_file_cb(void *obj_ptr, hid_t H5_ATTR_UNUSED obj_id, void H5_ATTR_PARA
 #endif                     /* H5_HAVE_PARALLEL */
     int ret_value = FALSE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
     HDassert(obj_ptr);
@@ -710,7 +710,7 @@ H5Z__prelude_callback(const H5O_pline_t *pline, hid_t dcpl_id, hid_t type_id, hi
     size_t        u;                /* Local index variable */
     htri_t        ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(pline->nused > 0);
 
@@ -790,7 +790,7 @@ H5Z__prepare_prelude_callback_dcpl(hid_t dcpl_id, hid_t type_id, H5Z_prelude_typ
     H5O_layout_t *dcpl_layout = NULL;    /* Dataset's layout information */
     herr_t        ret_value   = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(H5I_GENPROP_LST == H5I_get_type(dcpl_id));
     HDassert(H5I_DATATYPE == H5I_get_type(type_id));
@@ -1216,7 +1216,7 @@ H5Z__find_idx(H5Z_filter_t id)
     size_t i;                /* Local index variable */
     int    ret_value = FAIL; /* Return value */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     for (i = 0; i < H5Z_table_used_g; i++)
         if (H5Z_table_g[i].id == id)

--- a/src/H5Zdeflate.c
+++ b/src/H5Zdeflate.c
@@ -72,7 +72,7 @@ H5Z__filter_deflate(unsigned flags, size_t cd_nelmts, const unsigned cd_values[]
     int    status;        /* Status from zlib operation */
     size_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     HDassert(*buf_size > 0);

--- a/src/H5Zfletcher32.c
+++ b/src/H5Zfletcher32.c
@@ -67,7 +67,7 @@ H5Z__filter_fletcher32(unsigned flags, size_t H5_ATTR_UNUSED cd_nelmts,
     uint8_t        tmp;
     size_t         ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(sizeof(uint32_t) >= 4);
 

--- a/src/H5Znbit.c
+++ b/src/H5Znbit.c
@@ -127,7 +127,7 @@ H5Z__can_apply_nbit(hid_t H5_ATTR_UNUSED dcpl_id, hid_t type_id, hid_t H5_ATTR_U
     const H5T_t *type;             /* Datatype */
     htri_t       ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get datatype */
     if (NULL == (type = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
@@ -220,7 +220,7 @@ H5Z__calc_parms_array(const H5T_t *type, size_t *cd_values_actual_nparms)
     H5T_class_t dtype_base_class;    /* Array datatype's base datatype's class */
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Store datatype class code */
     *cd_values_actual_nparms += 1;
@@ -303,7 +303,7 @@ H5Z__calc_parms_compound(const H5T_t *type, size_t *cd_values_actual_nparms)
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Store compound datatype class code */
     *cd_values_actual_nparms += 1;
@@ -405,7 +405,7 @@ H5Z__set_parms_nooptype(const H5T_t *type, unsigned *cd_values_index, unsigned c
     size_t dtype_size;          /* No-op datatype's size (in bytes) */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Set datatype class code */
     cd_values[(*cd_values_index)++] = H5Z_NBIT_NOOPTYPE;
@@ -447,7 +447,7 @@ H5Z__set_parms_atomic(const H5T_t *type, unsigned *cd_values_index, unsigned cd_
     unsigned    dtype_offset;        /* Atomic datatype's offset (in bits) */
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Set datatype class code */
     cd_values[(*cd_values_index)++] = H5Z_NBIT_ATOMIC;
@@ -537,7 +537,7 @@ H5Z__set_parms_array(const H5T_t *type, unsigned *cd_values_index, unsigned cd_v
     htri_t      is_vlstring;         /* flag indicating if datatype is variable-length string */
     herr_t      ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Set datatype class code */
     cd_values[(*cd_values_index)++] = H5Z_NBIT_ARRAY;
@@ -645,7 +645,7 @@ H5Z__set_parms_compound(const H5T_t *type, unsigned *cd_values_index, unsigned c
     unsigned    u;                        /* Local index variable */
     herr_t      ret_value = SUCCEED;      /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Set "local" parameter for compound datatype class code */
     cd_values[(*cd_values_index)++] = H5Z_NBIT_COMPOUND;
@@ -792,7 +792,7 @@ H5Z__set_local_nbit(hid_t dcpl_id, hid_t type_id, hid_t space_id)
     hbool_t         need_not_compress;   /* Flag if TRUE indicating no need to do nbit compression */
     herr_t          ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get datatype */
     if (NULL == (type = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
@@ -956,7 +956,7 @@ H5Z__filter_nbit(unsigned flags, size_t cd_nelmts, const unsigned cd_values[], s
     unsigned       d_nelmts  = 0; /* number of elements in the chunk */
     size_t         ret_value = 0; /* return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments
      * cd_values[0] stores actual number of parameters in cd_values[]
@@ -1152,7 +1152,7 @@ H5Z__nbit_decompress_one_array(unsigned char *data, size_t data_offset, unsigned
     parms_atomic p;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     total_size = parms[(*parms_index)++];
     base_class = parms[(*parms_index)++];
@@ -1219,7 +1219,7 @@ H5Z__nbit_decompress_one_compound(unsigned char *data, size_t data_offset, unsig
     parms_atomic p;
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     size     = parms[(*parms_index)++];
     nmembers = parms[(*parms_index)++];
@@ -1289,7 +1289,7 @@ H5Z__nbit_decompress(unsigned char *data, unsigned d_nelmts, unsigned char *buff
     unsigned     parms_index;         /* index in array parms used by compression/decompression functions */
     herr_t       ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* may not have to initialize to zeros */
     HDmemset(data, 0, d_nelmts * (size_t)parms[4]);

--- a/src/H5Zscaleoffset.c
+++ b/src/H5Zscaleoffset.c
@@ -758,7 +758,7 @@ H5Z__can_apply_scaleoffset(hid_t H5_ATTR_UNUSED dcpl_id, hid_t type_id, hid_t H5
     H5T_order_t  dtype_order;      /* Datatype's endianness order */
     htri_t       ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get datatype */
     if (NULL == (type = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
@@ -808,7 +808,7 @@ H5Z__scaleoffset_get_type(unsigned dtype_class, unsigned dtype_size, unsigned dt
     enum H5Z_scaleoffset_t type      = t_bad; /* integer type */
     enum H5Z_scaleoffset_t ret_value = t_bad; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (dtype_class == H5Z_SCALEOFFSET_CLS_INTEGER) {
         if (dtype_sign == H5Z_SCALEOFFSET_SGN_NONE) { /* unsigned integer */
@@ -881,7 +881,7 @@ H5Z__scaleoffset_set_parms_fillval(H5P_genplist_t *dcpl_plist, H5T_t *type, enum
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (scale_type == t_uchar)
         H5Z_scaleoffset_set_filval_3(unsigned char, dcpl_plist, type, cd_values, need_convert);
@@ -944,7 +944,7 @@ H5Z__set_local_scaleoffset(hid_t dcpl_id, hid_t type_id, hid_t space_id)
     H5D_fill_value_t       status;              /* Status of fill value in property list */
     herr_t                 ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get the plist structure */
     if (NULL == (dcpl_plist = H5P_object_verify(dcpl_id, H5P_DATASET_CREATE)))
@@ -1126,7 +1126,7 @@ H5Z__filter_scaleoffset(unsigned flags, size_t cd_nelmts, const unsigned cd_valu
     unsigned               i;                    /* index */
     parms_atomic           p;                    /* parameters needed for compress/decompress functions */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check arguments */
     if (cd_nelmts != H5Z_SCALEOFFSET_TOTAL_NPARMS)
@@ -1563,7 +1563,7 @@ H5Z__scaleoffset_precompress_fd(void *data, unsigned d_nelmts, enum H5Z_scaleoff
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (type == t_float)
         H5Z_scaleoffset_precompress_3(float, HDpowf, HDfabsf, HDroundf, HDlroundf, HDllroundf, data, d_nelmts,
@@ -1586,7 +1586,7 @@ H5Z__scaleoffset_postdecompress_fd(void *data, unsigned d_nelmts, enum H5Z_scale
     long long sminval   = (long long)minval; /* for signed integer types */
     herr_t    ret_value = SUCCEED;           /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (type == t_float)
         H5Z_scaleoffset_postdecompress_3(float, HDpowf, data, d_nelmts, filavail, cd_values, minbits, sminval,

--- a/src/H5Zshuffle.c
+++ b/src/H5Zshuffle.c
@@ -65,7 +65,7 @@ H5Z__set_local_shuffle(hid_t dcpl_id, hid_t type_id, hid_t H5_ATTR_UNUSED space_
     unsigned        cd_values[H5Z_SHUFFLE_TOTAL_NPARMS]; /* Filter parameters */
     herr_t          ret_value = SUCCEED;                 /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get the plist structure */
     if (NULL == (dcpl_plist = H5P_object_verify(dcpl_id, H5P_DATASET_CREATE)))
@@ -127,7 +127,7 @@ H5Z__filter_shuffle(unsigned flags, size_t cd_nelmts, const unsigned cd_values[]
     size_t leftover;      /* Extra bytes at end of buffer */
     size_t ret_value = 0; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Check arguments */
     if (cd_nelmts != H5Z_SHUFFLE_TOTAL_NPARMS || cd_values[H5Z_SHUFFLE_PARM_SIZE] == 0)

--- a/src/H5Zszip.c
+++ b/src/H5Zszip.c
@@ -77,7 +77,7 @@ H5Z__can_apply_szip(hid_t H5_ATTR_UNUSED dcpl_id, hid_t type_id, hid_t H5_ATTR_U
     H5T_order_t  dtype_order;      /* Datatype's endianness order */
     htri_t       ret_value = TRUE; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get datatype */
     if (NULL == (type = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
@@ -135,7 +135,7 @@ H5Z__set_local_szip(hid_t dcpl_id, hid_t type_id, hid_t space_id)
     hsize_t         scanline;                         /* Size of dataspace's fastest changing dimension */
     herr_t          ret_value = SUCCEED;              /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Get the plist structure */
     if (NULL == (dcpl_plist = H5P_object_verify(dcpl_id, H5P_DATASET_CREATE)))
@@ -268,7 +268,7 @@ H5Z__filter_szip(unsigned flags, size_t cd_nelmts, const unsigned cd_values[], s
     unsigned char *newbuf    = NULL; /* Pointer to input buffer */
     SZ_com_t       sz_param;         /* szip parameter block */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* Sanity check to make certain that we haven't drifted out of date with
      * the mask options from the szlib.h header */

--- a/src/H5Ztrans.c
+++ b/src/H5Ztrans.c
@@ -343,7 +343,7 @@ static void       H5Z__xform_reduce_tree(H5Z_node *tree);
 static void
 H5Z__unget_token(H5Z_token *current)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* check args */
     HDassert(current);
@@ -378,7 +378,7 @@ H5Z__get_token(H5Z_token *current)
 {
     H5Z_token *ret_value = current;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(current);
@@ -516,7 +516,7 @@ done:
 static void
 H5Z__xform_destroy_parse_tree(H5Z_node *tree)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (tree) {
         H5Z__xform_destroy_parse_tree(tree->lchild);
@@ -547,7 +547,7 @@ H5Z__xform_parse(const char *expression, H5Z_datval_ptrs *dat_val_pointers)
     H5Z_token tok;
     void *    ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (!expression)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "No expression provided?")
@@ -584,7 +584,7 @@ H5Z__parse_expression(H5Z_token *current, H5Z_datval_ptrs *dat_val_pointers)
     H5Z_node *expr;
     H5Z_node *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     expr = H5Z__parse_term(current, dat_val_pointers);
 
@@ -676,7 +676,7 @@ H5Z__parse_term(H5Z_token *current, H5Z_datval_ptrs *dat_val_pointers)
     H5Z_node *term      = NULL;
     H5Z_node *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     term = H5Z__parse_factor(current, dat_val_pointers);
 
@@ -776,7 +776,7 @@ H5Z__parse_factor(H5Z_token *current, H5Z_datval_ptrs *dat_val_pointers)
     H5Z_node *new_node;
     H5Z_node *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     current = H5Z__get_token(current);
 
@@ -919,7 +919,7 @@ H5Z__new_node(H5Z_token_type type)
 {
     H5Z_node *ret_value = NULL; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     if (NULL == (ret_value = (H5Z_node *)H5MM_calloc(sizeof(H5Z_node))))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
@@ -1068,7 +1068,7 @@ H5Z__xform_eval_full(H5Z_node *tree, const size_t array_size, const hid_t array_
     H5Z_result resl, resr;
     herr_t     ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     /* check args */
     HDassert(tree);
@@ -1162,7 +1162,7 @@ H5Z__xform_find_type(const H5T_t *type)
     H5T_t *tmp;                 /* Temporary datatype */
     hid_t  ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(type);
 
@@ -1233,7 +1233,7 @@ H5Z__xform_copy_tree(H5Z_node *tree, H5Z_datval_ptrs *dat_val_pointers, H5Z_datv
 {
     H5Z_node *ret_value = NULL;
 
-    FUNC_ENTER_STATIC
+    FUNC_ENTER_PACKAGE
 
     HDassert(tree);
 
@@ -1302,7 +1302,7 @@ H5Z__op_is_numbs(H5Z_node *_tree)
 {
     hbool_t ret_value = FALSE;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(_tree);
 
@@ -1333,7 +1333,7 @@ H5Z__op_is_numbs2(H5Z_node *_tree)
 {
     hbool_t ret_value = FALSE;
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(_tree);
 
@@ -1364,7 +1364,7 @@ H5Z__op_is_numbs2(H5Z_node *_tree)
 static void
 H5Z__xform_reduce_tree(H5Z_node *tree)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (tree) {
         if ((tree->type == H5Z_XFORM_DIVIDE) || (tree->type == H5Z_XFORM_MULT)) {
@@ -1419,7 +1419,7 @@ H5Z__xform_reduce_tree(H5Z_node *tree)
 static void
 H5Z__do_op(H5Z_node *tree)
 {
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     if (tree->type == H5Z_XFORM_DIVIDE)
         H5Z_XFORM_DO_OP3(/)

--- a/src/H5checksum.c
+++ b/src/H5checksum.c
@@ -159,7 +159,7 @@ H5__checksum_crc_make_table(void)
     uint32_t c;    /* Checksum for each byte value */
     unsigned n, k; /* Local index variables */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Compute the checksum for each possible byte value */
     for (n = 0; n < 256; n++) {
@@ -196,7 +196,7 @@ H5__checksum_crc_update(uint32_t crc, const uint8_t *buf, size_t len)
 {
     size_t n; /* Local index variable */
 
-    FUNC_ENTER_STATIC_NOERR
+    FUNC_ENTER_PACKAGE_NOERR
 
     /* Initialize the CRC table if necessary */
     if (!H5_crc_table_computed)

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -2304,7 +2304,7 @@ H5_DLL herr_t H5CX_pop(hbool_t update_dxpl_props);
 
 /* Use this macro for staticly-scoped functions which propgate errors, but don't issue them */
 /* And that shouldn't push their name on the function stack */
-#define FUNC_ENTER_PACKAGE_NOERR_NOFS                                                                         \
+#define FUNC_ENTER_PACKAGE_NOERR_NOFS                                                                        \
     {                                                                                                        \
         FUNC_ENTER_COMMON_NOERR(H5_IS_PKG(__func__));                                                        \
         {

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -2302,23 +2302,9 @@ H5_DLL herr_t H5CX_pop(hbool_t update_dxpl_props);
         H5_PUSH_FUNC                                                                                         \
         {
 
-/* Use this macro for all "normal" staticly-scoped functions */
-#define FUNC_ENTER_STATIC                                                                                    \
-    {                                                                                                        \
-        FUNC_ENTER_COMMON(H5_IS_PKG(__func__));                                                              \
-        H5_PUSH_FUNC                                                                                         \
-        {
-
-/* Use this macro for staticly-scoped functions which propgate errors, but don't issue them */
-#define FUNC_ENTER_STATIC_NOERR                                                                              \
-    {                                                                                                        \
-        FUNC_ENTER_COMMON_NOERR(H5_IS_PKG(__func__));                                                        \
-        H5_PUSH_FUNC                                                                                         \
-        {
-
 /* Use this macro for staticly-scoped functions which propgate errors, but don't issue them */
 /* And that shouldn't push their name on the function stack */
-#define FUNC_ENTER_STATIC_NOERR_NOFS                                                                         \
+#define FUNC_ENTER_PACKAGE_NOERR_NOFS                                                                         \
     {                                                                                                        \
         FUNC_ENTER_COMMON_NOERR(H5_IS_PKG(__func__));                                                        \
         {
@@ -2330,20 +2316,9 @@ H5_DLL herr_t H5CX_pop(hbool_t update_dxpl_props);
  *    API name itself.  Examples are static routines in the H5TS package.
  *
  */
-#define FUNC_ENTER_STATIC_NAMECHECK_ONLY                                                                     \
+#define FUNC_ENTER_PACKAGE_NAMECHECK_ONLY                                                                    \
     {                                                                                                        \
         FUNC_ENTER_COMMON_NOERR(H5_IS_PKG(__func__));
-
-/* Use the following macro as replacement for the FUNC_ENTER_STATIC
- * macro when the function needs to set up a metadata tag. */
-#define FUNC_ENTER_STATIC_TAG(tag)                                                                           \
-    {                                                                                                        \
-        haddr_t prev_tag = HADDR_UNDEF;                                                                      \
-                                                                                                             \
-        FUNC_ENTER_COMMON(H5_IS_PKG(__func__));                                                              \
-        H5AC_tag(tag, &prev_tag);                                                                            \
-        H5_PUSH_FUNC                                                                                         \
-        {
 
 /*-------------------------------------------------------------------------
  * Purpose:  Register function exit for code profiling.  This should be


### PR DESCRIPTION
With the recent changes to initialization, the FUNC_ENTER_STATIC macros
are now identical to their FUNC_ENTER_PACKAGE counterparts and can
be replaced, simplifying the macro scheme.

Removed from H5private.h and replaced with PACKAGE variant in *.c/h:
    FUNC_ENTER_STATIC
    FUNC_ENTER_STATIC_NOERR
    FUNC_ENTER_STATIC_TAG

Converted to PACKAGE in H5private.h and replaced in *.c/h:
    FUNC_ENTER_STATIC_NOERR_NOFS
    FUNC_ENTER_STATIC_NAMECHECK_ONLY

Merging this commit into feature branches may be difficult due to the extent of
these changes. Alternatively, you can manually snip out and convert the
FUNC_ENTER macros in H5private.h as was done here, then run this command:

`find . -type f -name '*.c' -o -name '*.h' | xargs sed -i 's/FUNC_ENTER_STATIC/FUNC_ENTER_PACKAGE/g'`

Since the initialization scheme has not been moved to other branches,
this change does NOT need to be merged down to 1.12 or 1.10.