### PR TITLE
CMake: respect GNUInstallDirs

### DIFF
--- a/CMakeInstallation.cmake
+++ b/CMakeInstallation.cmake
@@ -31,7 +31,7 @@ if (NOT HDF5_EXTERNALLY_CONFIGURED)
   if (HDF5_EXPORTED_TARGETS)
     install (
         EXPORT ${HDF5_EXPORTED_TARGETS}
-        DESTINATION ${HDF5_INSTALL_CMAKE_DIR}
+        DESTINATION ${HDF5_INSTALL_LIB_DIR}/cmake
         FILE ${HDF5_PACKAGE}${HDF_PACKAGE_EXT}-targets.cmake
         NAMESPACE ${HDF_PACKAGE_NAMESPACE}
         COMPONENT configinstall
@@ -67,12 +67,12 @@ set (HDF5_VERSION_MINOR  ${HDF5_PACKAGE_VERSION_MINOR})
 # Configure the hdf5-config.cmake file for the build directory
 #-----------------------------------------------------------------------------
 set (INCLUDE_INSTALL_DIR ${HDF5_INSTALL_INCLUDE_DIR})
-set (SHARE_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/${HDF5_INSTALL_CMAKE_DIR}" )
+set (SHARE_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/${HDF5_INSTALL_LIB_DIR}/cmake" )
 set (CURRENT_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}" )
 configure_package_config_file (
     ${HDF_RESOURCES_DIR}/hdf5-config.cmake.in
     "${HDF5_BINARY_DIR}/${HDF5_PACKAGE}${HDF_PACKAGE_EXT}-config.cmake"
-    INSTALL_DESTINATION "${HDF5_INSTALL_CMAKE_DIR}"
+    INSTALL_DESTINATION "${HDF5_INSTALL_LIB_DIR}/cmake"
     PATH_VARS INCLUDE_INSTALL_DIR SHARE_INSTALL_DIR CURRENT_BUILD_DIR
     INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
 )
@@ -81,19 +81,19 @@ configure_package_config_file (
 # Configure the hdf5-config.cmake file for the install directory
 #-----------------------------------------------------------------------------
 set (INCLUDE_INSTALL_DIR ${HDF5_INSTALL_INCLUDE_DIR})
-set (SHARE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${HDF5_INSTALL_CMAKE_DIR}" )
+set (SHARE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${HDF5_INSTALL_LIB_DIR}/cmake" )
 set (CURRENT_BUILD_DIR "${CMAKE_INSTALL_PREFIX}" )
 configure_package_config_file (
     ${HDF_RESOURCES_DIR}/hdf5-config.cmake.in
     "${HDF5_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${HDF5_PACKAGE}${HDF_PACKAGE_EXT}-config.cmake"
-    INSTALL_DESTINATION "${HDF5_INSTALL_CMAKE_DIR}"
+    INSTALL_DESTINATION "${HDF5_INSTALL_LIB_DIR}/cmake"
     PATH_VARS INCLUDE_INSTALL_DIR SHARE_INSTALL_DIR CURRENT_BUILD_DIR
 )
 
 if (NOT HDF5_EXTERNALLY_CONFIGURED)
   install (
       FILES ${HDF5_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${HDF5_PACKAGE}${HDF_PACKAGE_EXT}-config.cmake
-      DESTINATION ${HDF5_INSTALL_CMAKE_DIR}
+      DESTINATION ${HDF5_INSTALL_LIB_DIR}/cmake
       COMPONENT configinstall
   )
 endif ()
@@ -113,7 +113,7 @@ if (NOT HDF5_EXTERNALLY_CONFIGURED)
   #)
   install (
       FILES ${HDF5_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${HDF5_PACKAGE}${HDF_PACKAGE_EXT}-config-version.cmake
-      DESTINATION ${HDF5_INSTALL_CMAKE_DIR}
+      DESTINATION ${HDF5_INSTALL_LIB_DIR}/cmake
       COMPONENT configinstall
   )
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,13 @@ if (CMAKE_VERSION VERSION_LESS "3.14.0")
   endif()
 endif ()
 
+include (GNUInstallDirs)
+set (HDF5_INSTALL_BIN_DIR "${CMAKE_INSTALL_FULL_BINDIR}")
+set (HDF5_INSTALL_DATA_DIR "${CMAKE_INSTALL_FULL_DATADIR}")
+set (HDF5_INSTALL_DOC_DIR "${CMAKE_INSTALL_FULL_DOCDIR}")
+set (HDF5_INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+set (HDF5_INSTALL_LIB_DIR "${CMAKE_INSTALL_FULL_LIBDIR}")
+
 #-----------------------------------------------------------------------------
 # Instructions for use : Sub-Project Build
 #

--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -173,8 +173,8 @@ endif ()
 #-----------------------------------------------------------------------------
 set (_PKG_CONFIG_PREFIX ${CMAKE_INSTALL_PREFIX})
 set (_PKG_CONFIG_EXEC_PREFIX \${prefix})
-set (_PKG_CONFIG_LIBDIR \${exec_prefix}/lib)
-set (_PKG_CONFIG_INCLUDEDIR \${prefix}/include)
+set (_PKG_CONFIG_LIBDIR \${exec_prefix}/${CMAKE_INSTALL_LIBDIR})
+set (_PKG_CONFIG_INCLUDEDIR \${prefix}/${CMAKE_INSTALL_INCLUDEDIR})
 set (_PKG_CONFIG_LIBNAME "${HDF5_CPP_LIB_CORENAME}")
 set (_PKG_CONFIG_VERSION "${HDF5_PACKAGE_VERSION}")
 

--- a/doxygen/CMakeLists.txt
+++ b/doxygen/CMakeLists.txt
@@ -36,7 +36,7 @@ if (DOXYGEN_FOUND)
 
   install (
       DIRECTORY ${HDF5_BINARY_DIR}/hdf5lib_docs/html
-      DESTINATION ${HDF5_INSTALL_DATA_DIR}
+      DESTINATION ${HDF5_INSTALL_DOC_DIR}
       COMPONENT Documents
   )
 

--- a/fortran/src/CMakeLists.txt
+++ b/fortran/src/CMakeLists.txt
@@ -537,8 +537,8 @@ endif ()
 #-----------------------------------------------------------------------------
 set (_PKG_CONFIG_PREFIX ${CMAKE_INSTALL_PREFIX})
 set (_PKG_CONFIG_EXEC_PREFIX \${prefix})
-set (_PKG_CONFIG_LIBDIR \${exec_prefix}/lib)
-set (_PKG_CONFIG_INCLUDEDIR \${prefix}/include)
+set (_PKG_CONFIG_LIBDIR \${exec_prefix}/${CMAKE_INSTALL_LIBDIR})
+set (_PKG_CONFIG_INCLUDEDIR \${prefix}/${CMAKE_INSTALL_INCLUDEDIR})
 set (_PKG_CONFIG_LIBNAME "${HDF5_F90_LIB_CORENAME}")
 set (_PKG_CONFIG_VERSION "${HDF5_PACKAGE_VERSION}")
 

--- a/hl/c++/src/CMakeLists.txt
+++ b/hl/c++/src/CMakeLists.txt
@@ -91,8 +91,8 @@ endif ()
 #-----------------------------------------------------------------------------
 set (_PKG_CONFIG_PREFIX ${CMAKE_INSTALL_PREFIX})
 set (_PKG_CONFIG_EXEC_PREFIX \${prefix})
-set (_PKG_CONFIG_LIBDIR \${exec_prefix}/lib)
-set (_PKG_CONFIG_INCLUDEDIR \${prefix}/include)
+set (_PKG_CONFIG_LIBDIR \${exec_prefix}/${CMAKE_INSTALL_LIBDIR})
+set (_PKG_CONFIG_INCLUDEDIR \${prefix}/${CMAKE_INSTALL_INCLUDEDIR})
 set (_PKG_CONFIG_LIBNAME "${HDF5_HL_CPP_LIB_CORENAME}")
 set (_PKG_CONFIG_VERSION "${HDF5_PACKAGE_VERSION}")
 

--- a/hl/fortran/src/CMakeLists.txt
+++ b/hl/fortran/src/CMakeLists.txt
@@ -324,8 +324,8 @@ endif ()
 #-----------------------------------------------------------------------------
 set (_PKG_CONFIG_PREFIX ${CMAKE_INSTALL_PREFIX})
 set (_PKG_CONFIG_EXEC_PREFIX \${prefix})
-set (_PKG_CONFIG_LIBDIR \${exec_prefix}/lib)
-set (_PKG_CONFIG_INCLUDEDIR \${prefix}/include)
+set (_PKG_CONFIG_LIBDIR \${exec_prefix}/${CMAKE_INSTALL_LIBDIR})
+set (_PKG_CONFIG_INCLUDEDIR \${prefix}/${CMAKE_INSTALL_INCLUDEDIR})
 set (_PKG_CONFIG_LIBNAME "${HDF5_HL_F90_LIB_CORENAME}")
 set (_PKG_CONFIG_VERSION "${HDF5_PACKAGE_VERSION}")
 

--- a/hl/src/CMakeLists.txt
+++ b/hl/src/CMakeLists.txt
@@ -123,8 +123,8 @@ endif ()
 #-----------------------------------------------------------------------------
 set (_PKG_CONFIG_PREFIX ${CMAKE_INSTALL_PREFIX})
 set (_PKG_CONFIG_EXEC_PREFIX \${prefix})
-set (_PKG_CONFIG_LIBDIR \${exec_prefix}/lib)
-set (_PKG_CONFIG_INCLUDEDIR \${prefix}/include)
+set (_PKG_CONFIG_LIBDIR \${exec_prefix}/${CMAKE_INSTALL_LIBDIR})
+set (_PKG_CONFIG_INCLUDEDIR \${prefix}/${CMAKE_INSTALL_INCLUDEDIR})
 set (_PKG_CONFIG_LIBNAME "${HDF5_HL_LIB_CORENAME}")
 set (_PKG_CONFIG_VERSION "${HDF5_PACKAGE_VERSION}")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1310,8 +1310,8 @@ endif ()
 #-----------------------------------------------------------------------------
 set (_PKG_CONFIG_PREFIX ${CMAKE_INSTALL_PREFIX})
 set (_PKG_CONFIG_EXEC_PREFIX \${prefix})
-set (_PKG_CONFIG_LIBDIR \${exec_prefix}/lib)
-set (_PKG_CONFIG_INCLUDEDIR \${prefix}/include)
+set (_PKG_CONFIG_LIBDIR \${exec_prefix}/${CMAKE_INSTALL_LIBDIR})
+set (_PKG_CONFIG_INCLUDEDIR \${prefix}/${CMAKE_INSTALL_INCLUDEDIR})
 set (_PKG_CONFIG_LIBNAME "${HDF5_LIB_CORENAME}")
 set (_PKG_CONFIG_VERSION "${HDF5_PACKAGE_VERSION}")
 


### PR DESCRIPTION
This makes life a lot easier for in particular Linux distributions
as it means CMake will respect a standard set of arguments for
libdir, docdir, etc.

It also brings the CMake in line with autotools in terms of paths.

We've been using this downstream in Gentoo for quite some time
with no problems.

Signed-off-by: Sam James <sam@gentoo.org>