### PR TITLE
Improve handling of copying of dynamic libraries and clean them up after test finishes

### DIFF
--- a/java/examples/datasets/JavaDatasetExample.sh.in
+++ b/java/examples/datasets/JavaDatasetExample.sh.in
@@ -29,6 +29,7 @@ CMP='cmp'
 DIFF='diff -c'
 CP='cp'
 DIRNAME='dirname'
+BASENAME='basename'
 LS='ls'
 AWK='awk'
 
@@ -103,17 +104,21 @@ COPY_LIBFILES_TO_BLDLIBDIR()
             INODE_SDIR=`$LS -i -d $SDIR | $AWK -F' ' '{print $1}'`
             INODE_DDIR=`$LS -i -d $BLDLIBDIR | $AWK -F' ' '{print $1}'`
             if [ "$INODE_SDIR" != "$INODE_DDIR" ]; then
-                $CP -f $tstfile $BLDLIBDIR
+                $CP -fR $tstfile $BLDLIBDIR
                 if [ $? -ne 0 ]; then
                     echo "Error: FAILED to copy $tstfile ."
 
                     # Comment out this to CREATE expected file
                     exit $EXIT_FAILURE
                 fi
+                BNAME=`$BASENAME $tstfile`
+                if [ "$BNAME" = "libhdf5_java.dylib" ]; then
+                    COPIED_LIBHDF5_JAVA=1
+                fi
             fi
         fi
     done
-    if [ "$IS_DARWIN" = "yes" ]; then
+    if [[ "$IS_DARWIN" = "yes" ]] && [[ $COPIED_LIBHDF5_JAVA -eq 1 ]]; then
        (cd $BLDLIBDIR; \
          install_name_tool -add_rpath @loader_path libhdf5_java.dylib; \
          exist_path=` otool -l libhdf5_java.dylib | grep libhdf5 | grep -v java | awk '{print $2}'`; \
@@ -134,7 +139,7 @@ COPY_LIBFILES_TO_BLDLIBDIR()
             INODE_SDIR=`$LS -i -d $SDIR | $AWK -F' ' '{print $1}'`
             INODE_DDIR=`$LS -i -d $BLDLIBDIR | $AWK -F' ' '{print $1}'`
             if [ "$INODE_SDIR" != "$INODE_DDIR" ]; then
-                $CP -f $tstfile $BLDLIBDIR
+                $CP -fR $tstfile $BLDLIBDIR
                 if [ $? -ne 0 ]; then
                     echo "Error: FAILED to copy $tstfile ."
 
@@ -155,10 +160,7 @@ CLEAN_LIBFILES_AND_BLDLIBDIR()
     INODE_SDIR=`$LS -i -d $SDIR | $AWK -F' ' '{print $1}'`
     INODE_DDIR=`$LS -i -d $BLDLIBDIR | $AWK -F' ' '{print $1}'`
     if [ "$INODE_SDIR" != "$INODE_DDIR" ]; then
-        for tstfile in $COPY_JARTESTFILES
-        do
-            $RM $BLDLIBDIR/tstfile
-        done
+        $RM -rf $BLDLIBDIR
     fi
 }
 

--- a/java/examples/datatypes/JavaDatatypeExample.sh.in
+++ b/java/examples/datatypes/JavaDatatypeExample.sh.in
@@ -26,6 +26,7 @@ CMP='cmp'
 DIFF='diff -c'
 CP='cp'
 DIRNAME='dirname'
+BASENAME='basename'
 LS='ls'
 AWK='awk'
 
@@ -100,17 +101,21 @@ COPY_LIBFILES_TO_BLDLIBDIR()
             INODE_SDIR=`$LS -i -d $SDIR | $AWK -F' ' '{print $1}'`
             INODE_DDIR=`$LS -i -d $BLDLIBDIR | $AWK -F' ' '{print $1}'`
             if [ "$INODE_SDIR" != "$INODE_DDIR" ]; then
-                $CP -f $tstfile $BLDLIBDIR
+                $CP -fR $tstfile $BLDLIBDIR
                 if [ $? -ne 0 ]; then
                     echo "Error: FAILED to copy $tstfile ."
 
                     # Comment out this to CREATE expected file
                     exit $EXIT_FAILURE
                 fi
+                BNAME=`$BASENAME $tstfile`
+                if [ "$BNAME" = "libhdf5_java.dylib" ]; then
+                    COPIED_LIBHDF5_JAVA=1
+                fi
             fi
         fi
     done
-    if [ "$IS_DARWIN" = "yes" ]; then
+    if [[ "$IS_DARWIN" = "yes" ]] && [[ $COPIED_LIBHDF5_JAVA -eq 1 ]]; then
        (cd $BLDLIBDIR; \
          install_name_tool -add_rpath @loader_path libhdf5_java.dylib; \
          exist_path=` otool -l libhdf5_java.dylib | grep libhdf5 | grep -v java | awk '{print $2}'`; \
@@ -131,7 +136,7 @@ COPY_LIBFILES_TO_BLDLIBDIR()
             INODE_SDIR=`$LS -i -d $SDIR | $AWK -F' ' '{print $1}'`
             INODE_DDIR=`$LS -i -d $BLDLIBDIR | $AWK -F' ' '{print $1}'`
             if [ "$INODE_SDIR" != "$INODE_DDIR" ]; then
-                $CP -f $tstfile $BLDLIBDIR
+                $CP -fR $tstfile $BLDLIBDIR
                 if [ $? -ne 0 ]; then
                     echo "Error: FAILED to copy $tstfile ."
 
@@ -152,10 +157,7 @@ CLEAN_LIBFILES_AND_BLDLIBDIR()
     INODE_SDIR=`$LS -i -d $SDIR | $AWK -F' ' '{print $1}'`
     INODE_DDIR=`$LS -i -d $BLDLIBDIR | $AWK -F' ' '{print $1}'`
     if [ "$INODE_SDIR" != "$INODE_DDIR" ]; then
-        for tstfile in $COPY_JARTESTFILES
-        do
-            $RM $BLDLIBDIR/tstfile
-        done
+        $RM -rf $BLDLIBDIR
     fi
 }
 

--- a/java/examples/groups/JavaGroupExample.sh.in
+++ b/java/examples/groups/JavaGroupExample.sh.in
@@ -26,6 +26,7 @@ CMP='cmp'
 DIFF='diff -c'
 CP='cp'
 DIRNAME='dirname'
+BASENAME='basename'
 LS='ls'
 AWK='awk'
 
@@ -95,17 +96,21 @@ COPY_LIBFILES_TO_BLDLIBDIR()
             INODE_SDIR=`$LS -i -d $SDIR | $AWK -F' ' '{print $1}'`
             INODE_DDIR=`$LS -i -d $BLDLIBDIR | $AWK -F' ' '{print $1}'`
             if [ "$INODE_SDIR" != "$INODE_DDIR" ]; then
-                $CP -f $tstfile $BLDLIBDIR
+                $CP -fR $tstfile $BLDLIBDIR
                 if [ $? -ne 0 ]; then
                     echo "Error: FAILED to copy $tstfile ."
 
                     # Comment out this to CREATE expected file
                     exit $EXIT_FAILURE
                 fi
+                BNAME=`$BASENAME $tstfile`
+                if [ "$BNAME" = "libhdf5_java.dylib" ]; then
+                    COPIED_LIBHDF5_JAVA=1
+                fi
             fi
         fi
     done
-    if [ "$IS_DARWIN" = "yes" ]; then
+    if [[ "$IS_DARWIN" = "yes" ]] && [[ $COPIED_LIBHDF5_JAVA -eq 1 ]]; then
        (cd $BLDLIBDIR; \
          install_name_tool -add_rpath @loader_path libhdf5_java.dylib; \
          exist_path=` otool -l libhdf5_java.dylib | grep libhdf5 | grep -v java | awk '{print $2}'`; \
@@ -126,7 +131,7 @@ COPY_LIBFILES_TO_BLDLIBDIR()
             INODE_SDIR=`$LS -i -d $SDIR | $AWK -F' ' '{print $1}'`
             INODE_DDIR=`$LS -i -d $BLDLIBDIR | $AWK -F' ' '{print $1}'`
             if [ "$INODE_SDIR" != "$INODE_DDIR" ]; then
-                $CP -f $tstfile $BLDLIBDIR
+                $CP -fR $tstfile $BLDLIBDIR
                 if [ $? -ne 0 ]; then
                     echo "Error: FAILED to copy $tstfile ."
 
@@ -147,10 +152,7 @@ CLEAN_LIBFILES_AND_BLDLIBDIR()
     INODE_SDIR=`$LS -i -d $SDIR | $AWK -F' ' '{print $1}'`
     INODE_DDIR=`$LS -i -d $BLDLIBDIR | $AWK -F' ' '{print $1}'`
     if [ "$INODE_SDIR" != "$INODE_DDIR" ]; then
-        for tstfile in $COPY_JARTESTFILES
-        do
-            $RM $BLDLIBDIR/tstfile
-        done
+        $RM -rf $BLDLIBDIR
     fi
 }
 

--- a/java/examples/intro/JavaIntroExample.sh.in
+++ b/java/examples/intro/JavaIntroExample.sh.in
@@ -26,6 +26,7 @@ CMP='cmp'
 DIFF='diff -c'
 CP='cp'
 DIRNAME='dirname'
+BASENAME='basename'
 LS='ls'
 AWK='awk'
 
@@ -89,17 +90,21 @@ COPY_LIBFILES_TO_BLDLIBDIR()
             INODE_SDIR=`$LS -i -d $SDIR | $AWK -F' ' '{print $1}'`
             INODE_DDIR=`$LS -i -d $BLDLIBDIR | $AWK -F' ' '{print $1}'`
             if [ "$INODE_SDIR" != "$INODE_DDIR" ]; then
-                $CP -f $tstfile $BLDLIBDIR
+                $CP -fR $tstfile $BLDLIBDIR
                 if [ $? -ne 0 ]; then
                     echo "Error: FAILED to copy $tstfile ."
 
                     # Comment out this to CREATE expected file
                     exit $EXIT_FAILURE
                 fi
+                BNAME=`$BASENAME $tstfile`
+                if [ "$BNAME" = "libhdf5_java.dylib" ]; then
+                    COPIED_LIBHDF5_JAVA=1
+                fi
             fi
         fi
     done
-    if [ "$IS_DARWIN" = "yes" ]; then
+    if [[ "$IS_DARWIN" = "yes" ]] && [[ $COPIED_LIBHDF5_JAVA -eq 1 ]]; then
        (cd $BLDLIBDIR; \
          install_name_tool -add_rpath @loader_path libhdf5_java.dylib; \
          exist_path=` otool -l libhdf5_java.dylib | grep libhdf5 | grep -v java | awk '{print $2}'`; \
@@ -120,7 +125,7 @@ COPY_LIBFILES_TO_BLDLIBDIR()
             INODE_SDIR=`$LS -i -d $SDIR | $AWK -F' ' '{print $1}'`
             INODE_DDIR=`$LS -i -d $BLDLIBDIR | $AWK -F' ' '{print $1}'`
             if [ "$INODE_SDIR" != "$INODE_DDIR" ]; then
-                $CP -f $tstfile $BLDLIBDIR
+                $CP -fR $tstfile $BLDLIBDIR
                 if [ $? -ne 0 ]; then
                     echo "Error: FAILED to copy $tstfile ."
 
@@ -141,10 +146,7 @@ CLEAN_LIBFILES_AND_BLDLIBDIR()
     INODE_SDIR=`$LS -i -d $SDIR | $AWK -F' ' '{print $1}'`
     INODE_DDIR=`$LS -i -d $BLDLIBDIR | $AWK -F' ' '{print $1}'`
     if [ "$INODE_SDIR" != "$INODE_DDIR" ]; then
-        for tstfile in $COPY_JARTESTFILES
-        do
-            $RM $BLDLIBDIR/tstfile
-        done
+        $RM -rf $BLDLIBDIR
     fi
 }
 

--- a/java/test/junit.sh.in
+++ b/java/test/junit.sh.in
@@ -31,6 +31,7 @@ CMP='cmp'
 DIFF='diff -c'
 CP='cp'
 DIRNAME='dirname'
+BASENAME='basename'
 LS='ls'
 AWK='awk'
 
@@ -141,17 +142,21 @@ COPY_LIBFILES_TO_BLDLIBDIR()
             INODE_SDIR=`$LS -i -d $SDIR | $AWK -F' ' '{print $1}'`
             INODE_DDIR=`$LS -i -d $BLDLIBDIR | $AWK -F' ' '{print $1}'`
             if [ "$INODE_SDIR" != "$INODE_DDIR" ]; then
-                $CP -f $tstfile $BLDLIBDIR
+                $CP -fR $tstfile $BLDLIBDIR
                 if [ $? -ne 0 ]; then
                     echo "Error: FAILED to copy $tstfile ."
 
                     # Comment out this to CREATE expected file
                     exit $EXIT_FAILURE
                 fi
+                BNAME=`$BASENAME $tstfile`
+                if [ "$BNAME" = "libhdf5_java.dylib" ]; then
+                    COPIED_LIBHDF5_JAVA=1
+                fi
             fi
         fi
     done
-    if [ "$IS_DARWIN" = "yes" ]; then
+    if [[ "$IS_DARWIN" = "yes" ]] && [[ $COPIED_LIBHDF5_JAVA -eq 1 ]]; then
        (cd testlibs; \
          install_name_tool -add_rpath @loader_path libhdf5_java.dylib; \
          exist_path=` otool -l libhdf5_java.dylib | grep libhdf5 | grep -v java | awk '{print $2}'`; \
@@ -172,7 +177,7 @@ COPY_LIBFILES_TO_BLDLIBDIR()
             INODE_SDIR=`$LS -i -d $SDIR | $AWK -F' ' '{print $1}'`
             INODE_DDIR=`$LS -i -d $BLDLIBDIR | $AWK -F' ' '{print $1}'`
             if [ "$INODE_SDIR" != "$INODE_DDIR" ]; then
-                $CP -f $tstfile $BLDLIBDIR
+                $CP -fR $tstfile $BLDLIBDIR
                 if [ $? -ne 0 ]; then
                     echo "Error: FAILED to copy $tstfile ."
 
@@ -195,7 +200,7 @@ COPY_LIBFILES_TO_BLDLIBDIR()
             INODE_SDIR=`$LS -i -d $SDIR | $AWK -F' ' '{print $1}'`
             INODE_DDIR=`$LS -i -d $BLDLIBDIR | $AWK -F' ' '{print $1}'`
             if [ "$INODE_SDIR" != "$INODE_DDIR" ]; then
-                $CP -f $tstfile $BLDLIBDIR
+                $CP -fR $tstfile $BLDLIBDIR
                 if [ $? -ne 0 ]; then
                     echo "Error: FAILED to copy $tstfile ."
 


### PR DESCRIPTION
Preserve softlinks, avoid actions on MacOS when dynamic libraries aren't copied and correctly clean up on test finish.