### PR TITLE
Removes unused definitions from module headers

### DIFF
--- a/src/H5ACmodule.h
+++ b/src/H5ACmodule.h
@@ -27,6 +27,5 @@
 #define H5AC_MODULE
 #define H5_MY_PKG      H5AC
 #define H5_MY_PKG_ERR  H5E_CACHE
-#define H5_MY_PKG_INIT YES
 
 #endif /* H5ACmodule_H */

--- a/src/H5ACmodule.h
+++ b/src/H5ACmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5AC_MODULE
-#define H5_MY_PKG      H5AC
-#define H5_MY_PKG_ERR  H5E_CACHE
+#define H5_MY_PKG     H5AC
+#define H5_MY_PKG_ERR H5E_CACHE
 
 #endif /* H5ACmodule_H */

--- a/src/H5Amodule.h
+++ b/src/H5Amodule.h
@@ -27,7 +27,6 @@
 #define H5A_MODULE
 #define H5_MY_PKG      H5A
 #define H5_MY_PKG_ERR  H5E_ATTR
-#define H5_MY_PKG_INIT YES
 
 /**\defgroup H5A H5A
  *

--- a/src/H5Amodule.h
+++ b/src/H5Amodule.h
@@ -25,8 +25,8 @@
  *      reporting macros.
  */
 #define H5A_MODULE
-#define H5_MY_PKG      H5A
-#define H5_MY_PKG_ERR  H5E_ATTR
+#define H5_MY_PKG     H5A
+#define H5_MY_PKG_ERR H5E_ATTR
 
 /**\defgroup H5A H5A
  *

--- a/src/H5B2module.h
+++ b/src/H5B2module.h
@@ -27,6 +27,5 @@
 #define H5B2_MODULE
 #define H5_MY_PKG      H5B2
 #define H5_MY_PKG_ERR  H5E_BTREE
-#define H5_MY_PKG_INIT NO
 
 #endif /* H5B2module_H */

--- a/src/H5B2module.h
+++ b/src/H5B2module.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5B2_MODULE
-#define H5_MY_PKG      H5B2
-#define H5_MY_PKG_ERR  H5E_BTREE
+#define H5_MY_PKG     H5B2
+#define H5_MY_PKG_ERR H5E_BTREE
 
 #endif /* H5B2module_H */

--- a/src/H5Bmodule.h
+++ b/src/H5Bmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5B_MODULE
-#define H5_MY_PKG      H5B
-#define H5_MY_PKG_ERR  H5E_BTREE
+#define H5_MY_PKG     H5B
+#define H5_MY_PKG_ERR H5E_BTREE
 
 #endif /* H5Bmodule_H */

--- a/src/H5Bmodule.h
+++ b/src/H5Bmodule.h
@@ -27,6 +27,5 @@
 #define H5B_MODULE
 #define H5_MY_PKG      H5B
 #define H5_MY_PKG_ERR  H5E_BTREE
-#define H5_MY_PKG_INIT NO
 
 #endif /* H5Bmodule_H */

--- a/src/H5CXmodule.h
+++ b/src/H5CXmodule.h
@@ -27,6 +27,5 @@
 #define H5CX_MODULE
 #define H5_MY_PKG      H5CX
 #define H5_MY_PKG_ERR  H5E_CONTEXT
-#define H5_MY_PKG_INIT YES
 
 #endif /* H5CXmodule_H */

--- a/src/H5CXmodule.h
+++ b/src/H5CXmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5CX_MODULE
-#define H5_MY_PKG      H5CX
-#define H5_MY_PKG_ERR  H5E_CONTEXT
+#define H5_MY_PKG     H5CX
+#define H5_MY_PKG_ERR H5E_CONTEXT
 
 #endif /* H5CXmodule_H */

--- a/src/H5Cmodule.h
+++ b/src/H5Cmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5C_MODULE
-#define H5_MY_PKG      H5C
-#define H5_MY_PKG_ERR  H5E_CACHE
+#define H5_MY_PKG     H5C
+#define H5_MY_PKG_ERR H5E_CACHE
 
 #endif /* H5Cmodule_H */

--- a/src/H5Cmodule.h
+++ b/src/H5Cmodule.h
@@ -27,6 +27,5 @@
 #define H5C_MODULE
 #define H5_MY_PKG      H5C
 #define H5_MY_PKG_ERR  H5E_CACHE
-#define H5_MY_PKG_INIT NO
 
 #endif /* H5Cmodule_H */

--- a/src/H5Dmodule.h
+++ b/src/H5Dmodule.h
@@ -27,7 +27,6 @@
 #define H5D_MODULE
 #define H5_MY_PKG      H5D
 #define H5_MY_PKG_ERR  H5E_DATASET
-#define H5_MY_PKG_INIT YES
 
 /**\defgroup H5D H5D
  *

--- a/src/H5Dmodule.h
+++ b/src/H5Dmodule.h
@@ -25,8 +25,8 @@
  *      reporting macros.
  */
 #define H5D_MODULE
-#define H5_MY_PKG      H5D
-#define H5_MY_PKG_ERR  H5E_DATASET
+#define H5_MY_PKG     H5D
+#define H5_MY_PKG_ERR H5E_DATASET
 
 /**\defgroup H5D H5D
  *

--- a/src/H5EAmodule.h
+++ b/src/H5EAmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5EA_MODULE
-#define H5_MY_PKG      H5EA
-#define H5_MY_PKG_ERR  H5E_EARRAY
+#define H5_MY_PKG     H5EA
+#define H5_MY_PKG_ERR H5E_EARRAY
 
 #endif /* H5EAmodule_H */

--- a/src/H5EAmodule.h
+++ b/src/H5EAmodule.h
@@ -27,6 +27,5 @@
 #define H5EA_MODULE
 #define H5_MY_PKG      H5EA
 #define H5_MY_PKG_ERR  H5E_EARRAY
-#define H5_MY_PKG_INIT NO
 
 #endif /* H5EAmodule_H */

--- a/src/H5ESmodule.h
+++ b/src/H5ESmodule.h
@@ -25,8 +25,8 @@
  *      reporting macros.
  */
 #define H5ES_MODULE
-#define H5_MY_PKG      H5ES
-#define H5_MY_PKG_ERR  H5E_EVENTSET
+#define H5_MY_PKG     H5ES
+#define H5_MY_PKG_ERR H5E_EVENTSET
 
 /**\defgroup H5ES H5ES
  *

--- a/src/H5ESmodule.h
+++ b/src/H5ESmodule.h
@@ -27,7 +27,6 @@
 #define H5ES_MODULE
 #define H5_MY_PKG      H5ES
 #define H5_MY_PKG_ERR  H5E_EVENTSET
-#define H5_MY_PKG_INIT YES
 
 /**\defgroup H5ES H5ES
  *

--- a/src/H5Emodule.h
+++ b/src/H5Emodule.h
@@ -25,8 +25,8 @@
  *      reporting macros.
  */
 #define H5E_MODULE
-#define H5_MY_PKG      H5E
-#define H5_MY_PKG_ERR  H5E_ERROR
+#define H5_MY_PKG     H5E
+#define H5_MY_PKG_ERR H5E_ERROR
 
 /**\defgroup H5E H5E
  *

--- a/src/H5Emodule.h
+++ b/src/H5Emodule.h
@@ -27,7 +27,6 @@
 #define H5E_MODULE
 #define H5_MY_PKG      H5E
 #define H5_MY_PKG_ERR  H5E_ERROR
-#define H5_MY_PKG_INIT YES
 
 /**\defgroup H5E H5E
  *

--- a/src/H5FAmodule.h
+++ b/src/H5FAmodule.h
@@ -27,6 +27,5 @@
 #define H5FA_MODULE
 #define H5_MY_PKG      H5FA
 #define H5_MY_PKG_ERR  H5E_FARRAY
-#define H5_MY_PKG_INIT NO
 
 #endif /* H5FAmodule_H */

--- a/src/H5FAmodule.h
+++ b/src/H5FAmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5FA_MODULE
-#define H5_MY_PKG      H5FA
-#define H5_MY_PKG_ERR  H5E_FARRAY
+#define H5_MY_PKG     H5FA
+#define H5_MY_PKG_ERR H5E_FARRAY
 
 #endif /* H5FAmodule_H */

--- a/src/H5FDdrvr_module.h
+++ b/src/H5FDdrvr_module.h
@@ -24,7 +24,7 @@
 /* Define the proper control macros for the generic FUNC_ENTER/LEAVE and error
  *      reporting macros.
  */
-#define H5_MY_PKG      H5FD
-#define H5_MY_PKG_ERR  H5E_FILE
+#define H5_MY_PKG     H5FD
+#define H5_MY_PKG_ERR H5E_FILE
 
 #endif /* H5FDdrvr_module_H */

--- a/src/H5FDdrvr_module.h
+++ b/src/H5FDdrvr_module.h
@@ -26,7 +26,5 @@
  */
 #define H5_MY_PKG      H5FD
 #define H5_MY_PKG_ERR  H5E_FILE
-#define H5_MY_PKG_INIT YES
-#define H5_PKG_SINGLE_SOURCE
 
 #endif /* H5FDdrvr_module_H */

--- a/src/H5FDmodule.h
+++ b/src/H5FDmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5FD_MODULE
-#define H5_MY_PKG      H5FD
-#define H5_MY_PKG_ERR  H5E_VFL
+#define H5_MY_PKG     H5FD
+#define H5_MY_PKG_ERR H5E_VFL
 
 #endif /* H5FDmodule_H */

--- a/src/H5FDmodule.h
+++ b/src/H5FDmodule.h
@@ -27,6 +27,5 @@
 #define H5FD_MODULE
 #define H5_MY_PKG      H5FD
 #define H5_MY_PKG_ERR  H5E_VFL
-#define H5_MY_PKG_INIT YES
 
 #endif /* H5FDmodule_H */

--- a/src/H5FLmodule.h
+++ b/src/H5FLmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5FL_MODULE
-#define H5_MY_PKG      H5FL
-#define H5_MY_PKG_ERR  H5E_RESOURCE
+#define H5_MY_PKG     H5FL
+#define H5_MY_PKG_ERR H5E_RESOURCE
 
 #endif /* H5FLmodule_H */

--- a/src/H5FLmodule.h
+++ b/src/H5FLmodule.h
@@ -27,6 +27,5 @@
 #define H5FL_MODULE
 #define H5_MY_PKG      H5FL
 #define H5_MY_PKG_ERR  H5E_RESOURCE
-#define H5_MY_PKG_INIT NO
 
 #endif /* H5FLmodule_H */

--- a/src/H5FSmodule.h
+++ b/src/H5FSmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5FS_MODULE
-#define H5_MY_PKG      H5FS
-#define H5_MY_PKG_ERR  H5E_FSPACE
+#define H5_MY_PKG     H5FS
+#define H5_MY_PKG_ERR H5E_FSPACE
 
 #endif /* H5FSmodule_H */

--- a/src/H5FSmodule.h
+++ b/src/H5FSmodule.h
@@ -27,6 +27,5 @@
 #define H5FS_MODULE
 #define H5_MY_PKG      H5FS
 #define H5_MY_PKG_ERR  H5E_FSPACE
-#define H5_MY_PKG_INIT NO
 
 #endif /* H5FSmodule_H */

--- a/src/H5Fmodule.h
+++ b/src/H5Fmodule.h
@@ -27,7 +27,6 @@
 #define H5F_MODULE
 #define H5_MY_PKG      H5F
 #define H5_MY_PKG_ERR  H5E_FILE
-#define H5_MY_PKG_INIT YES
 
 /**\defgroup H5F H5F
  *

--- a/src/H5Fmodule.h
+++ b/src/H5Fmodule.h
@@ -25,8 +25,8 @@
  *      reporting macros.
  */
 #define H5F_MODULE
-#define H5_MY_PKG      H5F
-#define H5_MY_PKG_ERR  H5E_FILE
+#define H5_MY_PKG     H5F
+#define H5_MY_PKG_ERR H5E_FILE
 
 /**\defgroup H5F H5F
  *

--- a/src/H5Gmodule.h
+++ b/src/H5Gmodule.h
@@ -25,8 +25,8 @@
  *      reporting macros.
  */
 #define H5G_MODULE
-#define H5_MY_PKG      H5G
-#define H5_MY_PKG_ERR  H5E_SYM
+#define H5_MY_PKG     H5G
+#define H5_MY_PKG_ERR H5E_SYM
 
 /** \defgroup H5G H5G
  *

--- a/src/H5Gmodule.h
+++ b/src/H5Gmodule.h
@@ -27,7 +27,6 @@
 #define H5G_MODULE
 #define H5_MY_PKG      H5G
 #define H5_MY_PKG_ERR  H5E_SYM
-#define H5_MY_PKG_INIT YES
 
 /** \defgroup H5G H5G
  *

--- a/src/H5HFmodule.h
+++ b/src/H5HFmodule.h
@@ -27,6 +27,5 @@
 #define H5HF_MODULE
 #define H5_MY_PKG      H5HF
 #define H5_MY_PKG_ERR  H5E_HEAP
-#define H5_MY_PKG_INIT NO
 
 #endif /* H5HFmodule_H */

--- a/src/H5HFmodule.h
+++ b/src/H5HFmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5HF_MODULE
-#define H5_MY_PKG      H5HF
-#define H5_MY_PKG_ERR  H5E_HEAP
+#define H5_MY_PKG     H5HF
+#define H5_MY_PKG_ERR H5E_HEAP
 
 #endif /* H5HFmodule_H */

--- a/src/H5HGmodule.h
+++ b/src/H5HGmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5HG_MODULE
-#define H5_MY_PKG      H5HG
-#define H5_MY_PKG_ERR  H5E_HEAP
+#define H5_MY_PKG     H5HG
+#define H5_MY_PKG_ERR H5E_HEAP
 
 #endif /* H5HGmodule_H */

--- a/src/H5HGmodule.h
+++ b/src/H5HGmodule.h
@@ -27,6 +27,5 @@
 #define H5HG_MODULE
 #define H5_MY_PKG      H5HG
 #define H5_MY_PKG_ERR  H5E_HEAP
-#define H5_MY_PKG_INIT NO
 
 #endif /* H5HGmodule_H */

--- a/src/H5HLmodule.h
+++ b/src/H5HLmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5HL_MODULE
-#define H5_MY_PKG      H5HL
-#define H5_MY_PKG_ERR  H5E_HEAP
+#define H5_MY_PKG     H5HL
+#define H5_MY_PKG_ERR H5E_HEAP
 
 #endif /* H5HLmodule_H */

--- a/src/H5HLmodule.h
+++ b/src/H5HLmodule.h
@@ -27,6 +27,5 @@
 #define H5HL_MODULE
 #define H5_MY_PKG      H5HL
 #define H5_MY_PKG_ERR  H5E_HEAP
-#define H5_MY_PKG_INIT NO
 
 #endif /* H5HLmodule_H */

--- a/src/H5HLpkg.h
+++ b/src/H5HLpkg.h
@@ -53,7 +53,6 @@ H5FL_BLK_EXTERN(lheap_chunk);
 #ifdef H5HL_PACKAGE
 #define H5_MY_PKG      H5HL
 #define H5_MY_PKG_ERR  H5E_HEAP
-#define H5_MY_PKG_INIT NO
 #endif
 
 #define H5HL_SIZEOF_HDR(F)                                                                                   \

--- a/src/H5HLpkg.h
+++ b/src/H5HLpkg.h
@@ -51,8 +51,8 @@ H5FL_BLK_EXTERN(lheap_chunk);
  *      error reporting macros.
  */
 #ifdef H5HL_PACKAGE
-#define H5_MY_PKG      H5HL
-#define H5_MY_PKG_ERR  H5E_HEAP
+#define H5_MY_PKG     H5HL
+#define H5_MY_PKG_ERR H5E_HEAP
 #endif
 
 #define H5HL_SIZEOF_HDR(F)                                                                                   \

--- a/src/H5Imodule.h
+++ b/src/H5Imodule.h
@@ -27,7 +27,6 @@
 #define H5I_MODULE
 #define H5_MY_PKG      H5I
 #define H5_MY_PKG_ERR  H5E_ID
-#define H5_MY_PKG_INIT NO
 
 /**\defgroup H5I H5I
  *

--- a/src/H5Imodule.h
+++ b/src/H5Imodule.h
@@ -25,8 +25,8 @@
  * reporting macros.
  */
 #define H5I_MODULE
-#define H5_MY_PKG      H5I
-#define H5_MY_PKG_ERR  H5E_ID
+#define H5_MY_PKG     H5I
+#define H5_MY_PKG_ERR H5E_ID
 
 /**\defgroup H5I H5I
  *

--- a/src/H5Lmodule.h
+++ b/src/H5Lmodule.h
@@ -25,8 +25,8 @@
  *      reporting macros.
  */
 #define H5L_MODULE
-#define H5_MY_PKG      H5L
-#define H5_MY_PKG_ERR  H5E_LINK
+#define H5_MY_PKG     H5L
+#define H5_MY_PKG_ERR H5E_LINK
 
 /**\defgroup H5L H5L
  *

--- a/src/H5Lmodule.h
+++ b/src/H5Lmodule.h
@@ -27,7 +27,6 @@
 #define H5L_MODULE
 #define H5_MY_PKG      H5L
 #define H5_MY_PKG_ERR  H5E_LINK
-#define H5_MY_PKG_INIT YES
 
 /**\defgroup H5L H5L
  *

--- a/src/H5MFmodule.h
+++ b/src/H5MFmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5MF_MODULE
-#define H5_MY_PKG      H5MF
-#define H5_MY_PKG_ERR  H5E_RESOURCE
+#define H5_MY_PKG     H5MF
+#define H5_MY_PKG_ERR H5E_RESOURCE
 
 #endif /* H5MFmodule_H */

--- a/src/H5MFmodule.h
+++ b/src/H5MFmodule.h
@@ -27,6 +27,5 @@
 #define H5MF_MODULE
 #define H5_MY_PKG      H5MF
 #define H5_MY_PKG_ERR  H5E_RESOURCE
-#define H5_MY_PKG_INIT NO
 
 #endif /* H5MFmodule_H */

--- a/src/H5Mmodule.h
+++ b/src/H5Mmodule.h
@@ -22,8 +22,8 @@
  *      reporting macros.
  */
 #define H5M_MODULE
-#define H5_MY_PKG      H5M
-#define H5_MY_PKG_ERR  H5E_MAP
+#define H5_MY_PKG     H5M
+#define H5_MY_PKG_ERR H5E_MAP
 
 /**\defgroup H5M H5M
  *

--- a/src/H5Mmodule.h
+++ b/src/H5Mmodule.h
@@ -24,7 +24,6 @@
 #define H5M_MODULE
 #define H5_MY_PKG      H5M
 #define H5_MY_PKG_ERR  H5E_MAP
-#define H5_MY_PKG_INIT YES
 
 /**\defgroup H5M H5M
  *

--- a/src/H5Omodule.h
+++ b/src/H5Omodule.h
@@ -27,7 +27,6 @@
 #define H5O_MODULE
 #define H5_MY_PKG      H5O
 #define H5_MY_PKG_ERR  H5E_OHDR
-#define H5_MY_PKG_INIT YES
 
 /**\defgroup H5O H5O
  *

--- a/src/H5Omodule.h
+++ b/src/H5Omodule.h
@@ -25,8 +25,8 @@
  *      reporting macros.
  */
 #define H5O_MODULE
-#define H5_MY_PKG      H5O
-#define H5_MY_PKG_ERR  H5E_OHDR
+#define H5_MY_PKG     H5O
+#define H5_MY_PKG_ERR H5E_OHDR
 
 /**\defgroup H5O H5O
  *

--- a/src/H5PBmodule.h
+++ b/src/H5PBmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5PB_MODULE
-#define H5_MY_PKG      H5PB
-#define H5_MY_PKG_ERR  H5E_RESOURCE
+#define H5_MY_PKG     H5PB
+#define H5_MY_PKG_ERR H5E_RESOURCE
 
 #endif /* H5PBmodule_H */

--- a/src/H5PBmodule.h
+++ b/src/H5PBmodule.h
@@ -27,6 +27,5 @@
 #define H5PB_MODULE
 #define H5_MY_PKG      H5PB
 #define H5_MY_PKG_ERR  H5E_RESOURCE
-#define H5_MY_PKG_INIT NO
 
 #endif /* H5PBmodule_H */

--- a/src/H5PLmodule.h
+++ b/src/H5PLmodule.h
@@ -23,8 +23,8 @@
  *      reporting macros.
  */
 #define H5PL_MODULE
-#define H5_MY_PKG      H5PL
-#define H5_MY_PKG_ERR  H5E_PLUGIN
+#define H5_MY_PKG     H5PL
+#define H5_MY_PKG_ERR H5E_PLUGIN
 
 /**\defgroup H5PL H5PL
  *

--- a/src/H5PLmodule.h
+++ b/src/H5PLmodule.h
@@ -25,7 +25,6 @@
 #define H5PL_MODULE
 #define H5_MY_PKG      H5PL
 #define H5_MY_PKG_ERR  H5E_PLUGIN
-#define H5_MY_PKG_INIT YES
 
 /**\defgroup H5PL H5PL
  *

--- a/src/H5Pmodule.h
+++ b/src/H5Pmodule.h
@@ -27,7 +27,6 @@
 #define H5P_MODULE
 #define H5_MY_PKG      H5P
 #define H5_MY_PKG_ERR  H5E_PLIST
-#define H5_MY_PKG_INIT YES
 
 /**\defgroup H5P H5P
  *

--- a/src/H5Pmodule.h
+++ b/src/H5Pmodule.h
@@ -25,8 +25,8 @@
  *      reporting macros.
  */
 #define H5P_MODULE
-#define H5_MY_PKG      H5P
-#define H5_MY_PKG_ERR  H5E_PLIST
+#define H5_MY_PKG     H5P
+#define H5_MY_PKG_ERR H5E_PLIST
 
 /**\defgroup H5P H5P
  *

--- a/src/H5RSmodule.h
+++ b/src/H5RSmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5RS_MODULE
-#define H5_MY_PKG      H5RS
-#define H5_MY_PKG_ERR  H5E_RS
+#define H5_MY_PKG     H5RS
+#define H5_MY_PKG_ERR H5E_RS
 
 #endif /* H5RSmodule_H */

--- a/src/H5RSmodule.h
+++ b/src/H5RSmodule.h
@@ -27,6 +27,5 @@
 #define H5RS_MODULE
 #define H5_MY_PKG      H5RS
 #define H5_MY_PKG_ERR  H5E_RS
-#define H5_MY_PKG_INIT NO
 
 #endif /* H5RSmodule_H */

--- a/src/H5Rmodule.h
+++ b/src/H5Rmodule.h
@@ -21,8 +21,8 @@
  *      reporting macros.
  */
 #define H5R_MODULE
-#define H5_MY_PKG      H5R
-#define H5_MY_PKG_ERR  H5E_REFERENCE
+#define H5_MY_PKG     H5R
+#define H5_MY_PKG_ERR H5E_REFERENCE
 
 /**
  * \defgroup H5R H5R

--- a/src/H5Rmodule.h
+++ b/src/H5Rmodule.h
@@ -23,7 +23,6 @@
 #define H5R_MODULE
 #define H5_MY_PKG      H5R
 #define H5_MY_PKG_ERR  H5E_REFERENCE
-#define H5_MY_PKG_INIT YES
 
 /**
  * \defgroup H5R H5R

--- a/src/H5SLmodule.h
+++ b/src/H5SLmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5SL_MODULE
-#define H5_MY_PKG      H5SL
-#define H5_MY_PKG_ERR  H5E_SLIST
+#define H5_MY_PKG     H5SL
+#define H5_MY_PKG_ERR H5E_SLIST
 
 #endif /* H5SLmodule_H */

--- a/src/H5SLmodule.h
+++ b/src/H5SLmodule.h
@@ -27,6 +27,5 @@
 #define H5SL_MODULE
 #define H5_MY_PKG      H5SL
 #define H5_MY_PKG_ERR  H5E_SLIST
-#define H5_MY_PKG_INIT YES
 
 #endif /* H5SLmodule_H */

--- a/src/H5SMmodule.h
+++ b/src/H5SMmodule.h
@@ -25,7 +25,7 @@
  *      reporting macros.
  */
 #define H5SM_MODULE
-#define H5_MY_PKG      H5SM
-#define H5_MY_PKG_ERR  H5E_SOHM
+#define H5_MY_PKG     H5SM
+#define H5_MY_PKG_ERR H5E_SOHM
 
 #endif /* H5SMmodule_H */

--- a/src/H5SMmodule.h
+++ b/src/H5SMmodule.h
@@ -27,6 +27,5 @@
 #define H5SM_MODULE
 #define H5_MY_PKG      H5SM
 #define H5_MY_PKG_ERR  H5E_SOHM
-#define H5_MY_PKG_INIT NO
 
 #endif /* H5SMmodule_H */

--- a/src/H5Smodule.h
+++ b/src/H5Smodule.h
@@ -25,8 +25,8 @@
  *      reporting macros.
  */
 #define H5S_MODULE
-#define H5_MY_PKG      H5S
-#define H5_MY_PKG_ERR  H5E_DATASPACE
+#define H5_MY_PKG     H5S
+#define H5_MY_PKG_ERR H5E_DATASPACE
 
 /**\defgroup H5S H5S
  *

--- a/src/H5Smodule.h
+++ b/src/H5Smodule.h
@@ -27,7 +27,6 @@
 #define H5S_MODULE
 #define H5_MY_PKG      H5S
 #define H5_MY_PKG_ERR  H5E_DATASPACE
-#define H5_MY_PKG_INIT YES
 
 /**\defgroup H5S H5S
  *

--- a/src/H5Tmodule.h
+++ b/src/H5Tmodule.h
@@ -27,7 +27,6 @@
 #define H5T_MODULE
 #define H5_MY_PKG      H5T
 #define H5_MY_PKG_ERR  H5E_DATATYPE
-#define H5_MY_PKG_INIT YES
 
 /**\defgroup H5T H5T
  *

--- a/src/H5Tmodule.h
+++ b/src/H5Tmodule.h
@@ -25,8 +25,8 @@
  *      reporting macros.
  */
 #define H5T_MODULE
-#define H5_MY_PKG      H5T
-#define H5_MY_PKG_ERR  H5E_DATATYPE
+#define H5_MY_PKG     H5T
+#define H5_MY_PKG_ERR H5E_DATATYPE
 
 /**\defgroup H5T H5T
  *

--- a/src/H5VLmodule.h
+++ b/src/H5VLmodule.h
@@ -23,8 +23,8 @@
  *      reporting macros.
  */
 #define H5VL_MODULE
-#define H5_MY_PKG      H5VL
-#define H5_MY_PKG_ERR  H5E_VOL
+#define H5_MY_PKG     H5VL
+#define H5_MY_PKG_ERR H5E_VOL
 
 /**\defgroup H5VL H5VL
  *

--- a/src/H5VLmodule.h
+++ b/src/H5VLmodule.h
@@ -25,7 +25,6 @@
 #define H5VL_MODULE
 #define H5_MY_PKG      H5VL
 #define H5_MY_PKG_ERR  H5E_VOL
-#define H5_MY_PKG_INIT YES
 
 /**\defgroup H5VL H5VL
  *

--- a/src/H5Zmodule.h
+++ b/src/H5Zmodule.h
@@ -27,7 +27,6 @@
 #define H5Z_MODULE
 #define H5_MY_PKG      H5Z
 #define H5_MY_PKG_ERR  H5E_PLINE
-#define H5_MY_PKG_INIT YES
 
 /**\defgroup H5Z H5Z
  *

--- a/src/H5Zmodule.h
+++ b/src/H5Zmodule.h
@@ -25,8 +25,8 @@
  *      reporting macros.
  */
 #define H5Z_MODULE
-#define H5_MY_PKG      H5Z
-#define H5_MY_PKG_ERR  H5E_PLINE
+#define H5_MY_PKG     H5Z
+#define H5_MY_PKG_ERR H5E_PLINE
 
 /**\defgroup H5Z H5Z
  *

--- a/src/H5module.h
+++ b/src/H5module.h
@@ -22,8 +22,8 @@
  *      reporting macros.
  */
 #define H5_MODULE
-#define H5_MY_PKG      H5
-#define H5_MY_PKG_ERR  H5E_LIB
+#define H5_MY_PKG     H5
+#define H5_MY_PKG_ERR H5E_LIB
 
 /**\defgroup H5 H5
  *

--- a/src/H5module.h
+++ b/src/H5module.h
@@ -24,7 +24,6 @@
 #define H5_MODULE
 #define H5_MY_PKG      H5
 #define H5_MY_PKG_ERR  H5E_LIB
-#define H5_MY_PKG_INIT YES
 
 /**\defgroup H5 H5
  *


### PR DESCRIPTION
This change probably does NOT need to be moved down to 1.12 or earlier.