### PR TITLE
Mirror vfd test fixes

### DIFF
--- a/config/conclude.am
+++ b/config/conclude.am
@@ -283,7 +283,9 @@ if BUILD_PARALLEL_CONDITIONAL
   # VFD_LIST += mpio
 endif
 if MIRROR_VFD_CONDITIONAL
-  VFD_LIST += mirror
+  # Mirror VFD needs network configuration, etc. and isn't easy to set
+  # reasonable defaults for that info.
+  # VFD_LIST += mirror
 endif
 if ROS3_VFD_CONDITIONAL
   VFD_LIST += ros3

--- a/test/cross_read.c
+++ b/test/cross_read.c
@@ -229,8 +229,10 @@ check_file(char *filename)
 #endif
 
     /* Open the file. */
-    if ((fid = H5Fopen(pathname, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
+    if ((fid = H5Fopen(pathname, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0) {
+        nerrors++;
         FAIL_STACK_ERROR;
+    }
 
     TESTING("regular dataset of LE DOUBLE");
     nerrors += check_data_f(DATASETNAME, fid);
@@ -356,6 +358,14 @@ main(void)
     int  nerrors = 0;
 
     h5_reset();
+
+    /*
+     * Skip tests for VFDs that need modified filenames.
+     */
+    if (h5_driver_uses_modified_filename()) {
+        HDputs(" -- SKIPPED for incompatible VFD --");
+        HDexit(EXIT_SUCCESS);
+    }
 
     HDputs("\n");
     HDputs("Testing reading data created on Linux");

--- a/test/mirror_vfd.c
+++ b/test/mirror_vfd.c
@@ -2254,7 +2254,6 @@ test_vanishing_datasets(void)
     hid_t                       fapl_id        = H5I_INVALID_HID;
     hid_t                       dset_id        = H5I_INVALID_HID;
     hid_t                       dspace_id      = H5I_INVALID_HID;
-    hid_t                       mirror_fapl_id = H5I_INVALID_HID;
     hsize_t                     dims[2]        = {DATABUFFER_SIZE, DATABUFFER_SIZE};
     uint32_t                    buf[DATABUFFER_SIZE][DATABUFFER_SIZE]; /* consider malloc? */
     H5G_info_t                  group_info;
@@ -2333,7 +2332,7 @@ test_vanishing_datasets(void)
     file_id = H5I_INVALID_HID;
 
     /* verify there are no datasets in file */
-    file_id = H5Fopen(names.rw, H5F_ACC_RDONLY, H5P_DEFAULT);
+    file_id = H5Fopen(names.rw, H5F_ACC_RDONLY, fapl_id);
     if (file_id < 0) {
         TEST_ERROR;
     }
@@ -2348,7 +2347,7 @@ test_vanishing_datasets(void)
     if (H5Fclose(file_id) < 0) {
         TEST_ERROR;
     }
-    file_id = H5Fopen(names.wo, H5F_ACC_RDONLY, H5P_DEFAULT);
+    file_id = H5Fopen(names.wo, H5F_ACC_RDONLY, fapl_id);
     if (file_id < 0) {
         TEST_ERROR;
     }
@@ -2384,9 +2383,6 @@ test_vanishing_datasets(void)
 error:
     H5E_BEGIN_TRY
     {
-        if (mirror_fapl_id != H5I_INVALID_HID) {
-            H5Pclose(mirror_fapl_id);
-        }
         if (fapl_id != H5I_INVALID_HID) {
             H5Pclose(fapl_id);
         }

--- a/test/mirror_vfd.c
+++ b/test/mirror_vfd.c
@@ -2250,11 +2250,11 @@ static int
 test_vanishing_datasets(void)
 {
     struct mirrortest_filenames names;
-    hid_t                       file_id        = H5I_INVALID_HID;
-    hid_t                       fapl_id        = H5I_INVALID_HID;
-    hid_t                       dset_id        = H5I_INVALID_HID;
-    hid_t                       dspace_id      = H5I_INVALID_HID;
-    hsize_t                     dims[2]        = {DATABUFFER_SIZE, DATABUFFER_SIZE};
+    hid_t                       file_id   = H5I_INVALID_HID;
+    hid_t                       fapl_id   = H5I_INVALID_HID;
+    hid_t                       dset_id   = H5I_INVALID_HID;
+    hid_t                       dspace_id = H5I_INVALID_HID;
+    hsize_t                     dims[2]   = {DATABUFFER_SIZE, DATABUFFER_SIZE};
     uint32_t                    buf[DATABUFFER_SIZE][DATABUFFER_SIZE]; /* consider malloc? */
     H5G_info_t                  group_info;
     unsigned int                i, j, k;

--- a/test/test_mirror.sh.in
+++ b/test/test_mirror.sh.in
@@ -45,7 +45,9 @@ done
 RUN_DIR=mirror_vfd_test
 MIRROR_UTILS=../utils/mirror_vfd # TODO: presupposes from test/
 
-mkdir $RUN_DIR
+if [[ ! -d $RUN_DIR ]] ; then
+    mkdir $RUN_DIR
+fi
 
 # Copy program files into dedicated test directory
 for FILE in $MIRROR_UTILS/mirror_* ; do
@@ -61,6 +63,10 @@ cp mirror_vfd $RUN_DIR
 # wrapper script. Copy these libs builds if appropriate.
 if [ -f $MIRROR_UTILS/.libs/mirror_server ] ; then
     RUN_LIBS=$RUN_DIR/.libs
+    # Delete previous .libs directory, to remove any generated libtool files
+    if [[ -d $RUN_LIBS ]] ; then
+        rm -rf $RUN_LIBS
+    fi
     mkdir $RUN_LIBS
     for FILE in $MIRROR_UTILS/.libs/mirror_* ; do
         case "$FILE" in


### PR DESCRIPTION
Mainly fixes "make check-vfd" when --enable-mirror-vfd is enabled, but also updates test script to handle testing failures w/debug cycles better.