### PR TITLE
Fix SWMR/refresh bug hidden by library free lists

### DIFF
--- a/src/H5Oflush.c
+++ b/src/H5Oflush.c
@@ -194,8 +194,9 @@ done:
 herr_t
 H5O_refresh_metadata(H5O_loc_t *oloc, hid_t oid)
 {
-    H5VL_object_t *vol_obj   = NULL;    /* VOL object associated with the ID */
-    hbool_t        objs_incr = FALSE;   /* Whether the object count in the file was incremented */
+    H5VL_object_t *vol_obj   = NULL;  /* VOL object associated with the ID */
+    hbool_t        objs_incr = FALSE; /* Whether the object count in the file was incremented */
+    H5F_t *        file      = NULL;
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_NOAPI(FAIL)
@@ -207,6 +208,11 @@ H5O_refresh_metadata(H5O_loc_t *oloc, hid_t oid)
         H5G_name_t   obj_path;
         H5O_shared_t cached_H5O_shared;
         H5VL_t *     connector = NULL;
+
+        /* Hold a copy of the object's file pointer, since closing the object will
+         * invalidate the file pointer in the oloc.
+         */
+        file = oloc->file;
 
         /* Create empty object location */
         obj_loc.oloc = &obj_oloc;
@@ -256,8 +262,8 @@ H5O_refresh_metadata(H5O_loc_t *oloc, hid_t oid)
     } /* end if */
 
 done:
-    if (objs_incr)
-        H5F_decr_nopen_objs(oloc->file);
+    if (objs_incr && file)
+        H5F_decr_nopen_objs(file);
 
     FUNC_LEAVE_NOAPI(ret_value);
 } /* end H5O_refresh_metadata() */


### PR DESCRIPTION
Use-after-free warnings in valgrind for SWMR tests that perform refresh operations. Was hidden by library's free lists and seems to have always worked, but definitely a bug. May or may not have been problematic when free lists are on since the memory is still around, but could have been overwritten at some point.