### PR TITLE
1.10 - Align H5T code with develop to quiet warnings

### DIFF
--- a/src/H5Odtype.c
+++ b/src/H5Odtype.c
@@ -1745,7 +1745,8 @@ H5O__dtype_debug(H5F_t *f, const void *mesg, FILE *stream, int indent, int fwidt
             HDfprintf(stream, "%*s%-*s 0x", indent, "", fwidth, "Raw bytes of value:");
             for (k = 0; k < dt->shared->parent->shared->size; k++)
                 HDfprintf(stream, "%02x",
-                          dt->shared->u.enumer.value[i * dt->shared->parent->shared->size + k]);
+                          (unsigned)*((uint8_t *)dt->shared->u.enumer.value +
+                                      (i * dt->shared->parent->shared->size) + k));
             HDfprintf(stream, "\n");
         } /* end for */
     }     /* end else if */

--- a/src/H5Tpkg.h
+++ b/src/H5Tpkg.h
@@ -237,7 +237,7 @@ typedef struct H5T_enum_t {
     unsigned   nalloc; /*num entries allocated		     */
     unsigned   nmembs; /*number of members defined in enum  */
     H5T_sort_t sorted; /*how are members sorted?	     */
-    uint8_t *  value;  /*array of values		     */
+    void *     value;  /*array of values		     */
     char **    name;   /*array of symbol names		     */
 } H5T_enum_t;
 


### PR DESCRIPTION
The casting here seems maybe a little suspicious to me, but this aligns the H5T code with develop and quiets the massive amount of H5T warnings in the 1.10 branch.