### PR TITLE
Be a bit safer with signed arithmetic, thus quieting some signed-overflow warnings from GCC

### DIFF
--- a/src/H5Bdbg.c
+++ b/src/H5Bdbg.c
@@ -110,20 +110,20 @@ H5B_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth, const H5
      */
     for (u = 0; u < bt->nchildren; u++) {
         HDfprintf(stream, "%*sChild %d...\n", indent, "", u);
-        HDfprintf(stream, "%*s%-*s %" PRIuHADDR "\n", indent + 3, "", MAX(0, fwidth - 3),
+        HDfprintf(stream, "%*s%-*s %" PRIuHADDR "\n", indent + 3, "", MAX(3, fwidth) - 3,
                   "Address:", bt->child[u]);
 
         /* If there is a key debugging routine, use it to display the left & right keys */
         if (type->debug_key) {
             /* Decode the 'left' key & print it */
-            HDfprintf(stream, "%*s%-*s\n", indent + 3, "", MAX(0, fwidth - 3), "Left Key:");
+            HDfprintf(stream, "%*s%-*s\n", indent + 3, "", MAX(3, fwidth) - 3, "Left Key:");
             HDassert(H5B_NKEY(bt, shared, u));
-            (void)(type->debug_key)(stream, indent + 6, MAX(0, fwidth - 6), H5B_NKEY(bt, shared, u), udata);
+            (void)(type->debug_key)(stream, indent + 6, MAX(6, fwidth) - 6, H5B_NKEY(bt, shared, u), udata);
 
             /* Decode the 'right' key & print it */
-            HDfprintf(stream, "%*s%-*s\n", indent + 3, "", MAX(0, fwidth - 3), "Right Key:");
+            HDfprintf(stream, "%*s%-*s\n", indent + 3, "", MAX(3, fwidth) - 3, "Right Key:");
             HDassert(H5B_NKEY(bt, shared, u + 1));
-            (void)(type->debug_key)(stream, indent + 6, MAX(0, fwidth - 6), H5B_NKEY(bt, shared, u + 1),
+            (void)(type->debug_key)(stream, indent + 6, MAX(6, fwidth) - 6, H5B_NKEY(bt, shared, u + 1),
                                     udata);
         } /* end if */
     }     /* end for */

--- a/src/H5C.c
+++ b/src/H5C.c
@@ -5525,8 +5525,8 @@ H5C__flush_invalidate_ring(H5F_t *f, H5C_ring_t ring, unsigned flags)
     hbool_t            restart_slist_scan;
     uint32_t           protected_entries = 0;
     int32_t            i;
-    uint32_t            cur_ring_pel_len;
-    uint32_t            old_ring_pel_len;
+    uint32_t           cur_ring_pel_len;
+    uint32_t           old_ring_pel_len;
     unsigned           cooked_flags;
     unsigned           evict_flags;
     H5SL_node_t *      node_ptr       = NULL;

--- a/src/H5C.c
+++ b/src/H5C.c
@@ -4667,10 +4667,11 @@ H5C__autoadjust__ageout__cycle_epoch_marker(H5C_t *cache_ptr)
     cache_ptr->epoch_marker_ringbuf_first =
         (cache_ptr->epoch_marker_ringbuf_first + 1) % (H5C__MAX_EPOCH_MARKERS + 1);
 
+    if (cache_ptr->epoch_marker_ringbuf_size <= 0)
+        HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "ring buffer underflow")
+
     cache_ptr->epoch_marker_ringbuf_size -= 1;
 
-    if (cache_ptr->epoch_marker_ringbuf_size < 0)
-        HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "ring buffer underflow")
     if ((cache_ptr->epoch_marker_active)[i] != TRUE)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "unused marker in LRU?!?")
 
@@ -4690,10 +4691,10 @@ H5C__autoadjust__ageout__cycle_epoch_marker(H5C_t *cache_ptr)
 
     (cache_ptr->epoch_marker_ringbuf)[cache_ptr->epoch_marker_ringbuf_last] = i;
 
-    cache_ptr->epoch_marker_ringbuf_size += 1;
-
-    if (cache_ptr->epoch_marker_ringbuf_size > H5C__MAX_EPOCH_MARKERS)
+    if (cache_ptr->epoch_marker_ringbuf_size >= H5C__MAX_EPOCH_MARKERS)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "ring buffer overflow")
+
+    cache_ptr->epoch_marker_ringbuf_size += 1;
 
     H5C__DLL_PREPEND((&((cache_ptr->epoch_markers)[i])), (cache_ptr)->LRU_head_ptr, (cache_ptr)->LRU_tail_ptr,
                      (cache_ptr)->LRU_list_len, (cache_ptr)->LRU_list_size, (FAIL))
@@ -4965,12 +4966,12 @@ H5C__autoadjust__ageout__insert_new_marker(H5C_t *cache_ptr)
 
     (cache_ptr->epoch_marker_ringbuf)[cache_ptr->epoch_marker_ringbuf_last] = i;
 
-    cache_ptr->epoch_marker_ringbuf_size += 1;
-
-    if (cache_ptr->epoch_marker_ringbuf_size > H5C__MAX_EPOCH_MARKERS) {
+    if (cache_ptr->epoch_marker_ringbuf_size >= H5C__MAX_EPOCH_MARKERS) {
 
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "ring buffer overflow")
     }
+
+    cache_ptr->epoch_marker_ringbuf_size += 1;
 
     H5C__DLL_PREPEND((&((cache_ptr->epoch_markers)[i])), (cache_ptr)->LRU_head_ptr, (cache_ptr)->LRU_tail_ptr,
                      (cache_ptr)->LRU_list_len, (cache_ptr)->LRU_list_size, (FAIL))
@@ -5019,10 +5020,10 @@ H5C__autoadjust__ageout__remove_all_markers(H5C_t *cache_ptr)
         cache_ptr->epoch_marker_ringbuf_first =
             (cache_ptr->epoch_marker_ringbuf_first + 1) % (H5C__MAX_EPOCH_MARKERS + 1);
 
-        cache_ptr->epoch_marker_ringbuf_size -= 1;
-
-        if (cache_ptr->epoch_marker_ringbuf_size < 0)
+        if (cache_ptr->epoch_marker_ringbuf_size <= 0)
             HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "ring buffer underflow")
+
+        cache_ptr->epoch_marker_ringbuf_size -= 1;
 
         if ((cache_ptr->epoch_marker_active)[i] != TRUE)
             HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "unused marker in LRU?!?")
@@ -5092,10 +5093,11 @@ H5C__autoadjust__ageout__remove_excess_markers(H5C_t *cache_ptr)
         cache_ptr->epoch_marker_ringbuf_first =
             (cache_ptr->epoch_marker_ringbuf_first + 1) % (H5C__MAX_EPOCH_MARKERS + 1);
 
+        if (cache_ptr->epoch_marker_ringbuf_size <= 0)
+            HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "ring buffer underflow")
+
         cache_ptr->epoch_marker_ringbuf_size -= 1;
 
-        if (cache_ptr->epoch_marker_ringbuf_size < 0)
-            HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "ring buffer underflow")
         if ((cache_ptr->epoch_marker_active)[i] != TRUE)
             HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "unused marker in LRU?!?")
 

--- a/src/H5C.c
+++ b/src/H5C.c
@@ -5523,8 +5523,8 @@ H5C__flush_invalidate_ring(H5F_t *f, H5C_ring_t ring, unsigned flags)
     hbool_t            restart_slist_scan;
     uint32_t           protected_entries = 0;
     int32_t            i;
-    int32_t            cur_ring_pel_len;
-    int32_t            old_ring_pel_len;
+    uint32_t            cur_ring_pel_len;
+    uint32_t            old_ring_pel_len;
     unsigned           cooked_flags;
     unsigned           evict_flags;
     H5SL_node_t *      node_ptr       = NULL;

--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -2693,8 +2693,8 @@ H5C__prep_for_file_close__setup_image_entries_array(H5C_t *cache_ptr)
 
                 if (entry_ptr->age >= H5AC__CACHE_IMAGE__ENTRY_AGEOUT__MAX)
                     image_entries[u].age = H5AC__CACHE_IMAGE__ENTRY_AGEOUT__MAX;
-		else
-		    image_entries[u].age     = entry_ptr->age + 1;
+                else
+                    image_entries[u].age = entry_ptr->age + 1;
             } /* end if */
             else {
                 image_entries[u].type_id = entry_ptr->type->id;

--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -2690,10 +2690,11 @@ H5C__prep_for_file_close__setup_image_entries_array(H5C_t *cache_ptr)
              */
             if (entry_ptr->type->id == H5AC_PREFETCHED_ENTRY_ID) {
                 image_entries[u].type_id = entry_ptr->prefetch_type_id;
-                image_entries[u].age     = entry_ptr->age + 1;
 
-                if (image_entries[u].age > H5AC__CACHE_IMAGE__ENTRY_AGEOUT__MAX)
+                if (entry_ptr->age >= H5AC__CACHE_IMAGE__ENTRY_AGEOUT__MAX)
                     image_entries[u].age = H5AC__CACHE_IMAGE__ENTRY_AGEOUT__MAX;
+		else
+		    image_entries[u].age     = entry_ptr->age + 1;
             } /* end if */
             else {
                 image_entries[u].type_id = entry_ptr->type->id;


### PR DESCRIPTION
Jordan mentioned these signed-overflow warnings to me. GCC reports some of the potential overflows on different lines than you would expect. In fact, some of the overflows are reported as if they affect the last line of the file! I figured out what was really going on so I went ahead and fixed the problems.