### PR TITLE
h5test.h testing macros get enclosed in do..while loops

### DIFF
--- a/hl/c++/test/ptableTest.cpp
+++ b/hl/c++/test/ptableTest.cpp
@@ -305,7 +305,7 @@ TestCompress()
         char filter_name[8];
         dcpl.getFilterById(H5Z_FILTER_DEFLATE, flags, cd_nelemts, NULL, 8, filter_name, config);
         if (HDstrncmp(filter_name, "deflate", 7) != 0)
-            H5_FAILED()
+            H5_FAILED();
     }
     catch (Exception const &) {
         H5_FAILED();

--- a/hl/test/h5hltest.h
+++ b/hl/test/h5hltest.h
@@ -29,21 +29,21 @@
 
 /* Macros used in HL tests */
 #define HL_TESTING2(WHAT)                                                                                    \
-    {                                                                                                        \
+    do {                                                                                                     \
         HDprintf("Testing %-62s", WHAT);                                                                     \
         HDfflush(stdout);                                                                                    \
-    }
+    } while (0)
 #define HL_TESTING3(WHAT)                                                                                    \
-    {                                                                                                        \
+    do {                                                                                                     \
         HDprintf("Testing %-62s", WHAT);                                                                     \
         HDfflush(stdout);                                                                                    \
-    }
+    } while (0)
 
 /* Implements verbose 'assert' with 'goto error' exit  */
 #define VERIFY(condition, string)                                                                            \
     do {                                                                                                     \
         if (!(condition))                                                                                    \
-            FAIL_PUTS_ERROR(string)                                                                          \
+            FAIL_PUTS_ERROR(string);                                                                         \
     } while (0)
 
 int test_packet_table_with_varlen(void);

--- a/hl/test/test_h5do_compat.c
+++ b/hl/test/test_h5do_compat.c
@@ -125,7 +125,7 @@ test_direct_chunk_write(hid_t did)
     offset[0] = 0;
     for (i = 0; i < NX / CHUNK_NX; i++) {
         if (H5DOwrite_chunk(did, H5P_DEFAULT, filter_mask, offset, data_size, chunk_data) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         offset[0] += CHUNK_NX;
     }
 
@@ -171,9 +171,9 @@ test_direct_chunk_read(hid_t did)
 
     /* Create dataspaces for reading */
     if ((mem_sid = H5Screate_simple(1, chunk_dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((file_sid = H5Screate_simple(1, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* For each chunk in the dataset, compare the result of H5Dread and H5DOread_chunk. */
     for (i = 0; i < NX / CHUNK_NX; i++) {
@@ -186,34 +186,34 @@ test_direct_chunk_read(hid_t did)
 
         /* Hyperslab selection equals single chunk */
         if (H5Sselect_hyperslab(file_sid, H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read the chunk back */
         if (H5Dread(did, H5T_NATIVE_INT, mem_sid, file_sid, H5P_DEFAULT, check) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read the raw chunk back */
         HDmemset(chunk_data, 0, CHUNK_NX * sizeof(int));
         filter_mask = UINT_MAX;
         offset[0]   = (hsize_t)i * CHUNK_NX;
         if (H5DOread_chunk(did, H5P_DEFAULT, offset, &filter_mask, chunk_data) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check filter mask return value */
         if (filter_mask != 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check that the values are correct */
         for (j = 0; j < CHUNK_NX; j++)
             if (chunk_data[i] != check[i])
-                TEST_ERROR
+                TEST_ERROR;
     }
 
     /* Close */
     if (H5Sclose(mem_sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(file_sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;

--- a/hl/test/test_ld.c
+++ b/hl/test/test_ld.c
@@ -69,7 +69,7 @@ int two_tests[TWO_NTESTS][2] = {{2, 2}, {2, -1}, {2, 0}, {-1, 2}, {-1, -1}, {-1,
     {                                                                                                        \
         long __x = (long)_x, __y = (long)_y;                                                                 \
         if (__x != __y)                                                                                      \
-            TEST_ERROR                                                                                       \
+            TEST_ERROR;                                                                                      \
     }
 
 /* Temporary buffer for reading in the test file */
@@ -247,7 +247,7 @@ test_LD_dims_params(const char *file)
 
     /* Open the copied file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * 1. Verify failure with negative dataset id
@@ -263,7 +263,7 @@ test_LD_dims_params(const char *file)
      * 2. Verify failure for NULL cur_dims
      */
     if ((did = H5Dopen2(fid, DSET_ALLOC_EARLY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     H5E_BEGIN_TRY
     {
         ret = H5LDget_dset_dims(did, NULL);
@@ -271,30 +271,30 @@ test_LD_dims_params(const char *file)
     H5E_END_TRY;
     VERIFY_EQUAL(ret, FAIL)
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * 3. Verify for nonNULL cur_dims
      */
     if ((did = H5Dopen2(fid, DSET_ALLOC_LATE, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5LDget_dset_dims(did, one_cur_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     VERIFY_EQUAL(one_cur_dims[0], 10)
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * 4. Verify nonNULL cur_dims for a 2-dimensional dataset
      */
     if ((did = H5Dopen2(fid, DSET_CMPD_TWO, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5LDget_dset_dims(did, two_cur_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     VERIFY_EQUAL(two_cur_dims[0], TWO_DIM_1)
     VERIFY_EQUAL(two_cur_dims[1], TWO_DIM_2)
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * 5. Verify nonNULL cur_dims for dataset with H5S_NULL dataspace
@@ -302,13 +302,13 @@ test_LD_dims_params(const char *file)
     one_cur_dims[0] = 0;
 
     if ((did = H5Dopen2(fid, DSET_NULL, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5LDget_dset_dims(did, one_cur_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     VERIFY_EQUAL(one_cur_dims[0], 0)
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * 6. Verify nonNULL cur_dims for dataset with H5S_SCALAR dataspace
@@ -316,17 +316,17 @@ test_LD_dims_params(const char *file)
     one_cur_dims[0] = 0;
 
     if ((did = H5Dopen2(fid, DSET_SCALAR, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5LDget_dset_dims(did, one_cur_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     VERIFY_EQUAL(one_cur_dims[0], 0)
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -396,21 +396,21 @@ test_LD_dims(const char *file)
 
     /* Make a copy of the test file */
     if (h5_make_local_copy(file, COPY_FILENAME) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the copied file */
     if ((fid = H5Fopen(COPY_FILENAME, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Testing with one-dimensional dataset: DSET_ONE
      */
     if ((did = H5Dopen2(fid, DSET_ONE, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve dimension sizes */
     if (H5LDget_dset_dims(did, one_prev_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     for (i = 0; i < ONE_NTESTS; i++) {
 
@@ -419,11 +419,11 @@ test_LD_dims(const char *file)
 
         /* Change the dimension size */
         if (H5Dset_extent(did, one_ext_dims) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Retrieve the dimension size */
         if (H5LDget_dset_dims(did, one_cur_dims) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify that the retrieved dimension size is correct as expected */
         VERIFY_EQUAL(one_cur_dims[0], one_ext_dims[0])
@@ -431,17 +431,17 @@ test_LD_dims(const char *file)
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Testing with two-dimensional dataset: DSET_TWO
      */
     if ((did = H5Dopen2(fid, DSET_TWO, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the dimension sizes */
     if (H5LDget_dset_dims(did, two_prev_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     for (i = 0; i < TWO_NTESTS; i++) {
 
@@ -451,11 +451,11 @@ test_LD_dims(const char *file)
 
         /* Change the dimension sizes */
         if (H5Dset_extent(did, two_ext_dims) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Retrieve the dimension sizes */
         if (H5LDget_dset_dims(did, two_cur_dims) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify that the retrieved dimension sizes are correct as expected */
         VERIFY_EQUAL(two_cur_dims[0], two_ext_dims[0])
@@ -464,11 +464,11 @@ test_LD_dims(const char *file)
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the copied file */
     HDremove(COPY_FILENAME);
@@ -537,7 +537,7 @@ test_LD_size(const char *file)
 
     /* Open the file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Verify failure with an invalid dataset id
@@ -556,90 +556,90 @@ test_LD_size(const char *file)
 
     /* Open dataset DSET_CMPD */
     if ((did = H5Dopen2(fid, DSET_CMPD, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Return size of the whole element */
     if ((dsize = H5LDget_dset_type_size(did, NULL)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the dataset's datatype and then its datatype size */
     if ((dtid = H5Tget_native_type(H5Dget_type(did), H5T_DIR_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((ck_dsize = H5Tget_size(dtid)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify case #1 */
     VERIFY_EQUAL(dsize, ck_dsize)
 
     /* Get datatype id for each member */
     if ((memb0_tid = H5Tget_member_type(dtid, 0)) < 0) /* "field1" */
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((memb1_tid = H5Tget_member_type(dtid, 1)) < 0) /* "field2" */
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((memb2_tid = H5Tget_member_type(dtid, 2)) < 0) /* "field3" */
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((memb3_tid = H5Tget_member_type(dtid, 3)) < 0) /* "field4" */
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Obtain size for VALID_FIELDS1: "field1,field2.a,field3,field4" */
     if ((dsize = H5LDget_dset_type_size(did, VALID_FIELDS1)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the datatype size for "field1" */
     if ((ck_dsize = H5Tget_size(memb0_tid)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Add the datatype size for "field2.a" */
     if ((memb_tid = H5Tget_member_type(memb1_tid, 0)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((ck_dsize += H5Tget_size(memb_tid)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Add the datatype size for "field3" */
     if ((ck_dsize += H5Tget_size(memb2_tid)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Add the datatype size for "field4" */
     if ((ck_dsize += H5Tget_size(memb3_tid)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify case #2 */
     VERIFY_EQUAL(dsize, ck_dsize)
 
     /* Obtain datatype size for VALID_FIELDS2: "field2.b.a,field2.c,field4.b" */
     if ((dsize = H5LDget_dset_type_size(did, VALID_FIELDS2)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the datatype size for "field2.b.a" */
     if ((memb_tid = H5Tget_member_type(memb1_tid, 1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((memb_tid2 = H5Tget_member_type(memb_tid, 0)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((ck_dsize = H5Tget_size(memb_tid2)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb_tid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Add the datatype size for "field2.c" */
     if ((memb_tid = H5Tget_member_type(memb1_tid, 2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((ck_dsize += H5Tget_size(memb_tid)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Add the datatype size for "field4.b" */
     if ((memb_tid = H5Tget_member_type(memb3_tid, 1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((ck_dsize += H5Tget_size(memb_tid)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify case #3 */
     VERIFY_EQUAL(dsize, ck_dsize)
@@ -664,17 +664,17 @@ test_LD_size(const char *file)
 
     /* Closing */
     if (H5Tclose(memb0_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb1_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb2_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb3_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(dtid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Testing one-dimensional dataset with compound datatype and
@@ -684,54 +684,54 @@ test_LD_size(const char *file)
 
     /* Open dataset DSET_CMPD_ESC */
     if ((did = H5Dopen2(fid, DSET_CMPD_ESC, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Return size of the whole element */
     if ((dsize = H5LDget_dset_type_size(did, NULL)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the dataset's datatype and then its datatype size */
     if ((dtid = H5Tget_native_type(H5Dget_type(did), H5T_DIR_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((ck_dsize = H5Tget_size(dtid)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify case #1 */
     VERIFY_EQUAL(dsize, ck_dsize)
 
     /* Get datatype id for each member */
     if ((memb0_tid = H5Tget_member_type(dtid, 0)) < 0) /* "field,1" */
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((memb1_tid = H5Tget_member_type(dtid, 1)) < 0) /* "field2." */
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((memb2_tid = H5Tget_member_type(dtid, 2)) < 0) /* "field\3" */
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((memb3_tid = H5Tget_member_type(dtid, 3)) < 0) /* "field4," */
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Obtain size for VALID_ESC_FIELDS1: "field\\,1,field2\\..\\.a,field\\\\3,field4\\," */
     if ((dsize = H5LDget_dset_type_size(did, VALID_ESC_FIELDS1)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the datatype size for "field\\,1" */
     if ((ck_dsize = H5Tget_size(memb0_tid)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Add the datatype size for "field2\\..\\.a" */
     if ((memb_tid = H5Tget_member_type(memb1_tid, 0)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((ck_dsize += H5Tget_size(memb_tid)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Add the datatype size for "field\\\\3" */
     if ((ck_dsize += H5Tget_size(memb2_tid)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Add the datatype size for "field4\\," */
     if ((ck_dsize += H5Tget_size(memb3_tid)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify case #2 */
     VERIFY_EQUAL(dsize, ck_dsize)
@@ -739,35 +739,35 @@ test_LD_size(const char *file)
     /* Obtain datatype size for VALID_ESC_FIELDS2:
         "field2\\..\\,b.a,field2\\..\\\\c,field4\\,.b\\," */
     if ((dsize = H5LDget_dset_type_size(did, VALID_ESC_FIELDS2)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the datatype size for "field2\..,b.a" */
     if ((memb_tid = H5Tget_member_type(memb1_tid, 1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((memb_tid2 = H5Tget_member_type(memb_tid, 0)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((ck_dsize = H5Tget_size(memb_tid2)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb_tid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Add the datatype size for "field2\..\\c" */
     if ((memb_tid = H5Tget_member_type(memb1_tid, 2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((ck_dsize += H5Tget_size(memb_tid)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Add the datatype size for "field4\,.b\," */
     if ((memb_tid = H5Tget_member_type(memb3_tid, 1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((ck_dsize += H5Tget_size(memb_tid)) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify case #3 */
     VERIFY_EQUAL(dsize, ck_dsize)
@@ -792,20 +792,20 @@ test_LD_size(const char *file)
 
     /* Closing */
     if (H5Tclose(memb0_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb1_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb2_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb3_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(dtid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -868,7 +868,7 @@ test_LD_elmts_invalid(const char *file)
 
     /* Open the copied file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Testing two-dimensional dataset: DSET_TWO
@@ -876,7 +876,7 @@ test_LD_elmts_invalid(const char *file)
 
     /* Open dataset: DSET_TWO */
     if ((did = H5Dopen2(fid, DSET_TWO, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify failure from case #1: cur_dims and prev_dims are NULL */
     ret = H5LDget_dset_elmts(did, NULL, NULL, NULL, NULL);
@@ -891,11 +891,11 @@ test_LD_elmts_invalid(const char *file)
     VERIFY_EQUAL(ret, FAIL)
 
     if ((sid = H5Dget_space(did)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the # of dimensions and current dimension sizes */
     if ((ndims = H5Sget_simple_extent_dims(sid, cur_dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set up valid cur_dims and prev_dims */
     for (i = 0; i < ndims; i++)
@@ -917,7 +917,7 @@ test_LD_elmts_invalid(const char *file)
 
     /* Close DSET_TWO */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Testing one-dimensional dataset with compound datatype:
@@ -934,11 +934,11 @@ test_LD_elmts_invalid(const char *file)
 
     /* Open dataset: DSET_CMPD */
     if ((did = H5Dopen2(fid, DSET_CMPD, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the current dimension sizes */
     if (H5LDget_dset_dims(did, cur_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set up valid cur_dims, prev_dims */
     prev_dims[0] = cur_dims[0] - 1;
@@ -949,11 +949,11 @@ test_LD_elmts_invalid(const char *file)
 
     /* Close DSET_CMPD */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -1004,7 +1004,7 @@ test_LD_elmts_one(const char *file, const char *dname, const char *fields)
 
     /* Copy the test file */
     if (h5_make_local_copy(file, COPY_FILENAME) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     for (i = 0; i < TEST_BUF_SIZE; i++) {
         cbuf[i].field1     = i;
@@ -1021,19 +1021,19 @@ test_LD_elmts_one(const char *file, const char *dname, const char *fields)
 
     /* Open the copied file */
     if ((fid = H5Fopen(COPY_FILENAME, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset */
     if ((did = H5Dopen2(fid, dname, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the dataset's data type */
     if ((dtype = H5Tget_native_type(H5Dget_type(did), H5T_DIR_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get current dimension sizes before extending the dataset's dimension sizes */
     if (H5LDget_dset_dims(did, prev_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Loop through different variations of extending the dataset */
     for (i = 0; i < ONE_NTESTS; i++) {
@@ -1046,16 +1046,16 @@ test_LD_elmts_one(const char *file, const char *dname, const char *fields)
 
         /* Change the dimension sizes of the dataset */
         if (H5Dset_extent(did, ext_dims) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Initialize data */
         if (!HDstrcmp(dname, DSET_CMPD) || !HDstrcmp(dname, DSET_CMPD_ESC)) {
             if (H5Dwrite(did, dtype, H5S_ALL, H5S_ALL, H5P_DEFAULT, cbuf) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         } /* end if */
         else if (!HDstrcmp(dname, DSET_ONE)) {
             if (H5Dwrite(did, dtype, H5S_ALL, H5S_ALL, H5P_DEFAULT, ibuf) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         } /* end if */
 
         /* There are changes in dimension sizes */
@@ -1065,24 +1065,24 @@ test_LD_elmts_one(const char *file, const char *dname, const char *fields)
                     if (!HDstrcmp(fields, VALID_FIELDS1) || !HDstrcmp(fields, VALID_ESC_FIELDS1)) {
                         /* Retrieve the elmemts in BUF */
                         if (H5LDget_dset_elmts(did, prev_dims, ext_dims, fields, vbuf1) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                         for (j = 0; j < one_tests[i]; j++)
                             VERIFY_ELMTS_VALID1(vbuf1[j], cbuf[prev_dims[0] + (hsize_t)j])
                     } /* end if */
                     else if (!HDstrcmp(fields, VALID_FIELDS2) || !HDstrcmp(fields, VALID_ESC_FIELDS2)) {
                         /* Retrieve the elmemts in BUF */
                         if (H5LDget_dset_elmts(did, prev_dims, ext_dims, fields, vbuf2) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                         for (j = 0; j < one_tests[i]; j++)
                             VERIFY_ELMTS_VALID2(vbuf2[j], cbuf[prev_dims[0] + (hsize_t)j])
                     } /* end else-if */
                     else
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end if */
                 else {
                     /* Retrieve the elmemts in BUF */
                     if (H5LDget_dset_elmts(did, prev_dims, ext_dims, fields, ccbuf) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     for (j = 0; j < one_tests[i]; j++)
                         VERIFY_ELMTS_ALL(ccbuf[j], cbuf[prev_dims[0] + (hsize_t)j])
                 } /* end else-if */
@@ -1090,7 +1090,7 @@ test_LD_elmts_one(const char *file, const char *dname, const char *fields)
             else {
                 /* Retrieve the elmemts in BUF */
                 if (H5LDget_dset_elmts(did, prev_dims, ext_dims, fields, iibuf) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 for (j = 0; j < one_tests[i]; j++)
                     VERIFY_EQUAL(iibuf[j], ibuf[prev_dims[0] + (hsize_t)j])
             } /* end else */
@@ -1104,11 +1104,11 @@ test_LD_elmts_one(const char *file, const char *dname, const char *fields)
 
     /* Closing */
     if (H5Tclose(dtype) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the copied file */
     HDremove(COPY_FILENAME);
@@ -1215,7 +1215,7 @@ test_LD_elmts_two(const char *file, const char *dname, const char *fields)
 
     /* Copy the test file */
     if (h5_make_local_copy(file, COPY_FILENAME) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     for (i = 0; i < TEST_BUF_SIZE; i++) {
         cbuf[i].field1     = i;
@@ -1232,19 +1232,19 @@ test_LD_elmts_two(const char *file, const char *dname, const char *fields)
 
     /* Open the copied file */
     if ((fid = H5Fopen(COPY_FILENAME, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset */
     if ((did = H5Dopen2(fid, dname, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the dataset's data type */
     if ((dtype = H5Tget_native_type(H5Dget_type(did), H5T_DIR_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get current dimension sizes before extending the dataset's dimension sizes */
     if (H5LDget_dset_dims(did, prev_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Loop through different variations of extending the dataset */
     for (i = 0; i < TWO_NTESTS; i++) {
@@ -1258,19 +1258,19 @@ test_LD_elmts_two(const char *file, const char *dname, const char *fields)
 
         /* Change the dimension sizes of the dataset */
         if (H5Dset_extent(did, ext_dims) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Initialize data */
         if (!HDstrcmp(dname, DSET_CMPD_TWO)) {
             if (H5Dwrite(did, dtype, H5S_ALL, H5S_ALL, H5P_DEFAULT, cbuf) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         } /* end if */
         else if (!HDstrcmp(dname, DSET_TWO)) {
             if (H5Dwrite(did, dtype, H5S_ALL, H5S_ALL, H5P_DEFAULT, ibuf) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         } /* end else-if */
         else
-            TEST_ERROR
+            TEST_ERROR;
 
         /* There are changes in dimension sizes */
         if (two_tests[i][0] > 0 || two_tests[i][1] > 0) {
@@ -1279,34 +1279,34 @@ test_LD_elmts_two(const char *file, const char *dname, const char *fields)
                     if (!HDstrcmp(fields, VALID_FIELDS1) || !HDstrcmp(fields, VALID_ESC_FIELDS1)) {
                         /* Retrieve the elmemts in BUF */
                         if (H5LDget_dset_elmts(did, prev_dims, ext_dims, fields, vbuf1) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                         if (verify_elmts_two(TWO_CMPD_VALID1, ext_dims, prev_dims, vbuf1, cbuf) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end if */
                     else if (!HDstrcmp(fields, VALID_FIELDS2) || !HDstrcmp(fields, VALID_ESC_FIELDS2)) {
                         /* Retrieve the elmemts in BUF */
                         if (H5LDget_dset_elmts(did, prev_dims, ext_dims, fields, vbuf2) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                         if (verify_elmts_two(TWO_CMPD_VALID2, ext_dims, prev_dims, vbuf2, cbuf) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end else-if */
                     else
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end if */
                 else {
                     /* Retrieve the elmemts in BUF */
                     if (H5LDget_dset_elmts(did, prev_dims, ext_dims, fields, ccbuf) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (verify_elmts_two(TWO_CMPD_NULL, ext_dims, prev_dims, ccbuf, cbuf) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 }  /* end else */
             }      /* end if */
             else { /* DSET_TWO */
                 /* Retrieve the elmemts in BUF */
                 if (H5LDget_dset_elmts(did, prev_dims, ext_dims, fields, iibuf) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (verify_elmts_two(TWO_NONE, ext_dims, prev_dims, iibuf, ibuf) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end else */
         }     /* end if */
         else {

--- a/test/accum.c
+++ b/test/accum.c
@@ -99,30 +99,30 @@ main(void)
     /* File access property list */
     h5_reset();
     if ((fapl = h5_fileaccess()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     /* Create a test file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Push API context */
     if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = TRUE;
 
     /* Get H5F_t * to internal file structure */
     if (NULL == (f = (H5F_t *)H5VL_object(fid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* We'll be writing lots of garbage data, so extend the
         file a ways. 10MB should do. */
     if (H5FD_set_eoa(f->shared->lf, H5FD_MEM_DEFAULT, (haddr_t)(1024 * 1024 * 10)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reset metadata accumulator for the file */
     if (accum_reset(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test Functions */
     nerrors += test_write_read(f);
@@ -140,12 +140,12 @@ main(void)
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = FALSE;
 
     /* End of test code, close and delete file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* This test uses a different file */
     nerrors += test_swmr_write_big(TRUE);
@@ -1295,7 +1295,7 @@ test_accum_adjust(H5F_t *f)
     /* Flush the accumulator -- we want to test the case when
         accumulator contains clean data */
     if (accum_flush(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write a small (1KB) block to the end of the accumulator */
     /* ==> Accumulator will need more buffer space */
@@ -1337,7 +1337,7 @@ test_accum_adjust(H5F_t *f)
 
     /* Flush the accumulator to clean it */
     if (accum_flush(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* write to part of the accumulator so just the start of it is dirty */
     if (accum_write(0, 5, wbuf) < 0)
@@ -1382,7 +1382,7 @@ test_accum_adjust(H5F_t *f)
 
     /* Flush the accumulator to clean it */
     if (accum_flush(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* write to part of the accumulator so it's dirty, but not entirely dirty */
     /* (just the begging few bytes will be clean) */
@@ -2106,9 +2106,9 @@ test_swmr_write_big(hbool_t newest_format)
     hbool_t  api_ctx_pushed  = FALSE; /* Whether API context pushed */
 
     if (newest_format)
-        TESTING("SWMR write of large metadata: with latest format")
+        TESTING("SWMR write of large metadata: with latest format");
     else
-        TESTING("SWMR write of large metadata: with non-latest-format")
+        TESTING("SWMR write of large metadata: with non-latest-format");
 
 #if !defined(H5_HAVE_UNISTD_H) && !defined(H5_HAVE_WIN32_API)
 
@@ -2130,43 +2130,43 @@ test_swmr_write_big(hbool_t newest_format)
 
     /* File access property list */
     if ((fapl = h5_fileaccess()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
 
     /* Both cases will result in v3 superblock and version 2 object header for SWMR */
     if (newest_format) { /* latest format */
         if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     else { /* non-latest-format */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC | H5F_ACC_SWMR_WRITE, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file with SWMR_WRITE */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Push API context */
     if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = TRUE;
 
     /* Get H5F_t * to internal file structure */
     if (NULL == (rf = (H5F_t *)H5VL_object(fid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* We'll be writing lots of garbage data, so extend the
         file a ways. 10MB should do. */
     if (H5FD_set_eoa(rf->shared->lf, H5FD_MEM_DEFAULT, (haddr_t)(1024 * 1024 * 10)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Fflush(fid, H5F_SCOPE_GLOBAL) < 0)
         FAIL_STACK_ERROR;
@@ -2288,7 +2288,7 @@ test_swmr_write_big(hbool_t newest_format)
 
     /* Check if the process terminated correctly */
     if (!process_success)
-        FAIL_PUTS_ERROR("child process exited abnormally")
+        FAIL_PUTS_ERROR("child process exited abnormally");
 
     /* Flush the accumulator */
     if (accum_reset(rf) < 0)
@@ -2304,7 +2304,7 @@ test_swmr_write_big(hbool_t newest_format)
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = FALSE;
 
     /* Release memory */

--- a/test/accum_swmr_reader.c
+++ b/test/accum_swmr_reader.c
@@ -67,21 +67,21 @@ main(void)
     }
 
     if ((fapl = h5_fileaccess()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
 
     /* Open the file with SWMR_READ */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Push API context */
     if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = TRUE;
 
     /* Get H5F_t * to internal file structure */
     if (NULL == (f = (H5F_t *)H5VL_object(fid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should read in [1024, 2024] with buf data */
     if (H5F_block_read(f, H5FD_MEM_DEFAULT, (haddr_t)1024, (size_t)1024, rbuf) < 0)
@@ -99,7 +99,7 @@ main(void)
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = FALSE;
 
     return EXIT_SUCCESS;

--- a/test/app_ref.c
+++ b/test/app_ref.c
@@ -30,13 +30,15 @@
 /* Macro to increment the reference count on id a random number of times (from
  * 1 to MAX_NINC).  Assumes integers i and ninc are in scope. */
 #define RAND_INC(id)                                                                                         \
-    ninc = (HDrand() % MAX_NINC) + 1;                                                                        \
+    do {                                                                                                     \
+        ninc = (HDrand() % MAX_NINC) + 1;                                                                    \
                                                                                                              \
-    for (i = 0; i < ninc; i++)                                                                               \
-        if (H5Iinc_ref(ids[id]) != i + 2)                                                                    \
-            TEST_ERROR                                                                                       \
+        for (i = 0; i < ninc; i++)                                                                           \
+            if (H5Iinc_ref(ids[id]) != i + 2)                                                                \
+                TEST_ERROR;                                                                                  \
                                                                                                              \
-    rc[id] = ninc + 1;
+        rc[id] = ninc + 1;                                                                                   \
+    } while (0)
 
 typedef enum {
     T_FILE,
@@ -110,76 +112,76 @@ main(void)
 
     /* Create the file */
     if ((ids[T_FILE] = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-    RAND_INC(T_FILE)
+    RAND_INC(T_FILE);
 
     /* Create the property list */
     if ((ids[T_PLIST] = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-    RAND_INC(T_PLIST)
+    RAND_INC(T_PLIST);
 
     /* Create a property class */
     if ((ids[T_PCLASS] = H5Pcreate_class(H5P_DATASET_CREATE, "foo", NULL, NULL, NULL, NULL, NULL, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-    RAND_INC(T_PCLASS)
+    RAND_INC(T_PCLASS);
 
     /* Create a datatype */
     if ((ids[T_TYPE] = H5Tcreate(H5T_OPAQUE, (size_t)16)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-    RAND_INC(T_TYPE)
+    RAND_INC(T_TYPE);
 
     /* Create a dataspace */
     if ((ids[T_SPACE] = H5Screate(H5S_SCALAR)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-    RAND_INC(T_SPACE)
+    RAND_INC(T_SPACE);
 
     /* Create a dataset */
     if ((ids[T_DSET] = H5Dcreate2(ids[T_FILE], APPREF_DSET, H5T_NATIVE_INT, ids[T_SPACE], H5P_DEFAULT,
                                   H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-    RAND_INC(T_DSET)
+    RAND_INC(T_DSET);
 
     /* Create an attribute */
     if ((ids[T_ATTR] = H5Acreate2(ids[T_DSET], APPREF_ATTR, H5T_NATIVE_INT, ids[T_SPACE], H5P_DEFAULT,
                                   H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-    RAND_INC(T_ATTR)
+    RAND_INC(T_ATTR);
 
     /* Create a group */
     if ((ids[T_GROUP] = H5Gcreate2(ids[T_FILE], APPREF_GROUP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-    RAND_INC(T_GROUP)
+    RAND_INC(T_GROUP);
 
     /* Create an error class */
     if ((ids[T_ECLASS] = H5Eregister_class("foo", "bar", "baz")) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-    RAND_INC(T_ECLASS)
+    RAND_INC(T_ECLASS);
 
     /* Create an error message */
     if ((ids[T_EMSG] = H5Ecreate_msg(ids[T_ECLASS], H5E_MAJOR, "mumble")) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-    RAND_INC(T_EMSG)
+    RAND_INC(T_EMSG);
 
     /* Create an error stack */
     if ((ids[T_ESTACK] = H5Eget_current_stack()) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-    RAND_INC(T_ESTACK)
+    RAND_INC(T_ESTACK);
 
     HDsignal(SIGABRT, &Abrt_Handler);
 
     if (H5close() < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -191,11 +193,11 @@ main(void)
     fapl = H5Pcreate(H5P_FILE_ACCESS);
     h5_cleanup(FILENAME, fapl);
 
-    return 0;
+    return EXIT_SUCCESS;
 
 error:
 
     HDputs("***** APPLICATION REFERENCE COUNT TESTS FAILED *****");
 
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/big.c
+++ b/test/big.c
@@ -506,17 +506,17 @@ reader(char *filename, hid_t fapl)
 
     /* Open HDF5 file */
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset */
     if ((d2 = H5Dopen2(file, "d2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fspace = H5Dget_space(d2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Describe `buf' */
     if ((mspace = H5Screate_simple(1, hs_size, hs_size)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read each region */
     while (HDfgets(ln, (int)sizeof(ln), script)) {
@@ -528,9 +528,9 @@ reader(char *filename, hid_t fapl)
         HDfflush(stdout);
 
         if (H5Sselect_hyperslab(fspace, H5S_SELECT_SET, hs_offset, NULL, hs_size, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Dread(d2, H5T_NATIVE_INT, mspace, fspace, H5P_DEFAULT, buf) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check */
         for (j = zero = wrong = 0; j < WRT_SIZE; j++) {
@@ -554,13 +554,13 @@ reader(char *filename, hid_t fapl)
     }
 
     if (H5Dclose(d2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(mspace) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(fspace) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDfree(buf);
     HDfclose(script);
 

--- a/test/btree2.c
+++ b/test/btree2.c
@@ -108,15 +108,15 @@ create_file(hid_t *file, H5F_t **f, hid_t fapl)
 
     /* Create the file to work on */
     if ((*file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (*f = (H5F_t *)H5VL_object(*file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(*f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Success */
     return (0);
@@ -143,11 +143,11 @@ create_btree(H5F_t *f, const H5B2_create_t *cparam, H5B2_t **bt2, haddr_t *bt2_a
 {
     /* Create the v2 B-tree & get its address */
     if (NULL == (*bt2 = H5B2_create(f, cparam, f)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5B2_get_addr(*bt2, bt2_addr /*out*/) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(*bt2_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Success */
     return (0);
@@ -179,15 +179,15 @@ reopen_file(hid_t *file, H5F_t **f, hid_t fapl)
 
     /* Create the file to work on */
     if ((*file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (*f = (H5F_t *)H5VL_object(*file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(*f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Success */
     return (0);
@@ -216,11 +216,11 @@ reopen_btree(H5F_t *f, H5B2_t **bt2, haddr_t bt2_addr, const bt2_test_param_t *t
     if (tparam->reopen_btree) {
         /* Close (empty) v2 B-tree */
         if (H5B2_close(*bt2) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Re-open v2 B-tree */
         if (NULL == (*bt2 = H5B2_open(f, bt2_addr, f)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Success */
@@ -250,11 +250,11 @@ check_stats(H5B2_t *bt2, const H5B2_stat_t *expected)
 
     /* Get current stats */
     if (H5B2_stat_info(bt2, &actual) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (actual.depth != expected->depth)
-        TEST_ERROR
+        TEST_ERROR;
     if (actual.nrecords != expected->nrecords)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return (0);
@@ -282,9 +282,9 @@ check_node_depth(H5B2_t *bt2, void *record, unsigned depth)
     int rec_depth; /* Depth of record in B-tree */
 
     if ((rec_depth = H5B2__get_node_depth_test(bt2, record)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((unsigned)rec_depth != depth)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return (0);
@@ -312,11 +312,11 @@ check_node_info(H5B2_t *bt2, hsize_t record, H5B2_node_info_test_t *ninfo)
     H5B2_node_info_test_t rec_ninfo; /* Node info for record in B-tree */
 
     if (H5B2__get_node_info_test(bt2, &record, &rec_ninfo) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (rec_ninfo.depth != ninfo->depth)
-        TEST_ERROR
+        TEST_ERROR;
     if (rec_ninfo.nrec != ninfo->nrec)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return (0);
@@ -641,11 +641,11 @@ test_insert_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -656,23 +656,23 @@ test_insert_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to iterate over a B-tree with no records */
     idx = 0;
     if (H5B2_iterate(bt2, iter_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Make certain that the index hasn't changed */
     if (idx != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find record in B-tree with no records */
     idx   = 0;
     found = FALSE;
     if (H5B2_find(bt2, &idx, &found, find_cb, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index record in B-tree with no records */
     idx = 0;
@@ -683,7 +683,7 @@ test_insert_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -694,43 +694,43 @@ test_insert_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     record = 42;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Attempt to find non-existent record in B-tree with 1 record */
     /* (Should not be found, but not fail) */
     idx   = 41;
     found = FALSE;
     if (H5B2_find(bt2, &idx, &found, find_cb, &idx) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try again with NULL 'op' */
     /* (Should not be found, but not fail) */
     found = FALSE;
     if (H5B2_find(bt2, &idx, &found, NULL, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in B-tree with 1 record */
     idx   = 42;
     found = FALSE;
     if (H5B2_find(bt2, &idx, &found, find_cb, &idx) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try again with NULL 'op' */
     found = FALSE;
     if (H5B2_find(bt2, &idx, &found, NULL, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index non-existent record in B-tree with 1 record */
     idx = 0;
@@ -741,12 +741,12 @@ test_insert_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in B-tree with 1 record */
     idx = 42;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)0, find_cb, &idx) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -757,45 +757,45 @@ test_insert_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test inserting second record into v2 B-tree, before all other records
      */
     record = 34;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Test inserting third record into v2 B-tree, after all other records
      */
     record = 56;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Test inserting fourth record into v2 B-tree, in the middle of other records
      */
     record = 38;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Attempt to find non-existent record in level-0 B-tree with several records */
     /* (Should not be found, but not fail) */
     idx   = 41;
     found = FALSE;
     if (H5B2_find(bt2, &idx, &found, find_cb, &idx) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in level-0 B-tree with several record */
     idx   = 56;
     found = FALSE;
     if (H5B2_find(bt2, &idx, &found, find_cb, &idx) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index non-existent record in B-tree with several records */
     idx = 0;
@@ -806,30 +806,30 @@ test_insert_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in B-tree with several records */
     idx = 34;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)0, find_cb, &idx) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     idx = 38;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)1, find_cb, &idx) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     idx = 42;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)2, find_cb, &idx) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     idx = 56;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)3, find_cb, &idx) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -884,104 +884,104 @@ test_insert_split_root(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_p
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert records to fill root leaf node */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC - 1); u++) {
         record = u + 2;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 0;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC - 1);
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = (hsize_t)33;
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert record to split root leaf node */
     record = INSERT_SPLIT_ROOT_NREC + 1;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = (hsize_t)33;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert a couple more records, on the left side of the B-tree */
     record = 0;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record = 1;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC + 2);
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = (hsize_t)33;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx = 0;
     if (H5B2_iterate(bt2, iter_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx != (INSERT_SPLIT_ROOT_NREC + 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find non-existent record in level-1 B-tree */
     /* (Should not be found, but not fail) */
     idx   = INSERT_SPLIT_ROOT_NREC + 10;
     found = FALSE;
     if (H5B2_find(bt2, &idx, &found, find_cb, &idx) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in root of level-1 B-tree */
     idx   = 33;
     found = FALSE;
     if (H5B2_find(bt2, &idx, &found, find_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in leaf of level-1 B-tree */
     idx   = 56;
     found = FALSE;
     if (H5B2_find(bt2, &idx, &found, find_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index non-existent record in level-1 B-tree */
     idx = 0;
@@ -992,30 +992,30 @@ test_insert_split_root(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_p
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in root of level-1 B-tree */
     idx = 33;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)33, find_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Attempt to index existing record in left leaf of level-1 B-tree */
     idx = 0;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)0, find_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Attempt to index existing record in right leaf of level-1 B-tree */
     idx = 50;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)50, find_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1067,51 +1067,51 @@ test_insert_level1_2leaf_redistrib(hid_t fapl, const H5B2_create_t *cparam, cons
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 leaves */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC; u++) {
         record = u + (INSERT_SPLIT_ROOT_NREC / 2) + 1;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = (hsize_t)INSERT_SPLIT_ROOT_NREC;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Force redistribution from left node into right node */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC / 2) + 1; u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC + (INSERT_SPLIT_ROOT_NREC / 2) + 1);
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = (hsize_t)((INSERT_SPLIT_ROOT_NREC / 2) + (INSERT_SPLIT_ROOT_NREC / 4) + 1);
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     PASSED();
@@ -1123,52 +1123,52 @@ test_insert_level1_2leaf_redistrib(hid_t fapl, const H5B2_create_t *cparam, cons
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 leaves */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC; u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = (hsize_t)(INSERT_SPLIT_ROOT_NREC / 2);
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Force redistribution from left node into right node */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC / 2) + 1; u++) {
         record = u + INSERT_SPLIT_ROOT_NREC;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC + (INSERT_SPLIT_ROOT_NREC / 2) + 1;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = (hsize_t)((INSERT_SPLIT_ROOT_NREC / 2) + (INSERT_SPLIT_ROOT_NREC / 4) + 1);
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1220,54 +1220,54 @@ test_insert_level1_side_split(hid_t fapl, const H5B2_create_t *cparam, const bt2
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 leaves */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC; u++) {
         record = u + INSERT_SPLIT_ROOT_NREC;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = INSERT_SPLIT_ROOT_NREC + (INSERT_SPLIT_ROOT_NREC / 2);
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Force left node to split */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC; u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = 2 * INSERT_SPLIT_ROOT_NREC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 31;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 63;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     PASSED();
@@ -1279,55 +1279,55 @@ test_insert_level1_side_split(hid_t fapl, const H5B2_create_t *cparam, const bt2
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 leaves */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC; u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = (INSERT_SPLIT_ROOT_NREC / 2);
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Force right node to split */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC; u++) {
         record = u + INSERT_SPLIT_ROOT_NREC;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = 2 * INSERT_SPLIT_ROOT_NREC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 62;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 94;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1382,95 +1382,95 @@ test_insert_level1_3leaf_redistrib(hid_t fapl, const H5B2_create_t *cparam, cons
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 leaves */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC; u++) {
         record = u + (INSERT_SPLIT_ROOT_NREC + (INSERT_SPLIT_ROOT_NREC / 2) + 1);
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = (2 * INSERT_SPLIT_ROOT_NREC);
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Force left node to split */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC; u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = 2 * INSERT_SPLIT_ROOT_NREC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = (INSERT_SPLIT_ROOT_NREC / 2);
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = (INSERT_SPLIT_ROOT_NREC + (INSERT_SPLIT_ROOT_NREC / 2) + 1);
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert records to force middle node to redistribute */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC / 2) + 1); u++) {
         record = u + INSERT_SPLIT_ROOT_NREC;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = (2 * INSERT_SPLIT_ROOT_NREC) + (INSERT_SPLIT_ROOT_NREC / 2) + 1;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 52;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 105;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx = 0;
     if (H5B2_iterate(bt2, iter_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx != ((INSERT_SPLIT_ROOT_NREC * 2) + (INSERT_SPLIT_ROOT_NREC / 2) + 1))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1524,75 +1524,75 @@ test_insert_level1_middle_split(hid_t fapl, const H5B2_create_t *cparam, const b
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 leaves */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC; u++) {
         record = u + (INSERT_SPLIT_ROOT_NREC * 2);
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = (2 * INSERT_SPLIT_ROOT_NREC) + (INSERT_SPLIT_ROOT_NREC / 2);
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Force split from left node into right node */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 2); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = 3 * INSERT_SPLIT_ROOT_NREC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 62;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 94;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 126;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx = 0;
     if (H5B2_iterate(bt2, iter_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx != (INSERT_SPLIT_ROOT_NREC * 3))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     PASSED();
 
@@ -1644,113 +1644,113 @@ test_insert_make_level2(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 internal nodes */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 9); u++) {
         record = u + 2;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
     for (; u < ((INSERT_SPLIT_ROOT_NREC * 29) + 1); u++) {
         record = u + 4;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 29) + 1;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 948;
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add some extra records to left-most leaf */
     record = 0;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record = 1;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Add some extra records to middle leaf */
     record = (INSERT_SPLIT_ROOT_NREC * 9) + 2;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record = (INSERT_SPLIT_ROOT_NREC * 9) + 3;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx = 0;
     if (H5B2_iterate(bt2, iter_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx != ((INSERT_SPLIT_ROOT_NREC * 29) + 5))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find non-existent record in level-2 B-tree */
     /* (Should not be found, but not fail) */
     idx   = INSERT_SPLIT_ROOT_NREC * 30;
     found = FALSE;
     if (H5B2_find(bt2, &idx, &found, find_cb, &idx) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in root of level-2 B-tree */
     idx   = 948;
     found = FALSE;
     if (H5B2_find(bt2, &idx, &found, find_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check with B-tree */
     record = 948;
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in internal node of level-2 B-tree */
     idx   = 505;
     found = FALSE;
     if (H5B2_find(bt2, &idx, &found, find_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check with B-tree */
     record = 505;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in leaf of level-2 B-tree */
     idx   = 555;
     found = FALSE;
     if (H5B2_find(bt2, &idx, &found, find_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check with B-tree */
     record = 555;
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index non-existent record in level-2 B-tree */
     idx = 0;
@@ -1761,31 +1761,31 @@ test_insert_make_level2(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in root of level-2 B-tree */
     idx = 948;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)948, find_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Attempt to index existing record in internal node of level-2 B-tree */
     idx = 505;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)505, find_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Attempt to index existing record in leaf of level-2 B-tree */
     idx = 555;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)555, find_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1837,63 +1837,63 @@ test_insert_level2_leaf_redistrib(hid_t fapl, const H5B2_create_t *cparam, const
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 internal nodes */
     /* And fill rightmost leaf */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 8); u++) {
         record = u + (INSERT_SPLIT_ROOT_NREC / 2) + 1;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
     for (; u < ((INSERT_SPLIT_ROOT_NREC * 29) + (INSERT_SPLIT_ROOT_NREC / 2)); u++) {
         record = u + INSERT_SPLIT_ROOT_NREC + 1;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 29) + (INSERT_SPLIT_ROOT_NREC / 2);
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1008;
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1859;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1921;
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert record to force redistribution of rightmost leaf */
     record = u + INSERT_SPLIT_ROOT_NREC + 1;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 29) + (INSERT_SPLIT_ROOT_NREC / 2) + 1;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1008;
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1875;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1922;
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1901,22 +1901,22 @@ test_insert_level2_leaf_redistrib(hid_t fapl, const H5B2_create_t *cparam, const
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 29) + (INSERT_SPLIT_ROOT_NREC / 2) + 1;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1008;
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 94;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 32;
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add more records to left-most leaf, to force a 2->1 split and then a
      *  2 node redistribution on left leaf
@@ -1924,23 +1924,23 @@ test_insert_level2_leaf_redistrib(hid_t fapl, const H5B2_create_t *cparam, const
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC / 2) + 1; u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 30) + 1;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1008;
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 47;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 0;
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1948,72 +1948,72 @@ test_insert_level2_leaf_redistrib(hid_t fapl, const H5B2_create_t *cparam, const
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 30) + 1;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1008;
     if (check_node_depth(bt2, &record, (unsigned)2) < 0) /* Record in root node */
-        TEST_ERROR
+        TEST_ERROR;
     record = 535;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0) /* Record in middle node before insertion point */
-        TEST_ERROR
+        TEST_ERROR;
     record = 630;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0) /* Record in middle node after insertion point */
-        TEST_ERROR
+        TEST_ERROR;
     record = 568;
     if (check_node_depth(bt2, &record, (unsigned)0) < 0) /* Record in leaf node just after insertion point */
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add more records to middle leaf, to force a split and a 3 node redistribution on middle leaf */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC / 2) + 1; u++) {
         record = u + (INSERT_SPLIT_ROOT_NREC * 8) + (INSERT_SPLIT_ROOT_NREC / 2) + 1;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 30) + (INSERT_SPLIT_ROOT_NREC / 2) + 2;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1008;
     if (check_node_depth(bt2, &record, (unsigned)2) < 0) /* Record in root node */
-        TEST_ERROR
+        TEST_ERROR;
     record = 524;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0) /* Record in middle node before insertion point */
-        TEST_ERROR
+        TEST_ERROR;
     record = 577;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0) /* Record in middle node after insertion point */
-        TEST_ERROR
+        TEST_ERROR;
     record = 568;
     if (check_node_depth(bt2, &record, (unsigned)0) < 0) /* Record in leaf node just after insertion point */
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx = 0;
     if (H5B2_iterate(bt2, iter_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx != ((INSERT_SPLIT_ROOT_NREC * 30) + (INSERT_SPLIT_ROOT_NREC / 2) + 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     PASSED();
 
@@ -2065,67 +2065,67 @@ test_insert_level2_leaf_split(hid_t fapl, const H5B2_create_t *cparam, const bt2
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 internal nodes */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 8); u++) {
         record = u + 1;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
     for (; u < ((INSERT_SPLIT_ROOT_NREC * 29) + (INSERT_SPLIT_ROOT_NREC / 2)); u++) {
         record = u + 2;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 29) + (INSERT_SPLIT_ROOT_NREC / 2);
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 946; /* Record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1797; /* Right-most record in right internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1859; /* Right-most record in right-most leaf */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force right-most leaf to split */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC / 2) + 1); u++) {
         record = u + (INSERT_SPLIT_ROOT_NREC * 29) + (INSERT_SPLIT_ROOT_NREC / 2) + 2;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC * 30;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 946; /* Record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1828; /* Next-to-right-most record in right-most internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1860; /* Right-most record in right-most internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1891; /* Right-most record in right-most leaf */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -2133,45 +2133,45 @@ test_insert_level2_leaf_split(hid_t fapl, const H5B2_create_t *cparam, const bt2
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC * 30;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 946; /* Record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 63; /* Left-most record in left-most internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1; /* Left-most record in left-most leaf */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add another record to left-most leaf, to force a 1->2 node split on left leaf */
     record = 0;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 30) + 1;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 946; /* Record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 63; /* Left-most record in left-most internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 32; /* Left-most record in left internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 0; /* Left-most record in left-most leaf */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -2179,73 +2179,73 @@ test_insert_level2_leaf_split(hid_t fapl, const H5B2_create_t *cparam, const bt2
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 30) + 1;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 946; /* Record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 504; /* Record in internal node just before insertion point */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 568; /* Record in internal node just after insertion point */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 506; /* Record in leaf node just after insertion point */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add another record to middle leaf, to force a node split on middle leaf */
     record = (INSERT_SPLIT_ROOT_NREC * 8) + 1;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 30) + 2;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 946; /* Record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 504; /* Left-most record of split in left internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 537; /* Middle record of split in left internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 568; /* Right-most record of split in left internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 506; /* Record in leaf node just after insertion point */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx = 0;
     if (H5B2_iterate(bt2, iter_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx != ((INSERT_SPLIT_ROOT_NREC * 30) + 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2299,58 +2299,58 @@ test_insert_level2_2internal_redistrib(hid_t fapl, const H5B2_create_t *cparam,
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 internal nodes */
     /* And fill up right internal node, to just before to redistribute it */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 44); u++) {
         record = u + (INSERT_SPLIT_ROOT_NREC * 6) - 4;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC * 44;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1318; /* Record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3114; /* Right-most record in right internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3145; /* Right-most record in right leaf node */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert record to redistribute right-most internal node */
     record = u + (INSERT_SPLIT_ROOT_NREC * 6) - 4;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC * 44 + 1;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1822; /* Record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3114; /* Right-most record in right internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3146; /* Right-most record in right leaf node */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -2358,66 +2358,66 @@ test_insert_level2_2internal_redistrib(hid_t fapl, const H5B2_create_t *cparam,
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC * 44 + 1;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1822; /* Record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 436; /* Left-most record in left internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 374; /* Left-most record in left leaf node */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Force left-most internal node to redistribute */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC * 6) - 4); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 50) - 3;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1570; /* Record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 61; /* Left-most record in left internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 0; /* Left-most record in left leaf node */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx = 0;
     if (H5B2_iterate(bt2, iter_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx != ((INSERT_SPLIT_ROOT_NREC * 50) - 3))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -2470,61 +2470,61 @@ test_insert_level2_2internal_split(hid_t fapl, const H5B2_create_t *cparam, cons
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 internal nodes */
     /* (And fill up two child internal nodes) */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 59); u++) {
         record = u + (INSERT_SPLIT_ROOT_NREC * 14) - (INSERT_SPLIT_ROOT_NREC / 4) + 3;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC * 59;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 2759; /* Record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 4555; /* Right-most record in right internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 4586; /* Right-most record in right leaf node */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert record to split right-most internal node */
     record = u + (INSERT_SPLIT_ROOT_NREC * 14) - (INSERT_SPLIT_ROOT_NREC / 4) + 3;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 59) + 1;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 2759; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3704; /* Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 4555; /* Right-most record in right internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 4387; /* Right-most record in right leaf node */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -2532,69 +2532,69 @@ test_insert_level2_2internal_split(hid_t fapl, const H5B2_create_t *cparam, cons
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 59) + 1;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 2759; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 932; /* Left-most record in left internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 870; /* Left-most record in left leaf node */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Force left-most internal node to split */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC * 14) - (INSERT_SPLIT_ROOT_NREC / 4) + 3); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 73) - (INSERT_SPLIT_ROOT_NREC / 4) + 4;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 870; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1814; /* Next-to-left-most record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 61; /* Left-most record in left internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 0; /* Left-most record in left leaf node */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx = 0;
     if (H5B2_iterate(bt2, iter_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx != ((INSERT_SPLIT_ROOT_NREC * 73) - (INSERT_SPLIT_ROOT_NREC / 4) + 4))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     PASSED();
 
@@ -2649,130 +2649,130 @@ test_insert_level2_3internal_redistrib(hid_t fapl, const H5B2_create_t *cparam,
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 3 internal nodes */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 36); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
     for (; u < ((INSERT_SPLIT_ROOT_NREC * 59) + 1); u++) {
         record = u + (INSERT_SPLIT_ROOT_NREC * 13) + ((3 * INSERT_SPLIT_ROOT_NREC) / 4) + 3;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 59) + 1;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1889; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3703; /* Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 2267; /* Record to left of insertion point in middle internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3199; /* Record to right of insertion point in middle internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3137; /* Record just above insertion point in leaf node */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert records to fill up middle internal node */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC * 13) + ((3 * INSERT_SPLIT_ROOT_NREC) / 4) + 2); u++) {
         record = u + (INSERT_SPLIT_ROOT_NREC * 36);
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 72) + ((3 * INSERT_SPLIT_ROOT_NREC) / 4) + 3;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1889; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3703; /* Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3104; /* Record to left of insertion point in middle internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3137; /* Record to right of insertion point in middle internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3135; /* Record just above insertion point in leaf node */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert another record, forcing the middle internal node to redistribute */
     record = u + (INSERT_SPLIT_ROOT_NREC * 36);
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 72) + ((3 * INSERT_SPLIT_ROOT_NREC) / 4) + 4;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1574; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3104; /* Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 #ifdef NONE
     record = 2862; /* Record to left of insertion point in right internal node (now) */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 #endif             /* NONE */
     record = 3137; /* Record to right of insertion point in right internal node (now) */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3135; /* Record just above insertion point in leaf node */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx = 0;
     if (H5B2_iterate(bt2, iter_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx != ((INSERT_SPLIT_ROOT_NREC * 72) + ((3 * INSERT_SPLIT_ROOT_NREC) / 4) + 4))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     PASSED();
 
@@ -2826,134 +2826,134 @@ test_insert_level2_3internal_split(hid_t fapl, const H5B2_create_t *cparam, cons
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 3 internal nodes */
     /* (and fill right internal node) */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 31); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
     for (; u < (INSERT_SPLIT_ROOT_NREC * 74); u++) {
         record = u + ((INSERT_SPLIT_ROOT_NREC * 13) + ((3 * INSERT_SPLIT_ROOT_NREC) / 4) + 3);
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC * 74;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1889; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3703; /* Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1952; /* Record to left of insertion point in middle internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 2884; /* Record to right of insertion point in middle internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 2822; /* Record just after insertion point in leaf node */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert records to fill up middle internal node */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC * 13) + ((3 * INSERT_SPLIT_ROOT_NREC) / 4) + 2); u++) {
         record = u + (INSERT_SPLIT_ROOT_NREC * 31);
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 87) + ((3 * INSERT_SPLIT_ROOT_NREC) / 4) + 2;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1889; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3703; /* Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 2789; /* Record to left of insertion point in middle internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 2822; /* Record to right of insertion point in middle internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 2823; /* Record just above insertion point in leaf node */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert record to split middle internal node */
     record = u + (INSERT_SPLIT_ROOT_NREC * 31);
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC * 87) + ((3 * INSERT_SPLIT_ROOT_NREC) / 4) + 3;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 1889; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 2789; /* Middle record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 3703; /* Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 #ifdef NONE
     record = 3049; /* Record to left of insertion point in middle internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 #endif             /* NONE */
     record = 2822; /* Record to right of insertion point in middle internal node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 2823; /* Record just above insertion point in leaf node */
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx = 0;
     if (H5B2_iterate(bt2, iter_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx != ((INSERT_SPLIT_ROOT_NREC * 87) + ((3 * INSERT_SPLIT_ROOT_NREC) / 4) + 3))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -3020,7 +3020,7 @@ HDfprintf(stderr,"curr_time=%lu\n",(unsigned long)curr_time);
 
     /* Allocate space for the records */
     if (NULL == (records = (hsize_t *)HDmalloc(sizeof(hsize_t) * INSERT_MANY)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize record #'s */
     for (u = 0; u < INSERT_MANY; u++)
@@ -3039,81 +3039,81 @@ HDfprintf(stderr,"curr_time=%lu\n",(unsigned long)curr_time);
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert random records */
     for (u = 0; u < INSERT_MANY; u++) {
         record = records[u];
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 4;
     bt2_stat.nrecords = INSERT_MANY;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Re-open v2 B-tree */
     if (NULL == (bt2 = H5B2_open(f, bt2_addr, f)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check up on B-tree after re-open */
     bt2_stat.depth    = 4;
     bt2_stat.nrecords = INSERT_MANY;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx = 0;
     if (H5B2_iterate(bt2, iter_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx != INSERT_MANY)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find non-existent record in level-4 B-tree */
     /* (Should not be found, but not fail) */
     idx   = INSERT_MANY * 2;
     found = FALSE;
     if (H5B2_find(bt2, &idx, &found, find_cb, &idx) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Find random records */
     for (u = 0; u < FIND_MANY; u++) {
@@ -3123,9 +3123,9 @@ HDfprintf(stderr,"curr_time=%lu\n",(unsigned long)curr_time);
         /* Attempt to find existent record in root of level-4 B-tree */
         found = FALSE;
         if (H5B2_find(bt2, &idx, &found, find_cb, &idx) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (!found)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Attempt to index non-existent record in level-4 B-tree, in increasing & decreasing order */
@@ -3136,7 +3136,7 @@ HDfprintf(stderr,"curr_time=%lu\n",(unsigned long)curr_time);
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         ret = H5B2_index(bt2, H5_ITER_DEC, (hsize_t)(INSERT_MANY * 3), find_cb, NULL);
@@ -3144,7 +3144,7 @@ HDfprintf(stderr,"curr_time=%lu\n",(unsigned long)curr_time);
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Find random records */
     for (u = 0; u < FIND_MANY; u++) {
@@ -3154,12 +3154,12 @@ HDfprintf(stderr,"curr_time=%lu\n",(unsigned long)curr_time);
         /* Attempt to find existent record in root of level-4 B-tree */
         /* (in increasing order) */
         if (H5B2_index(bt2, H5_ITER_INC, idx, find_cb, &idx) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Attempt to find existent record in root of level-4 B-tree */
         /* (in decreasing order) */
         if (H5B2_index(bt2, H5_ITER_DEC, idx, find_dec_cb, &idx) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     PASSED();
@@ -3168,7 +3168,7 @@ HDfprintf(stderr,"curr_time=%lu\n",(unsigned long)curr_time);
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     record = INSERT_MANY / 2;
     H5E_BEGIN_TRY
@@ -3178,24 +3178,24 @@ HDfprintf(stderr,"curr_time=%lu\n",(unsigned long)curr_time);
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != INSERT_MANY)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -3243,11 +3243,11 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test insert record into empty v2 B-tree
@@ -3256,12 +3256,12 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     record.key = 42;
     record.val = 72;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Attempt to find non-existent record in B-tree with 1 record */
     /* (Should not be found, but not fail) */
@@ -3269,41 +3269,41 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != (hsize_t)-1)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try again with NULL 'op' */
     /* (Should not be found, but not fail) */
     found = FALSE;
     if (H5B2_find(bt2, &find, &found, NULL, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != (hsize_t)-1)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in B-tree with 1 record */
     find.key = 42;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != 72)
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try again with NULL 'op' */
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, NULL, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != (hsize_t)-1)
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index non-existent record in B-tree with 1 record */
     H5E_BEGIN_TRY
@@ -3313,16 +3313,16 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in B-tree with 1 record */
     find.key = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)0, index_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.key != 42)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 72)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -3333,12 +3333,12 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     modify.key = 42;
     modify.val = 43;
     if (H5B2_update(bt2, &modify, modify_rec_cb, &modify) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Attempt to find non-existent record in B-tree with 1 record */
     /* (Should not be found, but not fail) */
@@ -3346,41 +3346,41 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != (hsize_t)-1)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try again with NULL 'op' */
     /* (Should not be found, but not fail) */
     found = FALSE;
     if (H5B2_find(bt2, &find, &found, NULL, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != (hsize_t)-1)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find modified record in B-tree with 1 record */
     find.key = 42;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != 43)
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try again with NULL 'op' */
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, NULL, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != (hsize_t)-1)
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index non-existent record in B-tree with 1 record */
     H5E_BEGIN_TRY
@@ -3390,17 +3390,17 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in B-tree with 1 record */
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)0, index_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.key != 42)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 43)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -3411,7 +3411,7 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test inserting second record into v2 B-tree, before all other records
@@ -3419,7 +3419,7 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     record.key = 34;
     record.val = 11;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Test inserting third record into v2 B-tree, after all other records
@@ -3427,7 +3427,7 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     record.key = 56;
     record.val = 12;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Test inserting fourth record into v2 B-tree, in the middle of other records
@@ -3435,7 +3435,7 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     record.key = 38;
     record.val = 13;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Attempt to find non-existent record in level-0 B-tree with several records */
     /* (Should not be found, but not fail) */
@@ -3443,21 +3443,21 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != (hsize_t)-1)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in level-0 B-tree with several records */
     find.key = 56;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 12)
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index non-existent record in B-tree with several records */
     H5E_BEGIN_TRY
@@ -3467,41 +3467,41 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in B-tree with several records */
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)0, index_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.key != 34)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 11)
-        TEST_ERROR
+        TEST_ERROR;
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)1, index_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.key != 38)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 13)
-        TEST_ERROR
+        TEST_ERROR;
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)2, index_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.key != 42)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 43)
-        TEST_ERROR
+        TEST_ERROR;
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)3, index_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.key != 56)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 12)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -3514,22 +3514,22 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     modify.key = 34;
     modify.val = 21;
     if (H5B2_update(bt2, &record, modify_rec_cb, &modify) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record.key = 38;
     modify.key = 38;
     modify.val = 23;
     if (H5B2_update(bt2, &record, modify_rec_cb, &modify) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record.key = 42;
     modify.key = 42;
     modify.val = 24;
     if (H5B2_update(bt2, &record, modify_rec_cb, &modify) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record.key = 56;
     modify.key = 56;
     modify.val = 22;
     if (H5B2_update(bt2, &record, modify_rec_cb, &modify) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Attempt to find non-existent record in level-0 B-tree with several records */
     /* (Should not be found, but not fail) */
@@ -3537,21 +3537,21 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != (hsize_t)-1)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in level-0 B-tree with several record */
     find.key = 56;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 22)
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index non-existent record in B-tree with several records */
     H5E_BEGIN_TRY
@@ -3561,50 +3561,50 @@ test_update_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in B-tree with several records */
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)0, index_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.key != 34)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 21)
-        TEST_ERROR
+        TEST_ERROR;
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)1, index_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.key != 38)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 23)
-        TEST_ERROR
+        TEST_ERROR;
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)2, index_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.key != 42)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 24)
-        TEST_ERROR
+        TEST_ERROR;
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)3, index_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.key != 56)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 22)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -3661,61 +3661,61 @@ test_update_split_root(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_p
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert records to fill root leaf node */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC_REC - 1); u++) {
         record.key = u + 2;
         record.val = u * 2 + 4;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 0;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC_REC - 1);
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = 33;
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert record to split root leaf node */
     record.key = INSERT_SPLIT_ROOT_NREC_REC + 1;
     record.val = (INSERT_SPLIT_ROOT_NREC_REC - 1) * 2 + 4;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC_REC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = 33;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx.key = 2;
     idx.val = 4;
     if (H5B2_iterate(bt2, iter_rec_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx.key != (INSERT_SPLIT_ROOT_NREC_REC + 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Modify all records */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC_REC; u++) {
@@ -3723,64 +3723,64 @@ test_update_split_root(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_p
         modify.key = u + 2;
         modify.val = u * 2 + 5;
         if (H5B2_update(bt2, &record, modify_rec_cb, &modify) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC_REC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = 33;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx.key = 2;
     idx.val = 5;
     if (H5B2_iterate(bt2, iter_rec_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx.key != (INSERT_SPLIT_ROOT_NREC_REC + 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert a couple more records, on the left side of the B-tree */
     record.key = 0;
     record.val = 1;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record.key = 1;
     record.val = 3;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC_REC + 2);
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = 33;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx.key = 0;
     idx.val = 1;
     if (H5B2_iterate(bt2, iter_rec_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx.key != (INSERT_SPLIT_ROOT_NREC_REC + 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find non-existent record in level-1 B-tree */
     /* (Should not be found, but not fail) */
@@ -3788,37 +3788,37 @@ test_update_split_root(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_p
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != (hsize_t)-1)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in root of level-1 B-tree */
     find.key = 33;
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.key != 33)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 67)
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in leaf of level-1 B-tree */
     find.key = 56;
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.key != 56)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 113)
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index non-existent record in level-1 B-tree */
     H5E_BEGIN_TRY
@@ -3828,45 +3828,45 @@ test_update_split_root(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_p
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in root of level-1 B-tree */
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)33, index_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.key != 33)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 67)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in left leaf of level-1 B-tree */
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)0, index_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.key != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in right leaf of level-1 B-tree */
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)50, index_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.key != 50)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != 101)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -3918,53 +3918,53 @@ test_update_level1_2leaf_redistrib(hid_t fapl, const H5B2_create_t *cparam, cons
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 leaves */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC_REC; u++) {
         record.key = u + (INSERT_SPLIT_ROOT_NREC_REC / 2) + 1;
         record.val = u + (INSERT_SPLIT_ROOT_NREC_REC / 2) + 10;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC_REC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = INSERT_SPLIT_ROOT_NREC_REC;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Force redistribution from left node into right node */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC_REC / 2) + 1; u++) {
         record.key = u;
         record.val = u + 9;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC_REC + (INSERT_SPLIT_ROOT_NREC_REC / 2) + 1);
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = (INSERT_SPLIT_ROOT_NREC_REC / 2) + (INSERT_SPLIT_ROOT_NREC_REC / 4);
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     PASSED();
@@ -3976,54 +3976,54 @@ test_update_level1_2leaf_redistrib(hid_t fapl, const H5B2_create_t *cparam, cons
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 leaves */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC_REC; u++) {
         record.key = u;
         record.val = u + 9;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC_REC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = (INSERT_SPLIT_ROOT_NREC_REC / 2) - 1;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Force redistribution from left node into right node */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC_REC / 2) + 1; u++) {
         record.key = u + INSERT_SPLIT_ROOT_NREC_REC;
         record.val = u + INSERT_SPLIT_ROOT_NREC_REC + 9;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC_REC + (INSERT_SPLIT_ROOT_NREC_REC / 2) + 1;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = (INSERT_SPLIT_ROOT_NREC_REC / 2) + (INSERT_SPLIT_ROOT_NREC_REC / 4) - 1;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -4075,56 +4075,56 @@ test_update_level1_side_split(hid_t fapl, const H5B2_create_t *cparam, const bt2
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 leaves */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC_REC; u++) {
         record.key = u + INSERT_SPLIT_ROOT_NREC_REC;
         record.val = u + INSERT_SPLIT_ROOT_NREC_REC + 10;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC_REC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = INSERT_SPLIT_ROOT_NREC_REC + (INSERT_SPLIT_ROOT_NREC_REC / 2) - 1;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Force left node to split */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC_REC; u++) {
         record.key = u;
         record.val = u + 10;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = 2 * INSERT_SPLIT_ROOT_NREC_REC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = 31;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = 64;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     PASSED();
@@ -4136,57 +4136,57 @@ test_update_level1_side_split(hid_t fapl, const H5B2_create_t *cparam, const bt2
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 leaves */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC_REC; u++) {
         record.key = u;
         record.val = u + 10;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC_REC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = (INSERT_SPLIT_ROOT_NREC_REC / 2) - 1;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Force right node to split */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC_REC; u++) {
         record.key = u + INSERT_SPLIT_ROOT_NREC_REC;
         record.val = u + INSERT_SPLIT_ROOT_NREC_REC + 10;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = 2 * INSERT_SPLIT_ROOT_NREC_REC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = 63;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = 95;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -4241,99 +4241,99 @@ test_update_level1_3leaf_redistrib(hid_t fapl, const H5B2_create_t *cparam, cons
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 leaves */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC_REC; u++) {
         record.key = u + (INSERT_SPLIT_ROOT_NREC_REC + (INSERT_SPLIT_ROOT_NREC_REC / 2) + 1);
         record.val = record.key * 2;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC_REC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = (2 * INSERT_SPLIT_ROOT_NREC_REC);
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Force left node to split */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC_REC; u++) {
         record.key = u;
         record.val = record.key * 2;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = 2 * INSERT_SPLIT_ROOT_NREC_REC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = (INSERT_SPLIT_ROOT_NREC_REC / 2) - 1;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = INSERT_SPLIT_ROOT_NREC_REC + (INSERT_SPLIT_ROOT_NREC_REC / 2) + 1;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert records to force middle node to redistribute */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC_REC / 2) + 1); u++) {
         record.key = u + INSERT_SPLIT_ROOT_NREC_REC;
         record.val = record.key * 2;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = (2 * INSERT_SPLIT_ROOT_NREC_REC) + (INSERT_SPLIT_ROOT_NREC_REC / 2) + 1;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = 52;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = 107;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx.key = 0;
     idx.val = 0;
     if (H5B2_iterate(bt2, iter_rec_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx.key != ((INSERT_SPLIT_ROOT_NREC_REC * 2) + (INSERT_SPLIT_ROOT_NREC_REC / 2) + 1))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -4387,78 +4387,78 @@ test_update_level1_middle_split(hid_t fapl, const H5B2_create_t *cparam, const b
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 leaves */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC_REC; u++) {
         record.key = u + (INSERT_SPLIT_ROOT_NREC_REC * 2);
         record.val = record.key * 2;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = INSERT_SPLIT_ROOT_NREC_REC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = (2 * INSERT_SPLIT_ROOT_NREC_REC) + (INSERT_SPLIT_ROOT_NREC_REC / 2) - 1;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Force split from left node into right node */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC_REC * 2); u++) {
         record.key = u;
         record.val = record.key * 2;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 1;
     bt2_stat.nrecords = 3 * INSERT_SPLIT_ROOT_NREC_REC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = 63;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = 95;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = 128;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx.key = 0;
     idx.val = 0;
     if (H5B2_iterate(bt2, iter_rec_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx.key != (INSERT_SPLIT_ROOT_NREC_REC * 3))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     PASSED();
 
@@ -4511,72 +4511,72 @@ test_update_make_level2(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 internal nodes */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC_REC * 9); u++) {
         record.key = u + 2; /* Leave a gap for later insertion */
         record.val = record.key * 2;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
     for (; u < (INSERT_SPLIT_ROOT_NREC_REC * 41); u++) {
         record.key = u + 4; /* Leave a gap for later insertion */
         record.val = record.key * 2;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC_REC * 41);
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = 1347;
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add some extra records to left-most leaf */
     record.key = 0;
     record.val = record.key * 2;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record.key = 1;
     record.val = record.key * 2;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Add some extra records to middle leaf */
     record.key = (INSERT_SPLIT_ROOT_NREC_REC * 9) + 2;
     record.val = record.key * 2;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record.key = (INSERT_SPLIT_ROOT_NREC_REC * 9) + 3;
     record.val = record.key * 2;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx.key = 0;
     idx.val = 0;
     if (H5B2_iterate(bt2, iter_rec_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx.key != ((INSERT_SPLIT_ROOT_NREC_REC * 41) + 4))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find non-existent record in level-2 B-tree */
     /* (Should not be found, but not fail) */
@@ -4584,59 +4584,59 @@ test_update_make_level2(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != (hsize_t)-1)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in root of level-2 B-tree */
     find.key = 1347;
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != (1347 * 2))
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check with B-tree */
     record.key = 1347;
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in internal node of level-2 B-tree */
     find.key = 513;
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != (513 * 2))
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check with B-tree */
     record.key = 513;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in leaf of level-2 B-tree */
     find.key = 555;
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != (555 * 2))
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check with B-tree */
     record.key = 555;
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index non-existent record in level-2 B-tree */
     H5E_BEGIN_TRY
@@ -4646,41 +4646,41 @@ test_update_make_level2(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in root of level-2 B-tree */
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)1347, index_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.key != 1347)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != (1347 * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in internal node of level-2 B-tree */
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)513, index_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.key != 513)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != (513 * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in leaf of level-2 B-tree */
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)555, index_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.key != 555)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != (555 * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     PASSED();
@@ -4692,68 +4692,68 @@ test_update_make_level2(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 internal nodes */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC_REC * 9); u++) {
         record.key = ((INSERT_SPLIT_ROOT_NREC_REC * 41) + 1) - u;
         record.val = record.key * 2;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
     for (; u < (INSERT_SPLIT_ROOT_NREC_REC * 41); u++) {
         record.key = ((INSERT_SPLIT_ROOT_NREC_REC * 41) + 1) - (u + 2); /* Leave a gap for later insertion */
         record.val = record.key * 2;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC_REC * 41);
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = 1344;
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add some extra records to right-most leaf */
     record.key = (INSERT_SPLIT_ROOT_NREC_REC * 41) + 2;
     record.val = record.key * 2;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record.key = (INSERT_SPLIT_ROOT_NREC_REC * 41) + 3;
     record.val = record.key * 2;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Add some extra records to middle leaf */
     record.key = ((INSERT_SPLIT_ROOT_NREC_REC * 41) - (INSERT_SPLIT_ROOT_NREC_REC * 9));
     record.val = record.key * 2;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record.key = ((INSERT_SPLIT_ROOT_NREC_REC * 41) - (INSERT_SPLIT_ROOT_NREC_REC * 9)) + 1;
     record.val = record.key * 2;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx.key = 0;
     idx.val = 0;
     if (H5B2_iterate(bt2, iter_rec_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx.key != ((INSERT_SPLIT_ROOT_NREC_REC * 41) + 4))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find non-existent record in level-2 B-tree */
     /* (Should not be found, but not fail) */
@@ -4761,59 +4761,59 @@ test_update_make_level2(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != (hsize_t)-1)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in root of level-2 B-tree */
     find.key = 1344;
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != (1344 * 2))
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check with B-tree */
     record.key = 1344;
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in internal node of level-2 B-tree */
     find.key = 512;
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != (512 * 2))
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check with B-tree */
     record.key = 512;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in leaf of level-2 B-tree */
     find.key = 555;
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != (555 * 2))
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check with B-tree */
     record.key = 555;
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index non-existent record in level-2 B-tree */
     H5E_BEGIN_TRY
@@ -4823,41 +4823,41 @@ test_update_make_level2(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in root of level-2 B-tree */
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)1344, index_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.key != 1344)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != (1344 * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in internal node of level-2 B-tree */
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)512, index_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.key != 512)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != (512 * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in leaf of level-2 B-tree */
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)555, index_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.key != 555)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != (555 * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     PASSED();
@@ -4869,78 +4869,78 @@ test_update_make_level2(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enough records to force root to split into 2 internal nodes */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC_REC * 9); u++) {
         record.key = ((INSERT_SPLIT_ROOT_NREC_REC * 41) + 3) - u;
         record.val = record.key * 2;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
     for (; u < (INSERT_SPLIT_ROOT_NREC_REC * 41); u++) {
         record.key = u - ((INSERT_SPLIT_ROOT_NREC_REC * 9) - 2); /* Leave a gap for later insertion */
         record.val = record.key * 2;
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 2;
     bt2_stat.nrecords = (INSERT_SPLIT_ROOT_NREC_REC * 41);
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record.key = 1345;
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add some extra records to right-most leaf */
     record.key = (INSERT_SPLIT_ROOT_NREC_REC * 41) + 4;
     record.val = record.key * 2;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record.key = (INSERT_SPLIT_ROOT_NREC_REC * 41) + 5;
     record.val = record.key * 2;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Add some extra records to middle leaf */
     record.key = ((INSERT_SPLIT_ROOT_NREC_REC * 41) - (INSERT_SPLIT_ROOT_NREC_REC * 9)) + 2;
     record.val = record.key * 2;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record.key = ((INSERT_SPLIT_ROOT_NREC_REC * 41) - (INSERT_SPLIT_ROOT_NREC_REC * 9)) + 3;
     record.val = record.key * 2;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Add some extra records to left-most leaf */
     record.key = 0;
     record.val = record.key * 2;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record.key = 1;
     record.val = record.key * 2;
     if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     idx.key = 0;
     idx.val = 0;
     if (H5B2_iterate(bt2, iter_rec_cb, &idx) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (idx.key != ((INSERT_SPLIT_ROOT_NREC_REC * 41) + 6))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find non-existent record in level-2 B-tree */
     /* (Should not be found, but not fail) */
@@ -4948,59 +4948,59 @@ test_update_make_level2(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != (hsize_t)-1)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in root of level-2 B-tree */
     find.key = 1345;
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != (1345 * 2))
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check with B-tree */
     record.key = 1345;
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in internal node of level-2 B-tree */
     find.key = 513;
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != (513 * 2))
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check with B-tree */
     record.key = 513;
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find existent record in leaf of level-2 B-tree */
     find.key = 555;
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.val != (555 * 2))
-        TEST_ERROR
+        TEST_ERROR;
     if (!found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check with B-tree */
     record.key = 555;
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index non-existent record in level-2 B-tree */
     H5E_BEGIN_TRY
@@ -5010,46 +5010,46 @@ test_update_make_level2(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in level-2 B-tree */
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)1345, index_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.key != 1345)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != (1345 * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in internal node of level-2 B-tree */
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)513, index_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.key != 513)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != (513 * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to index existing record in leaf of level-2 B-tree */
     find.key = (hsize_t)-1;
     find.val = (hsize_t)-1;
     if (H5B2_index(bt2, H5_ITER_INC, (hsize_t)555, index_rec_cb, &find) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (find.key != 555)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != (555 * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -5114,7 +5114,7 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
 
     /* Allocate space for the records */
     if (NULL == (records = (H5B2_test_rec_t *)HDmalloc(sizeof(H5B2_test_rec_t) * INSERT_MANY_REC)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize record #'s */
     for (u = 0; u < INSERT_MANY_REC; u++) {
@@ -5135,58 +5135,58 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert random records */
     for (u = 0; u < INSERT_MANY_REC; u++) {
         record = records[u];
         if (H5B2_update(bt2, &record, no_modify_cb, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     bt2_stat.depth    = 4;
     bt2_stat.nrecords = INSERT_MANY_REC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
     file = -1;
 
     /* Re-open the file for the test */
     if (reopen_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open v2 B-tree */
     if (NULL == (bt2 = H5B2_open(f, bt2_addr, f)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check up on B-tree after re-open */
     bt2_stat.depth    = 4;
     bt2_stat.nrecords = INSERT_MANY_REC;
     if (check_stats(bt2, &bt2_stat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over B-tree to check records have been inserted correctly */
     iter.key = 0;
     iter.val = 0;
     if (H5B2_iterate(bt2, iter_rec_cb, &iter) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the index is correct */
     if (iter.key != INSERT_MANY_REC)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find non-existent record in level-4 B-tree */
     /* (Should not be found, but not fail) */
@@ -5194,11 +5194,11 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
     find.val = (hsize_t)-1;
     found    = FALSE;
     if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (find.val != (hsize_t)-1)
-        TEST_ERROR
+        TEST_ERROR;
     if (found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Find random records */
     for (u = 0; u < FIND_MANY_REC; u++) {
@@ -5209,11 +5209,11 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
         /* Attempt to find existent record in level-4 B-tree */
         found = FALSE;
         if (H5B2_find(bt2, &find, &found, find_rec_cb, &find) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (find.val != (find.key * 2))
-            TEST_ERROR
+            TEST_ERROR;
         if (!found)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Attempt to index non-existent record in level-4 B-tree, in increasing & decreasing order */
@@ -5224,7 +5224,7 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         ret = H5B2_index(bt2, H5_ITER_DEC, (hsize_t)(INSERT_MANY_REC * 3), find_rec_cb, NULL);
@@ -5232,7 +5232,7 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Find random records */
     for (u = 0; u < FIND_MANY_REC; u++) {
@@ -5248,11 +5248,11 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
         /* Attempt to find existent record in level-4 B-tree */
         /* (in increasing order) */
         if (H5B2_index(bt2, H5_ITER_INC, idx, index_rec_cb, &find) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (find.key != idx)
-            TEST_ERROR
+            TEST_ERROR;
         if (find.val != (find.key * 2))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Reset find record */
         find.key = (hsize_t)-1;
@@ -5261,11 +5261,11 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
         /* Attempt to find existent record in level-4 B-tree */
         /* (in decreasing order) */
         if (H5B2_index(bt2, H5_ITER_DEC, idx, index_rec_cb, &find) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (find.key != (INSERT_MANY_REC - (idx + 1)))
-            TEST_ERROR
+            TEST_ERROR;
         if (find.val != (find.key * 2))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     PASSED();
@@ -5274,30 +5274,30 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     record.key = INSERT_MANY_REC / 2;
     modify.key = INSERT_MANY_REC / 2;
     modify.val = record.key * 3;
     if (H5B2_update(bt2, &record, modify_rec_cb, &modify) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != INSERT_MANY_REC)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -5350,19 +5350,19 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove a record from a B-tree with no records */
     record = 0;
@@ -5373,7 +5373,7 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -5381,28 +5381,28 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert one record into B-tree */
     record = 42;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove a non-existent record from a B-tree with 1 record */
     record = 0;
@@ -5413,7 +5413,7 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -5422,32 +5422,32 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     record  = 42;
     rrecord = 0;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 42)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the root node has been freed */
     if (H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -5456,29 +5456,29 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert several records into B-tree again */
     record = 42;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record = 34;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record = 56;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     record = 38;
     if (H5B2_insert(bt2, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != 4)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -5487,7 +5487,7 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     record = 0;
     H5E_BEGIN_TRY
@@ -5497,7 +5497,7 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -5506,116 +5506,116 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     record  = 42;
     rrecord = 0;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 42)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != 3)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the root node has not been freed */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     record  = 34;
     rrecord = 0;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 34)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the root node has not been freed */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     record  = 56;
     rrecord = 0;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 56)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the root node has not been freed */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     record  = 38;
     rrecord = 0;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 38)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the root node has been freed */
     if (H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -5664,34 +5664,34 @@ test_remove_level1_noredistrib(hid_t fapl, const H5B2_create_t *cparam, const bt
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-1 B-tree with 3 leaves */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 2); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove a non-existent record from a B-tree with 1 record */
     record = (INSERT_SPLIT_ROOT_NREC * 2) + 1;
@@ -5702,15 +5702,15 @@ test_remove_level1_noredistrib(hid_t fapl, const H5B2_create_t *cparam, const bt
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -5719,42 +5719,42 @@ test_remove_level1_noredistrib(hid_t fapl, const H5B2_create_t *cparam, const bt
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on B-tree */
     record = 62; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 94; /* Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = (INSERT_SPLIT_ROOT_NREC * 2) - 2;
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     rrecord = 0;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != ((INSERT_SPLIT_ROOT_NREC * 2) - 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that the leaf nodes didn't redistribute */
     record = 62; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 94; /* Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != ((INSERT_SPLIT_ROOT_NREC * 2) - 1))
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -5763,36 +5763,36 @@ test_remove_level1_noredistrib(hid_t fapl, const H5B2_create_t *cparam, const bt
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on B-tree */
     record = 0;
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     rrecord = 1;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that the leaf nodes didn't redistribute */
     record = 62; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 94; /* Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != ((INSERT_SPLIT_ROOT_NREC * 2) - 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -5801,45 +5801,45 @@ test_remove_level1_noredistrib(hid_t fapl, const H5B2_create_t *cparam, const bt
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on B-tree */
     record = INSERT_SPLIT_ROOT_NREC;
     if (check_node_depth(bt2, &record, (unsigned)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     rrecord = 0;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != INSERT_SPLIT_ROOT_NREC)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that the leaf nodes didn't redistribute */
     record = 62; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 94; /* Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != ((INSERT_SPLIT_ROOT_NREC * 2) - 3))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -5887,74 +5887,74 @@ test_remove_level1_redistrib(hid_t fapl, const H5B2_create_t *cparam, const bt2_
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-1 B-tree with 3 leaves */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 2); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 62; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 94; /* Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove enough records from right leaf of a level-1 B-tree to force redistribution */
     for (u = 0; u < 8; u++) {
         record  = (INSERT_SPLIT_ROOT_NREC * 2) - (u + 1);
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != ((INSERT_SPLIT_ROOT_NREC * 2) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != ((INSERT_SPLIT_ROOT_NREC * 2) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 62; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 90; /* Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -5963,34 +5963,34 @@ test_remove_level1_redistrib(hid_t fapl, const H5B2_create_t *cparam, const bt2_
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     for (u = 0; u < 39; u++) {
         record  = u;
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != u)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != (((INSERT_SPLIT_ROOT_NREC * 2) - 8) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 64; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 90; /* Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -5999,43 +5999,43 @@ test_remove_level1_redistrib(hid_t fapl, const H5B2_create_t *cparam, const bt2_
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     for (u = 0; u < 2; u++) {
         record  = INSERT_SPLIT_ROOT_NREC + 2 + u;
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != (INSERT_SPLIT_ROOT_NREC + 2 + u))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != ((((INSERT_SPLIT_ROOT_NREC * 2) - 47)) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 64; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 91; /* Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -6083,67 +6083,67 @@ test_remove_level1_2leaf_merge(hid_t fapl, const H5B2_create_t *cparam, const bt
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-1 B-tree with 3 leaves */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 2); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 62; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 1;
     ninfo.nrec  = 2;
     record      = 94; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove enough records from right leaf of a level-1 B-tree to force redistribution */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC / 4); u++) {
         record  = (INSERT_SPLIT_ROOT_NREC * 2) - (u + 1);
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != ((INSERT_SPLIT_ROOT_NREC * 2) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != ((INSERT_SPLIT_ROOT_NREC * 2) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
@@ -6151,7 +6151,7 @@ test_remove_level1_2leaf_merge(hid_t fapl, const H5B2_create_t *cparam, const bt
     ninfo.nrec  = 1;
     record      = 62; /* Left record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -6160,43 +6160,43 @@ test_remove_level1_2leaf_merge(hid_t fapl, const H5B2_create_t *cparam, const bt
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill B-tree back up */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC / 4); u++) {
         record = (INSERT_SPLIT_ROOT_NREC * 2) - (u + 1);
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 62; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 1;
     ninfo.nrec  = 2;
     record      = 94; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Remove records */
     for (u = 0; u < ((3 * INSERT_SPLIT_ROOT_NREC) / 4) - 1; u++) {
         record  = u;
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != u)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != ((INSERT_SPLIT_ROOT_NREC * 2) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
@@ -6204,16 +6204,16 @@ test_remove_level1_2leaf_merge(hid_t fapl, const H5B2_create_t *cparam, const bt
     ninfo.nrec  = 1;
     record      = 94; /* Left record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -6261,67 +6261,67 @@ test_remove_level1_3leaf_merge(hid_t fapl, const H5B2_create_t *cparam, const bt
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-1 B-tree with 3 leaves */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 2); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 62; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 1;
     ninfo.nrec  = 2;
     record      = 94; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove enough records from middle leaf of a level-1 B-tree to force merge */
     for (u = 0; u < ((5 * INSERT_SPLIT_ROOT_NREC) / 6) - 1; u++) {
         record  = ((3 * INSERT_SPLIT_ROOT_NREC) / 2) - (u + 1);
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != (((3 * INSERT_SPLIT_ROOT_NREC) / 2) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != ((INSERT_SPLIT_ROOT_NREC * 2) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
@@ -6329,16 +6329,16 @@ test_remove_level1_3leaf_merge(hid_t fapl, const H5B2_create_t *cparam, const bt
     ninfo.nrec  = 1;
     record      = 37; /* Only record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -6386,88 +6386,88 @@ test_remove_level1_promote(hid_t fapl, const H5B2_create_t *cparam, const bt2_te
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-1 B-tree with 5 leaves */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 4); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 62; /* Left-most record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 125; /* Center-Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 188; /* Center-Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 1;
     ninfo.nrec  = 4;
     record      = 220; /* Right-most record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 4))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove record from root node of a level-1 B-tree to force promotion from right leaf */
     record  = 220;
     rrecord = HSIZET_MAX;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 220)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check record values in root of B-tree */
     record = 62; /* Left-most record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 125; /* Center-Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 188; /* Center-Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 1;
     ninfo.nrec  = 4;
     record      = 221; /* Right-most record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 4) - 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -6480,40 +6480,40 @@ test_remove_level1_promote(hid_t fapl, const H5B2_create_t *cparam, const bt2_te
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     record  = 62;
     rrecord = HSIZET_MAX;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 62)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check record values in root of B-tree */
     record = 63; /* Left-most record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 125; /* Center-Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 188; /* Center-Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 1;
     ninfo.nrec  = 4;
     record      = 221; /* Right-most record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 4) - 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -6522,49 +6522,49 @@ test_remove_level1_promote(hid_t fapl, const H5B2_create_t *cparam, const bt2_te
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     record  = 125;
     rrecord = HSIZET_MAX;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 125)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check record values in root of B-tree */
     record = 63; /* Left-most record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 126; /* Center-Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     record = 188; /* Center-Right record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 1;
     ninfo.nrec  = 4;
     record      = 221; /* Right-most record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 4) - 3)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -6613,48 +6613,48 @@ test_remove_level1_promote_2leaf_redistrib(hid_t fapl, const H5B2_create_t *cpar
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-1 B-tree with 3 leaves */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 2); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 62; /* Left-most record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 1;
     ninfo.nrec  = 2;
     record      = 94; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove record from root node of a level-1 B-tree to force promotion from right leaf */
 
@@ -6663,56 +6663,56 @@ test_remove_level1_promote_2leaf_redistrib(hid_t fapl, const H5B2_create_t *cpar
         record  = (INSERT_SPLIT_ROOT_NREC * 2) - (u + 1);
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != ((INSERT_SPLIT_ROOT_NREC * 2) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != ((INSERT_SPLIT_ROOT_NREC * 2) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     record  = 94;
     rrecord = HSIZET_MAX;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 94)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check record values in root of B-tree */
     record = 62; /* Left-most record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 1;
     ninfo.nrec  = 2;
     record      = 90; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 2) - 8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -6761,48 +6761,48 @@ test_remove_level1_promote_3leaf_redistrib(hid_t fapl, const H5B2_create_t *cpar
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-1 B-tree with 3 leaves */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 2); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 62; /* Left-most record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 1;
     ninfo.nrec  = 2;
     record      = 94; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove record from root node of a level-1 B-tree to force promotion from middle leaf */
 
@@ -6811,56 +6811,56 @@ test_remove_level1_promote_3leaf_redistrib(hid_t fapl, const H5B2_create_t *cpar
         record  = 63 + u;
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != (63 + u))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != ((INSERT_SPLIT_ROOT_NREC * 2) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     record  = 62;
     rrecord = HSIZET_MAX;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 62)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check record values in root of B-tree */
     record = 39; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 1;
     ninfo.nrec  = 2;
     record      = 86; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 2) - 8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -6909,48 +6909,48 @@ test_remove_level1_promote_2leaf_merge(hid_t fapl, const H5B2_create_t *cparam,
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-1 B-tree with 3 leaves */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 2); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 62; /* Left-most record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 1;
     ninfo.nrec  = 2;
     record      = 94; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove record from root node of a level-1 B-tree to force promotion from right leaf */
 
@@ -6959,53 +6959,53 @@ test_remove_level1_promote_2leaf_merge(hid_t fapl, const H5B2_create_t *cparam,
         record  = (INSERT_SPLIT_ROOT_NREC * 2) - (u + 1);
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != ((INSERT_SPLIT_ROOT_NREC * 2) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != ((INSERT_SPLIT_ROOT_NREC * 2) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     record  = 87;
     rrecord = HSIZET_MAX;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 87)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check record values in root of B-tree */
     ninfo.depth = 1;
     ninfo.nrec  = 1;
     record      = 62; /* Middle record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 2) - 15)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -7054,48 +7054,48 @@ test_remove_level1_promote_3leaf_merge(hid_t fapl, const H5B2_create_t *cparam,
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-2 B-tree with 3 leaves */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 2); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 62; /* Left-most record in root node */
     if (check_node_depth(bt2, &record, (unsigned)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 1;
     ninfo.nrec  = 2;
     record      = 94; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove record from root node of a level-1 B-tree to force promotion from middle leaf */
 
@@ -7104,53 +7104,53 @@ test_remove_level1_promote_3leaf_merge(hid_t fapl, const H5B2_create_t *cparam,
         record  = ((3 * INSERT_SPLIT_ROOT_NREC) / 2) - (u + 1);
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != (((3 * INSERT_SPLIT_ROOT_NREC) / 2) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != ((INSERT_SPLIT_ROOT_NREC * 2) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     record  = 25;
     rrecord = HSIZET_MAX;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 25)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check record values in root of B-tree */
     ninfo.depth = 1;
     ninfo.nrec  = 1;
     record      = 37; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 2) - 51)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -7198,17 +7198,17 @@ test_remove_level1_collapse(hid_t fapl, const H5B2_create_t *cparam, const bt2_t
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-1 B-tree with 2 leaves */
     for (u = 0; u < INSERT_SPLIT_ROOT_NREC; u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
@@ -7216,46 +7216,46 @@ test_remove_level1_collapse(hid_t fapl, const H5B2_create_t *cparam, const bt2_t
     ninfo.nrec  = 1;
     record      = 31; /* Middle record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != INSERT_SPLIT_ROOT_NREC)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove records from B-tree to force a single leaf for the B-tree */
     for (u = 0; u < 14; u++) {
         record  = INSERT_SPLIT_ROOT_NREC - (u + 1);
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != (INSERT_SPLIT_ROOT_NREC - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != (INSERT_SPLIT_ROOT_NREC - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
@@ -7263,32 +7263,32 @@ test_remove_level1_collapse(hid_t fapl, const H5B2_create_t *cparam, const bt2_t
     ninfo.nrec  = (uint16_t)(INSERT_SPLIT_ROOT_NREC - u);
     record      = 31; /* Middle record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC - u))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -7336,80 +7336,80 @@ test_remove_level2_promote(hid_t fapl, const H5B2_create_t *cparam, const bt2_te
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-2 B-tree with 3 internal nodes */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC * 59) + 1); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 1889; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 2;
     ninfo.nrec  = 2;
     record      = 2834; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != ((INSERT_SPLIT_ROOT_NREC * 59) + 1))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information about record in right internal node */
     ninfo.depth = 1;
     ninfo.nrec  = 14;
     record      = 2960; /* Record in right internal node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove record from right internal node of a level-2 B-tree to force promotion */
     record  = 2960;
     rrecord = HSIZET_MAX;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 2960)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information about record promoted into right internal node */
     ninfo.depth = 1;
     ninfo.nrec  = 14;
     record      = 2961; /* Record in right internal node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 59))
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -7418,38 +7418,38 @@ test_remove_level2_promote(hid_t fapl, const H5B2_create_t *cparam, const bt2_te
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information about record in left internal node */
     ninfo.depth = 1;
     ninfo.nrec  = 29;
     record      = 1133; /* Record in left internal node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     record  = 1133;
     rrecord = HSIZET_MAX;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 1133)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information about record in left internal node */
     ninfo.depth = 1;
     ninfo.nrec  = 29;
     record      = 1134; /* Record in left internal node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 59) - 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -7458,38 +7458,38 @@ test_remove_level2_promote(hid_t fapl, const H5B2_create_t *cparam, const bt2_te
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information about record in middle internal node */
     ninfo.depth = 1;
     ninfo.nrec  = 14;
     record      = 2267; /* Record in middle internal node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     record  = 2267;
     rrecord = HSIZET_MAX;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 2267)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information about record in middle internal node */
     ninfo.depth = 1;
     ninfo.nrec  = 14;
     record      = 2268; /* Record in middle internal node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 59) - 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -7498,82 +7498,82 @@ test_remove_level2_promote(hid_t fapl, const H5B2_create_t *cparam, const bt2_te
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information about record in root node */
     ninfo.depth = 2;
     ninfo.nrec  = 2;
     record      = 1889; /* Left record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     record  = 1889;
     rrecord = HSIZET_MAX;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 1889)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information about record in root node */
     ninfo.depth = 2;
     ninfo.nrec  = 2;
     record      = 1890; /* Left record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 59) - 3)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information about record in root node */
     ninfo.depth = 2;
     ninfo.nrec  = 2;
     record      = 2834; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     record  = 2834;
     rrecord = HSIZET_MAX;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 2834)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information about record in root node */
     ninfo.depth = 2;
     ninfo.nrec  = 2;
     record      = 2835; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 59) - 4)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -7622,55 +7622,55 @@ test_remove_level2_promote_2internal_redistrib(hid_t fapl, const H5B2_create_t *
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-2 B-tree with 3 internal nodes */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC * 59) + 1); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 1889; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 2;
     ninfo.nrec  = 2;
     record      = 2834; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != ((INSERT_SPLIT_ROOT_NREC * 59) + 1))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check status of B-tree */
     ninfo.depth = 1;
     ninfo.nrec  = 14;
     record      = 3685; /* Right-most record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove record from right internal node of a level-2 B-tree to force promotion
      * w/redistribution */
@@ -7678,53 +7678,53 @@ test_remove_level2_promote_2internal_redistrib(hid_t fapl, const H5B2_create_t *
         record  = ((INSERT_SPLIT_ROOT_NREC * 59) + 1) - (u + 1);
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != (((INSERT_SPLIT_ROOT_NREC * 59) + 1) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != (((INSERT_SPLIT_ROOT_NREC * 59) + 1) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     record  = 3685;
     rrecord = HSIZET_MAX;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 3685)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check status of B-tree */
     ninfo.depth = 1;
     ninfo.nrec  = 14;
     record      = 3681; /* Right-most record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 59) - 8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -7773,55 +7773,55 @@ test_remove_level2_promote_3internal_redistrib(hid_t fapl, const H5B2_create_t *
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-2 B-tree with 3 internal nodes */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC * 59) + 1); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 1889; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 2;
     ninfo.nrec  = 2;
     record      = 2834; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != ((INSERT_SPLIT_ROOT_NREC * 59) + 1))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check status of B-tree */
     ninfo.depth = 1;
     ninfo.nrec  = 29;
     record      = 62; /* Left-most record in left node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove record from left internal node of a level-2 B-tree to force promotion
      * w/redistribution */
@@ -7829,53 +7829,53 @@ test_remove_level2_promote_3internal_redistrib(hid_t fapl, const H5B2_create_t *
         record  = 63 + u;
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != (63 + u))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != (((INSERT_SPLIT_ROOT_NREC * 59) + 1) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     record  = 62;
     rrecord = HSIZET_MAX;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 62)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check status of B-tree */
     ninfo.depth = 1;
     ninfo.nrec  = 29;
     record      = 49; /* Left-most record in left node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 59) - 38)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -7924,55 +7924,55 @@ test_remove_level2_promote_2internal_merge(hid_t fapl, const H5B2_create_t *cpar
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-2 B-tree with 3 internal nodes */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC * 59) + 1); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 1889; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 2;
     ninfo.nrec  = 2;
     record      = 2834; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != ((INSERT_SPLIT_ROOT_NREC * 59) + 1))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information about record in right internal node */
     ninfo.depth = 1;
     ninfo.nrec  = 14;
     record      = 3685; /* Right-most record in right internal node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove record from right internal node of a level-2 B-tree to force promotion
      * w/redistribution */
@@ -7980,54 +7980,54 @@ test_remove_level2_promote_2internal_merge(hid_t fapl, const H5B2_create_t *cpar
         record  = ((INSERT_SPLIT_ROOT_NREC * 59) + 1) - (u + 1);
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != (((INSERT_SPLIT_ROOT_NREC * 59) + 1) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != (((INSERT_SPLIT_ROOT_NREC * 59) + 1) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Force merge by promoting current right-most record */
     record  = 3678;
     rrecord = HSIZET_MAX;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 3678)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information about record in right internal node */
     ninfo.depth = 1;
     ninfo.nrec  = 13;
     record      = 3653; /* Right-most record in right internal node (now) */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 59) - 15)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -8076,55 +8076,55 @@ test_remove_level2_promote_3internal_merge(hid_t fapl, const H5B2_create_t *cpar
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-2 B-tree with 3 internal nodes */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC * 59) + 1); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 1889; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 2;
     ninfo.nrec  = 2;
     record      = 2834; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != ((INSERT_SPLIT_ROOT_NREC * 59) + 1))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information about record in left internal node */
     ninfo.depth = 1;
     ninfo.nrec  = 29;
     record      = 62; /* Left-most record in left internal node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove record from left internal node of a level-2 B-tree to force promotion
      * w/redistribution */
@@ -8132,54 +8132,54 @@ test_remove_level2_promote_3internal_merge(hid_t fapl, const H5B2_create_t *cpar
         record  = 48 + u;
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != (48 + u))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != (((INSERT_SPLIT_ROOT_NREC * 59) + 1) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Force merge of left-most internal nodes by promotion */
     record  = 25;
     rrecord = HSIZET_MAX;
     if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the record value is correct */
     if (rrecord != 25)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information about record in left internal node */
     ninfo.depth = 1;
     ninfo.nrec  = 28;
     record      = 37; /* Left-most record in left internal node (now) */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != (INSERT_SPLIT_ROOT_NREC * 59) - 112)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -8228,67 +8228,67 @@ test_remove_level2_2internal_merge_left(hid_t fapl, const H5B2_create_t *cparam,
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-2 B-tree with 3 internal nodes */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC * 59) + 1); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 1889; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 2;
     ninfo.nrec  = 2;
     record      = 2834; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != ((INSERT_SPLIT_ROOT_NREC * 59) + 1))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove records from a level-2 B-tree to force 2 internal nodes to merge */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC * 21) + 15); u++) {
         record  = u;
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != u)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != (((INSERT_SPLIT_ROOT_NREC * 59) + 1) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check status of B-tree */
@@ -8296,16 +8296,16 @@ test_remove_level2_2internal_merge_left(hid_t fapl, const H5B2_create_t *cparam,
     ninfo.nrec  = 1;
     record      = 2834; /* Middle record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -8354,67 +8354,67 @@ test_remove_level2_2internal_merge_right(hid_t fapl, const H5B2_create_t *cparam
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-2 B-tree with 3 internal nodes */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC * 59) + 1); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 1889; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 2;
     ninfo.nrec  = 2;
     record      = 2834; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != ((INSERT_SPLIT_ROOT_NREC * 59) + 1))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove records from a level-2 B-tree to force 2 internal nodes to merge */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC * 5) + 17); u++) {
         record  = ((INSERT_SPLIT_ROOT_NREC * 59) + 1) - (u + 1);
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != (((INSERT_SPLIT_ROOT_NREC * 59) + 1) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != (((INSERT_SPLIT_ROOT_NREC * 59) + 1) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check status of B-tree */
@@ -8422,16 +8422,16 @@ test_remove_level2_2internal_merge_right(hid_t fapl, const H5B2_create_t *cparam
     ninfo.nrec  = 1;
     record      = 1889; /* Middle record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -8479,48 +8479,48 @@ test_remove_level2_3internal_merge(hid_t fapl, const H5B2_create_t *cparam, cons
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-2 B-tree with 3 internal nodes */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC * 59) + 1); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 1889; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 2;
     ninfo.nrec  = 2;
     record      = 2834; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != ((INSERT_SPLIT_ROOT_NREC * 59) + 1))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove record from middle internal node of a level-2 B-tree to force promotion
      * w/redistribution */
@@ -8528,19 +8528,19 @@ test_remove_level2_3internal_merge(hid_t fapl, const H5B2_create_t *cparam, cons
         record  = (INSERT_SPLIT_ROOT_NREC * 20) + u;
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != ((INSERT_SPLIT_ROOT_NREC * 20) + u))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != (((INSERT_SPLIT_ROOT_NREC * 59) + 1) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check status of B-tree */
@@ -8548,16 +8548,16 @@ test_remove_level2_3internal_merge(hid_t fapl, const H5B2_create_t *cparam, cons
     ninfo.nrec  = 1;
     record      = 1196; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -8606,83 +8606,83 @@ test_remove_level2_collapse_right(hid_t fapl, const H5B2_create_t *cparam, const
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-2 B-tree with 3 internal nodes */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC * 59) + 1); u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check record values in root of B-tree */
     record = 1889; /* Left record in root node */
     if (check_node_depth(bt2, &record, (unsigned)2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ninfo.depth = 2;
     ninfo.nrec  = 2;
     record      = 2834; /* Right record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the number of records in the B-tree */
     if (H5B2_get_nrec(bt2, &nrec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the # of records is correct */
     if (nrec != ((INSERT_SPLIT_ROOT_NREC * 59) + 1))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (!H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to remove records from a level-2 B-tree to force back to level-1 */
     for (u = 0; u < (INSERT_SPLIT_ROOT_NREC * 34) + 17; u++) {
         record  = ((INSERT_SPLIT_ROOT_NREC * 59) + 1) - (u + 1);
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (record != (((INSERT_SPLIT_ROOT_NREC * 59) + 1) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != (((INSERT_SPLIT_ROOT_NREC * 59) + 1) - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     if (H5B2_stat_info(bt2, &bt2_stat) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (bt2_stat.depth != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -8725,41 +8725,41 @@ gen_l4_btree2(const char *filename, hid_t fapl, const H5B2_create_t *cparam, had
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert random records */
     for (u = 0; u < INSERT_MANY; u++) {
         record = records[u];
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     if (H5B2_stat_info(bt2, &bt2_stat) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (bt2_stat.depth != 4)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     return 0;
 
@@ -8825,7 +8825,7 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
 
     /* Allocate space for the records */
     if (NULL == (records = (hsize_t *)HDmalloc(sizeof(hsize_t) * INSERT_MANY)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize record #'s */
     for (u = 0; u < INSERT_MANY; u++)
@@ -8846,7 +8846,7 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
 
     /* Generate the v2 B-tree to test */
     if (gen_l4_btree2(filename, fapl, cparam, &bt2_addr, records))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for VFD which stores data in multiple files */
     single_file_vfd = !h5_driver_uses_multiple_files(env_h5_drvr, H5_EXCLUDE_NON_MULTIPART_DRIVERS);
@@ -8855,23 +8855,23 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
 
         /* Open the file just created */
         if ((fd = HDopen(filename, O_RDONLY)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Retrieve the file's size */
         if (HDfstat(fd, &sb) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate space for the file data */
         if (NULL == (file_data = HDmalloc((size_t)sb.st_size)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read file's data into memory */
         if (HDread(fd, file_data, (size_t)sb.st_size) < (ssize_t)sb.st_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file */
         if (HDclose(fd) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         fd = -1;
     } /* end if */
 
@@ -8880,15 +8880,15 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Re-shuffle record #'s */
     for (u = 0; u < INSERT_MANY; u++) {
@@ -8903,44 +8903,44 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
 
     /* Re-open v2 B-tree */
     if (NULL == (bt2 = H5B2_open(f, bt2_addr, f)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove all records */
     for (u = 0; u < INSERT_MANY; u++) {
         record  = records[u];
         rrecord = HSIZET_MAX;
         if (H5B2_remove(bt2, &record, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != records[u])
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != (INSERT_MANY - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     PASSED();
 
@@ -8950,21 +8950,21 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
 
         /* Open the file just created */
         if ((fd = HDopen(filename, O_RDWR | O_CREAT | O_TRUNC, H5_POSIX_CREATE_MODE_RW)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Write file's data from memory */
         if (HDwrite(fd, file_data, (size_t)sb.st_size) < (ssize_t)sb.st_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file */
         if (HDclose(fd) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         fd = -1;
     } /* end if */
     else {
         /* Re-generate the v2 B-tree to test */
         if (gen_l4_btree2(filename, fapl, cparam, &bt2_addr, records))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end else */
 
     /* Print banner for this test */
@@ -8972,19 +8972,19 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Re-open v2 B-tree */
     if (NULL == (bt2 = H5B2_open(f, bt2_addr, f)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove all records */
     for (u = 0; u < INSERT_MANY; u++) {
@@ -8994,37 +8994,37 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
 
         /* Remove random record */
         if (H5B2_remove_by_idx(bt2, H5_ITER_INC, (hsize_t)rem_idx, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord >= INSERT_MANY)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != (INSERT_MANY - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     PASSED();
 
@@ -9034,21 +9034,21 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
 
         /* Open the file just created */
         if ((fd = HDopen(filename, O_RDWR | O_CREAT | O_TRUNC, H5_POSIX_CREATE_MODE_RW)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Write file's data from memory */
         if (HDwrite(fd, file_data, (size_t)sb.st_size) < (ssize_t)sb.st_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file */
         if (HDclose(fd) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         fd = -1;
     } /* end if */
     else {
         /* Re-generate the v2 B-tree to test */
         if (gen_l4_btree2(filename, fapl, cparam, &bt2_addr, records))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end else */
 
     /* Print banner for this test */
@@ -9057,56 +9057,56 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Re-open v2 B-tree */
     if (NULL == (bt2 = H5B2_open(f, bt2_addr, f)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove all records */
     for (u = 0; u < INSERT_MANY; u++) {
         /* Remove first record */
         rrecord = HSIZET_MAX;
         if (H5B2_remove_by_idx(bt2, H5_ITER_INC, (hsize_t)0, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != u)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != (INSERT_MANY - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     PASSED();
 
@@ -9116,21 +9116,21 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
 
         /* Open the file just created */
         if ((fd = HDopen(filename, O_RDWR | O_CREAT | O_TRUNC, H5_POSIX_CREATE_MODE_RW)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Write file's data from memory */
         if (HDwrite(fd, file_data, (size_t)sb.st_size) < (ssize_t)sb.st_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file */
         if (HDclose(fd) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         fd = -1;
     } /* end if */
     else {
         /* Re-generate the v2 B-tree to test */
         if (gen_l4_btree2(filename, fapl, cparam, &bt2_addr, records))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end else */
 
     /* Print banner for this test */
@@ -9139,56 +9139,56 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Re-open v2 B-tree */
     if (NULL == (bt2 = H5B2_open(f, bt2_addr, f)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove all records */
     for (u = 0; u < INSERT_MANY; u++) {
         /* Remove last record */
         rrecord = HSIZET_MAX;
         if (H5B2_remove_by_idx(bt2, H5_ITER_DEC, (hsize_t)0, remove_cb, &rrecord) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the record value is correct */
         if (rrecord != (INSERT_MANY - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the number of records in the B-tree */
         if (H5B2_get_nrec(bt2, &nrec) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Make certain that the # of records is correct */
         if (nrec != (INSERT_MANY - (u + 1)))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Query the address of the root node in the B-tree */
     if (H5B2__get_root_addr_test(bt2, &root_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
     if (H5F_addr_defined(root_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     PASSED();
 
@@ -9248,7 +9248,7 @@ test_find_neighbor(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param
 
     /* Allocate space for the records */
     if (NULL == (records = (hsize_t *)HDmalloc(sizeof(hsize_t) * FIND_NEIGHBOR)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize record #'s */
     for (u = 0; u < FIND_NEIGHBOR; u++)
@@ -9261,17 +9261,17 @@ test_find_neighbor(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert records */
     for (u = 0; u < FIND_NEIGHBOR; u++) {
         record = records[u];
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Attempt to find record B-tree less than a value */
@@ -9283,65 +9283,65 @@ test_find_neighbor(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     search = 1;
     if (H5B2_neighbor(bt2, H5B2_COMPARE_LESS, &search, neighbor_cb, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (record != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     search = 2;
     if (H5B2_neighbor(bt2, H5B2_COMPARE_LESS, &search, neighbor_cb, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (record != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     search = 3;
     if (H5B2_neighbor(bt2, H5B2_COMPARE_LESS, &search, neighbor_cb, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (record != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     search = 4;
     if (H5B2_neighbor(bt2, H5B2_COMPARE_LESS, &search, neighbor_cb, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (record != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check status of B-tree */
     ninfo.depth = 1;
     ninfo.nrec  = 14;
     record      = 250; /* Record in left internal node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Neighbor is in internal node */
     search = 251;
     if (H5B2_neighbor(bt2, H5B2_COMPARE_LESS, &search, neighbor_cb, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (record != 250)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check status of B-tree */
     ninfo.depth = 2;
     ninfo.nrec  = 1;
     record      = 1888; /* Record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Neighbor is in root node */
     search = 1889;
     if (H5B2_neighbor(bt2, H5B2_COMPARE_LESS, &search, neighbor_cb, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (record != 1888)
-        TEST_ERROR
+        TEST_ERROR;
 
     search = (FIND_NEIGHBOR * 2) + 1;
     if (H5B2_neighbor(bt2, H5B2_COMPARE_LESS, &search, neighbor_cb, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (record != ((FIND_NEIGHBOR - 1) * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -9352,7 +9352,7 @@ test_find_neighbor(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find record B-tree less than a value */
     search = (FIND_NEIGHBOR * 2) + 1;
@@ -9363,67 +9363,67 @@ test_find_neighbor(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     search = 0;
     if (H5B2_neighbor(bt2, H5B2_COMPARE_GREATER, &search, neighbor_cb, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (record != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     search = 1;
     if (H5B2_neighbor(bt2, H5B2_COMPARE_GREATER, &search, neighbor_cb, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (record != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     search = 2;
     if (H5B2_neighbor(bt2, H5B2_COMPARE_GREATER, &search, neighbor_cb, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (record != 4)
-        TEST_ERROR
+        TEST_ERROR;
 
     search = 3;
     if (H5B2_neighbor(bt2, H5B2_COMPARE_GREATER, &search, neighbor_cb, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (record != 4)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check status of B-tree */
     ninfo.depth = 1;
     ninfo.nrec  = 16;
     record      = 2896; /* Record in right internal node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Neighbor is in internal node */
     search = 2895;
     if (H5B2_neighbor(bt2, H5B2_COMPARE_GREATER, &search, neighbor_cb, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (record != 2896)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Neighbor is in root node */
     search = 1887;
     if (H5B2_neighbor(bt2, H5B2_COMPARE_GREATER, &search, neighbor_cb, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (record != 1888)
-        TEST_ERROR
+        TEST_ERROR;
 
     search = ((FIND_NEIGHBOR - 1) * 2) - 1;
     if (H5B2_neighbor(bt2, H5B2_COMPARE_GREATER, &search, neighbor_cb, &record) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (record != ((FIND_NEIGHBOR - 1) * 2))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     PASSED();
 
@@ -9480,54 +9480,54 @@ test_delete(hid_t fapl, const H5B2_create_t *cparam)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Get the size of an empty file */
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /*
      * Delete v2 B-tree
      */
     if (H5B2_delete(f, bt2_addr, f, NULL, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -9536,55 +9536,55 @@ test_delete(hid_t fapl, const H5B2_create_t *cparam)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert records */
     for (u = 0; u < DELETE_SMALL; u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     if (H5B2_stat_info(bt2, &bt2_stat) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (bt2_stat.depth != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /*
      * Delete v2 B-tree
      */
     if (H5B2_delete(f, bt2_addr, f, NULL, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -9593,55 +9593,55 @@ test_delete(hid_t fapl, const H5B2_create_t *cparam)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert records */
     for (u = 0; u < DELETE_MEDIUM; u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     if (H5B2_stat_info(bt2, &bt2_stat) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (bt2_stat.depth != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /*
      * Delete v2 B-tree
      */
     if (H5B2_delete(f, bt2_addr, f, NULL, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -9650,55 +9650,55 @@ test_delete(hid_t fapl, const H5B2_create_t *cparam)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert records */
     for (u = 0; u < DELETE_LARGE; u++) {
         record = u;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     if (H5B2_stat_info(bt2, &bt2_stat) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (bt2_stat.depth != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /*
      * Delete v2 B-tree
      */
     if (H5B2_delete(f, bt2_addr, f, NULL, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -9752,24 +9752,24 @@ test_modify(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_t *tpa
 
     /* Create the file for the test */
     if (create_file(&file, &f, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create level-2 B-tree with 3 internal nodes */
     for (u = 0; u < ((INSERT_SPLIT_ROOT_NREC * 59) + 1); u++) {
         record = u * 5;
         if (H5B2_insert(bt2, &record) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check up on B-tree */
     if (H5B2_stat_info(bt2, &bt2_stat) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (bt2_stat.depth != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to modify a non-existent record */
     record = 3;
@@ -9781,7 +9781,7 @@ test_modify(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_t *tpa
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -9789,38 +9789,38 @@ test_modify(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_t *tpa
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check status of B-tree */
     ninfo.depth = 0;
     ninfo.nrec  = 62;
     record      = 4330; /* Record in leaf node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to modify a record in a leaf node */
     record = 4330;
     modify = 4331;
     if (H5B2_modify(bt2, &record, modify_cb, &modify) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check status of B-tree */
     ninfo.depth = 0;
     ninfo.nrec  = 62;
     record      = 4331; /* Record in leaf node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find modified record */
     record    = 4331;
     found     = 4331;
     rec_found = FALSE;
     if (H5B2_find(bt2, &record, &rec_found, find_cb, &found) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (found != 4331)
-        TEST_ERROR
+        TEST_ERROR;
     if (!rec_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find original record */
     record = 4330;
@@ -9832,7 +9832,7 @@ test_modify(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_t *tpa
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -9840,38 +9840,38 @@ test_modify(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_t *tpa
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check status of B-tree */
     ninfo.depth = 1;
     ninfo.nrec  = 29;
     record      = 5350; /* Record in internal node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to modify a record in an internal node */
     record = 5350;
     modify = 5352;
     if (H5B2_modify(bt2, &record, modify_cb, &modify) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check status of B-tree */
     ninfo.depth = 1;
     ninfo.nrec  = 29;
     record      = 5352; /* Record in internal node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find modified record */
     record    = 5352;
     found     = 5352;
     rec_found = FALSE;
     if (H5B2_find(bt2, &record, &rec_found, find_cb, &found) < 0)
-        STACK_ERROR
+        STACK_ERROR;
     if (found != 5352)
-        TEST_ERROR
+        TEST_ERROR;
     if (!rec_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find original record */
     record = 5350;
@@ -9883,7 +9883,7 @@ test_modify(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_t *tpa
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -9891,38 +9891,38 @@ test_modify(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_t *tpa
 
     /* Check for closing & re-opening the B-tree */
     if (reopen_btree(f, &bt2, bt2_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check status of B-tree */
     ninfo.depth = 2;
     ninfo.nrec  = 2;
     record      = 9445; /* Record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to modify a record in a root node */
     record = 9445;
     modify = 9448;
     if (H5B2_modify(bt2, &record, modify_cb, &modify) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check status of B-tree */
     ninfo.depth = 2;
     ninfo.nrec  = 2;
     record      = 9448; /* Record in root node */
     if (check_node_info(bt2, record, &ninfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find modified record */
     record    = 9448;
     found     = 9448;
     rec_found = FALSE;
     if (H5B2_find(bt2, &record, &rec_found, find_cb, &found) < 0)
-        STACK_ERROR
+        STACK_ERROR;
     if (found != 9448)
-        TEST_ERROR
+        TEST_ERROR;
     if (!rec_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to find original record */
     record = 9445;
@@ -9934,16 +9934,16 @@ test_modify(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_t *tpa
     H5E_END_TRY;
     /* Should fail */
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the v2 B-tree */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -9999,27 +9999,27 @@ test_open_twice_diff(hid_t fapl, const H5B2_create_t *cparam)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the v2 B-tree & get its address */
     if (create_btree(f, cparam, &bt2, &bt2_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open v2 B-tree */
     if (NULL == (bt2_2 = H5B2_open(f, bt2_addr, f)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the second v2 B-tree wrapper */
     if (H5B2_close(bt2_2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2_2 = NULL;
 
     /* Re-open the file */
@@ -10027,11 +10027,11 @@ test_open_twice_diff(hid_t fapl, const H5B2_create_t *cparam)
      *  array is closed)
      */
     if ((file0 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the first v2 B-tree wrapper */
     if (H5B2_close(bt2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2 = NULL;
 
     /* Close the file */
@@ -10039,7 +10039,7 @@ test_open_twice_diff(hid_t fapl, const H5B2_create_t *cparam)
      *  shared file information)
      */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     file = -1;
 
     /* Open a different file */
@@ -10049,34 +10049,34 @@ test_open_twice_diff(hid_t fapl, const H5B2_create_t *cparam)
      */
     h5_fixname(FILENAME[1], fapl, filename_tmp, sizeof(filename_tmp));
     if ((file00 = H5Fcreate(filename_tmp, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file with the v2 B-tree array */
     if ((file2 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f2 = (H5F_t *)H5VL_object(file2)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the B-tree through the second file handle */
     if (NULL == (bt2_2 = H5B2_open(f2, bt2_addr, f2)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the extra file handles */
     if (H5Fclose(file0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file00) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the second v2 B-tree */
     if (H5B2_close(bt2_2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     bt2_2 = NULL;
 
     /* Close file */
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -10147,7 +10147,7 @@ main(void)
 
     /* Push API context */
     if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = TRUE;
 
     /* Loop over re-opening B-tree during tests */
@@ -10240,7 +10240,7 @@ main(void)
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = FALSE;
 
     if (nerrors)

--- a/test/cache.c
+++ b/test/cache.c
@@ -262,9 +262,9 @@ smoke_check_1(int express_test, unsigned paged)
     H5F_t * file_ptr         = NULL;
 
     if (paged)
-        TESTING("smoke check #1P -- all clean, ins, dest, ren, 4/2 MB cache")
+        TESTING("smoke check #1P -- all clean, ins, dest, ren, 4/2 MB cache");
     else
-        TESTING("smoke check #1 -- all clean, ins, dest, ren, 4/2 MB cache")
+        TESTING("smoke check #1 -- all clean, ins, dest, ren, 4/2 MB cache");
 
     if (paged && (express_test > 0)) {
 
@@ -460,9 +460,9 @@ smoke_check_2(int express_test, unsigned paged)
     H5F_t * file_ptr         = NULL;
 
     if (paged)
-        TESTING("smoke check #2P -- ~1/2 dirty, ins, dest, ren, 4/2 MB cache")
+        TESTING("smoke check #2P -- ~1/2 dirty, ins, dest, ren, 4/2 MB cache");
     else
-        TESTING("smoke check #2 -- ~1/2 dirty, ins, dest, ren, 4/2 MB cache")
+        TESTING("smoke check #2 -- ~1/2 dirty, ins, dest, ren, 4/2 MB cache");
 
     if (paged && (express_test > 0)) {
 
@@ -657,9 +657,9 @@ smoke_check_3(int express_test, unsigned paged)
     H5F_t * file_ptr         = NULL;
 
     if (paged)
-        TESTING("smoke check #3P -- all clean, ins, dest, ren, 2/1 KB cache")
+        TESTING("smoke check #3P -- all clean, ins, dest, ren, 2/1 KB cache");
     else
-        TESTING("smoke check #3 -- all clean, ins, dest, ren, 2/1 KB cache")
+        TESTING("smoke check #3 -- all clean, ins, dest, ren, 2/1 KB cache");
 
     if (paged && (express_test > 0)) {
 
@@ -855,9 +855,9 @@ smoke_check_4(int express_test, unsigned paged)
     H5F_t * file_ptr         = NULL;
 
     if (paged)
-        TESTING("smoke check #4P -- ~1/2 dirty, ins, dest, ren, 2/1 KB cache")
+        TESTING("smoke check #4P -- ~1/2 dirty, ins, dest, ren, 2/1 KB cache");
     else
-        TESTING("smoke check #4 -- ~1/2 dirty, ins, dest, ren, 2/1 KB cache")
+        TESTING("smoke check #4 -- ~1/2 dirty, ins, dest, ren, 2/1 KB cache");
 
     if (paged && (express_test > 0)) {
 
@@ -1098,9 +1098,9 @@ smoke_check_5(int express_test, unsigned paged)
     };
 
     if (paged)
-        TESTING("smoke check #5P -- all clean, ins, prot, unprot, AR cache 1")
+        TESTING("smoke check #5P -- all clean, ins, prot, unprot, AR cache 1");
     else
-        TESTING("smoke check #5 -- all clean, ins, prot, unprot, AR cache 1")
+        TESTING("smoke check #5 -- all clean, ins, prot, unprot, AR cache 1");
 
     if (paged && (express_test > 0)) {
 
@@ -1330,9 +1330,9 @@ smoke_check_6(int express_test, unsigned paged)
     };
 
     if (paged)
-        TESTING("smoke check #6P -- ~1/2 dirty, ins, prot, unprot, AR cache 1")
+        TESTING("smoke check #6P -- ~1/2 dirty, ins, prot, unprot, AR cache 1");
     else
-        TESTING("smoke check #6 -- ~1/2 dirty, ins, prot, unprot, AR cache 1")
+        TESTING("smoke check #6 -- ~1/2 dirty, ins, prot, unprot, AR cache 1");
 
     if (paged && (express_test > 0)) {
 
@@ -1563,9 +1563,9 @@ smoke_check_7(int express_test, unsigned paged)
     };
 
     if (paged)
-        TESTING("smoke check #7P -- all clean, ins, prot, unprot, AR cache 2")
+        TESTING("smoke check #7P -- all clean, ins, prot, unprot, AR cache 2");
     else
-        TESTING("smoke check #7 -- all clean, ins, prot, unprot, AR cache 2")
+        TESTING("smoke check #7 -- all clean, ins, prot, unprot, AR cache 2");
 
     if (paged && (express_test > 0)) {
 
@@ -1796,9 +1796,9 @@ smoke_check_8(int express_test, unsigned paged)
     };
 
     if (paged)
-        TESTING("smoke check #8P -- ~1/2 dirty, ins, prot, unprot, AR cache 2")
+        TESTING("smoke check #8P -- ~1/2 dirty, ins, prot, unprot, AR cache 2");
     else
-        TESTING("smoke check #8 -- ~1/2 dirty, ins, prot, unprot, AR cache 2")
+        TESTING("smoke check #8 -- ~1/2 dirty, ins, prot, unprot, AR cache 2");
 
     if (paged && (express_test > 0)) {
 
@@ -1993,9 +1993,9 @@ smoke_check_9(int express_test, unsigned paged)
     H5C_t * cache_ptr              = NULL;
 
     if (paged)
-        TESTING("smoke check #9P -- all clean, ins, dest, ren, 4/2 MB, corked")
+        TESTING("smoke check #9P -- all clean, ins, dest, ren, 4/2 MB, corked");
     else
-        TESTING("smoke check #9 -- all clean, ins, dest, ren, 4/2 MB, corked")
+        TESTING("smoke check #9 -- all clean, ins, dest, ren, 4/2 MB, corked");
 
     if (paged && (express_test > 0)) {
 
@@ -2311,9 +2311,9 @@ smoke_check_10(int express_test, unsigned paged)
     H5C_t * cache_ptr              = NULL;
 
     if (paged)
-        TESTING("smoke check #10P -- ~1/2 dirty, ins, dest, ren, 4/2 MB, corked")
+        TESTING("smoke check #10P -- ~1/2 dirty, ins, dest, ren, 4/2 MB, corked");
     else
-        TESTING("smoke check #10 -- ~1/2 dirty, ins, dest, ren, 4/2 MB, corked")
+        TESTING("smoke check #10 -- ~1/2 dirty, ins, dest, ren, 4/2 MB, corked");
 
     if (paged && (express_test > 0)) {
 
@@ -2626,9 +2626,9 @@ write_permitted_check(int
 #endif /* H5C_MAINTAIN_CLEAN_AND_DIRTY_LRU_LISTS */
 
     if (paged)
-        TESTING("write permitted check -- 1/0 MB cache (paged aggregation)")
+        TESTING("write permitted check -- 1/0 MB cache (paged aggregation)");
     else
-        TESTING("write permitted check -- 1/0 MB cache")
+        TESTING("write permitted check -- 1/0 MB cache");
 
 #if H5C_MAINTAIN_CLEAN_AND_DIRTY_LRU_LISTS
 
@@ -2840,9 +2840,9 @@ check_insert_entry(unsigned paged)
     struct H5C_cache_entry_t *search_ptr;
 
     if (paged)
-        TESTING("H5C_insert_entry() functionality (paged aggregation)")
+        TESTING("H5C_insert_entry() functionality (paged aggregation)");
     else
-        TESTING("H5C_insert_entry() functionality")
+        TESTING("H5C_insert_entry() functionality");
 
     pass = TRUE;
 
@@ -3105,9 +3105,9 @@ check_flush_cache(unsigned paged)
     H5F_t *file_ptr = NULL;
 
     if (paged)
-        TESTING("H5C_flush_cache() functionality (paged aggregation)")
+        TESTING("H5C_flush_cache() functionality (paged aggregation)");
     else
-        TESTING("H5C_flush_cache() functionality")
+        TESTING("H5C_flush_cache() functionality");
 
     pass = TRUE;
 
@@ -11382,9 +11382,9 @@ check_get_entry_status(unsigned paged)
     test_entry_t *entry_ptr = NULL;
 
     if (paged)
-        TESTING("H5C_get_entry_status() functionality (paged aggregation)")
+        TESTING("H5C_get_entry_status() functionality (paged aggregation)");
     else
-        TESTING("H5C_get_entry_status() functionality")
+        TESTING("H5C_get_entry_status() functionality");
 
     pass = TRUE;
 
@@ -11603,9 +11603,9 @@ check_expunge_entry(unsigned paged)
     test_entry_t *entry_ptr;
 
     if (paged)
-        TESTING("H5C_expunge_entry() functionality (paged aggregation)")
+        TESTING("H5C_expunge_entry() functionality (paged aggregation)");
     else
-        TESTING("H5C_expunge_entry() functionality")
+        TESTING("H5C_expunge_entry() functionality");
 
     pass = TRUE;
 
@@ -11880,9 +11880,9 @@ check_multiple_read_protect(unsigned paged)
     test_entry_t *entry_ptr;
 
     if (paged)
-        TESTING("multiple read only protects on a single entry (paged aggr)")
+        TESTING("multiple read only protects on a single entry (paged aggr)");
     else
-        TESTING("multiple read only protects on a single entry")
+        TESTING("multiple read only protects on a single entry");
 
     pass = TRUE;
 
@@ -12284,9 +12284,9 @@ check_move_entry(unsigned paged)
     };
 
     if (paged)
-        TESTING("H5C_move_entry() functionality (paged aggregation)")
+        TESTING("H5C_move_entry() functionality (paged aggregation)");
     else
-        TESTING("H5C_move_entry() functionality")
+        TESTING("H5C_move_entry() functionality");
 
     pass = TRUE;
 
@@ -12334,7 +12334,7 @@ check_move_entry(unsigned paged)
     if (pass)
         PASSED();
     else
-        H5_FAILED()
+        H5_FAILED();
 
     if (!pass)
         HDfprintf(stdout, "%s(): failure_mssg = \"%s\".\n", __func__, failure_mssg);
@@ -12525,9 +12525,9 @@ check_pin_protected_entry(unsigned paged)
     test_entry_t *entry_ptr;
 
     if (paged)
-        TESTING("H5C_pin_protected_entry() functionality (paged aggregation)")
+        TESTING("H5C_pin_protected_entry() functionality (paged aggregation)");
     else
-        TESTING("H5C_pin_protected_entry() functionality")
+        TESTING("H5C_pin_protected_entry() functionality");
 
     pass = TRUE;
 
@@ -12639,9 +12639,9 @@ check_resize_entry(unsigned paged)
     test_entry_t *entry_ptr = NULL;
 
     if (paged)
-        TESTING("entry resize functionality (paged aggregation)")
+        TESTING("entry resize functionality (paged aggregation)");
     else
-        TESTING("entry resize functionality")
+        TESTING("entry resize functionality");
 
     /* Setup a cache and verify that it is empty.
      *
@@ -13506,9 +13506,9 @@ check_evictions_enabled(unsigned paged)
     test_entry_t *entry_ptr;
 
     if (paged)
-        TESTING("evictions enabled/disabled functionality (paged aggregation)")
+        TESTING("evictions enabled/disabled functionality (paged aggregation)");
     else
-        TESTING("evictions enabled/disabled functionality")
+        TESTING("evictions enabled/disabled functionality");
 
     /* Setup a cache and verify that it is empty.
      *
@@ -14148,9 +14148,9 @@ check_flush_protected_err(unsigned paged)
     H5C_t *cache_ptr = NULL;
 
     if (paged)
-        TESTING("flush cache with protected entry error (paged aggregation)")
+        TESTING("flush cache with protected entry error (paged aggregation)");
     else
-        TESTING("flush cache with protected entry error")
+        TESTING("flush cache with protected entry error");
 
     pass = TRUE;
 
@@ -14241,9 +14241,9 @@ check_destroy_pinned_err(unsigned paged)
     H5F_t *file_ptr = NULL;
 
     if (paged)
-        TESTING("destroy cache with permanently pinned entry error (pgd aggr)")
+        TESTING("destroy cache with permanently pinned entry error (pgd aggr)");
     else
-        TESTING("destroy cache with permanently pinned entry error")
+        TESTING("destroy cache with permanently pinned entry error");
 
     pass = TRUE;
 
@@ -14328,9 +14328,9 @@ check_destroy_protected_err(unsigned paged)
     H5F_t *file_ptr = NULL;
 
     if (paged)
-        TESTING("destroy cache with protected entry error (paged aggregation)")
+        TESTING("destroy cache with protected entry error (paged aggregation)");
     else
-        TESTING("destroy cache with protected entry error")
+        TESTING("destroy cache with protected entry error");
 
     pass = TRUE;
 
@@ -14427,9 +14427,9 @@ check_duplicate_insert_err(unsigned paged)
     test_entry_t *entry_ptr;
 
     if (paged)
-        TESTING("duplicate entry insertion error (paged aggregation)")
+        TESTING("duplicate entry insertion error (paged aggregation)");
     else
-        TESTING("duplicate entry insertion error")
+        TESTING("duplicate entry insertion error");
 
     pass = TRUE;
 
@@ -14510,9 +14510,9 @@ check_double_pin_err(unsigned paged)
     test_entry_t *entry_ptr;
 
     if (paged)
-        TESTING("pin a pinned entry error (paged aggregation)")
+        TESTING("pin a pinned entry error (paged aggregation)");
     else
-        TESTING("pin a pinned entry error")
+        TESTING("pin a pinned entry error");
 
     pass = TRUE;
 
@@ -14599,9 +14599,9 @@ check_double_unpin_err(unsigned paged)
     test_entry_t *entry_ptr;
 
     if (paged)
-        TESTING("unpin an unpinned entry error (paged aggregation)")
+        TESTING("unpin an unpinned entry error (paged aggregation)");
     else
-        TESTING("unpin an unpinned entry error")
+        TESTING("unpin an unpinned entry error");
 
     pass = TRUE;
 
@@ -14697,9 +14697,9 @@ check_pin_entry_errs(unsigned paged)
     test_entry_t *entry_ptr;
 
     if (paged)
-        TESTING("pin entry related errors (paged aggregation)")
+        TESTING("pin entry related errors (paged aggregation)");
     else
-        TESTING("pin entry related errors")
+        TESTING("pin entry related errors");
 
     pass = TRUE;
 
@@ -14805,9 +14805,9 @@ check_double_protect_err(unsigned paged)
     H5C_cache_entry_t *cache_entry_ptr;
 
     if (paged)
-        TESTING("protect a protected entry error (paged aggregation)")
+        TESTING("protect a protected entry error (paged aggregation)");
     else
-        TESTING("protect a protected entry error")
+        TESTING("protect a protected entry error");
 
     pass = TRUE;
 
@@ -14887,9 +14887,9 @@ check_double_unprotect_err(unsigned paged)
     test_entry_t *entry_ptr;
 
     if (paged)
-        TESTING("unprotect an unprotected entry error (paged aggregation)")
+        TESTING("unprotect an unprotected entry error (paged aggregation)");
     else
-        TESTING("unprotect an unprotected entry error")
+        TESTING("unprotect an unprotected entry error");
 
     pass = TRUE;
 
@@ -14968,9 +14968,9 @@ check_mark_entry_dirty_errs(unsigned paged)
     test_entry_t *entry_ptr;
 
     if (paged)
-        TESTING("mark entry dirty related errors (paged aggregation)")
+        TESTING("mark entry dirty related errors (paged aggregation)");
     else
-        TESTING("mark entry dirty related errors")
+        TESTING("mark entry dirty related errors");
 
     pass = TRUE;
 
@@ -15051,9 +15051,9 @@ check_expunge_entry_errs(unsigned paged)
     test_entry_t *entry_ptr;
 
     if (paged)
-        TESTING("expunge entry related errors (paged aggregation)")
+        TESTING("expunge entry related errors (paged aggregation)");
     else
-        TESTING("expunge entry related errors")
+        TESTING("expunge entry related errors");
 
     pass = TRUE;
 
@@ -15167,9 +15167,9 @@ check_move_entry_errs(unsigned paged)
     test_entry_t *entry_1_0_ptr;
 
     if (paged)
-        TESTING("move entry related errors (paged aggregation)")
+        TESTING("move entry related errors (paged aggregation)");
     else
-        TESTING("move entry related errors")
+        TESTING("move entry related errors");
 
     pass = TRUE;
 
@@ -15250,7 +15250,7 @@ check_move_entry_errs(unsigned paged)
     if (pass)
         PASSED();
     else {
-        H5_FAILED()
+        H5_FAILED();
 
         HDfprintf(stdout, "%s: failure_mssg = \"%s\".\n", __func__, failure_mssg);
     } /* end else */
@@ -15280,9 +15280,9 @@ check_resize_entry_errs(unsigned paged)
     test_entry_t *entry_ptr;
 
     if (paged)
-        TESTING("resize entry related errors (paged aggregation)")
+        TESTING("resize entry related errors (paged aggregation)");
     else
-        TESTING("resize entry related errors")
+        TESTING("resize entry related errors");
 
     pass = TRUE;
 
@@ -15381,9 +15381,9 @@ check_unprotect_ro_dirty_err(unsigned paged)
     test_entry_t *entry_ptr;
 
     if (paged)
-        TESTING("unprotect a read only entry dirty error (paged aggregation)")
+        TESTING("unprotect a read only entry dirty error (paged aggregation)");
     else
-        TESTING("unprotect a read only entry dirty error")
+        TESTING("unprotect a read only entry dirty error");
 
     pass = TRUE;
 
@@ -15506,9 +15506,9 @@ check_protect_ro_rw_err(unsigned paged)
     void *        thing_ptr = NULL;
 
     if (paged)
-        TESTING("protect a read only entry rw error (paged aggregation)")
+        TESTING("protect a read only entry rw error (paged aggregation)");
     else
-        TESTING("protect a read only entry rw error")
+        TESTING("protect a read only entry rw error");
 
     pass = TRUE;
 
@@ -15591,9 +15591,9 @@ check_protect_retries(unsigned paged)
     int32_t            idx;
 
     if (paged)
-        TESTING("protect an entry to verify retries (paged aggregation)")
+        TESTING("protect an entry to verify retries (paged aggregation)");
     else
-        TESTING("protect an entry to verify retries")
+        TESTING("protect an entry to verify retries");
 
     pass = TRUE;
 
@@ -15723,9 +15723,9 @@ check_check_evictions_enabled_err(unsigned paged)
     H5C_t * cache_ptr = NULL;
 
     if (paged)
-        TESTING("get/set evictions enabled errors (paged aggregation)")
+        TESTING("get/set evictions enabled errors (paged aggregation)");
     else
-        TESTING("get/set evictions enabled errors")
+        TESTING("get/set evictions enabled errors");
 
     pass = TRUE;
 
@@ -15917,9 +15917,9 @@ check_auto_cache_resize(hbool_t cork_ageout, unsigned paged)
         /* double      empty_reserve          = */ 0.05};
 
     if (paged)
-        TESTING("automatic cache resizing (paged aggregation)")
+        TESTING("automatic cache resizing (paged aggregation)");
     else
-        TESTING("automatic cache resizing")
+        TESTING("automatic cache resizing");
 
     pass = TRUE;
 
@@ -19772,9 +19772,9 @@ check_auto_cache_resize_disable(unsigned paged)
         /* double      empty_reserve          = */ 0.05};
 
     if (paged)
-        TESTING("automatic cache resize disable (paged aggregation)")
+        TESTING("automatic cache resize disable (paged aggregation)");
     else
-        TESTING("automatic cache resize disable")
+        TESTING("automatic cache resize disable");
 
     pass = TRUE;
 
@@ -22371,9 +22371,9 @@ check_auto_cache_resize_epoch_markers(unsigned paged)
         /* double      empty_reserve          = */ 0.05};
 
     if (paged)
-        TESTING("automatic cache resize epoch marker management (paged aggr)")
+        TESTING("automatic cache resize epoch marker management (paged aggr)");
     else
-        TESTING("automatic cache resize epoch marker management")
+        TESTING("automatic cache resize epoch marker management");
 
     pass = TRUE;
 
@@ -23062,9 +23062,9 @@ check_auto_cache_resize_input_errs(unsigned paged)
     H5C_auto_size_ctl_t test_auto_size_ctl;
 
     if (paged)
-        TESTING("automatic cache resize input errors (paged aggregation)")
+        TESTING("automatic cache resize input errors (paged aggregation)");
     else
-        TESTING("automatic cache resize input errors")
+        TESTING("automatic cache resize input errors");
 
     pass = TRUE;
 
@@ -25301,9 +25301,9 @@ check_auto_cache_resize_aux_fcns(unsigned paged)
     };
 
     if (paged)
-        TESTING("automatic cache resize auxiliary functions (paged aggregation)")
+        TESTING("automatic cache resize auxiliary functions (paged aggregation)");
     else
-        TESTING("automatic cache resize auxiliary functions")
+        TESTING("automatic cache resize auxiliary functions");
 
     pass = TRUE;
 
@@ -25803,15 +25803,15 @@ check_metadata_blizzard_absence(hbool_t fill_via_insertion, unsigned paged)
 
     if (fill_via_insertion) {
         if (paged)
-            TESTING("to ensure metadata blizzard absence when inserting (pgd aggr)")
+            TESTING("to ensure metadata blizzard absence when inserting (pgd aggr)");
         else
-            TESTING("to ensure metadata blizzard absence when inserting")
+            TESTING("to ensure metadata blizzard absence when inserting");
     } /* end if */
     else {
         if (paged)
-            TESTING("to ensure metadata blizzard absence on protect/unprotect (pa)")
+            TESTING("to ensure metadata blizzard absence on protect/unprotect (pa)");
         else
-            TESTING("to ensure metadata blizzard absence on protect/unprotect")
+            TESTING("to ensure metadata blizzard absence on protect/unprotect");
     } /* end else */
 
     if (show_progress) /* 0 */
@@ -26487,9 +26487,9 @@ check_flush_deps(unsigned paged)
     /* clang-format on */
 
     if (paged)
-        TESTING("flush dependencies (paged aggregation)")
+        TESTING("flush dependencies (paged aggregation)");
     else
-        TESTING("flush dependencies")
+        TESTING("flush dependencies");
 
     pass = TRUE;
 
@@ -28395,9 +28395,9 @@ check_flush_deps_err(unsigned paged)
     unsigned test_count;                   /* Test iteration variable */
 
     if (paged)
-        TESTING("flush dependency errors (paged aggregation)")
+        TESTING("flush dependency errors (paged aggregation)");
     else
-        TESTING("flush dependency errors")
+        TESTING("flush dependency errors");
 
     pass = TRUE;
 
@@ -28684,9 +28684,9 @@ check_flush_deps_order(unsigned paged)
     /* clang-format on */
 
     if (paged)
-        TESTING("flush dependencies flush order (paged aggregation)")
+        TESTING("flush dependencies flush order (paged aggregation)");
     else
-        TESTING("flush dependencies flush order")
+        TESTING("flush dependencies flush order");
 
     pass = TRUE;
 
@@ -31414,9 +31414,9 @@ check_notify_cb(unsigned paged)
     /* clang-format on */
 
     if (paged)
-        TESTING("'notify' callback (paged)")
+        TESTING("'notify' callback (paged)");
     else
-        TESTING("'notify' callback")
+        TESTING("'notify' callback");
 
     pass = TRUE;
 
@@ -31667,9 +31667,9 @@ check_metadata_cork(hbool_t fill_via_insertion, unsigned paged)
     reset_entries();
 
     if (fill_via_insertion)
-        TESTING("to ensure cork/uncork metadata when inserting")
+        TESTING("to ensure cork/uncork metadata when inserting");
     else
-        TESTING("to ensure cork/uncork metadata on protect/unprotect")
+        TESTING("to ensure cork/uncork metadata on protect/unprotect");
 
     if (show_progress) /* 0 */
         HDfprintf(stdout, "\n%s: check point %d -- pass %d\n", fcn_name, checkpoint++, pass);
@@ -32220,9 +32220,9 @@ check_entry_deletions_during_scans(unsigned paged)
     H5F_t *file_ptr = NULL;
 
     if (paged)
-        TESTING("entry deletion during list scan detection and adaption (par)")
+        TESTING("entry deletion during list scan detection and adaption (par)");
     else
-        TESTING("entry deletion during list scan detection and adaption")
+        TESTING("entry deletion during list scan detection and adaption");
 
     pass = TRUE;
 
@@ -33690,9 +33690,9 @@ check_stats(unsigned paged)
 #endif /* H5C_COLLECT_CACHE_STATS */
 
     if (paged)
-        TESTING("metadata cache statistics collection (paged aggregation)")
+        TESTING("metadata cache statistics collection (paged aggregation)");
     else
-        TESTING("metadata cache statistics collection")
+        TESTING("metadata cache statistics collection");
 
 #if H5C_COLLECT_CACHE_STATS
 

--- a/test/cache_api.c
+++ b/test/cache_api.c
@@ -110,9 +110,9 @@ check_fapl_mdc_api_calls(unsigned paged, hid_t fcpl_id)
     H5C_auto_size_ctl_t mod_auto_size_ctl;
 
     if (paged)
-        TESTING("MDC/FAPL related API calls for paged aggregation strategy")
+        TESTING("MDC/FAPL related API calls for paged aggregation strategy");
     else
-        TESTING("MDC/FAPL related API calls")
+        TESTING("MDC/FAPL related API calls");
 
     pass = TRUE;
 
@@ -652,9 +652,9 @@ check_file_mdc_api_calls(unsigned paged, hid_t fcpl_id)
         H5AC__DEFAULT_METADATA_WRITE_STRATEGY};
 
     if (paged)
-        TESTING("MDC/FILE related API calls for paged aggregation strategy")
+        TESTING("MDC/FILE related API calls for paged aggregation strategy");
     else
-        TESTING("MDC/FILE related API calls")
+        TESTING("MDC/FILE related API calls");
 
     pass = TRUE;
 
@@ -975,9 +975,9 @@ mdc_api_call_smoke_check(int express_test, unsigned paged, hid_t fcpl_id)
         H5AC__DEFAULT_METADATA_WRITE_STRATEGY};
 
     if (paged)
-        TESTING("MDC API smoke check for paged aggregation strategy")
+        TESTING("MDC API smoke check for paged aggregation strategy");
     else
-        TESTING("MDC API smoke check")
+        TESTING("MDC API smoke check");
 
     pass = TRUE;
 
@@ -1879,9 +1879,9 @@ check_file_mdc_api_errs(unsigned paged, hid_t fcpl_id)
     H5AC_cache_config_t scratch;
 
     if (paged)
-        TESTING("MDC/FILE related API input errors for paged aggregation strategy")
+        TESTING("MDC/FILE related API input errors for paged aggregation strategy");
     else
-        TESTING("MDC/FILE related API input errors")
+        TESTING("MDC/FILE related API input errors");
 
     pass = TRUE;
 

--- a/test/cache_tagging.c
+++ b/test/cache_tagging.c
@@ -4481,7 +4481,7 @@ check_invalid_tag_application(void)
 
     /* Push API context */
     if (H5CX_push() < 0)
-        TEST_ERROR
+        TEST_ERROR;
     api_ctx_pushed = TRUE;
 
     /* Get internal file pointer*/
@@ -4521,7 +4521,7 @@ check_invalid_tag_application(void)
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     api_ctx_pushed = FALSE;
 
     /* Close open objects and file */

--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -178,7 +178,7 @@ verify_get_chunk_info(hid_t dset, hid_t dspace, hsize_t chk_index, hsize_t exp_c
     haddr_t  addr          = 0;      /* Address of an allocated/written chunk */
 
     if (H5Dget_chunk_info(dset, dspace, chk_index, out_offset, &read_flt_msk, &addr, &size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     CHECK(addr, HADDR_UNDEF, "H5Dget_chunk_info");
     VERIFY(size, exp_chk_size, "H5Dget_chunk_info, chunk size");
     VERIFY(read_flt_msk, exp_flt_msk, "H5Dget_chunk_info, filter mask");
@@ -212,7 +212,7 @@ verify_get_chunk_info_by_coord(hid_t dset, hsize_t *offset, hsize_t exp_chk_size
 
     /* Get info of the chunk at logical coordinates specified by offset */
     if (H5Dget_chunk_info_by_coord(dset, offset, &read_flt_msk, &addr, &size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     CHECK(addr, HADDR_UNDEF, "H5Dget_chunk_info_by_coord");
     VERIFY(size, exp_chk_size, "H5Dget_chunk_info_by_coord, chunk size");
     VERIFY(read_flt_msk, exp_flt_msk, "H5Dget_chunk_info_by_coord, filter mask");
@@ -244,7 +244,7 @@ verify_empty_chunk_info(hid_t dset, hsize_t *offset)
 
     /* Get info of the chunk at logical coordinates specified by offset */
     if (H5Dget_chunk_info_by_coord(dset, offset, &read_flt_msk, &addr, &size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     VERIFY(addr, HADDR_UNDEF, "H5Dget_chunk_info_by_coord, chunk address");
     VERIFY(size, EMPTY_CHK_SIZE, "H5Dget_chunk_info_by_coord, chunk size");
     return SUCCEED;
@@ -331,7 +331,7 @@ verify_selected_chunks(hid_t dset, hid_t plist, const hsize_t *start, const hsiz
 
             /* Read the current chunk */
             if (H5Dread_chunk(dset, plist, offset, &read_flt_msk, read_buf) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Verify that read chunk is the same as the corresponding written one */
             if (HDmemcmp(expected_buf[chk_index], read_buf, CHUNK_NX * CHUNK_NY) != 0) {
@@ -386,7 +386,7 @@ write_selected_chunks(hid_t dset, hid_t plist, const hsize_t *start, const hsize
             offset[0] = ii * CHUNK_NX;
             offset[1] = jj * CHUNK_NY;
             if (H5Dwrite_chunk(dset, plist, flt_msk, offset, CHK_SIZE, (void *)direct_buf[chk_index]) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         }
 
     return SUCCEED;
@@ -416,7 +416,7 @@ verify_idx_nchunks(hid_t dset, hid_t dspace, H5D_chunk_index_t exp_idx_type, hsi
 
     /* Get the chunk indexing type of the dataset */
     if (H5Dget_chunk_index_type(dset, &idx_type) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Ensure the correct chunk indexing scheme is used */
     if (idx_type != exp_idx_type) {
@@ -427,12 +427,12 @@ verify_idx_nchunks(hid_t dset, hid_t dspace, H5D_chunk_index_t exp_idx_type, hsi
 
     /* Get and verify the number of chunks */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     VERIFY(nchunks, exp_num_chunks, "H5Dget_num_chunks, number of chunks");
 
     /* Get and verify the number of chunks again, passing in H5S_ALL */
     if (H5Dget_num_chunks(dset, H5S_ALL, &nchunks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     VERIFY(nchunks, exp_num_chunks, "H5Dget_num_chunks, number of chunks");
 
     return SUCCEED;
@@ -504,36 +504,36 @@ test_get_chunk_info_highest_v18(hid_t fapl)
     /* Set version bounds for creating the file.  High bound to V18 to test
        chunked dataset that use B-tree v1 structures to index chunks. */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_EARLIEST, H5F_LIBVER_V18) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     chunkfile = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
     if (chunkfile < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the file and memory dataspace */
     if ((dspace = H5Screate_simple(RANK, dims, maxdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dset creation properties with chunking, compression, and fillvalue */
     if ((cparms = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(cparms, RANK, chunk_dims) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #ifdef H5_HAVE_FILTER_DEFLATE
     if (H5Pset_deflate(cparms, (unsigned)aggression) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 #endif /* end H5_HAVE_FILTER_DEFLATE */
 
     /* Set fill value */
     if (H5Pset_fill_value(cparms, H5T_NATIVE_INT, &fillvalue) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a new dataset using cparms creation properties */
     dset = H5Dcreate2(chunkfile, SIMPLE_CHUNKED_DSET_NAME, H5T_NATIVE_INT, dspace, H5P_DEFAULT, cparms,
                       H5P_DEFAULT);
     if (dset < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize a chunk of data */
     for (ii = 0; ii < CHUNK_NX; ii++)
@@ -556,20 +556,20 @@ test_get_chunk_info_highest_v18(hid_t fapl)
     /* Check for various zlib errors */
     if (Z_BUF_ERROR == ret) {
         HDfprintf(stderr, "overflow");
-        TEST_ERROR
+        TEST_ERROR;
     }
     else if (Z_MEM_ERROR == ret) {
         HDfprintf(stderr, "deflate memory error");
-        TEST_ERROR
+        TEST_ERROR;
     }
     else if (Z_OK != ret) {
         HDfprintf(stderr, "other deflate error");
-        TEST_ERROR
+        TEST_ERROR;
     }
 #else
     /* Allocate input (non-compressed) buffer */
     if (NULL == (inbuf = HDcalloc(1, CHK_SIZE)))
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(inbuf, direct_buf, CHK_SIZE);
 #endif /* end H5_HAVE_FILTER_DEFLATE */
 
@@ -582,7 +582,7 @@ test_get_chunk_info_highest_v18(hid_t fapl)
             offset[1] = jj * CHUNK_NY;
             ret       = H5Dwrite_chunk(dset, H5P_DEFAULT, flt_msk, offset, chunk_size, (void *)inbuf);
             if (ret < 0)
-                TEST_ERROR
+                TEST_ERROR;
         }
 
     /* Free the input buffer */
@@ -590,19 +590,19 @@ test_get_chunk_info_highest_v18(hid_t fapl)
         HDfree(inbuf);
 
     if (H5Fflush(dset, H5F_SCOPE_LOCAL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* ...open it again to test the chunk query functions */
     if ((dset = H5Dopen2(chunkfile, SIMPLE_CHUNKED_DSET_NAME, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     VERIFY(nchunks, NUM_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
 
     /* Get and verify info of the last written chunk again, passing in H5S_ALL
@@ -650,22 +650,22 @@ test_get_chunk_info_highest_v18(hid_t fapl)
 
     /* Close the first dataset */
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an empty dataset and close it */
     dset = H5Dcreate2(chunkfile, EMPTY_DSET_NAME, H5T_NATIVE_INT, dspace, H5P_DEFAULT, cparms, H5P_DEFAULT);
     if (dset < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reopen the empty dataset to verify the chunk query functions on it */
     if ((dset = H5Dopen2(chunkfile, EMPTY_DSET_NAME, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the number of chunks is 0 */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     VERIFY(nchunks, NO_CHUNK_WRITTEN, "H5Dget_num_chunks, number of chunks");
 
     /* Attempt to get info of a chunk from an empty dataset, should fail */
@@ -686,7 +686,7 @@ test_get_chunk_info_highest_v18(hid_t fapl)
         FAIL_PUTS_ERROR("Verification of H5Dget_chunk_info_by_coord on empty chunk failed\n");
 
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /************************************************************************
      * Test empty dataset with H5D_ALLOC_TIME_EARLY                         *
@@ -695,25 +695,25 @@ test_get_chunk_info_highest_v18(hid_t fapl)
     /* Set space allocation to early so that chunk query functions will
        retrieve chunk information even though the dataset is empty */
     if (H5Pset_alloc_time(cparms, H5D_ALLOC_TIME_EARLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an empty dataset and close it */
     dset = H5Dcreate2(chunkfile, EMPTY_EARLY_ALLOC_DSET_NAME, H5T_NATIVE_INT, dspace, H5P_DEFAULT, cparms,
                       H5P_DEFAULT);
     if (dset < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reopen the empty dataset to verify the chunk query functions on it */
     if ((dset = H5Dopen2(chunkfile, EMPTY_EARLY_ALLOC_DSET_NAME, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the number of chunks is NUM_CHUNKS */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (nchunks != NUM_CHUNKS)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to get info of a chunk from an empty dataset, verify the
        returned address and size in the case of H5D_ALLOC_TIME_EARLY */
@@ -721,47 +721,47 @@ test_get_chunk_info_highest_v18(hid_t fapl)
     reinit_vars(&read_flt_msk, &addr, &size);
     ret = H5Dget_chunk_info(dset, dspace, chk_index, out_offset, &read_flt_msk, &addr, &size);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Because of H5D_ALLOC_TIME_EARLY, addr cannot be HADDR_UNDEF and size not 0 */
     if (addr == HADDR_UNDEF)
-        TEST_ERROR
+        TEST_ERROR;
     if (size == EMPTY_CHK_SIZE)
-        TEST_ERROR
+        TEST_ERROR;
 
     chk_index = 10;
     reinit_vars(&read_flt_msk, &addr, &size);
     ret = H5Dget_chunk_info(dset, dspace, chk_index, out_offset, &read_flt_msk, &addr, &size);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Because of H5D_ALLOC_TIME_EARLY, addr cannot be HADDR_UNDEF and size not 0 */
     if (addr == HADDR_UNDEF)
-        TEST_ERROR
+        TEST_ERROR;
     if (size == EMPTY_CHK_SIZE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to get info of a chunk given its coords from an empty dataset,
        verify the returned address and size */
     offset[0] = 0;
     offset[1] = 0;
     if (H5Dget_chunk_info_by_coord(dset, offset, &read_flt_msk, &addr, &size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Because of H5D_ALLOC_TIME_EARLY, addr cannot be HADDR_UNDEF and size not 0 */
     if (addr == HADDR_UNDEF)
-        TEST_ERROR
+        TEST_ERROR;
     if (size == 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close/release resources. */
     if (H5Sclose(dspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(cparms) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(chunkfile) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -823,45 +823,45 @@ test_chunk_info_single_chunk(const char *filename, hid_t fapl)
 
     /* Open the file for reading/writing */
     if ((chunkfile = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace */
     if ((dspace = H5Screate_simple(RANK, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Enable chunking */
     if ((cparms = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pset_chunk(cparms, RANK, chunk_dims) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a new dataset using cparms creation properties */
     dset = H5Dcreate2(chunkfile, SINGLE_CHUNK_DSET_NAME, H5T_NATIVE_INT, dspace, H5P_DEFAULT, cparms,
                       H5P_DEFAULT);
     if (dset < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* ...open it again to test the chunk query functions on a single empty
        chunk */
     if ((dset = H5Dopen2(chunkfile, SINGLE_CHUNK_DSET_NAME, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Ensure the correct chunk indexing scheme is used */
     if (H5Dget_chunk_index_type(dset, &idx_type) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (idx_type != H5D_CHUNK_IDX_SINGLE)
         FAIL_PUTS_ERROR("Should be using Single Chunk index type");
 
     /* Get the number of chunks and verify that no chunk has been written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (nchunks != NO_CHUNK_WRITTEN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize the array of chunk data for the single chunk */
     for (ii = 0; ii < NX; ii++)
@@ -870,13 +870,13 @@ test_chunk_info_single_chunk(const char *filename, hid_t fapl)
 
     /* Write the chunk */
     if (H5Dwrite(dset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get and verify that one chunk had been written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (nchunks != ONE_CHUNK_WRITTEN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Offset of the only chunk */
     offset[0] = 0;
@@ -900,15 +900,15 @@ test_chunk_info_single_chunk(const char *filename, hid_t fapl)
     }
     H5E_END_TRY;
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Release resourse */
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(dspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(chunkfile) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -963,36 +963,36 @@ test_chunk_info_implicit(char *filename, hid_t fapl)
 
     /* Open the file for reading/writing */
     if ((chunkfile = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace */
     if ((dspace = H5Screate_simple(RANK, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Enable chunking */
     if ((cparms = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pset_chunk(cparms, RANK, chunk_dims) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set allocation time to early */
     if (H5Pset_alloc_time(cparms, H5D_ALLOC_TIME_EARLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a new dataset using cparms creation properties */
     dset = H5Dcreate2(chunkfile, IMPLICIT_INDEX_DSET_NAME, H5T_NATIVE_INT, dspace, H5P_DEFAULT, cparms,
                       H5P_DEFAULT);
     if (dset < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the dataset again to test getting chunk info */
     if ((dset = H5Dopen2(chunkfile, IMPLICIT_INDEX_DSET_NAME, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify chunk indexing scheme and number of chunks */
     if (verify_idx_nchunks(dset, dspace, H5D_CHUNK_IDX_NONE, NUM_CHUNKS) == FAIL)
@@ -1021,13 +1021,13 @@ test_chunk_info_implicit(char *filename, hid_t fapl)
 
     /* Release resourse */
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(dspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(cparms) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(chunkfile) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -1089,32 +1089,32 @@ test_chunk_info_fixed_array(const char *filename, hid_t fapl)
 
     /* Open the file for reading/writing */
     if ((chunkfile = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace */
     if ((dspace = H5Screate_simple(RANK, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Enable chunking */
     if ((cparms = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pset_chunk(cparms, RANK, chunk_dims) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a new dataset using cparms creation properties */
     dset = H5Dcreate2(chunkfile, FIXED_ARR_INDEX_DSET_NAME, H5T_NATIVE_INT, dspace, H5P_DEFAULT, cparms,
                       H5P_DEFAULT);
     if (dset < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the dataset again to test getting chunk info */
     if ((dset = H5Dopen2(chunkfile, FIXED_ARR_INDEX_DSET_NAME, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify chunk indexing scheme and number of chunks */
     if (verify_idx_nchunks(dset, dspace, H5D_CHUNK_IDX_FARRAY, NO_CHUNK_WRITTEN) == FAIL)
@@ -1127,7 +1127,7 @@ test_chunk_info_fixed_array(const char *filename, hid_t fapl)
 
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     VERIFY(nchunks, NUM_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
 
     /* Get and verify info of each written chunk */
@@ -1165,11 +1165,11 @@ test_chunk_info_fixed_array(const char *filename, hid_t fapl)
 
         /* Release resourse */
         if (H5Dclose(dset) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if (H5Sclose(dspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(chunkfile) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -1232,32 +1232,32 @@ test_chunk_info_extensible_array(const char *filename, hid_t fapl)
 
     /* Open the file for reading/writing */
     if ((chunkfile = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace */
     if ((dspace = H5Screate_simple(RANK, dims, maxdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Enable chunking */
     if ((cparms = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pset_chunk(cparms, RANK, chunk_dims) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a new dataset using cparms creation properties */
     dset = H5Dcreate2(chunkfile, EXT_ARR_INDEX_DSET_NAME, H5T_NATIVE_INT, dspace, H5P_DEFAULT, cparms,
                       H5P_DEFAULT);
     if (dset < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the dataset again to test getting chunk info */
     if ((dset = H5Dopen2(chunkfile, EXT_ARR_INDEX_DSET_NAME, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify chunk indexing scheme and number of chunks */
     if (verify_idx_nchunks(dset, dspace, H5D_CHUNK_IDX_EARRAY, NO_CHUNK_WRITTEN) == FAIL)
@@ -1270,7 +1270,7 @@ test_chunk_info_extensible_array(const char *filename, hid_t fapl)
 
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     VERIFY(nchunks, NUM_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
 
     /* Get and verify info of each written chunk */
@@ -1313,11 +1313,11 @@ test_chunk_info_extensible_array(const char *filename, hid_t fapl)
 
         /* Release resourse */
         if (H5Dclose(dset) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if (H5Sclose(dspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(chunkfile) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -1380,32 +1380,32 @@ test_chunk_info_version2_btrees(const char *filename, hid_t fapl)
 
     /* Open the file for reading/writing */
     if ((chunkfile = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace */
     if ((dspace = H5Screate_simple(RANK, dims, maxdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Enable chunking */
     if ((cparms = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pset_chunk(cparms, RANK, chunk_dims) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a new dataset using cparms creation properties */
     dset = H5Dcreate2(chunkfile, V2_BTREE_INDEX_DSET_NAME, H5T_NATIVE_INT, dspace, H5P_DEFAULT, cparms,
                       H5P_DEFAULT);
     if (dset < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the dataset again to test getting chunk info */
     if ((dset = H5Dopen2(chunkfile, V2_BTREE_INDEX_DSET_NAME, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify chunk indexing scheme and number of chunks */
     if (verify_idx_nchunks(dset, dspace, H5D_CHUNK_IDX_BT2, NO_CHUNK_WRITTEN) == FAIL)
@@ -1418,7 +1418,7 @@ test_chunk_info_version2_btrees(const char *filename, hid_t fapl)
 
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     VERIFY(nchunks, NUM_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
 
     /* Go through all written chunks, get their info and verify the values */
@@ -1461,11 +1461,11 @@ test_chunk_info_version2_btrees(const char *filename, hid_t fapl)
 
         /* Release resourse */
         if (H5Dclose(dset) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if (H5Sclose(dspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(chunkfile) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -1584,24 +1584,24 @@ test_basic_query(hid_t fapl)
 
     /* Create dataspace */
     if ((dspace = H5Screate_simple(RANK, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Enable chunking */
     if ((cparms = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pset_chunk(cparms, RANK, chunk_dims) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a new dataset using cparms creation properties */
     dset = H5Dcreate2(basicfile, SIMPLE_CHUNKED_DSET_NAME, H5T_NATIVE_INT, dspace, H5P_DEFAULT, cparms,
                       H5P_DEFAULT);
     if (dset < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the number of chunks and verify that no chunk has been written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     VERIFY(nchunks, NO_CHUNK_WRITTEN, "H5Dget_num_chunks, number of chunks");
 
     /* Initialize the array of chunk data for the single chunk */
@@ -1617,7 +1617,7 @@ test_basic_query(hid_t fapl)
 
     /* Get and verify that one chunk had been written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     VERIFY(nchunks, ONE_CHUNK_WRITTEN, "H5Dget_num_chunks, number of chunks");
 
     /* Get and verify info of the first and only chunk */
@@ -1638,7 +1638,7 @@ test_basic_query(hid_t fapl)
     }
     H5E_END_TRY;
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Write the chunk of data to another location */
     offset[0] = 0;
@@ -1648,7 +1648,7 @@ test_basic_query(hid_t fapl)
 
     /* Get and verify that two chunks had been written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     VERIFY(nchunks, TWO_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
 
     /* Get and verify info of the first written chunk in the dataset, its
@@ -1713,13 +1713,13 @@ test_basic_query(hid_t fapl)
 
     /* Release resourse */
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(dspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(cparms) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(basicfile) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Remove the test file */
     HDremove(filename);
@@ -1779,17 +1779,17 @@ test_failed_attempts(const char *filename, hid_t fapl)
 
     /* Open the file for reading/writing */
     if ((chunkfile = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace */
     if ((dspace = H5Screate_simple(RANK, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a contiguous dataset */
     dset = H5Dcreate2(chunkfile, CONTIGUOUS_DSET_NAME, H5T_NATIVE_INT, dspace, H5P_DEFAULT, H5P_DEFAULT,
                       H5P_DEFAULT);
     if (dset < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize the array of data */
     for (ii = 0; ii < NX; ii++)
@@ -1798,15 +1798,15 @@ test_failed_attempts(const char *filename, hid_t fapl)
 
     /* Write the data */
     if (H5Dwrite(dset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open it again to test the chunk query functions on contiguous dataset */
     if ((dset = H5Dopen2(chunkfile, CONTIGUOUS_DSET_NAME, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to get the number of chunks on contiguous dataset, should fail */
     H5E_BEGIN_TRY
@@ -1815,7 +1815,7 @@ test_failed_attempts(const char *filename, hid_t fapl)
     }
     H5E_END_TRY;
     if (ret != FAIL)
-        FAIL_PUTS_ERROR("    Attempt a chunk query function on a contiguous dataset.")
+        FAIL_PUTS_ERROR("    Attempt a chunk query function on a contiguous dataset.");
 
     /* Attempt to get chunk info on contiguous data, should fail */
     chk_index = 0;
@@ -1826,7 +1826,7 @@ test_failed_attempts(const char *filename, hid_t fapl)
     }
     H5E_END_TRY;
     if (ret != FAIL)
-        FAIL_PUTS_ERROR("    Attempt a chunk query function on a contiguous dataset.")
+        FAIL_PUTS_ERROR("    Attempt a chunk query function on a contiguous dataset.");
 
     /* Attempt to get chunk info at logical coordinates (0,0) on contiguous
      * dataset, should fail */
@@ -1838,15 +1838,15 @@ test_failed_attempts(const char *filename, hid_t fapl)
     }
     H5E_END_TRY;
     if (ret != FAIL)
-        FAIL_PUTS_ERROR("    Attempt a chunk query function on a contiguous dataset.")
+        FAIL_PUTS_ERROR("    Attempt a chunk query function on a contiguous dataset.");
 
     /* Release resourse */
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(dspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(chunkfile) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -1902,42 +1902,42 @@ test_get_chunk_info_v110(hid_t fapl)
     for (low = H5F_LIBVER_V110; low <= H5F_LIBVER_LATEST; low++) {
         /* Set version bounds for creating file */
         if (H5Pset_libver_bounds(fapl, low, high) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create the file */
         h5_fixname(FILENAME[low], fapl, filename, sizeof filename);
         chunkfile = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
         if (chunkfile < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file, individual tests will re-open the file with different
            libvers via the fapl */
         if (H5Fclose(chunkfile) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Test getting chunk info when Single Chunk index type is used */
         if (test_chunk_info_single_chunk(filename, fapl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Test getting chunk info when Implicit index type is used */
         if (test_chunk_info_implicit(filename, fapl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Test getting chunk info when Fixed Array index type is used */
         if (test_chunk_info_fixed_array(filename, fapl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Test getting chunk info when Extensible Array index type is used */
         if (test_chunk_info_extensible_array(filename, fapl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Test getting chunk info when Version 2 B-trees index type is used */
         if (test_chunk_info_version2_btrees(filename, fapl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Test various attempts to use the functions incorrectly */
         if (test_failed_attempts(filename, fapl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     } /* for low libver bound */
 
@@ -2101,7 +2101,7 @@ test_flt_msk_with_skip_compress(hid_t fapl)
 
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, H5S_ALL, &nchunks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     VERIFY(nchunks, ONE_CHUNK_WRITTEN, "H5Dget_num_chunks, number of chunks");
 
     /* Get and verify info of the first and only chunk */
@@ -2117,17 +2117,17 @@ test_flt_msk_with_skip_compress(hid_t fapl)
 
     /* Release resourse */
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(mem_space) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(dspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(cparms) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dxpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(filter_file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Remove the test file */
     HDremove(filename);
@@ -2173,7 +2173,7 @@ main(void)
 
     /* Create a copy of file access property list */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test basic operations on the chunk query functions */
     nerrors += test_basic_query(fapl) < 0 ? 1 : 0;

--- a/test/cmpd_dset.c
+++ b/test/cmpd_dset.c
@@ -1378,32 +1378,32 @@ test_hdf5_src_subset(char *filename, hid_t fapl)
 
     /* Create xfer properties to preserve initialized data */
     if ((dxpl = H5Pcreate(H5P_DATASET_XFER)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Pset_preserve(dxpl, TRUE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Rewrite contiguous data set */
     if ((dataset = H5Dopen2(file, DSET_NAME[0], H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write the data to the dataset */
     if (H5Dwrite(dataset, rew_tid, H5S_ALL, H5S_ALL, dxpl, rew_buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Rewrite chunked data set */
     if ((dataset = H5Dopen2(file, DSET_NAME[1], H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write the data to the dataset */
     if (H5Dwrite(dataset, rew_tid, H5S_ALL, H5S_ALL, dxpl, rew_buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1415,48 +1415,48 @@ test_hdf5_src_subset(char *filename, hid_t fapl)
 
     /* Check contiguous data set */
     if ((dataset = H5Dopen2(file, DSET_NAME[0], H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dread(dataset, dst_tid, H5S_ALL, H5S_ALL, dxpl, rbuf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (compare_data(orig, rbuf, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check chunked data set */
     if ((dataset = H5Dopen2(file, DSET_NAME[1], H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dread(dataset, dst_tid, H5S_ALL, H5S_ALL, dxpl, rbuf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (compare_data(orig, rbuf, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Finishing test and release resources */
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Pclose(dxpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Tclose(src_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(dst_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(rew_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDfree(orig);
     HDfree(rbuf);
@@ -1993,207 +1993,207 @@ test_ooo_order(char *filename, hid_t fapl_id)
     hid_t  dtype_tmp = -1;   /* Temp Datatype ID */
     H5T_t *dt        = NULL; /* Datatype pointer */
 
-    TESTING("that compound member insertion order is preserved")
+    TESTING("that compound member insertion order is preserved");
 
     /* Create the file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the compound */
     if ((dtype = H5Tcreate(H5T_COMPOUND, (size_t)20)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(dtype, "A", (size_t)8, H5T_STD_I32LE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(dtype, "B", (size_t)12, H5T_STD_I32LE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(dtype, "C", (size_t)0, H5T_STD_I32LE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(dtype, "D", (size_t)16, H5T_STD_I32LE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the compound is not packed */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(dtype, H5I_DATATYPE)))
-        TEST_ERROR
+        TEST_ERROR;
     if (dt->shared->u.compnd.packed)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the order is the same as the insertion order */
     if (H5Tget_member_offset(dtype, 0) != 8)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 1) != 12)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 2) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 3) != 16)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Commit the datatype */
     if (H5Tcommit2(file, "dtype", dtype, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close and reopen the file */
     if (H5Tclose(dtype))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file))
-        TEST_ERROR
+        TEST_ERROR;
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the type */
     if ((dtype_tmp = H5Topen2(file, "dtype", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the compound is not packed */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(dtype_tmp, H5I_DATATYPE)))
-        TEST_ERROR
+        TEST_ERROR;
     if (dt->shared->u.compnd.packed)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the order is the same as the insertion order */
     if (H5Tget_member_offset(dtype_tmp, 0) != 8)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype_tmp, 1) != 12)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype_tmp, 2) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype_tmp, 3) != 16)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Copy the datatype */
     if ((dtype = H5Tcopy(dtype_tmp)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the compound is not packed */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(dtype, H5I_DATATYPE)))
-        TEST_ERROR
+        TEST_ERROR;
     if (dt->shared->u.compnd.packed)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the order is the same as the insertion order */
     if (H5Tget_member_offset(dtype, 0) != 8)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 1) != 12)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 2) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 3) != 16)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert the last member */
     if (H5Tinsert(dtype, "E", (size_t)4, H5T_STD_I32LE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the compound is packed */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(dtype, H5I_DATATYPE)))
-        TEST_ERROR
+        TEST_ERROR;
     if (!dt->shared->u.compnd.packed)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the order is the same as the insertion order */
     if (H5Tget_member_offset(dtype, 0) != 8)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 1) != 12)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 2) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 3) != 16)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 4) != 4)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Commit the modified datatype */
     if (H5Tcommit2(file, "dtype2", dtype, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close and reopen the file */
     if (H5Tclose(dtype_tmp))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(dtype))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file))
-        TEST_ERROR
+        TEST_ERROR;
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the type, and verify status */
     if ((dtype_tmp = H5Topen2(file, "dtype2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (dt = (H5T_t *)H5I_object_verify(dtype_tmp, H5I_DATATYPE)))
-        TEST_ERROR
+        TEST_ERROR;
     if (!dt->shared->u.compnd.packed)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype_tmp, 0) != 8)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype_tmp, 1) != 12)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype_tmp, 2) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype_tmp, 3) != 16)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype_tmp, 4) != 4)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Copy the datatype, and verify status */
     if ((dtype = H5Tcopy(dtype_tmp)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (dt = (H5T_t *)H5I_object_verify(dtype, H5I_DATATYPE)))
-        TEST_ERROR
+        TEST_ERROR;
     if (!dt->shared->u.compnd.packed)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 0) != 8)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 1) != 12)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 2) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 3) != 16)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 4) != 4)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Expand the type, and verify that it became unpacked */
     if (H5Tset_size(dtype, (size_t)21) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (dt = (H5T_t *)H5I_object_verify(dtype, H5I_DATATYPE)))
-        TEST_ERROR
+        TEST_ERROR;
     if (dt->shared->u.compnd.packed)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 0) != 8)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 1) != 12)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 2) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 3) != 16)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 4) != 4)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Shrink the type, and verify that it became packed */
     if (H5Tset_size(dtype, (size_t)20) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (dt = (H5T_t *)H5I_object_verify(dtype, H5I_DATATYPE)))
-        TEST_ERROR
+        TEST_ERROR;
     if (!dt->shared->u.compnd.packed)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 0) != 8)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 1) != 12)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 2) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 3) != 16)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tget_member_offset(dtype, 4) != 4)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Tclose(dtype_tmp))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(dtype))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file))
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;

--- a/test/cmpd_dtransform.c
+++ b/test/cmpd_dtransform.c
@@ -54,46 +54,46 @@ main(void)
 
     /* String type */
     if ((str_dtyp_id = H5Tcopy(H5T_C_S1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_size(str_dtyp_id, 64) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Attribute type */
     if ((att_dtyp_id = H5Tcreate(H5T_COMPOUND, sizeof(att_t))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(att_dtyp_id, "NAME", HOFFSET(att_t, name), str_dtyp_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(att_dtyp_id, "UNIT", HOFFSET(att_t, unit), str_dtyp_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create file. */
     if ((file_id = H5Fcreate(FILENAME, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create file dataspace. */
     if ((fspace_id = H5Screate_simple(1, dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataset. */
     if ((dset_id = H5Dcreate2(file_id, "test_dset", H5T_NATIVE_INT, fspace_id, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write the attribute (compound) to the dataset */
     if ((att_dspc_id = H5Screate_simple(1, dima, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((att_attr_id =
              H5Acreate2(dset_id, "ATTRIBUTES", att_dtyp_id, att_dspc_id, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Awrite(att_attr_id, att_dtyp_id, atts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataset transfer property list */
     if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_data_transform(dxpl_id, expr) < 0) {
         HDprintf("**** ERROR: H5Pset_data_transform (expression: %s) ****\n", expr);
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     }
 
     if (NULL == (data = HDmalloc(LENGTH * sizeof(int))))
@@ -107,13 +107,13 @@ main(void)
 
     /* Write the data */
     if (H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, dxpl_id, data) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read attribute */
     if (NULL == (atts_res = HDmalloc(sizeof(att_t))))
         TEST_ERROR;
     if (H5Aread(att_attr_id, att_dtyp_id, atts_res) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify attribute */
     if (HDstrcmp(atts_res[0].name, atts[0].name) != 0)
@@ -123,7 +123,7 @@ main(void)
 
     /* Read the data */
     if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify data */
     for (unsigned idx = 0; idx < LENGTH; idx++)
@@ -137,21 +137,21 @@ main(void)
 
     /* Close all identifiers. */
     if (H5Pclose(dxpl_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Aclose(att_attr_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(att_dspc_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(fspace_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(att_dtyp_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(str_dtyp_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     return 0;
 

--- a/test/cork.c
+++ b/test/cork.c
@@ -112,33 +112,33 @@ verify_old_dset_cork(void)
 
     /* Create the file */
     if ((fid = H5Fcreate(FILENAME, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dcpl */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to use chunked dataset */
     if (H5Pset_chunk(dcpl, 2, chunk_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create chunked dataset with v1-btree indexing: DSET_BT1 */
     if ((sid = H5Screate_simple(2, dims, max_dims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did = H5Dcreate2(fid, DSET_BT1, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get dataset object header address: DSET_BT1 */
     if (H5Oget_info3(did, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset: DSET_BT1 */
     if (H5Odisable_mdc_flushes(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status */
     if (H5C__verify_cork_tag_test(fid, oinfo.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set up data array */
     if (NULL == (buf_data = (int *)HDcalloc(100 * 20, sizeof(int))))
@@ -155,105 +155,105 @@ verify_old_dset_cork(void)
 
     /* Write to the dataset: DSET_BT1 */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the cork status for DSET_BT1 */
     if (H5C__verify_cork_tag_test(fid, oinfo.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create compact dataset: DSET_COMPACT */
     if ((sid2 = H5Screate_simple(2, dims2, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dcpl2 = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_layout(dcpl2, H5D_COMPACT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_alloc_time(dcpl2, H5D_ALLOC_TIME_EARLY) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did2 = H5Dcreate2(fid, DSET_COMPACT, H5T_NATIVE_INT, sid2, H5P_DEFAULT, dcpl2, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get dataset object address */
     if (H5Oget_info3(did2, &oinfo2, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset: DSET_COMPACT */
     if (H5Odisable_mdc_flushes(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status */
     if (H5C__verify_cork_tag_test(fid, oinfo2.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reopen the file */
     if ((fid = H5Fopen(FILENAME, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open and write to the dataset: DSET_BT1 */
     if ((did = H5Dopen2(fid, DSET_BT1, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create contiguous dataset: DSET_CONTIG */
     if ((sid3 = H5Screate_simple(2, dims2, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dcpl3 = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_layout(dcpl3, H5D_CONTIGUOUS) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did3 = H5Dcreate2(fid, DSET_CONTIG, H5T_NATIVE_INT, sid3, H5P_DEFAULT, dcpl3, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get dataset object address: DSET_CONTIG */
     if (H5Oget_info3(did3, &oinfo3, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset: DSET_CONTIG */
     if (H5Odisable_mdc_flushes(did3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the cork status for DSET_CONTIG */
     if (H5C__verify_cork_tag_test(fid, oinfo3.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the cork status for DSET_BT1 */
     if (H5C__verify_cork_tag_test(fid, oinfo.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Un-cork the dataset: DSET_CONTIG */
     if (H5Oenable_mdc_flushes(did3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the cork status for DSET_CONTIG */
     if (H5C__verify_cork_tag_test(fid, oinfo3.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Dclose(did3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDfree(buf);
     HDfree(buf_data);
@@ -323,149 +323,149 @@ verify_obj_dset_cork(hbool_t swmr)
 
     /* Create fapl */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Set to use latest format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the file with/without SWMR access */
     flags = H5F_ACC_TRUNC;
     if (swmr)
         flags |= H5F_ACC_SWMR_WRITE;
     if ((fid = H5Fcreate(FILENAME, flags, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace */
     if ((sid = H5Screate(H5S_SCALAR)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataset: DSET */
     if ((did = H5Dcreate2(fid, DSET, H5T_NATIVE_UCHAR, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get dataset object header address */
     if (H5Oget_info3(did, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the dataset: DSET */
     if (H5C__verify_cork_tag_test(fid, oinfo.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset: DSET */
     if (H5Odisable_mdc_flushes(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attach and write to an attribute to the dataset: DSET */
     if ((aid = H5Acreate2(did, ATTR, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the dataset: DSET */
     if (H5C__verify_cork_tag_test(fid, oinfo.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the attribute */
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the dataset: DSET */
     if (H5C__verify_cork_tag_test(fid, oinfo.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dcpl */
     if ((dcpl2 = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Set to early allocation for dataset space */
     if (H5Pset_alloc_time(dcpl2, H5D_ALLOC_TIME_EARLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create chunked dataset with implicit indexing: DSET_NONE */
     if (H5Pset_chunk(dcpl2, 1, chunk_dim) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sid2 = H5Screate_simple(1, dim, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did2 = H5Dcreate2(fid, DSET_NONE, H5T_NATIVE_INT, sid2, H5P_DEFAULT, dcpl2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get dataset object header address */
     if (H5Oget_info3(did2, &oinfo2, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset: DSET_NONE */
     if (H5Odisable_mdc_flushes(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attach 8 attributes to the dataset */
     for (i = 0; i < 8; i++) {
         HDsprintf(attrname, "attr %d", i);
         if ((aid = H5Acreate2(did2, attrname, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Awrite(aid, H5T_NATIVE_INT, &i) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Aclose(aid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Verify cork status of the dataset: DSET_NONE */
     if (H5C__verify_cork_tag_test(fid, oinfo2.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Oclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     flags = H5F_ACC_RDWR;
     if (swmr)
         flags |= H5F_ACC_SWMR_WRITE;
     if ((fid = H5Fopen(FILENAME, flags, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the dataset object: DSET_NONE */
     if ((oid = H5Oopen(fid, DSET_NONE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the dataset: DSET */
     if (H5C__verify_cork_tag_test(fid, oinfo2.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the attribute attached to the dataset object: DSET_NONE */
     if ((aid = H5Aopen_by_idx(oid, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)4, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset: DSET_NONE */
     if (H5Odisable_mdc_flushes(oid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the dataset: DSET_NONE */
     if (H5C__verify_cork_tag_test(fid, oinfo2.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the attribute */
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the dataset: DSET */
     if (H5C__verify_cork_tag_test(fid, oinfo.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Oclose(oid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -539,11 +539,11 @@ verify_dset_cork(hbool_t swmr, hbool_t new_format)
 
     /* Create fapl */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (new_format) {
         /* Set to use latest format */
         if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Create the file */
@@ -551,106 +551,106 @@ verify_dset_cork(hbool_t swmr, hbool_t new_format)
     if (swmr)
         flags |= H5F_ACC_SWMR_WRITE;
     if ((fid = H5Fcreate(FILENAME, flags, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dcpl */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to use chunked dataset */
     if (H5Pset_chunk(dcpl, 2, chunk_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create chunked dataset with extensive array indexing: DSET_EA */
     if ((sid = H5Screate_simple(2, dims, max_dims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did = H5Dcreate2(fid, DSET_EA, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get dataset object header address: DSET_EA */
     if (H5Oget_info3(did, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset: DSET_EA */
     if (H5Odisable_mdc_flushes(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status */
     if (H5C__verify_cork_tag_test(fid, oinfo.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create chunked dataset with fixed array indexing: DSET_FA */
     if ((sid2 = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did2 = H5Dcreate2(fid, DSET_FA, H5T_NATIVE_INT, sid2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get dataset object header address: DSET_FA */
     if (H5Oget_info3(did2, &oinfo2, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset: DSET_FA */
     if (H5Odisable_mdc_flushes(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Uncork the dataset: DSET_EA */
     if (H5Oenable_mdc_flushes(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the cork status for DSET_FA */
     if (H5C__verify_cork_tag_test(fid, oinfo2.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the cork status for DSET_EA */
     if (H5C__verify_cork_tag_test(fid, oinfo.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create chunked dataset with v2-Btree indexing */
     max_dims[0] = H5S_UNLIMITED;
     if ((sid3 = H5Screate_simple(2, dims, max_dims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did3 = H5Dcreate2(fid, DSET_BT2, H5T_NATIVE_INT, sid3, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get dataset object header address: DSET_BT2 */
     if (H5Oget_info3(did3, &oinfo3, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset: DSET_BT2 */
     if (H5Odisable_mdc_flushes(did3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the cork status for DSET_BT2 */
     if (H5C__verify_cork_tag_test(fid, oinfo3.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Dclose(did3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reopen the file */
     flags = H5F_ACC_RDWR;
     if (swmr)
         flags |= H5F_ACC_SWMR_WRITE;
     if ((fid = H5Fopen(FILENAME, flags, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set up data array */
     if (NULL == (buf_data = (int *)HDcalloc(100 * 20, sizeof(int))))
@@ -667,57 +667,57 @@ verify_dset_cork(hbool_t swmr, hbool_t new_format)
 
     /* Open and write to the dataset: DSET_EA */
     if ((did = H5Dopen2(fid, DSET_EA, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the cork status for DSET_EA */
     if (H5C__verify_cork_tag_test(fid, oinfo.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open and write to the dataset: DSET_FA */
     if ((did2 = H5Dopen2(fid, DSET_FA, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did2, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset: DSET_FA */
     if (H5Odisable_mdc_flushes(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the cork status for DSET_FA */
     if (H5C__verify_cork_tag_test(fid, oinfo2.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open and write to the dataset: DSET_BT2 */
     if ((did3 = H5Dopen2(fid, DSET_BT2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did3, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the cork status for DSET_BT2 */
     if (H5C__verify_cork_tag_test(fid, oinfo3.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset: DSET_BT2 */
     if (H5Odisable_mdc_flushes(did3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the cork status for DSET_BT2 */
     if (H5C__verify_cork_tag_test(fid, oinfo3.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDfree(buf);
     HDfree(buf_data);
@@ -783,120 +783,120 @@ verify_group_cork(hbool_t swmr)
 
     /* Create fapl */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Set to use latest format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the file */
     flags = H5F_ACC_TRUNC;
     if (swmr)
         flags |= H5F_ACC_SWMR_WRITE;
     if ((fid = H5Fcreate(FILENAME, flags, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create 3 groups */
     if ((gid = H5Gcreate2(fid, GRP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid2 = H5Gcreate2(gid, GRP2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid3 = H5Gcreate2(gid2, GRP3, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the second group: GRP2 */
     if (H5Odisable_mdc_flushes(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get group object header addresses */
     if (H5Oget_info3(gid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(gid2, &oinfo2, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(gid3, &oinfo3, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the groups */
     if (H5C__verify_cork_tag_test(fid, oinfo.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5C__verify_cork_tag_test(fid, oinfo2.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5C__verify_cork_tag_test(fid, oinfo3.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the second group: GRP2 */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the second group: GRP2 */
     if ((gid2 = H5Gopen2(gid, GRP2, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify cork status of the second group: GRP2 */
     if (H5C__verify_cork_tag_test(fid, oinfo2.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file and the three groups */
     flags = H5F_ACC_RDWR;
     if (swmr)
         flags |= H5F_ACC_SWMR_WRITE;
     if ((fid = H5Fopen(FILENAME, flags, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((gid = H5Gopen2(fid, GRP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((gid2 = H5Gopen2(gid, GRP2, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((gid3 = H5Gopen2(gid2, GRP3, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataspace */
     if ((sid = H5Screate(H5S_SCALAR)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attach 8 attributes to the third group: GRP3 */
     for (i = 0; i < 8; i++) {
         HDsprintf(attrname, "attr %d", i);
         if ((aid = H5Acreate2(gid3, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Awrite(aid, H5T_NATIVE_UINT, &i) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         /* Cork the third group while attaching attributes */
         if (i == 3) {
             if (H5Odisable_mdc_flushes(gid3) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5C__verify_cork_tag_test(fid, oinfo3.token, TRUE) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         }
         if (H5Aclose(aid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Verify cork status of the third group: GRP3 */
     if (H5C__verify_cork_tag_test(fid, oinfo3.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -954,222 +954,222 @@ verify_named_cork(hbool_t swmr)
 
     /* Create fapl */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Set to use latest format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the file */
     flags = H5F_ACC_TRUNC;
     if (swmr)
         flags |= H5F_ACC_SWMR_WRITE;
     if ((fid = H5Fcreate(FILENAME, flags, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create 3 copies of datatypes */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid2 = H5Tcopy(H5T_NATIVE_LONG)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid3 = H5Tcopy(H5T_NATIVE_CHAR)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Commit datatype /DT */
     if (H5Tcommit2(fid, DT, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create /GRP */
     if ((gid = H5Gcreate2(fid, GRP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Commit datatype /GRP/DT2 */
     if (H5Tcommit2(gid, DT2, tid2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create /GRP/GRP2 */
     if ((gid2 = H5Gcreate2(gid, GRP2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Commit datatype /GRP/GRP2/DT3 */
     if (H5Tcommit2(gid2, DT3, tid3, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork 2 named datatypes: /DT and /GRP/GRP2/DT3 */
     if (H5Odisable_mdc_flushes(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Odisable_mdc_flushes(tid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get named datatype object header addresses */
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid2, &oinfo2, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid3, &oinfo3, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the named datatypes */
     if (H5C__verify_cork_tag_test(fid, oinfo.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5C__verify_cork_tag_test(fid, oinfo2.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5C__verify_cork_tag_test(fid, oinfo3.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the datatypes */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the named datatypes */
     if ((tid = H5Topen2(fid, DT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((tid2 = H5Topen2(gid, DT2, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((tid3 = H5Topen2(gid2, DT3, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify cork status of the named datatypes */
     if (H5C__verify_cork_tag_test(fid, oinfo.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5C__verify_cork_tag_test(fid, oinfo2.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5C__verify_cork_tag_test(fid, oinfo3.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file and the three groups */
     flags = H5F_ACC_RDWR;
     if (swmr)
         flags |= H5F_ACC_SWMR_WRITE;
     if ((fid = H5Fopen(FILENAME, flags, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((gid = H5Gopen2(fid, GRP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((gid2 = H5Gopen2(gid, GRP2, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the named datatypes */
     if ((tid = H5Topen2(fid, DT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((tid2 = H5Topen2(gid, DT2, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((tid3 = H5Topen2(gid2, DT3, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Cork the datatype: DT2 */
     if (H5Odisable_mdc_flushes(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace */
     if ((sid = H5Screate(H5S_SCALAR)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attach 8 attributes to datatype: DT3 */
     for (i = 0; i < 8; i++) {
         HDsprintf(attrname, "attr %d", i);
         if ((aid = H5Acreate2(tid3, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Awrite(aid, H5T_NATIVE_UINT, &i) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         /* Cork the datatype while attaching attributes */
         if (i == 3) {
             if (H5Odisable_mdc_flushes(tid3) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5C__verify_cork_tag_test(fid, oinfo3.token, TRUE) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         }
         if (H5Aclose(aid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Create a dataset with named datatype: DT */
     if ((did = H5Dcreate2(fid, DSET, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get dataset object header address */
     if (H5Oget_info3(did, &oinfo4, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset: DSET */
     if (H5Odisable_mdc_flushes(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the datatype: DT */
     if (H5C__verify_cork_tag_test(fid, oinfo.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Verify cork status of the datatype: DT2 */
     if (H5C__verify_cork_tag_test(fid, oinfo2.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Verify cork status of the datatype: DT3 */
     if (H5C__verify_cork_tag_test(fid, oinfo3.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Un-cork the datatype: DT3 */
     if (H5Oenable_mdc_flushes(tid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Verify cork status of the datatype: DT3 */
     if (H5C__verify_cork_tag_test(fid, oinfo3.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the datatype: DT */
     if (H5Odisable_mdc_flushes(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the datatype: DT */
     if (H5C__verify_cork_tag_test(fid, oinfo.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Verify cork status of the datatype: DT2 */
     if (H5C__verify_cork_tag_test(fid, oinfo2.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the dataset: DSET */
     if (H5C__verify_cork_tag_test(fid, oinfo4.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the datatype: DT */
     if (H5C__verify_cork_tag_test(fid, oinfo.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the dataset: DSET */
     if (H5C__verify_cork_tag_test(fid, oinfo4.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -1234,244 +1234,244 @@ verify_multiple_cork(hbool_t swmr)
 
     /* Create fapl */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Set to use latest format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the file */
     flags = H5F_ACC_TRUNC;
     if (swmr)
         flags |= H5F_ACC_SWMR_WRITE;
     if ((fid1 = H5Fcreate(FILENAME, flags, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open root group */
     if ((gid1 = H5Gopen2(fid1, "/", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create and commit datatype */
     if ((tid1 = H5Tcopy(H5T_STD_I32LE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(fid1, DT, tid1, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataset */
     if ((sid = H5Screate_simple(1, dim, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did1 = H5Dcreate2(fid1, DSET, tid1, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create attribute on root group */
     if ((aidg1 = H5Acreate2(gid1, GRP_ATTR, tid1, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create attribute on dataset */
     if ((aidd1 = H5Acreate2(did1, DSET_ATTR, tid1, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create attribute on datatype */
     if ((aidt1 = H5Acreate2(tid1, DT_ATTR, tid1, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Aclose(aidt1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aidd1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aidg1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the file twice: fid1, fid2 */
     flags = H5F_ACC_RDWR;
     if (swmr)
         flags |= H5F_ACC_SWMR_WRITE;
     if ((fid1 = H5Fopen(FILENAME, flags, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fopen(FILENAME, flags, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the root group twice: gid1, gid2 */
     if ((gid1 = H5Gopen2(fid1, "/", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid2 = H5Gopen2(fid2, "/", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the root group attribute twice: aidg1, aidg2 */
     if ((aidg1 = H5Aopen(gid1, GRP_ATTR, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((aidg2 = H5Aopen(gid2, GRP_ATTR, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the group: gid2 */
     if (H5Odisable_mdc_flushes(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the group: gid2 */
     if (H5Oget_info3(gid2, &oinfo1, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5C__verify_cork_tag_test(fid2, oinfo1.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the group: gid1 */
     if (H5Oare_mdc_flushes_disabled(gid1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the dataset twice: did1, did2 */
     if ((did1 = H5Dopen2(fid1, DSET, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did2 = H5Dopen2(fid2, DSET, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the dataset attribute twice: aidd1, aidd2 */
     if ((aidd1 = H5Aopen(did1, DSET_ATTR, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((aidd2 = H5Aopen(did2, DSET_ATTR, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset: did1 */
     if (H5Odisable_mdc_flushes(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the dataset: did1 */
     if (H5Oget_info3(did1, &oinfo2, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5C__verify_cork_tag_test(fid1, oinfo2.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the dataset: did2 */
     if (H5Oare_mdc_flushes_disabled(did2, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the datatype twice: tid1, tid2 */
     if ((tid1 = H5Topen2(fid1, DT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid2 = H5Topen2(fid2, DT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the datatype attribute twice: aidt1, aidt2 */
     if ((aidt1 = H5Aopen(tid1, DT_ATTR, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((aidt2 = H5Aopen(tid2, DT_ATTR, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the datatype: tid2 */
     if (H5Odisable_mdc_flushes(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the datatype: tid2 */
     if (H5Oget_info3(tid2, &oinfo3, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5C__verify_cork_tag_test(fid2, oinfo3.token, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the datatype: tid1 */
     if (H5Oare_mdc_flushes_disabled(tid1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Uncork the group: gid1 */
     if (H5Oenable_mdc_flushes(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the group: gid1 */
     if (H5Oget_info3(gid1, &oinfo1, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5C__verify_cork_tag_test(fid1, oinfo1.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the group: gid2 */
     if (H5Oare_mdc_flushes_disabled(gid2, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group: gid2 */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the group: gid1 */
     if (H5Oare_mdc_flushes_disabled(gid1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the group: gid1 */
     if (H5C__verify_cork_tag_test(fid1, oinfo1.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group: gid1 */
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Uncork the dataset: gid2 */
     if (H5Oenable_mdc_flushes(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the dataset: did2 */
     if (H5Oget_info3(did2, &oinfo2, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5C__verify_cork_tag_test(fid2, oinfo2.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the dataset: did1 */
     if (H5Oare_mdc_flushes_disabled(did1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset: did2 */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the dataset: did1 */
     if (H5Oare_mdc_flushes_disabled(did1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify cork status of the dataset: did1 */
     if (H5C__verify_cork_tag_test(fid1, oinfo2.token, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset: did1 */
     if (H5Dclose(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the datatype: tid1 */
     if (H5Oare_mdc_flushes_disabled(tid1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close datatype: tid1 */
     if (H5Tclose(tid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the datatype: tid2 */
     if (H5Oare_mdc_flushes_disabled(tid2, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close datatype: tid2 */
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should fail to cork the attribute: aidg2; not an object */
     H5E_BEGIN_TRY
@@ -1480,7 +1480,7 @@ verify_multiple_cork(hbool_t swmr)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should fail to uncork the attribute: aidd1; not an object */
     H5E_BEGIN_TRY
@@ -1489,7 +1489,7 @@ verify_multiple_cork(hbool_t swmr)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should fail to check cork status of the attribute: aidt2; not an object */
     H5E_BEGIN_TRY
@@ -1498,21 +1498,21 @@ verify_multiple_cork(hbool_t swmr)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close all attributes */
     if (H5Aclose(aidg1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aidg2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aidd1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aidd2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aidt1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aidt2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should fail to cork the file: fid1; not an object */
     H5E_BEGIN_TRY
@@ -1522,7 +1522,7 @@ verify_multiple_cork(hbool_t swmr)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should fail to uncork the file: fid2; not an object */
     H5E_BEGIN_TRY
@@ -1531,15 +1531,15 @@ verify_multiple_cork(hbool_t swmr)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Pclose(fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -1619,12 +1619,12 @@ test_objs_cork(hbool_t swmr, hbool_t new_format)
 
     /* Create fapl */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set to use latest format */
     if (new_format) {
         if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Create the file with/without SWMR access */
@@ -1632,35 +1632,35 @@ test_objs_cork(hbool_t swmr, hbool_t new_format)
     if (swmr)
         flags |= H5F_ACC_SWMR_WRITE;
     if ((fid = H5Fcreate(FILENAME, flags, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group */
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the group: not corked */
     if (H5Oare_mdc_flushes_disabled(gid, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the group: an object */
     if (H5Odisable_mdc_flushes(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the group: corked */
     if (H5Oare_mdc_flushes_disabled(gid, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a transient copy of a native type */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should fail to cork the datatype: not an object */
     H5E_BEGIN_TRY
@@ -1669,37 +1669,37 @@ test_objs_cork(hbool_t swmr, hbool_t new_format)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a named datatype */
     if (H5Tcommit2(fid, "group/datatype", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the named datatype: not corked */
     if (H5Oare_mdc_flushes_disabled(tid, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the named datatype: an object */
     if (H5Odisable_mdc_flushes(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the named datatype: corked */
     if (H5Oare_mdc_flushes_disabled(tid, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the named datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace */
     dims[0] = DIM0;
     dims[1] = DIM1;
     if ((sid = H5Screate_simple(RANK, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should fail to uncork the dataspace: not an object */
     H5E_BEGIN_TRY
@@ -1708,15 +1708,15 @@ test_objs_cork(hbool_t swmr, hbool_t new_format)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataset. */
     if ((did = H5Dcreate2(fid, "dataset", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create attribute on the dataset */
     if ((aid = H5Acreate2(did, "attr", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should fail to check cork status of the attribute: not an object */
     H5E_BEGIN_TRY
@@ -1725,41 +1725,41 @@ test_objs_cork(hbool_t swmr, hbool_t new_format)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the dataset: not corked */
     if (H5Oare_mdc_flushes_disabled(did, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset: an object */
     if (H5Odisable_mdc_flushes(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the dataset: corked */
     if (H5Oare_mdc_flushes_disabled(did, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset and dataspace */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group */
     if ((gid = H5Oopen(fid, "group", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the group */
     if (H5Oare_mdc_flushes_disabled(gid, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the group */
     if (H5Odisable_mdc_flushes(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should fail to cork the group again */
     H5E_BEGIN_TRY
@@ -1768,23 +1768,23 @@ test_objs_cork(hbool_t swmr, hbool_t new_format)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the group */
     if (H5Oare_mdc_flushes_disabled(gid, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the named datatype */
     if ((tid = H5Oopen(fid, "group/datatype", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the named datatype */
     if (H5Oare_mdc_flushes_disabled(tid, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should fail to un-cork the named datatype that is not corked yet */
     H5E_BEGIN_TRY
@@ -1793,63 +1793,63 @@ test_objs_cork(hbool_t swmr, hbool_t new_format)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the named datatype */
     if (H5Odisable_mdc_flushes(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the named datatype */
     if (H5Oare_mdc_flushes_disabled(tid, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the dataset */
     if ((did = H5Oopen(fid, "/dataset", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the dataset */
     if (H5Oare_mdc_flushes_disabled(did, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset */
     if (H5Odisable_mdc_flushes(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of dataset */
     if (H5Oare_mdc_flushes_disabled(did, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Un-cork the dataset */
     if (H5Oenable_mdc_flushes(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the dataset */
     if (H5Oare_mdc_flushes_disabled(did, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -1927,12 +1927,12 @@ test_dset_cork(hbool_t swmr, hbool_t new_format)
 
     /* Create fapl */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set to use latest format */
     if (new_format) {
         if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Create the file with/without SWMR access */
@@ -1940,65 +1940,65 @@ test_dset_cork(hbool_t swmr, hbool_t new_format)
     if (swmr)
         flags |= H5F_ACC_SWMR_WRITE;
     if ((fid = H5Fcreate(FILENAME, flags, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group */
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Commit the datatype with the group */
     if ((tid1 = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(gid, "datatype", tid1, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the named datatype */
     if (H5Odisable_mdc_flushes(tid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set up dataset creation property list */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Enable chunking */
     if (H5Pset_chunk(dcpl, RANK, cdims) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set up a fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fillval) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace */
     dims[0] = DIMS0;
     dims[1] = DIMS1;
     if ((sid = H5Screate_simple(RANK, dims, maxdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the dataset inside the group with the named datatype */
     if ((did1 = H5Dcreate2(gid, "dataset", tid1, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the named datatype */
     if (H5Oare_mdc_flushes_disabled(tid1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset */
     if (H5Odisable_mdc_flushes(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the dataset */
     if (H5Oare_mdc_flushes_disabled(did1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the group */
     if (H5Oare_mdc_flushes_disabled(gid, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set up data array */
     if (NULL == (wbuf_data = (int *)HDcalloc(DIMS0 * DIMS1, sizeof(int))))
@@ -2015,37 +2015,37 @@ test_dset_cork(hbool_t swmr, hbool_t new_format)
 
     /* Write to the dataset */
     if (H5Dwrite(did1, tid1, sid, sid, H5P_DEFAULT, wbuf_data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Flush the dataset */
     if (H5Oflush(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the dataset */
     if (H5Oare_mdc_flushes_disabled(did1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the named datatype */
     if (H5Oare_mdc_flushes_disabled(tid1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the dataset again */
     if ((did1 = H5Dopen2(gid, "dataset", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of dataset */
     if (H5Oare_mdc_flushes_disabled(did1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set up data array */
     if (NULL == (rbuf_data = (int *)HDcalloc(DIMS0 * DIMS1, sizeof(int))))
@@ -2053,147 +2053,147 @@ test_dset_cork(hbool_t swmr, hbool_t new_format)
 
     /* Read from the dataset */
     if (H5Dread(did1, tid1, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf_data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset */
     if (H5Odisable_mdc_flushes(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete the dataset */
     if (H5Ldelete(gid, "dataset", H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the dataset */
     if (H5Oare_mdc_flushes_disabled(did1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Oclose(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the dataset again */
     if ((did1 = H5Dcreate2(gid, "dataset", tid1, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the dataset */
     if (H5Odisable_mdc_flushes(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Write to the dataset */
     if (H5Dwrite(did1, tid1, sid, sid, H5P_DEFAULT, wbuf_data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Refresh the dataset */
     if (H5Drefresh(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the dataset */
     if (H5Oare_mdc_flushes_disabled(did1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* First open of the dataset */
     if ((did1 = H5Dopen2(gid, "dataset", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Second open of the dataset */
     if ((did2 = H5Dopen2(gid, "dataset", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cork the first opened dataset */
     if (H5Odisable_mdc_flushes(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the first opened dataset */
     if (H5Oare_mdc_flushes_disabled(did1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the second opened dataset */
     if (H5Oare_mdc_flushes_disabled(did2, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the second opened dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the first opened dataset */
     if (H5Oare_mdc_flushes_disabled(did1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the first opened dastaset */
     if (H5Dclose(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the named datatype */
     if (H5Oare_mdc_flushes_disabled(tid1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Second open of the named datatype */
     if ((tid2 = H5Topen2(gid, "datatype", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the second opened named datatype */
     if (H5Oare_mdc_flushes_disabled(tid2, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Uncork the second opened named datatype */
     if (H5Oenable_mdc_flushes(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the second opened named datatype */
     if (H5Oare_mdc_flushes_disabled(tid2, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the first opened named datatype */
     if (H5Oare_mdc_flushes_disabled(tid1, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the first opened datatype */
     if (H5Tclose(tid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the second opened datatype */
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check cork status of the group */
     if (H5Oare_mdc_flushes_disabled(gid, &corked) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (corked)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDfree(wbuf);
     HDfree(wbuf_data);

--- a/test/cross_read.c
+++ b/test/cross_read.c
@@ -111,7 +111,7 @@ check_data_i(const char *dsetname, hid_t fid)
 
     /* Close/release resources. */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Failure */
     if (nerrors) {
@@ -185,7 +185,7 @@ check_data_f(const char *dsetname, hid_t fid)
 
     /* Close/release resources. */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Failure */
     if (nerrors) {
@@ -327,7 +327,7 @@ check_file(char *filename)
     nerrors += check_data_f(DATASETNAME23, fid);
 
     if (H5Fclose(fid))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     return nerrors;
 
 error:

--- a/test/dangle.c
+++ b/test/dangle.c
@@ -170,7 +170,7 @@ test_dangle_group(H5F_close_degree_t degree)
         TEST_ERROR;
 
     if ((gid = H5Gcreate2(fid, GROUPNAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Gclose(gid) < 0)
         TEST_ERROR;
@@ -182,15 +182,15 @@ test_dangle_group(H5F_close_degree_t degree)
     }
     H5E_END_TRY;
     if (gid >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Leave open a _lot_ of objects */
     for (u = 0; u < MAX_DANGLE; u++)
         if ((gid = H5Gopen2(fid, GROUPNAME, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
     if ((gid = H5Gopen2(fid, GROUPNAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (degree == H5F_CLOSE_SEMI) {
         H5E_BEGIN_TRY
@@ -288,7 +288,7 @@ test_dangle_datatype1(H5F_close_degree_t degree)
     /* Leave open a _lot_ of objects */
     for (u = 0; u < MAX_DANGLE; u++)
         if ((tid = H5Topen2(fid, TYPENAME, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
     if (degree == H5F_CLOSE_SEMI) {
         H5E_BEGIN_TRY
@@ -481,10 +481,10 @@ test_dangle_attribute(H5F_close_degree_t degree)
     /* Leave open a _lot_ of objects */
     for (u = 0; u < MAX_DANGLE; u++)
         if ((aid = H5Aopen(dsid, ATTRNAME, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     if (H5Dclose(dsid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (degree == H5F_CLOSE_SEMI) {
         H5E_BEGIN_TRY
@@ -548,63 +548,63 @@ test_dangle_force(void)
 
     h5_fixname(FILENAME[0], H5P_DEFAULT, filename, sizeof filename);
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataspace for the dataset & attribute to use */
     if ((sid = H5Screate(H5S_SCALAR)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataset */
     if ((dsid = H5Dcreate2(fid, DSETNAME, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the dataset */
     if ((dsid2 = H5Dopen2(fid, DSETNAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create an attribute on the dataset */
     if ((aid = H5Acreate2(dsid, ATTRNAME, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the attribute */
     if ((aid2 = H5Aopen(dsid, ATTRNAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataspace ID */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open a group ID */
     if ((gid = H5Gopen2(fid, "/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open group again */
     if ((gid2 = H5Gopen2(fid, "/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a named datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tcommit2(fid, TYPENAME, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the named datatype */
     if ((tid2 = H5Topen2(fid, TYPENAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Increment the ref count on all the "second" objects */
     if (H5Iinc_ref(dsid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Iinc_ref(aid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Iinc_ref(gid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Iinc_ref(aid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the number of open objects */
     if ((count = H5Fget_obj_count((hid_t)H5F_OBJ_ALL, H5F_OBJ_ALL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (0 == count)
         TEST_ERROR;
 
@@ -614,7 +614,7 @@ test_dangle_force(void)
 
     /* Get the list of open IDs */
     if (H5Fget_obj_ids((hid_t)H5F_OBJ_ALL, H5F_OBJ_ALL, (size_t)count, objs) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close all open IDs */
     for (u = 0; u < (size_t)count; u++)
@@ -623,7 +623,7 @@ test_dangle_force(void)
 
     /* Get the number of open objects */
     if ((count = H5Fget_obj_count((hid_t)H5F_OBJ_ALL, H5F_OBJ_ALL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (0 != count)
         TEST_ERROR;
 

--- a/test/del_many_dense_attrs.c
+++ b/test/del_many_dense_attrs.c
@@ -75,46 +75,46 @@ main(void)
 
     /* To exit from the file for SIGABRT signal */
     if (HDsignal(SIGABRT, catch_signal) == SIG_ERR)
-        TEST_ERROR
+        TEST_ERROR;
 
     fapl = h5_fileaccess();
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
     /* Set to latest format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the file  */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the group creation property list */
     if ((gcpl = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set to use dense storage for all attributes on the group */
     if (H5Pset_attr_phase_change(gcpl, 0, 0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the group in the file */
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, gcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace */
     if ((sid = H5Screate(H5S_SCALAR)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a copy of the datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_FLOAT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create attributes in the group */
     for (i = ATTR_COUNT; i >= 0; i--) {
@@ -123,44 +123,44 @@ main(void)
 
         /* Create the attribute */
         if ((aid = H5Acreate2(gid, aname, tid, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Write to the attribute */
         if (H5Awrite(aid, tid, &i) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the attribute */
         if (H5Aclose(aid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* Close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group creation property list */
     if (H5Pclose(gcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group */
     if ((gid = H5Gopen2(fid, "group", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete the attributes */
     for (i = 0; i <= ATTR_COUNT; i++) {
@@ -169,16 +169,16 @@ main(void)
 
         /* Delete the attribute */
         if (H5Adelete(gid, aname) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Close the group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     h5_cleanup(FILENAME, fapl);
 

--- a/test/direct_chunk.c
+++ b/test/direct_chunk.c
@@ -412,19 +412,19 @@ test_direct_chunk_overwrite_data(hid_t fid)
 
     /* Create the dataset's data space */
     if ((sid = H5Screate_simple(OVERWRITE_NDIMS, dset_dims, dset_max_dims)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set chunk size and filll value */
     if ((dcpl_id = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_fill_value(dcpl_id, tid, &fill_value) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl_id, OVERWRITE_NDIMS, chunk_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataset */
     if ((did = H5Dcreate2(fid, DATASETNAME7, tid, sid, H5P_DEFAULT, dcpl_id, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize data buffers */
     n = 0;
@@ -437,35 +437,35 @@ test_direct_chunk_overwrite_data(hid_t fid)
 
     /* Write chunk data using the direct write function. */
     if (H5Dwrite_chunk(did, H5P_DEFAULT, filter_mask, offset, buf_size, data_buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write second chunk. */
     offset[2] = OVERWRITE_CHUNK_NX;
     if (H5Dwrite_chunk(did, H5P_DEFAULT, filter_mask, offset, buf_size, data_buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Overwrite first chunk. */
     offset[2] = 0;
     if (H5Dwrite_chunk(did, H5P_DEFAULT, filter_mask, offset, buf_size, overwrite_buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read the data back out */
     if (H5Dread(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ensure that the data are correct in chunk 1 */
     for (i = 0; i < OVERWRITE_CHUNK_NY; i++)
         for (j = 0; j < OVERWRITE_CHUNK_NX; j++) {
             if (read_buf[i][j] != OVERWRITE_VALUE)
-                TEST_ERROR
+                TEST_ERROR;
         }
 
     if (H5Pclose(dcpl_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -2040,7 +2040,7 @@ test_read_unallocated_chunk(hid_t file)
 
             /* Check that the chunk read call does not succeed. */
             if (status != -1)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Query the size of the non-existent chunk */
             direct_chunk_nbytes = ULONG_MAX;
@@ -2052,9 +2052,9 @@ test_read_unallocated_chunk(hid_t file)
 
             /* Check that the chunk storage size call does not succeed. */
             if (status != -1)
-                TEST_ERROR
+                TEST_ERROR;
             if (direct_chunk_nbytes != ULONG_MAX)
-                TEST_ERROR
+                TEST_ERROR;
         }
     }
 
@@ -2204,7 +2204,7 @@ test_single_chunk(unsigned config)
 
         /* Verify returned filter mask */
         if (filters != 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else
         /* Read the data */
@@ -2215,7 +2215,7 @@ test_single_chunk(unsigned config)
     for (i = 0; i < DIM0; i++)
         for (j = 0; j < DIM1; j++)
             if (rdata[i][j] != wdata[i][j])
-                TEST_ERROR
+                TEST_ERROR;
 
     /*
      * Close and release resources

--- a/test/dsets.c
+++ b/test/dsets.c
@@ -586,7 +586,7 @@ test_simple_io(const char *env_h5_drvr, hid_t fapl)
                                   H5P_DEFAULT)) < 0)
             goto error;
         if (H5Sclose(space) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         space = -1;
 
         /* Test dataset address.  Should be undefined. */
@@ -665,16 +665,16 @@ test_simple_io(const char *env_h5_drvr, hid_t fapl)
 error:
     if (space > 0)
         if (H5Sclose(space) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if (xfer > 0)
         if (H5Pclose(xfer) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if (dataset > 0)
         if (H5Dclose(dataset) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if (file > 0)
         if (H5Fclose(file) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if (f > 0)
         HDclose(f);
 
@@ -732,7 +732,7 @@ test_userblock_offset(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
             goto error;
         if (H5Pclose(fcpl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         fcpl = -1;
 
         /* Create the data space */
@@ -746,7 +746,7 @@ test_userblock_offset(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
                                   H5P_DEFAULT, H5P_DEFAULT)) < 0)
             goto error;
         if (H5Sclose(space) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         space = -1;
 
         /* Write the data to the dataset */
@@ -801,16 +801,16 @@ test_userblock_offset(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
 error:
     if (space > 0)
         if (H5Sclose(space) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if (fcpl > 0)
         if (H5Pclose(fcpl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if (dataset > 0)
         if (H5Dclose(dataset) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if (file > 0)
         if (H5Fclose(file) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if (f > 0)
         HDclose(f);
 
@@ -862,52 +862,52 @@ test_compact_io(hid_t fapl)
     dims[0] = 16;
     dims[1] = 8;
     if ((space = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a file */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create property list for compact dataset creation */
     if ((plist = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_layout(plist, H5D_COMPACT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_alloc_time(plist, H5D_ALLOC_TIME_EARLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create and write to a compact dataset */
     if ((dataset = H5Dcreate2(file, DSET_COMPACT_IO_NAME, H5T_NATIVE_INT, space, H5P_DEFAULT, plist,
                               H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test dataset address.  Should be undefined. */
     if (H5Dget_offset(dataset) != HADDR_UNDEF)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, wbuf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test dataset address.  Should be undefined. */
     if (H5Dget_offset(dataset) != HADDR_UNDEF)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Open the file and check data
      */
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dataset = H5Dopen2(file, DSET_COMPACT_IO_NAME, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the values read are the same as the values written */
     for (i = 0; i < 16; i++)
@@ -922,9 +922,9 @@ test_compact_io(hid_t fapl)
             } /* end  */
 
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /**************************************
      * Additional test for version bounds *
@@ -932,7 +932,7 @@ test_compact_io(hid_t fapl)
 
     /* Create a copy of file access property list */
     if ((new_fapl = h5_fileaccess()) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop through all the combinations of low/high library format bounds,
        skipping invalid combinations.
@@ -954,26 +954,26 @@ test_compact_io(hid_t fapl)
             /* Create a file */
             h5_fixname(FILENAME[25], new_fapl, filename, sizeof filename);
             if ((verfile = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, new_fapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create the compact dataset */
             dataset = H5Dcreate2(verfile, DSET_DEFAULT_NAME, H5T_NATIVE_INT, space, H5P_DEFAULT, plist,
                                  H5P_DEFAULT);
             if (dataset < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Write the same data as of DSET_COMPACT_IO_NAME */
             if (H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, wbuf) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close DSET_DEFAULT_NAME, then reopen it to read and verify
                the data */
             if (H5Dclose(dataset) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if ((dataset = H5Dopen2(verfile, DSET_DEFAULT_NAME, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check that the values read are the same as the values written */
             for (i = 0; i < 16; i++)
@@ -989,11 +989,11 @@ test_compact_io(hid_t fapl)
 
             /* Get the internal file pointer */
             if ((fp = (H5F_t *)H5VL_object(verfile)) == NULL)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Get the internal dataset pointer */
             if ((dsetp = (H5D_t *)H5VL_object(dataset)) == NULL)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Verify the dataset's layout and fill message versions */
             if (fp->shared->low_bound == H5F_LIBVER_EARLIEST) {
@@ -1009,23 +1009,23 @@ test_compact_io(hid_t fapl)
 
             /* Close the dataset and delete from the file */
             if (H5Dclose(dataset) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Ldelete(verfile, DSET_DEFAULT_NAME, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close the file */
             if (H5Fclose(verfile) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
         } /* end for high */
     }     /* end for low */
 
     if (H5Pclose(new_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(space) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -1077,9 +1077,9 @@ test_max_compact(hid_t fapl)
     compact_size = (SIXTY_FOUR_KB - 64) / sizeof(int);
 
     if (NULL == (wbuf = (int *)HDmalloc(sizeof(int) * compact_size)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (rbuf = (int *)HDmalloc(sizeof(int) * compact_size)))
-        TEST_ERROR
+        TEST_ERROR;
 
     n = 0;
     for (u = 0; u < compact_size; u++)
@@ -1088,46 +1088,46 @@ test_max_compact(hid_t fapl)
     /* Create a small data space for compact dataset */
     dims[0] = (hsize_t)compact_size;
     if ((space = H5Screate_simple(1, dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a file */
     h5_fixname(FILENAME[3], fapl, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create property list for compact dataset creation */
     if ((plist = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_layout(plist, H5D_COMPACT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create and write to a compact dataset */
     if ((dataset = H5Dcreate2(file, DSET_COMPACT_MAX_NAME, H5T_NATIVE_INT, space, H5P_DEFAULT, plist,
                               H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, wbuf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(plist) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Open the file and check data
      */
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dataset = H5Dopen2(file, DSET_COMPACT_MAX_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that the values read are the same as the values written */
     for (u = 0; u < compact_size; u++)
@@ -1139,9 +1139,9 @@ test_max_compact(hid_t fapl)
         } /* end if */
 
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDfree(wbuf);
     wbuf = NULL;
     HDfree(rbuf);
@@ -1153,7 +1153,7 @@ test_max_compact(hid_t fapl)
     compact_size = SIXTY_FOUR_KB / sizeof(int);
     dims[0]      = (hsize_t)compact_size;
     if ((space = H5Screate_simple(1, dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
@@ -1161,9 +1161,9 @@ test_max_compact(hid_t fapl)
 
     /* Create property list for compact dataset creation */
     if ((plist = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_layout(plist, H5D_COMPACT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create and write to a compact dataset */
     H5E_BEGIN_TRY
@@ -1174,11 +1174,11 @@ test_max_compact(hid_t fapl)
 
     /* Close file */
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(plist) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -1234,26 +1234,26 @@ test_layout_extend(hid_t fapl)
     /* Create a file */
     h5_fixname(FILENAME[15], fapl, filename, sizeof filename);
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataspace */
     if ((sid_fix = H5Screate_simple(1, cur_size, max_fix)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sid_unlim = H5Screate_simple(1, cur_size, max_unlim)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create property list for compact dataset creation */
     if ((dcpl_compact = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_layout(dcpl_compact, H5D_COMPACT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataset with extendible dataspace (fixed max_dims) should fail */
     H5E_BEGIN_TRY
     {
         if (H5Dcreate2(fid, "compact", H5T_NATIVE_INT, sid_fix, H5P_DEFAULT, dcpl_compact, H5P_DEFAULT) !=
             FAIL)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
@@ -1262,21 +1262,21 @@ test_layout_extend(hid_t fapl)
     {
         if (H5Dcreate2(fid, "compact", H5T_NATIVE_INT, sid_unlim, H5P_DEFAULT, dcpl_compact, H5P_DEFAULT) !=
             FAIL)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
     /* Create property list for contiguous dataset creation */
     if ((dcpl_contig = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((H5Pset_layout(dcpl_contig, H5D_CONTIGUOUS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataset with extendible dataspace (fixed max_dims) should fail */
     H5E_BEGIN_TRY
     {
         if (H5Dcreate2(fid, "contig", H5T_NATIVE_INT, sid_fix, H5P_DEFAULT, dcpl_contig, H5P_DEFAULT) != FAIL)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
@@ -1285,48 +1285,48 @@ test_layout_extend(hid_t fapl)
     {
         if (H5Dcreate2(fid, "contig", H5T_NATIVE_INT, sid_unlim, H5P_DEFAULT, dcpl_contig, H5P_DEFAULT) !=
             FAIL)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
     /* Create property list for chunked dataset creation */
     if ((dcpl_chunked = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_layout(dcpl_chunked, H5D_CHUNKED) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl_chunked, 1, chunk_dim) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataset with extendible dataspace (fixed max_dims) should succeed */
     if ((did_fixed = H5Dcreate2(fid, "chunked_fixed", H5T_NATIVE_INT, sid_fix, H5P_DEFAULT, dcpl_chunked,
                                 H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataset with extendible dataspace (unlimited max_dims) should succeed */
     if ((did_unlim = H5Dcreate2(fid, "chunked_unlim", H5T_NATIVE_INT, sid_unlim, H5P_DEFAULT, dcpl_chunked,
                                 H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Closing */
     if (H5Sclose(sid_fix) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(sid_unlim) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Pclose(dcpl_compact) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl_contig) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl_chunked) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dclose(did_fixed) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did_unlim) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -1816,21 +1816,21 @@ filter_corrupt(unsigned int flags, size_t cd_nelmts, const unsigned int *cd_valu
     size_t         ret_value = 0;
 
     if (cd_nelmts != 3 || !cd_values)
-        TEST_ERROR
+        TEST_ERROR;
     offset = cd_values[0];
     length = cd_values[1];
     value  = cd_values[2];
     if (offset > nbytes || (offset + length) > nbytes || length < sizeof(unsigned int))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL == (data = HDmalloc((size_t)length)))
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(data, (int)value, (size_t)length);
 
     if (flags & H5Z_FLAG_REVERSE) { /* Varify data is actually corrupted during read */
         dst += offset;
         if (HDmemcmp(data, dst, (size_t)length) != 0)
-            TEST_ERROR
+            TEST_ERROR;
         else {
             *buf_size = nbytes;
             ret_value = nbytes;
@@ -2431,41 +2431,41 @@ test_get_filter_info(void)
      * of encoder and decoder.
      */
     if (H5Zget_filter_info(H5Z_FILTER_FLETCHER32, &flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (((flags & H5Z_FILTER_CONFIG_ENCODE_ENABLED) == 0) ||
         ((flags & H5Z_FILTER_CONFIG_DECODE_ENABLED) == 0))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Zget_filter_info(H5Z_FILTER_SHUFFLE, &flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (((flags & H5Z_FILTER_CONFIG_ENCODE_ENABLED) == 0) ||
         ((flags & H5Z_FILTER_CONFIG_DECODE_ENABLED) == 0))
-        TEST_ERROR
+        TEST_ERROR;
 
 #ifdef H5_HAVE_FILTER_DEFLATE
     if (H5Zget_filter_info(H5Z_FILTER_DEFLATE, &flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (((flags & H5Z_FILTER_CONFIG_ENCODE_ENABLED) == 0) ||
         ((flags & H5Z_FILTER_CONFIG_DECODE_ENABLED) == 0))
-        TEST_ERROR
+        TEST_ERROR;
 #endif
 
 #ifdef H5_HAVE_FILTER_SZIP
     if (H5Zget_filter_info(H5Z_FILTER_SZIP, &flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Z_SZIP->encoder_present) {
         if (((flags & H5Z_FILTER_CONFIG_ENCODE_ENABLED) == 0) ||
             ((flags & H5Z_FILTER_CONFIG_DECODE_ENABLED) == 0))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else {
         if (((flags & H5Z_FILTER_CONFIG_ENCODE_ENABLED) != 0) ||
             ((flags & H5Z_FILTER_CONFIG_DECODE_ENABLED) == 0))
-            TEST_ERROR
+            TEST_ERROR;
     }  /* end else */
 #endif /* H5_HAVE_FILTER_SZIP */
 
@@ -2477,7 +2477,7 @@ test_get_filter_info(void)
     }
     H5E_END_TRY;
     if (err >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -2868,7 +2868,7 @@ test_missing_filter(hid_t file)
 
     /* Push API context */
     if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = TRUE;
 
     /* Unregister deflate filter */
@@ -3071,7 +3071,7 @@ test_missing_filter(hid_t file)
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = FALSE;
 
     PASSED();
@@ -3339,33 +3339,33 @@ test_nbit_float(hid_t file)
     /* Define user-defined single-precision floating-point type for dataset */
     datatype = H5Tcopy(H5T_IEEE_F32BE);
     if (H5Tset_fields(datatype, (size_t)26, (size_t)20, (size_t)6, (size_t)7, (size_t)13) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     offset = 7;
     if (H5Tset_offset(datatype, offset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     precision = 20;
     if (H5Tset_precision(datatype, precision) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_size(datatype, (size_t)4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_ebias(datatype, (size_t)31) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the data space */
     if ((space = H5Screate_simple(2, size, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Use nbit filter  */
     if ((dc = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dc, 2, chunk_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_nbit(dc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dataset */
     if ((dataset = H5Dcreate2(file, DSET_NBIT_FLOAT_NAME, datatype, space, H5P_DEFAULT, dc, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /*----------------------------------------------------------------------
@@ -3376,7 +3376,7 @@ test_nbit_float(hid_t file)
     TESTING("    nbit float (write)");
 
     if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, orig_data) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -3388,7 +3388,7 @@ test_nbit_float(hid_t file)
 
     /* Read the dataset back */
     if (H5Dread(dataset, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, new_data) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that the values read are the same as the values written
      * Assume size of int = size of float
@@ -3411,13 +3411,13 @@ test_nbit_float(hid_t file)
      *----------------------------------------------------------------------
      */
     if (H5Tclose(datatype) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -3460,34 +3460,34 @@ test_nbit_double(hid_t file)
     /* Define user-defined doule-precision floating-point type for dataset */
     datatype = H5Tcopy(H5T_IEEE_F64BE);
     if (H5Tset_fields(datatype, (size_t)55, (size_t)46, (size_t)9, (size_t)5, (size_t)41) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     offset = 5;
     if (H5Tset_offset(datatype, offset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     precision = 51;
     if (H5Tset_precision(datatype, precision) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_size(datatype, (size_t)8) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_ebias(datatype, (size_t)255) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the data space */
     if ((space = H5Screate_simple(2, size, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Use nbit filter  */
     if ((dc = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dc, 2, chunk_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_nbit(dc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dataset */
     if ((dataset = H5Dcreate2(file, DSET_NBIT_DOUBLE_NAME, datatype, space, H5P_DEFAULT, dc, H5P_DEFAULT)) <
         0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -3499,7 +3499,7 @@ test_nbit_double(hid_t file)
     TESTING("    nbit double (write)");
 
     if (H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, orig_data) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /*----------------------------------------------------------------------
@@ -3510,7 +3510,7 @@ test_nbit_double(hid_t file)
 
     /* Read the dataset back */
     if (H5Dread(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, new_data) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that the values read are the same as the values written
      * Assume size of long long = size of double
@@ -3533,13 +3533,13 @@ test_nbit_double(hid_t file)
      *----------------------------------------------------------------------
      */
     if (H5Tclose(datatype) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -3731,85 +3731,85 @@ test_nbit_compound(hid_t file)
 
     /* Define datatypes of members of compound datatype */
     if ((i_tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((c_tid = H5Tcopy(H5T_NATIVE_CHAR)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((s_tid = H5Tcopy(H5T_NATIVE_SHORT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((f_tid = H5Tcopy(H5T_IEEE_F32BE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set precision and offset etc. */
     if (H5Tset_precision(i_tid, precision[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_offset(i_tid, offset[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Tset_precision(c_tid, precision[1]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_offset(c_tid, offset[1]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Tset_precision(s_tid, precision[2]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_offset(s_tid, offset[2]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Tset_fields(f_tid, (size_t)26, (size_t)20, (size_t)6, (size_t)7, (size_t)13) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_offset(f_tid, (size_t)7) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_precision(f_tid, (size_t)20) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_size(f_tid, (size_t)4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_ebias(f_tid, (size_t)31) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a memory compound datatype before setting the order */
     if ((mem_cmpd_tid = H5Tcreate(H5T_COMPOUND, sizeof(atomic))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(mem_cmpd_tid, "i", HOFFSET(atomic, i), i_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(mem_cmpd_tid, "c", HOFFSET(atomic, c), c_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(mem_cmpd_tid, "s", HOFFSET(atomic, s), s_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(mem_cmpd_tid, "f", HOFFSET(atomic, f), H5T_NATIVE_FLOAT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataset compound datatype and insert some atomic types */
     if ((cmpd_tid = H5Tcreate(H5T_COMPOUND, sizeof(atomic))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(cmpd_tid, "i", HOFFSET(atomic, i), i_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(cmpd_tid, "c", HOFFSET(atomic, c), c_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(cmpd_tid, "s", HOFFSET(atomic, s), s_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(cmpd_tid, "f", HOFFSET(atomic, f), f_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set order of dataset compound datatype */
     if (H5Tset_order(cmpd_tid, H5T_ORDER_BE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the data space */
     if ((space = H5Screate_simple(2, size, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Use nbit filter  */
     if ((dc = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dc, 2, chunk_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_nbit(dc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dataset */
     if ((dataset = H5Dcreate2(file, DSET_NBIT_COMPOUND_NAME, cmpd_tid, space, H5P_DEFAULT, dc, H5P_DEFAULT)) <
         0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize data, assuming size of long long >= size of member datatypes */
     for (i = 0; i < (size_t)size[0]; i++)
@@ -3839,7 +3839,7 @@ test_nbit_compound(hid_t file)
     TESTING("    nbit compound (write)");
 
     if (H5Dwrite(dataset, mem_cmpd_tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, orig_data) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /*----------------------------------------------------------------------
@@ -3850,7 +3850,7 @@ test_nbit_compound(hid_t file)
 
     /* Read the dataset back */
     if (H5Dread(dataset, mem_cmpd_tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, new_data) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that the values read are the same as the values written
      * Use mask for checking the significant bits, ignoring the padding bits
@@ -3877,23 +3877,23 @@ test_nbit_compound(hid_t file)
      *----------------------------------------------------------------------
      */
     if (H5Tclose(i_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(c_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(s_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(f_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(cmpd_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(mem_cmpd_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -3961,137 +3961,137 @@ test_nbit_compound_2(hid_t file)
 
     /* Define datatypes of members of compound datatype */
     if ((i_tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((c_tid = H5Tcopy(H5T_NATIVE_CHAR)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((s_tid = H5Tcopy(H5T_NATIVE_SHORT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((v_tid = H5Tcopy(H5T_NATIVE_UINT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((f_tid = H5Tcopy(H5T_IEEE_F32BE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set precision and offset etc. of atomic compound datatype members */
     if (H5Tset_precision(i_tid, precision[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_offset(i_tid, offset[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Tset_precision(c_tid, precision[1]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_offset(c_tid, offset[1]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Tset_precision(s_tid, precision[2]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_offset(s_tid, offset[2]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Tset_fields(f_tid, (size_t)26, (size_t)20, (size_t)6, (size_t)7, (size_t)13) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_offset(f_tid, (size_t)7) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_precision(f_tid, (size_t)20) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_size(f_tid, (size_t)4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_ebias(f_tid, (size_t)31) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a memory atomic compound datatype before setting the order */
     if ((mem_cmpd_tid1 = H5Tcreate(H5T_COMPOUND, sizeof(atomic))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(mem_cmpd_tid1, "i", HOFFSET(atomic, i), i_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(mem_cmpd_tid1, "c", HOFFSET(atomic, c), c_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(mem_cmpd_tid1, "s", HOFFSET(atomic, s), s_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(mem_cmpd_tid1, "f", HOFFSET(atomic, f), H5T_NATIVE_FLOAT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataset atomic compound datatype and insert some atomic types */
     if ((cmpd_tid1 = H5Tcreate(H5T_COMPOUND, sizeof(atomic))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(cmpd_tid1, "i", HOFFSET(atomic, i), i_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(cmpd_tid1, "c", HOFFSET(atomic, c), c_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(cmpd_tid1, "s", HOFFSET(atomic, s), s_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(cmpd_tid1, "f", HOFFSET(atomic, f), f_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set order of dataset compound datatype */
     if (H5Tset_order(cmpd_tid1, H5T_ORDER_BE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set precision and offset of the other data member */
     if (H5Tset_precision(v_tid, precision[3]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_offset(v_tid, offset[3]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the simple array datatype */
     if ((base_tid = H5Tcopy(H5T_NATIVE_CHAR)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_precision(base_tid, precision[4]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_offset(base_tid, offset[4]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((array_tid = H5Tarray_create2(base_tid, 2, array_dims)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the complex memory and dataset array datatype */
     if ((array_cmplx_tid = H5Tarray_create2(cmpd_tid1, 2, array_dims)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((mem_array_cmplx_tid = H5Tarray_create2(mem_cmpd_tid1, 2, array_dims)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a memory complex compound datatype before setting the order */
     if ((mem_cmpd_tid2 = H5Tcreate(H5T_COMPOUND, sizeof(complex))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(mem_cmpd_tid2, "a", HOFFSET(complex, a), mem_cmpd_tid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(mem_cmpd_tid2, "v", HOFFSET(complex, v), v_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(mem_cmpd_tid2, "b", HOFFSET(complex, b), array_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(mem_cmpd_tid2, "d", HOFFSET(complex, d), mem_array_cmplx_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set order of dataset other complex compound member datatype */
     if (H5Tset_order(v_tid, H5T_ORDER_BE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataset complex compound datatype and insert members */
     if ((cmpd_tid2 = H5Tcreate(H5T_COMPOUND, sizeof(complex))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(cmpd_tid2, "a", HOFFSET(complex, a), cmpd_tid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(cmpd_tid2, "v", HOFFSET(complex, v), v_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(cmpd_tid2, "b", HOFFSET(complex, b), array_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(cmpd_tid2, "d", HOFFSET(complex, d), array_cmplx_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the data space */
     if ((space = H5Screate_simple(2, size, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Use nbit filter  */
     if ((dc = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dc, 2, chunk_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_nbit(dc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dataset */
     if ((dataset =
              H5Dcreate2(file, DSET_NBIT_COMPOUND_NAME_2, cmpd_tid2, space, H5P_DEFAULT, dc, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize data, assuming size of long long >= size of member datatypes */
     for (i = 0; i < (size_t)size[0]; i++)
@@ -4138,7 +4138,7 @@ test_nbit_compound_2(hid_t file)
     TESTING("    nbit compound complex (write)");
 
     if (H5Dwrite(dataset, mem_cmpd_tid2, H5S_ALL, H5S_ALL, H5P_DEFAULT, orig_data) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /*----------------------------------------------------------------------
@@ -4149,7 +4149,7 @@ test_nbit_compound_2(hid_t file)
 
     /* Read the dataset back */
     if (H5Dread(dataset, mem_cmpd_tid2, H5S_ALL, H5S_ALL, H5P_DEFAULT, new_data) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that the values read are the same as the values written
      * Use mask for checking the significant bits, ignoring the padding bits
@@ -4215,37 +4215,37 @@ out:
      *----------------------------------------------------------------------
      */
     if (H5Tclose(i_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(c_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(s_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(f_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(v_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(cmpd_tid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(cmpd_tid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(mem_cmpd_tid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(mem_cmpd_tid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(array_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(base_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(array_cmplx_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(mem_array_cmplx_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -6790,61 +6790,61 @@ test_compare_dcpl(hid_t file)
 
     /* Create the data space */
     if ((sid = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dcpl with special filter */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(dcpl, 2, chunk_dims) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
         /* Set gzip parameter (if available) */
 #ifdef H5_HAVE_FILTER_DEFLATE
     if (H5Pset_deflate(dcpl, 9) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 #endif /* H5_HAVE_FILTER_DEFLATE */
 
     /* Create first dataset */
     if ((dsid = H5Dcreate2(file, DSET_COMPARE_DCPL_NAME, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl,
                            H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get copy of dataset's dataset creation property list */
     if ((dcpl1 = H5Dget_create_plist(dsid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dsid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create second dataset */
     if ((dsid = H5Dcreate2(file, DSET_COMPARE_DCPL_NAME_2, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl,
                            H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get copy of dataset's dataset creation property list */
     if ((dcpl2 = H5Dget_create_plist(dsid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dsid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compare dataset creation property lists */
     if (H5Pequal(dcpl1, dcpl2) <= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset creation property lists */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -6897,112 +6897,112 @@ test_copy_dcpl(hid_t file, hid_t fapl)
 
     /* Create the data space */
     if ((sid = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dcpl with special filter */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(dcpl, 2, chunk_dims) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_fletcher32(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create first dataset of chunking with filter */
     if ((dsid1 = H5Dcreate2(file, DSET_COPY_DCPL_NAME_1, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl,
                             H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dsid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reopen the first dataset */
     if ((dsid1 = H5Dopen2(file, DSET_COPY_DCPL_NAME_1, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the copy of dataset's creation property list */
     if ((dcpl1 = H5Dget_create_plist(dsid1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dcpl1_copy = H5Pcopy(dcpl1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dsid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Change the DCPL for contiguous layout with external storage.  The size of the reserved
      * space in the external file is the size of the dataset - 500*4096*sizeof(int).
      * There's no need to clean up the external file since the library doesn't create it
      * until the data is written to it. */
     if (H5Pset_layout(dcpl, H5D_CONTIGUOUS) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Premove_filter(dcpl, H5Z_FILTER_FLETCHER32) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_external(dcpl, COPY_DCPL_EXTFILE_NAME, (off_t)0, (hsize_t)(500 * 4096 * sizeof(int))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create second dataset of contiguous layout with external storage */
     if ((dsid2 = H5Dcreate2(file, DSET_COPY_DCPL_NAME_2, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl,
                             H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dsid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reopen the second dataset */
     if ((dsid2 = H5Dopen2(file, DSET_COPY_DCPL_NAME_2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get copy of dataset's dataset creation property list */
     if ((dcpl2 = H5Dget_create_plist(dsid2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dcpl2_copy = H5Pcopy(dcpl2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dsid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a second file and create 2 datasets with the copies of the DCPLs in the first
      * file.  Test whether the copies of DCPLs work. */
     h5_fixname(FILENAME[13], fapl, filename, sizeof filename);
     if ((new_file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((new_dsid1 = H5Dcreate2(new_file, DSET_COPY_DCPL_NAME_1, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl1_copy,
                                 H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((new_dsid2 = H5Dcreate2(new_file, DSET_COPY_DCPL_NAME_2, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl2_copy,
                                 H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close datasets */
     if (H5Dclose(new_dsid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(new_dsid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the second file */
     if (H5Fclose(new_file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset creation property lists */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl1_copy) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl2_copy) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -7295,15 +7295,15 @@ test_filters_endianess(void)
 
     /* open */
     if ((fid = H5Fopen(data_file, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* read */
     if (auxread_fdata(fid, "dset") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*-------------------------------------------------------------------------
      * step 2: open a file written on a big-endian machine
@@ -7315,15 +7315,15 @@ test_filters_endianess(void)
 
     /* open */
     if ((fid = H5Fopen(data_file, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* read */
     if (auxread_fdata(fid, "dset") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -7372,27 +7372,27 @@ test_zero_dims(hid_t file)
 
     /* Get the file's file access property list */
     if ((fapl = H5Fget_access_plist(file)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get library format */
     if (H5Pget_libver_bounds(fapl, &low, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close FAPL */
     if (H5Pclose(fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * One-dimensional dataset
      */
     if ((s = H5Screate_simple(1, &dzero, &dmax)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Try creating chunked dataset with undefined chunk dimensions */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_layout(dcpl, H5D_CHUNKED) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -7401,7 +7401,7 @@ test_zero_dims(hid_t file)
     H5E_END_TRY;
     if (d > 0) {
         H5Dclose(d);
-        FAIL_PUTS_ERROR("created dataset with undefined chunk dimensions")
+        FAIL_PUTS_ERROR("created dataset with undefined chunk dimensions");
     } /* end if */
 
     /* Try creating chunked dataset with zero-sized chunk dimensions */
@@ -7411,22 +7411,22 @@ test_zero_dims(hid_t file)
     }
     H5E_END_TRY;
     if (ret > 0)
-        FAIL_PUTS_ERROR("set zero-sized chunk dimensions")
+        FAIL_PUTS_ERROR("set zero-sized chunk dimensions");
 
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the zero-sized extendible dataset */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl, 1, &csize) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((d = H5Dcreate2(file, ZERODIM_DATASET, H5T_NATIVE_INT, s, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the chunk index type */
     if (H5D__layout_idx_type_test(d, &idx_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify index type */
     if (low == H5F_LIBVER_LATEST) {
@@ -7438,42 +7438,42 @@ test_zero_dims(hid_t file)
 
     /* Various no-op writes */
     if (H5Dwrite(d, H5T_NATIVE_INT, s, s, H5P_DEFAULT, (void *)911) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dwrite(d, H5T_NATIVE_INT, s, s, H5P_DEFAULT, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dwrite(d, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, (void *)911) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dwrite(d, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Various no-op reads */
     if (H5Dread(d, H5T_NATIVE_INT, s, s, H5P_DEFAULT, (void *)911) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dread(d, H5T_NATIVE_INT, s, s, H5P_DEFAULT, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dread(d, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, (void *)911) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dread(d, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dclose(d) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(s) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Two-dimensional dataset
      */
     if ((s2 = H5Screate_simple(2, dzero2, dmax2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Try creating chunked dataset with undefined chunk dimensions */
     if ((dcpl2 = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_layout(dcpl2, H5D_CHUNKED) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -7482,7 +7482,7 @@ test_zero_dims(hid_t file)
     H5E_END_TRY;
     if (d2 > 0) {
         H5Dclose(d2);
-        FAIL_PUTS_ERROR("created dataset with undefined chunk dimensions")
+        FAIL_PUTS_ERROR("created dataset with undefined chunk dimensions");
     } /* end if */
 
     /* Try creating chunked dataset with zero-sized chunk dimensions */
@@ -7492,24 +7492,24 @@ test_zero_dims(hid_t file)
     }
     H5E_END_TRY;
     if (ret > 0)
-        FAIL_PUTS_ERROR("set zero-sized chunk dimensions")
+        FAIL_PUTS_ERROR("set zero-sized chunk dimensions");
 
     if (H5Pclose(dcpl2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write to the zero-sized extendible dataset */
     if ((dcpl2 = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl2, 2, csize2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dataset */
     if ((d2 = H5Dcreate2(file, ZERODIM_DATASET2, H5T_NATIVE_INT, s2, H5P_DEFAULT, dcpl2, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the chunk index type */
     if (H5D__layout_idx_type_test(d2, &idx_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify index type */
     if (low == H5F_LIBVER_LATEST) {
@@ -7521,14 +7521,14 @@ test_zero_dims(hid_t file)
 
     /* Just a no-op */
     if (H5Dwrite(d2, H5T_NATIVE_INT, s2, s2, H5P_DEFAULT, (void *)911) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dclose(d2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(s2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -7627,7 +7627,7 @@ test_missing_chunk(hid_t file)
 
     /* Close FAPL */
     if (H5Pclose(fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize data for 1-D dataset */
     for (u = 0; u < MISSING_CHUNK_DIM; u++) {
@@ -8653,11 +8653,11 @@ test_huge_chunks(hid_t fapl)
 
     /* Create file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataset creation property list */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Try to set too large of a chunk for 1-D dataset (# of elements) */
     chunk_dim = TOO_HUGE_CHUNK_DIM;
@@ -8667,7 +8667,7 @@ test_huge_chunks(hid_t fapl)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        FAIL_PUTS_ERROR("    Set chunk size with too large of chunk dimensions.")
+        FAIL_PUTS_ERROR("    Set chunk size with too large of chunk dimensions.");
 
     /* Try to set too large of a chunk for n-D dataset (# of elements) */
     chunk_dim2[0] = TOO_HUGE_CHUNK_DIM2_0;
@@ -8679,17 +8679,17 @@ test_huge_chunks(hid_t fapl)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        FAIL_PUTS_ERROR("    Set chunk size with too large of chunk dimensions.")
+        FAIL_PUTS_ERROR("    Set chunk size with too large of chunk dimensions.");
 
     /* Set 1-D chunk size */
     chunk_dim = HUGE_CHUNK_DIM;
     if (H5Pset_chunk(dcpl, 1, &chunk_dim) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create 1-D dataspace */
     dim = HUGE_DIM;
     if ((sid = H5Screate_simple(1, &dim, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Try to create dataset */
     H5E_BEGIN_TRY
@@ -8698,25 +8698,25 @@ test_huge_chunks(hid_t fapl)
     }
     H5E_END_TRY;
     if (dsid >= 0)
-        FAIL_PUTS_ERROR("    1-D Dataset with too large of chunk dimensions created.")
+        FAIL_PUTS_ERROR("    1-D Dataset with too large of chunk dimensions created.");
 
     /* Close 1-D dataspace */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set n-D chunk size */
     chunk_dim2[0] = HUGE_CHUNK_DIM2_0;
     chunk_dim2[1] = HUGE_CHUNK_DIM2_1;
     chunk_dim2[2] = HUGE_CHUNK_DIM2_2;
     if (H5Pset_chunk(dcpl, 3, chunk_dim2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create n-D dataspace */
     dim2[0] = HUGE_DIM2_0;
     dim2[1] = HUGE_DIM2_1;
     dim2[2] = HUGE_DIM2_2;
     if ((sid = H5Screate_simple(3, dim2, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Try to create dataset */
     H5E_BEGIN_TRY
@@ -8725,17 +8725,17 @@ test_huge_chunks(hid_t fapl)
     }
     H5E_END_TRY;
     if (dsid >= 0)
-        FAIL_PUTS_ERROR("    n-D Dataset with too large of chunk dimensions created.")
+        FAIL_PUTS_ERROR("    n-D Dataset with too large of chunk dimensions created.");
 
     /* Close n-D dataspace */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close everything else */
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -8788,72 +8788,72 @@ test_chunk_cache(hid_t fapl)
 
     /* Create a default fapl and dapl */
     if ((fapl_def = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dapl1 = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Pget_chunk_cache(dapl) returns the same values as are in
      * the default fapl.
      */
     if (H5Pget_cache(fapl_def, NULL, &nslots_1, &nbytes_1, &w0_1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pget_chunk_cache(dapl1, &nslots_4, &nbytes_4, &w0_4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((nslots_1 != nslots_4) || (nbytes_1 != nbytes_4) || !H5_DBL_ABS_EQUAL(w0_1, w0_4))
-        FAIL_PUTS_ERROR("    Cache values from default dapl do not match those from fapl.")
+        FAIL_PUTS_ERROR("    Cache values from default dapl do not match those from fapl.");
 
     /* Set a lapl property on dapl1 (to verify inheritance) */
     if (H5Pset_nlinks(dapl1, (size_t)134) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pget_nlinks(dapl1, &nlinks) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (nlinks != 134)
-        FAIL_PUTS_ERROR("    nlinks parameter not set properly on dapl.")
+        FAIL_PUTS_ERROR("    nlinks parameter not set properly on dapl.");
 
     /* Copy fapl passed to this function (as we will be modifying it) */
     if ((fapl_local = H5Pcopy(fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set new rdcc settings on fapl */
     nslots_2 = nslots_1 * 2;
     nbytes_2 = nbytes_1 * 2;
     w0_2     = w0_1 / 2.0;
     if (H5Pset_cache(fapl_local, 0, nslots_2, nbytes_2, w0_2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     h5_fixname(FILENAME[8], fapl, filename, sizeof filename);
 
     /* Create file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_local)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataset creation property list */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set chunking */
     chunk_dim = 10;
     if (H5Pset_chunk(dcpl, 1, &chunk_dim) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create 1-D dataspace */
     dim = 100;
     if ((sid = H5Screate_simple(1, &dim, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataset with default dapl */
     if ((dsid = H5Dcreate2(fid, "dset", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, dapl1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve dapl from dataset, verify cache values are the same as on fapl_local */
     if ((dapl2 = H5Dget_access_plist(dsid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pget_chunk_cache(dapl2, &nslots_4, &nbytes_4, &w0_4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((nslots_2 != nslots_4) || (nbytes_2 != nbytes_4) || !H5_DBL_ABS_EQUAL(w0_2, w0_4))
-        FAIL_PUTS_ERROR("    Cache values from retrieved dapl do not match those from fapl.")
+        FAIL_PUTS_ERROR("    Cache values from retrieved dapl do not match those from fapl.");
     if (H5Pclose(dapl2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set new values on dapl1.  nbytes will be set to default, so the file
      * property will override this setting */
@@ -8861,13 +8861,13 @@ test_chunk_cache(hid_t fapl)
     nbytes_3 = H5D_CHUNK_CACHE_NBYTES_DEFAULT;
     w0_3     = w0_2 / 2;
     if (H5Pset_chunk_cache(dapl1, nslots_3, nbytes_3, w0_3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close dataset, reopen with dapl1.  Note the use of a dapl with H5Oopen */
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dsid = H5Oopen(fid, "dset", dapl1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve dapl from dataset, verify cache values are the same as on dapl1 */
     /* Note we rely on the knowledge that H5Pget_chunk_cache retrieves these
@@ -8875,116 +8875,133 @@ test_chunk_cache(hid_t fapl)
      * dapl used to open the dataset (which is not preserved).
      */
     if ((dapl2 = H5Dget_access_plist(dsid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pget_chunk_cache(dapl2, &nslots_4, &nbytes_4, &w0_4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((nslots_3 != nslots_4) || (nbytes_2 != nbytes_4) || !H5_DBL_ABS_EQUAL(w0_3, w0_4))
-        FAIL_PUTS_ERROR("    Cache values from retrieved dapl do not match those from dapl1.")
+        FAIL_PUTS_ERROR("    Cache values from retrieved dapl do not match those from dapl1.");
     if (H5Pclose(dapl2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close dataset, reopen with H5P_DEFAULT as dapl */
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dsid = H5Dopen2(fid, "dset", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve dapl from dataset, verify cache values are the same on fapl_local */
     if ((dapl2 = H5Dget_access_plist(dsid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pget_chunk_cache(dapl2, &nslots_4, &nbytes_4, &w0_4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((nslots_2 != nslots_4) || (nbytes_2 != nbytes_4) || !H5_DBL_ABS_EQUAL(w0_2, w0_4))
-        FAIL_PUTS_ERROR("    Cache values from retrieved dapl do not match those from fapl.")
+        FAIL_PUTS_ERROR("    Cache values from retrieved dapl do not match those from fapl.");
     if (H5Pclose(dapl2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Similarly, test use of H5Dcreate2 with H5P_DEFAULT */
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dsid = H5Dcreate2(fid, "dset2", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dapl2 = H5Dget_access_plist(dsid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pget_chunk_cache(dapl2, &nslots_4, &nbytes_4, &w0_4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((nslots_2 != nslots_4) || (nbytes_2 != nbytes_4) || !H5_DBL_ABS_EQUAL(w0_2, w0_4))
-        FAIL_PUTS_ERROR("    Cache values from retrieved dapl do not match those from fapl.")
+        FAIL_PUTS_ERROR("    Cache values from retrieved dapl do not match those from fapl.");
     /* Don't close dapl2, we will use it in the next section */
 
     /* Modify cache values on fapl_local */
     nbytes_3 = nbytes_2 * 2;
     if (H5Pset_cache(fapl_local, 0, nslots_3, nbytes_3, w0_3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close and reopen file with new fapl_local */
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl_local)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that dapl2 retrieved earlier (using values from the old fapl)
      * sets its values in the new file (test use of H5Dopen2 with a dapl)
      */
     if ((dsid = H5Dopen2(fid, "dset", dapl2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dapl2) < 0)
-        FAIL_STACK_ERROR /* Close dapl2, to avoid id leak */
-            if ((dapl2 = H5Dget_access_plist(dsid)) < 0)
-                FAIL_STACK_ERROR if (H5Pget_chunk_cache(dapl2, &nslots_4, &nbytes_4, &w0_4) < 0)
-                    FAIL_STACK_ERROR if ((nslots_2 != nslots_4) || (nbytes_2 != nbytes_4) ||
-                                         !H5_DBL_ABS_EQUAL(w0_2, w0_4))
-                        FAIL_PUTS_ERROR("    Cache values from retrieved dapl do not match those from dapl2.")
+        FAIL_STACK_ERROR; /* Close dapl2, to avoid id leak */
+    if ((dapl2 = H5Dget_access_plist(dsid)) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Pget_chunk_cache(dapl2, &nslots_4, &nbytes_4, &w0_4) < 0)
+        FAIL_STACK_ERROR;
+    if ((nslots_2 != nslots_4) || (nbytes_2 != nbytes_4) || !H5_DBL_ABS_EQUAL(w0_2, w0_4))
+        FAIL_PUTS_ERROR("    Cache values from retrieved dapl do not match those from dapl2.");
 
-            /* Test H5D_CHUNK_CACHE_NSLOTS_DEFAULT and H5D_CHUNK_CACHE_W0_DEFAULT */
-            nslots_2 = H5D_CHUNK_CACHE_NSLOTS_DEFAULT;
-    w0_2 = H5D_CHUNK_CACHE_W0_DEFAULT;
+    /* Test H5D_CHUNK_CACHE_NSLOTS_DEFAULT and H5D_CHUNK_CACHE_W0_DEFAULT */
+    nslots_2 = H5D_CHUNK_CACHE_NSLOTS_DEFAULT;
+    w0_2     = H5D_CHUNK_CACHE_W0_DEFAULT;
     if (H5Pset_chunk_cache(dapl2, nslots_2, nbytes_2, w0_2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dsid = H5Dopen2(fid, "dset", dapl2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dapl2) < 0)
-        FAIL_STACK_ERROR /* Close dapl2, to avoid id leak */
-            if ((dapl2 = H5Dget_access_plist(dsid)) <
-                0) FAIL_STACK_ERROR if (H5Pget_chunk_cache(dapl2, &nslots_4, &nbytes_4, &w0_4) <
-                                        0) FAIL_STACK_ERROR if ((nslots_3 != nslots_4) ||
-                                                                (nbytes_2 != nbytes_4) ||
-                                                                !H5_DBL_ABS_EQUAL(w0_3, w0_4))
-                FAIL_PUTS_ERROR(
-                    "    Cache values from retrieved dapl do not match those expected.") if (H5Pclose(dapl2) <
-                                                                                             0)
-                    FAIL_STACK_ERROR
+        FAIL_STACK_ERROR; /* Close dapl2, to avoid id leak */
+    if ((dapl2 = H5Dget_access_plist(dsid)) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Pget_chunk_cache(dapl2, &nslots_4, &nbytes_4, &w0_4) < 0)
+        FAIL_STACK_ERROR;
+    if ((nslots_3 != nslots_4) || (nbytes_2 != nbytes_4) || !H5_DBL_ABS_EQUAL(w0_3, w0_4))
+        FAIL_PUTS_ERROR("    Cache values from retrieved dapl do not match those expected.");
+    if (H5Pclose(dapl2) < 0)
+        FAIL_STACK_ERROR;
 
-            /* Verify that the file has indeed started using the new cache values (test
-             * use of H5Oopen with H5P_DEFAULT) */
-            if (H5Dclose(dsid) < 0) FAIL_STACK_ERROR if ((dsid = H5Oopen(fid, "dset", H5P_DEFAULT)) < 0)
-                FAIL_STACK_ERROR if ((dapl2 = H5Dget_access_plist(dsid)) < 0)
-                    FAIL_STACK_ERROR if (H5Pget_chunk_cache(dapl2, &nslots_4, &nbytes_4, &w0_4) < 0)
-                        FAIL_STACK_ERROR if ((nslots_3 != nslots_4) || (nbytes_3 != nbytes_4) ||
-                                             !H5_DBL_ABS_EQUAL(w0_3, w0_4))
-                            FAIL_PUTS_ERROR("    Cache values from retrieved dapl do not match those from "
-                                            "fapl.") if (H5Pclose(dapl2) < 0) FAIL_STACK_ERROR
+    /* Verify that the file has indeed started using the new cache values (test
+     * use of H5Oopen with H5P_DEFAULT) */
+    if (H5Dclose(dsid) < 0)
+        FAIL_STACK_ERROR;
+    if ((dsid = H5Oopen(fid, "dset", H5P_DEFAULT)) < 0)
+        FAIL_STACK_ERROR;
+    if ((dapl2 = H5Dget_access_plist(dsid)) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Pget_chunk_cache(dapl2, &nslots_4, &nbytes_4, &w0_4) < 0)
+        FAIL_STACK_ERROR;
+    if ((nslots_3 != nslots_4) || (nbytes_3 != nbytes_4) || !H5_DBL_ABS_EQUAL(w0_3, w0_4))
+        FAIL_PUTS_ERROR("    Cache values from retrieved dapl do not match those from fapl.");
+    if (H5Pclose(dapl2) < 0)
+        FAIL_STACK_ERROR;
 
-            /* Verify functionality of H5Pcopy with a dapl */
-            if ((dapl2 = H5Pcopy(dapl1)) < 0)
-                FAIL_STACK_ERROR if (H5Pget_chunk_cache(dapl2, &nslots_4, &nbytes_4, &w0_4) < 0)
-                    FAIL_STACK_ERROR if ((nslots_3 != nslots_4) || (nbytes_1 != nbytes_4) ||
-                                         !H5_DBL_ABS_EQUAL(w0_3, w0_4))
-                        FAIL_PUTS_ERROR("    Cache values from dapl2 do not match those from dapl1.")
+    /* Verify functionality of H5Pcopy with a dapl */
+    if ((dapl2 = H5Pcopy(dapl1)) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Pget_chunk_cache(dapl2, &nslots_4, &nbytes_4, &w0_4) < 0)
+        FAIL_STACK_ERROR;
+    if ((nslots_3 != nslots_4) || (nbytes_1 != nbytes_4) || !H5_DBL_ABS_EQUAL(w0_3, w0_4))
+        FAIL_PUTS_ERROR("    Cache values from dapl2 do not match those from dapl1.");
 
-            /* Close */
-            if (H5Dclose(dsid) < 0) FAIL_STACK_ERROR if (H5Sclose(sid) < 0)
-                FAIL_STACK_ERROR if (H5Pclose(fapl_local) < 0) FAIL_STACK_ERROR if (H5Pclose(fapl_def) < 0)
-                    FAIL_STACK_ERROR if (H5Pclose(dapl1) < 0) FAIL_STACK_ERROR if (H5Pclose(dapl2) < 0)
-                        FAIL_STACK_ERROR if (H5Pclose(dcpl) < 0) FAIL_STACK_ERROR if (H5Fclose(fid) < 0)
-                            FAIL_STACK_ERROR
+    /* Close */
+    if (H5Dclose(dsid) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Sclose(sid) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Pclose(fapl_local) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Pclose(fapl_def) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Pclose(dapl1) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Pclose(dapl2) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Pclose(dcpl) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Fclose(fid) < 0)
+        FAIL_STACK_ERROR;
 
-                            PASSED();
+    PASSED();
     return SUCCEED;
 
 error:
@@ -9080,74 +9097,74 @@ test_big_chunks_bypass_cache(hid_t fapl)
 
     /* Check if we are using the latest version of the format */
     if (H5Pget_libver_bounds(fapl, &low, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Copy fapl passed to this function (as we will be modifying it) */
     if ((fapl_local = H5Pcopy(fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Define cache size to be smaller than chunk size */
     rdcc_nelmts = BYPASS_CHUNK_DIM / 5;
     rdcc_nbytes = sizeof(int) * BYPASS_CHUNK_DIM / 5;
     if (H5Pset_cache(fapl_local, 0, rdcc_nelmts, rdcc_nbytes, 0.0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_local)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create 1-D & 2-D dataspace */
     dim = t_dim[0] = t_dim[1] = BYPASS_DIM;
     t_max[0] = t_max[1] = H5S_UNLIMITED;
     if ((sid = H5Screate_simple(1, &dim, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((t_sid = H5Screate_simple(2, t_dim, t_max)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create 1-D & 2-D dataset creation property list */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((t_dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Define chunk size. */
     /* There will be 2 chunks in 1-D dataset & 4 chunks in the 2-D dataset */
     chunk_dim = t_chunk_dim[0] = t_chunk_dim[1] = BYPASS_CHUNK_DIM;
     if (H5Pset_chunk(dcpl, 1, &chunk_dim) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(t_dcpl, 2, t_chunk_dim) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Define fill value, fill time, and chunk allocation time */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fvalue) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_fill_value(t_dcpl, H5T_NATIVE_INT, &fvalue) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_IFSET) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_fill_time(t_dcpl, H5D_FILL_TIME_IFSET) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Pset_alloc_time(dcpl, H5D_ALLOC_TIME_INCR) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_alloc_time(t_dcpl, H5D_ALLOC_TIME_INCR) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the first 1-D dataset */
     if ((dsid = H5Dcreate2(fid, BYPASS_DATASET1, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the first 2-D dataset */
     if ((t_dsid =
              H5Dcreate2(fid, T_BYPASS_DATASET1, H5T_NATIVE_INT, t_sid, H5P_DEFAULT, t_dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the chunk index types for 1-D and 2-d datasets */
     if (H5D__layout_idx_type_test(dsid, &idx_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5D__layout_idx_type_test(t_dsid, &t_idx_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Chunk index type expected depends on whether we are using the latest version of the format */
     if (low == H5F_LIBVER_LATEST) {
@@ -9171,18 +9188,18 @@ test_big_chunks_bypass_cache(hid_t fapl)
     stride = t_stride[0] = t_stride[1] = 1;
     block = t_block[0] = t_block[1] = BYPASS_CHUNK_DIM / 2;
     if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, &offset, &stride, &count, &block) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Sselect_hyperslab(t_sid, H5S_SELECT_SET, t_offset, t_stride, t_count, t_block) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Allocate buffers */
     if (NULL == (wdata = (int *)HDmalloc(sizeof(int) * (BYPASS_CHUNK_DIM / 2))))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (rdata1 = (int *)HDmalloc(sizeof(int) * BYPASS_DIM)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (rdata2 = (int *)HDmalloc(sizeof(int) * (BYPASS_CHUNK_DIM / 2))))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize data to write for 1-D dataset */
     for (i = 0; i < BYPASS_CHUNK_DIM / 2; i++)
@@ -9199,28 +9216,28 @@ test_big_chunks_bypass_cache(hid_t fapl)
     /* Write to the first 1-D & 2-D datasets */
     /* This write should go through the cache because fill value is used. */
     if (H5Dwrite(dsid, H5T_NATIVE_INT, H5S_ALL, sid, H5P_DEFAULT, wdata) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dwrite(t_dsid, H5T_NATIVE_INT, mid, t_sid, H5P_DEFAULT, t_wdata_bytes) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the first 1-D & 2-D datasets */
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(t_dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reopen the first 1-D & 2-D datasets */
     if ((dsid = H5Dopen2(fid, BYPASS_DATASET1, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((t_dsid = H5Dopen2(fid, T_BYPASS_DATASET1, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reads both 2 chunks.  Reading the second chunk should bypass the cache because the
      * chunk is bigger than the cache size and it isn't allocated on disk. */
     if (H5Dread(dsid, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rdata1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dread(t_dsid, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, t_rdata1_bytes) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify data for the first 1-D dataset */
     for (i = 0; i < BYPASS_CHUNK_DIM / 2; i++)
@@ -9228,7 +9245,7 @@ test_big_chunks_bypass_cache(hid_t fapl)
             HDprintf("    Read different values than written in the 1st chunk.\n");
             HDprintf("    At line %d and index %d, rdata1 = %d. It should be %d.\n", __LINE__, i, rdata1[i],
                      i);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
 
     for (j = BYPASS_CHUNK_DIM / 2; j < BYPASS_DIM; j++)
@@ -9236,7 +9253,7 @@ test_big_chunks_bypass_cache(hid_t fapl)
             HDprintf("    Read different values than written in the 2nd chunk.\n");
             HDprintf("    At line %d and index %d, rdata1 = %d. It should be %d.\n", __LINE__, i, rdata1[i],
                      fvalue);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
 
     /* Verify data for the first 2-D dataset */
@@ -9246,7 +9263,7 @@ test_big_chunks_bypass_cache(hid_t fapl)
                 HDprintf("    Read different values than written in the 1st chunk.\n");
                 HDprintf("    At line %d and index (%d, %d), t_rdata1 = %d. It should be %d.\n", __LINE__, i,
                          j, t_rdata1[i][j], j);
-                TEST_ERROR
+                TEST_ERROR;
             } /* end if */
 
     for (i = BYPASS_CHUNK_DIM / 2; i < BYPASS_DIM; i++)
@@ -9255,55 +9272,55 @@ test_big_chunks_bypass_cache(hid_t fapl)
                 HDprintf("    Read different values than written in the 2nd chunk.\n");
                 HDprintf("    At line %d and index (%d, %d), t_rdata1 = %d. It should be %d.\n", __LINE__, i,
                          j, t_rdata1[i][j], fvalue);
-                TEST_ERROR
+                TEST_ERROR;
             } /* end if */
 
     /* Close the first 1-D & 2-D datasets */
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(t_dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a second dataset without fill value.  This time, both write
      * and read should bypass the cache because the chunk is bigger than the
      * cache size and it's not allocated on disk. */
     if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_NEVER) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_fill_time(t_dcpl, H5D_FILL_TIME_NEVER) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a second 1-D & 2-D dataset */
     if ((dsid = H5Dcreate2(fid, BYPASS_DATASET2, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((t_dsid =
              H5Dcreate2(fid, T_BYPASS_DATASET2, H5T_NATIVE_INT, t_sid, H5P_DEFAULT, t_dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write to the second 1-D & 2-D dataset */
     if (H5Dwrite(dsid, H5T_NATIVE_INT, H5S_ALL, sid, H5P_DEFAULT, wdata) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dwrite(t_dsid, H5T_NATIVE_INT, mid, t_sid, H5P_DEFAULT, t_wdata_bytes) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the second 1-D & 2-D dataset */
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(t_dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reopen the second 1-d dataset and 2-d dataset */
     if ((dsid = H5Dopen2(fid, BYPASS_DATASET2, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((t_dsid = H5Dopen2(fid, T_BYPASS_DATASET2, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read back only the part that was written to the file.  Reading the
      * half chunk should bypass the cache because the chunk is bigger than
      * the cache size. */
     if (H5Dread(dsid, H5T_NATIVE_INT, H5S_ALL, sid, H5P_DEFAULT, rdata2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dread(t_dsid, H5T_NATIVE_INT, mid, t_sid, H5P_DEFAULT, t_rdata2_bytes) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify data for the second 1-D dataset */
     for (i = 0; i < BYPASS_CHUNK_DIM / 2; i++)
@@ -9311,7 +9328,7 @@ test_big_chunks_bypass_cache(hid_t fapl)
             HDprintf("    Read different values than written in the chunk.\n");
             HDprintf("    At line %d and index %d, rdata2 = %d. It should be %d.\n", __LINE__, i, rdata2[i],
                      i);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
 
     /* Verify data for the second 2-D dataset */
@@ -9321,26 +9338,26 @@ test_big_chunks_bypass_cache(hid_t fapl)
                 HDprintf("    Read different values than written in the chunk.\n");
                 HDprintf("    At line %d and index (%d, %d), t_rdata2 = %d. It should be %d.\n", __LINE__, i,
                          j, t_rdata2[i][j], j);
-                TEST_ERROR
+                TEST_ERROR;
             } /* end if */
 
     /* Close IDs */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(t_sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(t_dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(t_dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(fapl_local) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Release buffers */
     HDfree(wdata);
@@ -9418,29 +9435,29 @@ test_chunk_fast(const char *env_h5_driver, hid_t fapl)
 
     /* Copy the file access property list */
     if ((my_fapl = H5Pcopy(fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
-        /* Turn on the chunk cache again */
-        {
-            int    mdc_nelmts;  /* # of elements in metadata cache */
-            size_t rdcc_nelmts; /* # of chunks in chunk cache */
-            size_t rdcc_nbytes; /* # of bytes in chunk cache */
-            double rdcc_w0;     /* write-ratio for chunk cache */
+    /* Turn on the chunk cache again */
+    {
+        int    mdc_nelmts;  /* # of elements in metadata cache */
+        size_t rdcc_nelmts; /* # of chunks in chunk cache */
+        size_t rdcc_nbytes; /* # of bytes in chunk cache */
+        double rdcc_w0;     /* write-ratio for chunk cache */
 
-            if (H5Pget_cache(my_fapl, &mdc_nelmts, &rdcc_nelmts, &rdcc_nbytes, &rdcc_w0) < 0)
-                FAIL_STACK_ERROR
-            rdcc_nbytes = 1048576;
-            if (H5Pset_cache(my_fapl, mdc_nelmts, rdcc_nelmts, rdcc_nbytes, rdcc_w0) < 0)
-                FAIL_STACK_ERROR
-        } /* end block */
+        if (H5Pget_cache(my_fapl, &mdc_nelmts, &rdcc_nelmts, &rdcc_nbytes, &rdcc_w0) < 0)
+            FAIL_STACK_ERROR;
+        rdcc_nbytes = 1048576;
+        if (H5Pset_cache(my_fapl, mdc_nelmts, rdcc_nelmts, rdcc_nbytes, rdcc_w0) < 0)
+            FAIL_STACK_ERROR;
+    } /* end block */
 
     /* Check if we are using the latest version of the format */
     if (H5Pget_libver_bounds(my_fapl, &low, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create scalar dataspace */
     if ((scalar_sid = H5Screate(H5S_SCALAR)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize chunk dimensions */
     fill = EARRAY_CHUNK_DIM;
@@ -9483,26 +9500,26 @@ test_chunk_fast(const char *env_h5_driver, hid_t fapl)
 
                     /* Create dataset creation property list */
                     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Set chunking & chunk dims */
                     if (H5Pset_chunk(dcpl, (int)ndims, chunk_dim) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
 #ifdef H5_HAVE_FILTER_DEFLATE
                     /* Check if we should compress the chunks */
                     if (compress)
                         if (H5Pset_deflate(dcpl, 9) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 #endif /* H5_HAVE_FILTER_DEFLATE */
 
                     /* Set fill time */
                     if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_ALLOC) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Set allocation time */
                     if (H5Pset_alloc_time(dcpl, alloc_time) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Loop over which dimension is unlimited */
                     for (unlim_dim = 0; unlim_dim < ndims; unlim_dim++) {
@@ -9520,7 +9537,7 @@ test_chunk_fast(const char *env_h5_driver, hid_t fapl)
                         /* Create file */
                         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC | (swmr ? H5F_ACC_SWMR_WRITE : 0),
                                              H5P_DEFAULT, my_fapl)) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Create n-D dataspace */
                         fill = EARRAY_DSET_DIM;
@@ -9531,11 +9548,11 @@ test_chunk_fast(const char *env_h5_driver, hid_t fapl)
                         fill               = EARRAY_DSET_DIM;
                         H5VM_array_fill(swizzled_dim, &fill, sizeof(fill), EARRAY_MAX_RANK);
                         if ((sid = H5Screate_simple((int)ndims, dim, max_dim)) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Get the number of points in the dataspace */
                         if ((snpoints = H5Sget_simple_extent_npoints(sid)) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
                         npoints = (hsize_t)snpoints;
 
                         /* Compute the "down" dimension values */
@@ -9544,11 +9561,11 @@ test_chunk_fast(const char *env_h5_driver, hid_t fapl)
                         /* Create chunked dataset */
                         if ((dsid = H5Dcreate2(fid, "dset", H5T_NATIVE_UINT, sid, H5P_DEFAULT, dcpl,
                                                H5P_DEFAULT)) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Get the chunk index type */
                         if (H5D__layout_idx_type_test(dsid, &idx_type) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Chunk index type expected depends on whether we are using the latest version of the
                          * format */
@@ -9567,19 +9584,19 @@ test_chunk_fast(const char *env_h5_driver, hid_t fapl)
                         for (u = 0; u < npoints; u++) {
                             /* Compute the coordinate from the linear offset */
                             if (H5VM_array_calc_pre(u, ndims, down, hs_offset) < 0)
-                                FAIL_STACK_ERROR
+                                FAIL_STACK_ERROR;
 
                             /* Un-swizzle hyperslab offset in same way as swizzled dimensions */
                             H5VM_unswizzle_coords(hsize_t, hs_offset, unlim_dim);
 
                             /* Select a single element in the dataset */
                             if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, hs_offset, NULL, hs_size, NULL) < 0)
-                                FAIL_STACK_ERROR
+                                FAIL_STACK_ERROR;
 
                             /* Read (unwritten) element from dataset */
                             read_elem = 1;
                             if (H5Dread(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &read_elem) < 0)
-                                FAIL_STACK_ERROR
+                                FAIL_STACK_ERROR;
 
                             /* Verify unwritten element is fill value (0) */
                             if (read_elem != 0)
@@ -9589,12 +9606,12 @@ test_chunk_fast(const char *env_h5_driver, hid_t fapl)
                             write_elem = (unsigned)u;
                             if (H5Dwrite(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &write_elem) <
                                 0)
-                                FAIL_STACK_ERROR
+                                FAIL_STACK_ERROR;
 
                             /* Read element from dataset */
                             read_elem = write_elem + 1;
                             if (H5Dread(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &read_elem) < 0)
-                                FAIL_STACK_ERROR
+                                FAIL_STACK_ERROR;
 
                             /* Verify written element is read in */
                             if (read_elem != write_elem)
@@ -9610,26 +9627,26 @@ test_chunk_fast(const char *env_h5_driver, hid_t fapl)
                             dim[unlim_dim] += EARRAY_EXTEND_INCR;
                             swizzled_dim[0] += EARRAY_EXTEND_INCR;
                             if (H5Dset_extent(dsid, dim) < 0)
-                                FAIL_STACK_ERROR
+                                FAIL_STACK_ERROR;
 
                             /* Close old dataspace */
                             if (H5Sclose(sid) < 0)
-                                FAIL_STACK_ERROR
+                                FAIL_STACK_ERROR;
 
                             /* Get dataspace for dataset now */
                             if ((sid = H5Dget_space(dsid)) < 0)
-                                FAIL_STACK_ERROR
+                                FAIL_STACK_ERROR;
 
                             /* Get the new number of points in the dataspace */
                             if ((snew_npoints = H5Sget_simple_extent_npoints(sid)) < 0)
-                                FAIL_STACK_ERROR
+                                FAIL_STACK_ERROR;
                             new_npoints = (hsize_t)snew_npoints;
 
                             /* Fill new elements */
                             for (u = npoints; u < new_npoints; u++) {
                                 /* Compute the coordinate from the linear offset */
                                 if (H5VM_array_calc(u, ndims, swizzled_dim, hs_offset) < 0)
-                                    FAIL_STACK_ERROR
+                                    FAIL_STACK_ERROR;
 
                                 /* Un-swizzle hyperslab offset in same way as swizzled dimensions */
                                 H5VM_unswizzle_coords(hsize_t, hs_offset, unlim_dim);
@@ -9637,13 +9654,13 @@ test_chunk_fast(const char *env_h5_driver, hid_t fapl)
                                 /* Select a single element in the dataset */
                                 if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, hs_offset, NULL, hs_size, NULL) <
                                     0)
-                                    FAIL_STACK_ERROR
+                                    FAIL_STACK_ERROR;
 
                                 /* Read (unwritten) element from dataset */
                                 read_elem = 1;
                                 if (H5Dread(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &read_elem) <
                                     0)
-                                    FAIL_STACK_ERROR
+                                    FAIL_STACK_ERROR;
 
                                 /* Verify unwritten element is fill value (0) */
                                 if (read_elem != 0)
@@ -9653,13 +9670,13 @@ test_chunk_fast(const char *env_h5_driver, hid_t fapl)
                                 write_elem = (unsigned)u;
                                 if (H5Dwrite(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT,
                                              &write_elem) < 0)
-                                    FAIL_STACK_ERROR
+                                    FAIL_STACK_ERROR;
 
                                 /* Read element from dataset */
                                 read_elem = write_elem + 1;
                                 if (H5Dread(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &read_elem) <
                                     0)
-                                    FAIL_STACK_ERROR
+                                    FAIL_STACK_ERROR;
 
                                 /* Verify written element is read in */
                                 if (read_elem != write_elem)
@@ -9672,24 +9689,24 @@ test_chunk_fast(const char *env_h5_driver, hid_t fapl)
 
                         /* Close everything */
                         if (H5Dclose(dsid) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
                         if (H5Sclose(sid) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
                         if (H5Fclose(fid) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Re-open file & dataset */
                         if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | (swmr ? H5F_ACC_SWMR_READ : 0),
                                            my_fapl)) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Open dataset */
                         if ((dsid = H5Dopen2(fid, "dset", H5P_DEFAULT)) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Get the chunk index type */
                         if (H5D__layout_idx_type_test(dsid, &idx_type) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Chunk index tyepe expected depends on whether we are using the latest version of
                          * the format */
@@ -9706,16 +9723,16 @@ test_chunk_fast(const char *env_h5_driver, hid_t fapl)
 
                         /* Get dataspace for dataset now */
                         if ((sid = H5Dget_space(dsid)) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Get the number of points in the dataspace */
                         if ((snpoints = H5Sget_simple_extent_npoints(sid)) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
                         npoints = (hsize_t)snpoints;
 
                         /* Get the current dimensions into swizzled_dim array */
                         if (H5Sget_simple_extent_dims(sid, swizzled_dim, NULL) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Generate the swizzled dimensions */
                         H5VM_swizzle_coords(hsize_t, swizzled_dim, unlim_dim);
@@ -9727,19 +9744,19 @@ test_chunk_fast(const char *env_h5_driver, hid_t fapl)
                         for (u = 0; u < npoints; u++) {
                             /* Compute the coordinate from the linear offset */
                             if (H5VM_array_calc_pre(u, ndims, down, hs_offset) < 0)
-                                FAIL_STACK_ERROR
+                                FAIL_STACK_ERROR;
 
                             /* Unswizzle hyperslab offset in same way as swizzled dimensions */
                             H5VM_unswizzle_coords(hsize_t, hs_offset, unlim_dim);
 
                             /* Select a single element in the dataset */
                             if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, hs_offset, NULL, hs_size, NULL) < 0)
-                                FAIL_STACK_ERROR
+                                FAIL_STACK_ERROR;
 
                             /* Read written element from dataset */
                             read_elem = (unsigned)(u + 1);
                             if (H5Dread(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &read_elem) < 0)
-                                FAIL_STACK_ERROR
+                                FAIL_STACK_ERROR;
 
                             /* Verify written element is correct */
                             if (read_elem != u)
@@ -9748,28 +9765,28 @@ test_chunk_fast(const char *env_h5_driver, hid_t fapl)
 
                         /* Close everything */
                         if (H5Dclose(dsid) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
                         if (H5Sclose(sid) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
                         if (H5Fclose(fid) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Re-open file */
                         if ((fid = H5Fopen(filename, H5F_ACC_RDWR, my_fapl)) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Delete dataset */
                         if (H5Ldelete(fid, "dset", H5P_DEFAULT) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Close everything */
                         if (H5Fclose(fid) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
                     } /* end for */
 
                     /* Close everything */
                     if (H5Pclose(dcpl) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
                 } /* end for */
             }     /* end for */
         }         /* end for */
@@ -9777,9 +9794,9 @@ test_chunk_fast(const char *env_h5_driver, hid_t fapl)
 
     /* Close everything */
     if (H5Sclose(scalar_sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(my_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -9840,38 +9857,38 @@ test_reopen_chunk_fast(hid_t fapl)
     for (alloc_time = H5D_ALLOC_TIME_EARLY; alloc_time <= H5D_ALLOC_TIME_INCR; alloc_time++) {
         /* Create file */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create dataset creation property list */
         if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set chunking */
         chunk_dim = 10;
         if (H5Pset_chunk(dcpl, 1, &chunk_dim) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set fill time */
         if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_ALLOC) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set allocation time */
         if (H5Pset_alloc_time(dcpl, alloc_time) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create scalar dataspace */
         if ((scalar_sid = H5Screate(H5S_SCALAR)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create 1-D dataspace */
         dim     = 100;
         max_dim = H5S_UNLIMITED;
         if ((sid = H5Screate_simple(1, &dim, &max_dim)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create chunked dataset */
         if ((dsid = H5Dcreate2(fid, "dset", H5T_NATIVE_UINT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Fill existing elements */
         hs_size = 1;
@@ -9879,20 +9896,20 @@ test_reopen_chunk_fast(hid_t fapl)
             /* Select a single element in the dataset */
             hs_offset = u;
             if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, &hs_offset, NULL, &hs_size, NULL) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             /* Write element to dataset */
             write_elem = u;
             if (H5Dwrite(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &write_elem) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         } /* end for */
 
         /* Close everything */
         if (H5Dclose(dsid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Reopen the dataset */
         if ((dsid = H5Dopen2(fid, "dset", H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         hs_size = 1;
 
         /* Read from dataset */
@@ -9900,23 +9917,23 @@ test_reopen_chunk_fast(hid_t fapl)
             /* Select a single element in the dataset */
             hs_offset = u;
             if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, &hs_offset, NULL, &hs_size, NULL) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Read element from dataset */
             if (H5Dread(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &read_elem) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         } /* end for */
 
         if (H5Dclose(dsid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Sclose(sid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Sclose(scalar_sid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Pclose(dcpl) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Fclose(fid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
     } /* end for */
 
@@ -10001,47 +10018,47 @@ test_chunk_fast_bug1(hid_t fapl)
     max_dim[0] = 40;
     max_dim[1] = H5S_UNLIMITED;
     if ((sid = H5Screate_simple(2, dim, max_dim)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Loop over storage allocation time */
     for (alloc_time = H5D_ALLOC_TIME_EARLY; alloc_time <= H5D_ALLOC_TIME_INCR; alloc_time++) {
         /* Create file */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create dataset creation property list */
         if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set chunking */
         chunk_dim[0] = 20;
         chunk_dim[1] = 10;
         if (H5Pset_chunk(dcpl, 2, chunk_dim) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set allocation time */
         if (H5Pset_alloc_time(dcpl, alloc_time) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create chunked dataset */
         if ((dsid = H5Dcreate2(fid, "dset", H5T_NATIVE_UINT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Write buffer to dataset */
         if (H5Dwrite(dsid, H5T_NATIVE_UINT, sid, sid, H5P_DEFAULT, wbuf_bytes) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close everything */
         if (H5Dclose(dsid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Reopen the dataset */
         if ((dsid = H5Dopen2(fid, "dset", H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Read from dataset */
         if (H5Dread(dsid, H5T_NATIVE_UINT, sid, sid, H5P_DEFAULT, rbuf_bytes) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify read data */
         for (i = 0; i < 40; i++)
@@ -10050,16 +10067,16 @@ test_chunk_fast_bug1(hid_t fapl)
                     FAIL_PUTS_ERROR("invalid element read");
 
         if (H5Dclose(dsid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Pclose(dcpl) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Fclose(fid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
     } /* end for */
 
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDfree(wbuf);
     HDfree(rbuf);
@@ -10190,7 +10207,7 @@ test_chunk_expand(hid_t fapl)
 
     /* Check if we are using the latest version of the format */
     if (H5Pget_libver_bounds(fapl, &low, &high) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (sizeof(size_t) <= 4 && low != H5F_LIBVER_LATEST) {
         SKIPPED();
@@ -10199,61 +10216,61 @@ test_chunk_expand(hid_t fapl)
     else {
         /* Register "expansion" filter */
         if (H5Zregister(H5Z_EXPAND) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check that the filter was registered */
         if (TRUE != H5Zfilter_avail(H5Z_FILTER_EXPAND))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Loop over storage allocation time */
         for (alloc_time = H5D_ALLOC_TIME_EARLY; alloc_time <= H5D_ALLOC_TIME_INCR; alloc_time++) {
 
             /* Create file */
             if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create dataset creation property list */
             if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((dcpl2 = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Set chunking */
             chunk_dim = chunk_dim2[0] = chunk_dim2[1] = 10;
             if (H5Pset_chunk(dcpl, 1, &chunk_dim) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Pset_chunk(dcpl2, 2, chunk_dim2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Set fill time */
             if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_ALLOC) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Pset_fill_time(dcpl2, H5D_FILL_TIME_ALLOC) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Set allocation time */
             if (H5Pset_alloc_time(dcpl, alloc_time) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Pset_alloc_time(dcpl2, alloc_time) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Set "expand" filter */
             if (H5Pset_filter(dcpl, H5Z_FILTER_EXPAND, 0, (size_t)0, NULL) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Pset_filter(dcpl2, H5Z_FILTER_EXPAND, 0, (size_t)0, NULL) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create scalar dataspace */
             if ((scalar_sid = H5Screate(H5S_SCALAR)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create 1-D and 2-D dataspace */
             dim = dim2[0] = dim2[1] = 100;
             max_dim = max_dim2[0] = max_dim2[1] = H5S_UNLIMITED;
             if ((sid = H5Screate_simple(1, &dim, &max_dim)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((sid2 = H5Screate_simple(2, dim2, max_dim2)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create 1-D & 2-D chunked datasets */
             if (H5D_ALLOC_TIME_EARLY == alloc_time) {
@@ -10280,17 +10297,17 @@ test_chunk_expand(hid_t fapl)
             else {
                 if ((dsid = H5Dcreate2(fid, "dset", H5T_NATIVE_UINT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) <
                     0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 if ((dsid2 = H5Dcreate2(fid, "dset2", H5T_NATIVE_UINT, sid2, H5P_DEFAULT, dcpl2,
                                         H5P_DEFAULT)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Get the chunk index type */
                 if (H5D__layout_idx_type_test(dsid, &idx_type) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5D__layout_idx_type_test(dsid2, &idx_type2) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Chunk index type expected depends on whether we are using the latest version of the format
                  */
@@ -10317,18 +10334,18 @@ test_chunk_expand(hid_t fapl)
 
                     /* Select a single element in the 1-D dataset */
                     if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, &hs_offset, NULL, &hs_size, NULL) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Select a single element in the 2-D dataset; NOT every element is selected */
                     if (H5Sselect_hyperslab(sid2, H5S_SELECT_SET, hs_offset2, NULL, hs_size2, NULL) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Read (unwritten) element from dataset */
                     read_elem = read_elem2 = 1;
                     if (H5Dread(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &read_elem) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
                     if (H5Dread(dsid2, H5T_NATIVE_UINT, scalar_sid, sid2, H5P_DEFAULT, &read_elem2) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Verify unwritten element is fill value (0) */
                     if (read_elem != 0)
@@ -10342,17 +10359,17 @@ test_chunk_expand(hid_t fapl)
                     /* Write element to the datasets */
                     write_elem = write_elem2 = u;
                     if (H5Dwrite(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &write_elem) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
                     if (H5Dwrite(dsid2, H5T_NATIVE_UINT, scalar_sid, sid2, H5P_DEFAULT, &write_elem2) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Read element from the datasets */
                     read_elem  = write_elem + 1;
                     read_elem2 = write_elem2 + 1;
                     if (H5Dread(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &read_elem) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
                     if (H5Dread(dsid2, H5T_NATIVE_UINT, scalar_sid, sid2, H5P_DEFAULT, &read_elem2) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Verify written element is read in */
                     if (read_elem != write_elem)
@@ -10390,21 +10407,21 @@ test_chunk_expand(hid_t fapl)
                     dim2[0] += 100;
                     dim2[1] += 100;
                     if (H5Dset_extent(dsid, &dim) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
                     if (H5Dset_extent(dsid2, dim2) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Close old dataspace */
                     if (H5Sclose(sid) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
                     if (H5Sclose(sid2) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Get dataspace for the datasets now */
                     if ((sid = H5Dget_space(dsid)) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
                     if ((sid2 = H5Dget_space(dsid2)) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Fill new elements */
                     hs_size = hs_size2[0] = hs_size2[1] = 1;
@@ -10414,16 +10431,16 @@ test_chunk_expand(hid_t fapl)
                         hs_offset2[0] = (dim2[0] + u) - 100;
                         hs_offset2[1] = (dim2[1] + u) - 100;
                         if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, &hs_offset, NULL, &hs_size, NULL) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
                         if (H5Sselect_hyperslab(sid2, H5S_SELECT_SET, hs_offset2, NULL, hs_size2, NULL) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Read (unwritten) element from the datasets */
                         read_elem = read_elem2 = 1;
                         if (H5Dread(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &read_elem) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
                         if (H5Dread(dsid2, H5T_NATIVE_UINT, scalar_sid, sid2, H5P_DEFAULT, &read_elem2) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Verify unwritten element is fill value (0) */
                         if (read_elem != 0)
@@ -10437,17 +10454,17 @@ test_chunk_expand(hid_t fapl)
                         /* Write element to the datasets */
                         write_elem = write_elem2 = u;
                         if (H5Dwrite(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &write_elem) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
                         if (H5Dwrite(dsid2, H5T_NATIVE_UINT, scalar_sid, sid2, H5P_DEFAULT, &write_elem2) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Read element from the datasets */
                         read_elem  = write_elem + 1;
                         read_elem2 = write_elem2 + 1;
                         if (H5Dread(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &read_elem) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
                         if (H5Dread(dsid2, H5T_NATIVE_UINT, scalar_sid, sid2, H5P_DEFAULT, &read_elem2) < 0)
-                            FAIL_STACK_ERROR
+                            FAIL_STACK_ERROR;
 
                         /* Verify written element is read in */
                         if (read_elem != write_elem)
@@ -10484,42 +10501,42 @@ test_chunk_expand(hid_t fapl)
 
                 /* Close the datasets */
                 if (H5Dclose(dsid) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5Dclose(dsid2) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
             } /* end else */
 
             /* Close everything */
             if (H5Sclose(sid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Sclose(sid2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Sclose(scalar_sid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Pclose(dcpl) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Pclose(dcpl2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Fclose(fid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* If the dataset was created, do some extra testing */
             if (H5D_ALLOC_TIME_EARLY != alloc_time) {
                 /* Re-open file & datasets */
                 if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Open the datasets */
                 if ((dsid = H5Dopen2(fid, "dset", H5P_DEFAULT)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if ((dsid2 = H5Dopen2(fid, "dset2", H5P_DEFAULT)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Get the chunk index type for the two datasets */
                 if (H5D__layout_idx_type_test(dsid, &idx_type) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5D__layout_idx_type_test(dsid2, &idx_type2) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Chunk index type expected depends on whether we are using the latest version of the format
                  */
@@ -10540,13 +10557,13 @@ test_chunk_expand(hid_t fapl)
 
                 /* Create scalar dataspace */
                 if ((scalar_sid = H5Screate(H5S_SCALAR)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Get dataspace for the datasets now */
                 if ((sid = H5Dget_space(dsid)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if ((sid2 = H5Dget_space(dsid2)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Read elements */
                 hs_size = hs_size2[0] = hs_size2[1] = 1;
@@ -10554,16 +10571,16 @@ test_chunk_expand(hid_t fapl)
                     /* Select a single element in the datasets */
                     hs_offset = hs_offset2[0] = hs_offset2[1] = u;
                     if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, &hs_offset, NULL, &hs_size, NULL) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
                     if (H5Sselect_hyperslab(sid2, H5S_SELECT_SET, hs_offset2, NULL, hs_size2, NULL) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Read element from the datasets */
                     read_elem = read_elem2 = u + 1;
                     if (H5Dread(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &read_elem) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
                     if (H5Dread(dsid2, H5T_NATIVE_UINT, scalar_sid, sid2, H5P_DEFAULT, &read_elem2) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Verify unwritten element is proper value */
                     if (read_elem != (u % 100))
@@ -10577,17 +10594,17 @@ test_chunk_expand(hid_t fapl)
                     /* Write element to the datasets */
                     write_elem = write_elem2 = u % 100;
                     if (H5Dwrite(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &write_elem) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
                     if (H5Dwrite(dsid2, H5T_NATIVE_UINT, scalar_sid, sid2, H5P_DEFAULT, &write_elem2) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Read element from the datasets */
                     read_elem  = write_elem + 1;
                     read_elem2 = write_elem2 + 1;
                     if (H5Dread(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &read_elem) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
                     if (H5Dread(dsid2, H5T_NATIVE_UINT, scalar_sid, sid2, H5P_DEFAULT, &read_elem2) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Verify written element is read in */
                     if (read_elem != write_elem)
@@ -10620,41 +10637,41 @@ test_chunk_expand(hid_t fapl)
 
                 /* Close everything */
                 if (H5Sclose(sid) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5Sclose(sid2) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5Sclose(scalar_sid) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5Dclose(dsid) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5Dclose(dsid2) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5Fclose(fid) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Re-open file */
                 if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Delete the datasets */
                 if (H5Ldelete(fid, "dset", H5P_DEFAULT) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5Ldelete(fid, "dset2", H5P_DEFAULT) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Close everything */
                 if (H5Fclose(fid) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
             } /* end if */
         }     /* end for */
 
         /* Unregister "expansion" filter */
         if (H5Zunregister(H5Z_FILTER_EXPAND) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check that the filter was unregistered */
         if (FALSE != H5Zfilter_avail(H5Z_FILTER_EXPAND))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     } /* end else */
@@ -10804,23 +10821,23 @@ test_fixed_array(hid_t fapl)
 
     /* Check if we are using the latest version of the format */
     if (H5Pget_libver_bounds(fapl, &low, &high) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create and close the file to get the file size */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        STACK_ERROR
+        STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Get the size of the empty file */
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate the "big" buffers */
     if (NULL == (wbuf_big = (int *)HDmalloc(sizeof(int) * POINTS_BIG)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (rbuf_big = (int *)HDmalloc(sizeof(int) * POINTS_BIG)))
-        TEST_ERROR
+        TEST_ERROR;
 
 #ifdef H5_HAVE_FILTER_DEFLATE
     /* Loop over compressing chunks */
@@ -10831,30 +10848,30 @@ test_fixed_array(hid_t fapl)
         for (alloc_time = H5D_ALLOC_TIME_EARLY; alloc_time <= H5D_ALLOC_TIME_INCR; alloc_time++) {
             /* Create file */
             if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create dataset creation property list */
             if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Set chunking */
             if ((ret = H5Pset_chunk(dcpl, 2, chunk_dim2)) < 0)
-                FAIL_PUTS_ERROR("    Problem with setting chunk.")
+                FAIL_PUTS_ERROR("    Problem with setting chunk.");
 
 #ifdef H5_HAVE_FILTER_DEFLATE
             /* Check if we should compress the chunks */
             if (compress)
                 if (H5Pset_deflate(dcpl, 9) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 #endif /* H5_HAVE_FILTER_DEFLATE */
 
             /* Set fill time */
             if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_ALLOC) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Set allocation time */
             if (H5Pset_alloc_time(dcpl, alloc_time) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Initialization of chunk array for repeated coordinates */
             for (i = 0; i < dim2[0] / chunk_dim2[0]; i++)
@@ -10879,15 +10896,15 @@ test_fixed_array(hid_t fapl)
 
             /* Create first dataset with cur and max dimensions */
             if ((sid_max = H5Screate_simple(2, dim2, dim2_max)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             dsid_max =
                 H5Dcreate2(fid, DSET_FIXED_MAX, H5T_NATIVE_INT, sid_max, H5P_DEFAULT, dcpl, H5P_DEFAULT);
             if (dsid_max < 0)
-                FAIL_PUTS_ERROR("    Creating Chunked Dataset with maximum dimensions.")
+                FAIL_PUTS_ERROR("    Creating Chunked Dataset with maximum dimensions.");
 
             /* Get the chunk index type */
             if (H5D__layout_idx_type_test(dsid_max, &idx_type) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Chunk index type depends on whether we are using the latest version of the format */
             if (low == H5F_LIBVER_LATEST) {
@@ -10921,22 +10938,22 @@ test_fixed_array(hid_t fapl)
 
             /* Closing */
             if (H5Dclose(dsid_max) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Sclose(sid_max) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Sclose(mem_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create second dataset with curr dim but NULL max dim */
             if ((sid = H5Screate_simple(2, dim2, NULL)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             dsid = H5Dcreate2(fid, DSET_FIXED_NOMAX, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT);
             if (dsid < 0)
-                FAIL_PUTS_ERROR("    Creating Chunked Dataset.")
+                FAIL_PUTS_ERROR("    Creating Chunked Dataset.");
 
             /* Get the chunk index type */
             if (H5D__layout_idx_type_test(dsid, &idx_type) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Chunk index type depends on whether we are using the latest version of the format */
             if (low == H5F_LIBVER_LATEST) {
@@ -10970,23 +10987,23 @@ test_fixed_array(hid_t fapl)
 
             /* Closing */
             if (H5Dclose(dsid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Sclose(sid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Sclose(mem_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create the third dataset with bigger size and both curr & max dimensions are the same */
             if ((sid_big = H5Screate_simple(2, dim2_big, dim2_big)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             dsid_big =
                 H5Dcreate2(fid, DSET_FIXED_BIG, H5T_NATIVE_INT, sid_big, H5P_DEFAULT, dcpl, H5P_DEFAULT);
             if (dsid_big < 0)
-                FAIL_PUTS_ERROR("    Creating Big Chunked Dataset.")
+                FAIL_PUTS_ERROR("    Creating Big Chunked Dataset.");
 
             /* Get the chunk index type */
             if (H5D__layout_idx_type_test(dsid_big, &idx_type) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Chunk index type depends on whether we are using the latest version of the format */
             if (low == H5F_LIBVER_LATEST) {
@@ -11041,13 +11058,13 @@ test_fixed_array(hid_t fapl)
 
             /* Closing */
             if (H5Dclose(dsid_big) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Sclose(sid_big) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Sclose(big_mem_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Pclose(dcpl) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Open the first dataset */
             if ((dsid = H5Dopen2(fid, DSET_FIXED_MAX, H5P_DEFAULT)) < 0)
@@ -11079,11 +11096,11 @@ test_fixed_array(hid_t fapl)
 
             /* Closing */
             if (H5Dclose(dsid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Sclose(sid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Sclose(mem_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Open the second dataset */
             if ((dsid = H5Dopen2(fid, DSET_FIXED_NOMAX, H5P_DEFAULT)) < 0)
@@ -11115,11 +11132,11 @@ test_fixed_array(hid_t fapl)
 
             /* Closing */
             if (H5Dclose(dsid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Sclose(sid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Sclose(mem_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Open the third dataset */
             if ((dsid_big = H5Dopen2(fid, DSET_FIXED_BIG, H5P_DEFAULT)) < 0)
@@ -11149,31 +11166,31 @@ test_fixed_array(hid_t fapl)
 
             /* Closing */
             if (H5Dclose(dsid_big) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Sclose(sid_big) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Sclose(big_mem_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Delete datasets */
             if (H5Ldelete(fid, DSET_FIXED_BIG, H5P_DEFAULT) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Ldelete(fid, DSET_FIXED_NOMAX, H5P_DEFAULT) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Ldelete(fid, DSET_FIXED_MAX, H5P_DEFAULT) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Close everything */
             if (H5Fclose(fid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Get the size of the file */
             if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Verify the file is correct size */
             if (file_size != empty_size)
-                TEST_ERROR
+                TEST_ERROR;
 
         } /* end for */
 #ifdef H5_HAVE_FILTER_DEFLATE
@@ -11282,27 +11299,27 @@ test_single_chunk(hid_t fapl)
 
     /* Check if we are using the latest version of the format */
     if (H5Pget_libver_bounds(fapl, &low, &high) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create and close the file to get the file size */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        STACK_ERROR
+        STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Get the size of the empty file */
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate the buffers */
     if (NULL == (wbuf = (int *)HDmalloc(sizeof(int) * (DSET_DIM1 * DSET_DIM2))))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (rbuf = (int *)HDmalloc(sizeof(int) * (DSET_DIM1 * DSET_DIM2))))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (t_wbuf = (int *)HDmalloc(sizeof(int) * (DSET_TMP_DIM1 * DSET_TMP_DIM2))))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (t_rbuf = (int *)HDmalloc(sizeof(int) * (DSET_TMP_DIM1 * DSET_TMP_DIM2))))
-        TEST_ERROR
+        TEST_ERROR;
 
     for (i = n = 0; i < (DSET_DIM1 * DSET_DIM2); i++)
         wbuf[i] = (int)n++;
@@ -11319,54 +11336,54 @@ test_single_chunk(hid_t fapl)
         for (alloc_time = H5D_ALLOC_TIME_EARLY; alloc_time <= H5D_ALLOC_TIME_INCR; alloc_time++) {
             /* Create file */
             if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create dataset creation property list */
             if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((t_dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Set chunking */
             if ((ret = H5Pset_chunk(dcpl, 2, dim2)) < 0)
-                FAIL_PUTS_ERROR("    Problem with setting chunk.")
+                FAIL_PUTS_ERROR("    Problem with setting chunk.");
 
             if ((ret = H5Pset_chunk(t_dcpl, 2, t_dim2)) < 0)
-                FAIL_PUTS_ERROR("    Problem with setting chunk.")
+                FAIL_PUTS_ERROR("    Problem with setting chunk.");
 
 #ifdef H5_HAVE_FILTER_DEFLATE
             /* Check if we should compress the chunks */
             if (compress) {
                 if (H5Pset_deflate(dcpl, 9) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5Pset_deflate(t_dcpl, 9) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
             }
 #endif /* H5_HAVE_FILTER_DEFLATE */
 
             /* Set fill time */
             if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_ALLOC) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Pset_fill_time(t_dcpl, H5D_FILL_TIME_ALLOC) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Set allocation time */
             if (H5Pset_alloc_time(dcpl, alloc_time) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Pset_alloc_time(t_dcpl, alloc_time) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create first dataset with cur and max dimensions */
             if ((sid_max = H5Screate_simple(2, dim2, dim2)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             did_max =
                 H5Dcreate2(fid, DSET_SINGLE_MAX, H5T_NATIVE_INT, sid_max, H5P_DEFAULT, dcpl, H5P_DEFAULT);
             if (did_max < 0)
-                FAIL_PUTS_ERROR("    Creating Chunked Dataset with maximum dimensions.")
+                FAIL_PUTS_ERROR("    Creating Chunked Dataset with maximum dimensions.");
 
             /* Get the chunk index type */
             if (H5D__layout_idx_type_test(did_max, &idx_type) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Chunk index type depends on whether we are using the latest version of the format */
             if (low == H5F_LIBVER_LATEST) {
@@ -11384,20 +11401,20 @@ test_single_chunk(hid_t fapl)
 
             /* Closing */
             if (H5Dclose(did_max) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Sclose(sid_max) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create second dataset with curr dim but NULL max dim */
             if ((sid = H5Screate_simple(2, t_dim2, NULL)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             did = H5Dcreate2(fid, DSET_SINGLE_NOMAX, H5T_NATIVE_INT, sid, H5P_DEFAULT, t_dcpl, H5P_DEFAULT);
             if (did < 0)
-                FAIL_PUTS_ERROR("    Creating Chunked Dataset.")
+                FAIL_PUTS_ERROR("    Creating Chunked Dataset.");
 
             /* Get the chunk index type */
             if (H5D__layout_idx_type_test(did, &idx_type) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Chunk index type depends on whether we are using the latest version of the format */
             if (low == H5F_LIBVER_LATEST) {
@@ -11415,9 +11432,9 @@ test_single_chunk(hid_t fapl)
 
             /* Closing */
             if (H5Dclose(did) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Sclose(sid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Open the first dataset */
             if ((did_max = H5Dopen2(fid, DSET_SINGLE_MAX, H5P_DEFAULT)) < 0)
@@ -11437,7 +11454,7 @@ test_single_chunk(hid_t fapl)
 
             /* Closing */
             if (H5Dclose(did_max) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Open the second dataset */
             if ((did = H5Dopen2(fid, DSET_SINGLE_NOMAX, H5P_DEFAULT)) < 0)
@@ -11459,25 +11476,25 @@ test_single_chunk(hid_t fapl)
 
             /* Closing */
             if (H5Dclose(did) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Delete datasets */
             if (H5Ldelete(fid, DSET_SINGLE_NOMAX, H5P_DEFAULT) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Ldelete(fid, DSET_SINGLE_MAX, H5P_DEFAULT) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Close everything */
             if (H5Fclose(fid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Get the size of the file */
             if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Verify the file is correct size */
             if (file_size != empty_size)
-                TEST_ERROR
+                TEST_ERROR;
 
         } /* end for */
 #ifdef H5_HAVE_FILTER_DEFLATE
@@ -11545,41 +11562,41 @@ test_idx_compatible(void)
 
         /* Open the file */
         if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Should be able to read the dataset w/o filter created under 1.8/1.6 */
         if ((did = H5Dopen2(fid, DSET, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get the chunk index type */
         if (H5D__layout_idx_type_test(did, &idx_type) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify index type */
         if (idx_type != H5D_CHUNK_IDX_BTREE)
-            FAIL_PUTS_ERROR("should be using v1 B-tree as index")
+            FAIL_PUTS_ERROR("should be using v1 B-tree as index");
 
         if (H5Dclose(did) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Should be able to read the dataset w/ filter created under 1.8/1.6 */
         if ((did = H5Dopen2(fid, DSET_FILTER, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get the chunk index type */
         if (H5D__layout_idx_type_test(did, &idx_type) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify index type */
         if (idx_type != H5D_CHUNK_IDX_BTREE)
-            FAIL_PUTS_ERROR("should be using v1 B-tree as index")
+            FAIL_PUTS_ERROR("should be using v1 B-tree as index");
 
         if (H5Dclose(did) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close the file */
         if (H5Fclose(fid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
 
     PASSED();
@@ -11627,34 +11644,34 @@ test_unfiltered_edge_chunks(hid_t fapl)
 
     /* Create the file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Register byte-counting filter */
     if (H5Zregister(H5Z_COUNT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace */
     if ((sid = H5Screate_simple(2, dim, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create DCPL */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set chunk dimensions */
     if (H5Pset_chunk(dcpl, 2, cdim) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add "count" filter */
     if (H5Pset_filter(dcpl, H5Z_FILTER_COUNT, 0U, (size_t)0, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Disable filters on partial chunks */
     if (H5Pget_chunk_opts(dcpl, &opts) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     opts |= H5D_CHUNK_DONT_FILTER_PARTIAL_CHUNKS;
     if (H5Pset_chunk_opts(dcpl, opts) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize write buffer */
     for (i = 0; i < dim[0]; i++)
@@ -11667,59 +11684,59 @@ test_unfiltered_edge_chunks(hid_t fapl)
 
     /* Create dataset */
     if ((did = H5Dcreate2(fid, DSET_CHUNKED_NAME, H5T_NATIVE_CHAR, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Nothing should have been written, as we are not using early allocation */
     if (count_nbytes_read != (size_t)0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count_nbytes_written != (size_t)0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Write data */
     if (H5Dwrite(did, H5T_NATIVE_CHAR, H5S_ALL, H5S_ALL, H5P_DEFAULT, wbuf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make sure only 2 of the 4 chunks were written through the filter (4 bytes
      * each) */
     if (count_nbytes_read != (size_t)0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count_nbytes_written != (size_t)(2 * cdim[0] * cdim[1]))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reopen the dataset */
     if ((did = H5Dopen2(fid, DSET_CHUNKED_NAME, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read the dataset */
     if (H5Dread(did, H5T_NATIVE_CHAR, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that data read == data written */
     for (i = 0; i < dim[0]; i++)
         for (j = 0; j < dim[1]; j++)
             if (rbuf[i][j] != wbuf[i][j])
-                TEST_ERROR
+                TEST_ERROR;
 
     /* Make sure only 2 of the 4 chunks were read through the filter (4 bytes
      * each) */
     if (count_nbytes_read != (size_t)(2 * cdim[0] * cdim[1]))
-        TEST_ERROR
+        TEST_ERROR;
     if (count_nbytes_written != (size_t)(2 * cdim[0] * cdim[1]))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close IDs */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -11770,41 +11787,41 @@ test_large_chunk_shrink(hid_t fapl)
 
     /* Create file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataset creation property list */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set 2 MB chunk size */
     chunk_dim = 2 * 1024 * 1024 / sizeof(unsigned);
     if (H5Pset_chunk(dcpl, 1, &chunk_dim) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create scalar dataspace */
     if ((scalar_sid = H5Screate(H5S_SCALAR)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create 1-D dataspace */
     dim     = 2 * 1024 * 1024 / sizeof(unsigned);
     max_dim = H5S_UNLIMITED;
     if ((sid = H5Screate_simple(1, &dim, &max_dim)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create 2 MB chunked dataset */
     if ((dsid = H5Dcreate2(fid, "dset", H5T_NATIVE_UINT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Select last element in the dataset */
     hs_offset = dim - 1;
     hs_size   = 1;
     if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, &hs_offset, NULL, &hs_size, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read (unwritten) element from dataset */
     read_elem = 1;
     if (H5Dread(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &read_elem) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify unwritten element is fill value (0) */
     if (read_elem != 0)
@@ -11813,12 +11830,12 @@ test_large_chunk_shrink(hid_t fapl)
     /* Write element to dataset */
     write_elem = 2;
     if (H5Dwrite(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &write_elem) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read element from dataset */
     read_elem = write_elem + 1;
     if (H5Dread(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &read_elem) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify written element is read in */
     if (read_elem != write_elem)
@@ -11827,17 +11844,17 @@ test_large_chunk_shrink(hid_t fapl)
     /* Shrink dataset to 512 KB */
     dim = 512 * 1024 / sizeof(unsigned);
     if (H5Dset_extent(dsid, &dim) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Expand dataset back to 2MB */
     dim = 2 * 1024 * 1024 / sizeof(unsigned);
     if (H5Dset_extent(dsid, &dim) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read element from dataset */
     read_elem = 1;
     if (H5Dread(dsid, H5T_NATIVE_UINT, scalar_sid, sid, H5P_DEFAULT, &read_elem) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify element is now 0 */
     if (read_elem != 0)
@@ -11845,15 +11862,15 @@ test_large_chunk_shrink(hid_t fapl)
 
     /* Close everything */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(scalar_sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -11921,43 +11938,43 @@ test_zero_dim_dset(hid_t fapl)
 
             /* Create file */
             if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create dataset creation property list */
             if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Set 1 chunk size */
             chunk_dim = 1;
             if (H5Pset_chunk(dcpl, 1, &chunk_dim) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create 1D dataspace with 0 dim size */
             dim = 0;
             if ((sid = H5Screate_simple(1, &dim, NULL)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create chunked dataset */
             if ((dsid = H5Dcreate2(fid, "dset", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* write 0 elements from dataset */
             if (H5Dwrite(dsid, H5T_NATIVE_INT, sid, sid, H5P_DEFAULT, data) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Read 0 elements from dataset */
             if (H5Dread(dsid, H5T_NATIVE_INT, sid, sid, H5P_DEFAULT, data) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Close everything */
             if (H5Sclose(sid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Dclose(dsid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Pclose(dcpl) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Fclose(fid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
         } /* end for high */
     }     /* end for low */
@@ -12021,216 +12038,216 @@ test_swmr_non_latest(const char *env_h5_driver, hid_t fapl)
 
     /* Check if we are using the latest version of the format */
     if (H5Pget_libver_bounds(fapl, &low, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     h5_fixname(FILENAME[18], fapl, filename, sizeof filename);
 
     if (low == H5F_LIBVER_LATEST) {
         /* Create file with write+latest-format */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     else {
         /* Create file with SWMR-write+non-latest-format */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC | H5F_ACC_SWMR_WRITE, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end else */
 
     /* Create a chunked dataset: this will use extensible array chunk indexing */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     chunk_dim[0] = 6;
     if (H5Pset_chunk(dcpl, 1, chunk_dim) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     dim[0]     = 1;
     max_dim[0] = H5S_UNLIMITED;
     if ((sid = H5Screate_simple(1, dim, max_dim)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((did = H5Dcreate2(fid, DSET_CHUNKED_NAME, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write to the dataset */
     data = 100;
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &data) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the dataset's indexing type */
     if (H5D__layout_idx_type_test(did, &idx_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (idx_type != H5D_CHUNK_IDX_EARRAY)
-        FAIL_PUTS_ERROR("created dataset not indexed by extensible array")
+        FAIL_PUTS_ERROR("created dataset not indexed by extensible array");
 
     /* Closing */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file again */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset in the file */
     if ((did = H5Dopen2(fid, DSET_CHUNKED_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the dataset's indexing type */
     if (H5D__layout_idx_type_test(did, &idx_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (idx_type != H5D_CHUNK_IDX_EARRAY)
-        FAIL_PUTS_ERROR("created dataset not indexed by extensible array")
+        FAIL_PUTS_ERROR("created dataset not indexed by extensible array");
 
     /* Read from the dataset and verify data read is correct */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &data) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (data != 100)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a group in the file */
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a chunked dataset in the group: this will use v2 B-tree chunk indexing */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     chunk_dims2[0] = chunk_dims2[1] = 10;
     if (H5Pset_chunk(dcpl, 2, chunk_dims2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     dims2[0] = dims2[1] = 1;
     max_dims2[0] = max_dims2[1] = H5S_UNLIMITED;
     if ((sid = H5Screate_simple(2, dims2, max_dims2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((did = H5Dcreate2(gid, DSET_CHUNKED_NAME, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the dataset's indexing type */
     if (H5D__layout_idx_type_test(did, &idx_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (idx_type != H5D_CHUNK_IDX_BT2)
-        FAIL_PUTS_ERROR("created dataset not indexed by v2 B-tree")
+        FAIL_PUTS_ERROR("created dataset not indexed by v2 B-tree");
 
     /* Closing */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file again */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the group */
     if ((gid = H5Gopen2(fid, "group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset in the group */
     if ((did = H5Dopen2(gid, DSET_CHUNKED_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the dataset's indexing type */
     if (H5D__layout_idx_type_test(did, &idx_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (idx_type != H5D_CHUNK_IDX_BT2)
-        FAIL_PUTS_ERROR("created dataset not indexed by v2 B-tree")
+        FAIL_PUTS_ERROR("created dataset not indexed by v2 B-tree");
 
     /* Closing */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reopen the file with SWMR-write */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset in the file */
     if ((did = H5Dopen2(fid, DSET_CHUNKED_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the dataset's indexing type */
     if (H5D__layout_idx_type_test(did, &idx_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (idx_type != H5D_CHUNK_IDX_EARRAY)
-        FAIL_PUTS_ERROR("created dataset not indexed by extensible array")
+        FAIL_PUTS_ERROR("created dataset not indexed by extensible array");
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the group */
     if ((gid = H5Gopen2(fid, "group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset in the group */
     if ((did = H5Dopen2(gid, DSET_CHUNKED_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the dataset's indexing type */
     if (H5D__layout_idx_type_test(did, &idx_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (idx_type != H5D_CHUNK_IDX_BT2)
-        FAIL_PUTS_ERROR("created dataset not indexed by v2 B-tree")
+        FAIL_PUTS_ERROR("created dataset not indexed by v2 B-tree");
 
     /* Write to the dataset in the group */
     data = 99;
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &data) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Closing */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file again with SWMR read access */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((gid = H5Gopen2(fid, "group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset */
     if ((did = H5Dopen2(gid, DSET_CHUNKED_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read from the dataset and verify data read is correct */
     data = 0;
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &data) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (data != 99)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -12649,23 +12666,23 @@ test_storage_size(hid_t fapl)
 
     /* Create file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataset creation property list */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set chunk size */
     chunk_dims[0] = STORAGE_SIZE_CHUNK_DIM1;
     chunk_dims[1] = STORAGE_SIZE_CHUNK_DIM2;
     if (H5Pset_chunk(dcpl, 2, chunk_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Copy the DCPL, and set it to early allocation */
     if ((dcpl2 = H5Pcopy(dcpl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_alloc_time(dcpl2, H5D_ALLOC_TIME_EARLY) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create 2D dataspace, with max dims same as current dimensions */
     dims[0]     = STORAGE_SIZE_DIM1;
@@ -12673,48 +12690,48 @@ test_storage_size(hid_t fapl)
     max_dims[0] = STORAGE_SIZE_DIM1;
     max_dims[1] = STORAGE_SIZE_DIM2;
     if ((sid = H5Screate_simple(2, dims, max_dims)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create chunked dataset */
     if ((dsid = H5Dcreate2(fid, "dset", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize buffer to zeroes */
     HDmemset(wdata, 0, sizeof(wdata));
 
     /* write elements to dataset */
     if (H5Dwrite(dsid, H5T_NATIVE_INT, sid, sid, H5P_DEFAULT, wdata) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 6 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset & dataspace */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Copy the dataset */
     if (H5Ocopy(fid, "dset", fid, "dset_copy", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the copied dataset */
     if ((dsid = H5Dopen2(fid, "dset_copy", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 6 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close copied dataset */
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create 2D dataspace with max dims > current dims (but not unlimited) */
     dims[0]     = STORAGE_SIZE_DIM1;
@@ -12722,60 +12739,60 @@ test_storage_size(hid_t fapl)
     max_dims[0] = STORAGE_SIZE_MAX_DIM1;
     max_dims[1] = STORAGE_SIZE_MAX_DIM2;
     if ((sid = H5Screate_simple(2, dims, max_dims)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create chunked dataset */
     if ((dsid = H5Dcreate2(fid, "dset2", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize buffer to zeroes */
     HDmemset(wdata, 0, sizeof(wdata));
 
     /* write elements to dataset */
     if (H5Dwrite(dsid, H5T_NATIVE_INT, sid, sid, H5P_DEFAULT, wdata) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 6 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Extend dataset's dimensions */
     new_dims[0] = STORAGE_SIZE_DIM1 * 2;
     new_dims[1] = STORAGE_SIZE_DIM2 * 2;
     if (H5Dset_extent(dsid, new_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 6 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset & dataspace */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Copy the dataset */
     if (H5Ocopy(fid, "dset2", fid, "dset2_copy", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the copied dataset */
     if ((dsid = H5Dopen2(fid, "dset2_copy", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 6 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close copied dataset */
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create 2D dataspace with max dims > current dims (but not unlimited) */
     dims[0]     = STORAGE_SIZE_DIM1;
@@ -12783,60 +12800,60 @@ test_storage_size(hid_t fapl)
     max_dims[0] = STORAGE_SIZE_MAX_DIM1;
     max_dims[1] = STORAGE_SIZE_MAX_DIM2;
     if ((sid = H5Screate_simple(2, dims, max_dims)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create chunked dataset, w/early allocation */
     if ((dsid = H5Dcreate2(fid, "dset2a", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl2, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize buffer to zeroes */
     HDmemset(wdata, 0, sizeof(wdata));
 
     /* write elements to dataset */
     if (H5Dwrite(dsid, H5T_NATIVE_INT, sid, sid, H5P_DEFAULT, wdata) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 6 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Extend dataset's dimensions */
     new_dims[0] = STORAGE_SIZE_DIM1 * 2;
     new_dims[1] = STORAGE_SIZE_DIM2 * 2;
     if (H5Dset_extent(dsid, new_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 15 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset & dataspace */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Copy the dataset */
     if (H5Ocopy(fid, "dset2a", fid, "dset2a_copy", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the copied dataset */
     if ((dsid = H5Dopen2(fid, "dset2a_copy", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 15 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close copied dataset */
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create 2D dataspace with max dims > current dims (and 1 unlimited dim) */
     dims[0]     = STORAGE_SIZE_DIM1;
@@ -12844,60 +12861,60 @@ test_storage_size(hid_t fapl)
     max_dims[0] = H5S_UNLIMITED;
     max_dims[1] = STORAGE_SIZE_MAX_DIM2;
     if ((sid = H5Screate_simple(2, dims, max_dims)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create chunked dataset */
     if ((dsid = H5Dcreate2(fid, "dset3", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize buffer to zeroes */
     HDmemset(wdata, 0, sizeof(wdata));
 
     /* write elements to dataset */
     if (H5Dwrite(dsid, H5T_NATIVE_INT, sid, sid, H5P_DEFAULT, wdata) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 6 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Extend dataset's dimensions */
     new_dims[0] = STORAGE_SIZE_DIM1 * 2;
     new_dims[1] = STORAGE_SIZE_DIM2 * 2;
     if (H5Dset_extent(dsid, new_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 6 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset & dataspace */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Copy the dataset */
     if (H5Ocopy(fid, "dset3", fid, "dset3_copy", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the copied dataset */
     if ((dsid = H5Dopen2(fid, "dset3_copy", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 6 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close copied dataset */
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create 2D dataspace with max dims > current dims (and 1 unlimited dim) */
     dims[0]     = STORAGE_SIZE_DIM1;
@@ -12905,60 +12922,60 @@ test_storage_size(hid_t fapl)
     max_dims[0] = H5S_UNLIMITED;
     max_dims[1] = STORAGE_SIZE_MAX_DIM2;
     if ((sid = H5Screate_simple(2, dims, max_dims)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create chunked dataset, w/early allocation */
     if ((dsid = H5Dcreate2(fid, "dset3a", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl2, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize buffer to zeroes */
     HDmemset(wdata, 0, sizeof(wdata));
 
     /* write elements to dataset */
     if (H5Dwrite(dsid, H5T_NATIVE_INT, sid, sid, H5P_DEFAULT, wdata) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 6 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Extend dataset's dimensions */
     new_dims[0] = STORAGE_SIZE_DIM1 * 2;
     new_dims[1] = STORAGE_SIZE_DIM2 * 2;
     if (H5Dset_extent(dsid, new_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 15 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset & dataspace */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Copy the dataset */
     if (H5Ocopy(fid, "dset3a", fid, "dset3a_copy", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the copied dataset */
     if ((dsid = H5Dopen2(fid, "dset3a_copy", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 15 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close copied dataset */
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create 2D dataspace with max dims > current dims (and 2 unlimited dims) */
     dims[0]     = STORAGE_SIZE_DIM1;
@@ -12966,60 +12983,60 @@ test_storage_size(hid_t fapl)
     max_dims[0] = H5S_UNLIMITED;
     max_dims[1] = H5S_UNLIMITED;
     if ((sid = H5Screate_simple(2, dims, max_dims)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create chunked dataset */
     if ((dsid = H5Dcreate2(fid, "dset4", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize buffer to zeroes */
     HDmemset(wdata, 0, sizeof(wdata));
 
     /* write elements to dataset */
     if (H5Dwrite(dsid, H5T_NATIVE_INT, sid, sid, H5P_DEFAULT, wdata) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 6 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Extend dataset's dimensions */
     new_dims[0] = STORAGE_SIZE_DIM1 * 2;
     new_dims[1] = STORAGE_SIZE_DIM2 * 2;
     if (H5Dset_extent(dsid, new_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 6 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset & dataspace */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Copy the dataset */
     if (H5Ocopy(fid, "dset4", fid, "dset4_copy", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the copied dataset */
     if ((dsid = H5Dopen2(fid, "dset4_copy", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 6 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close copied dataset */
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create 2D dataspace with max dims > current dims (and 2 unlimited dims) */
     dims[0]     = STORAGE_SIZE_DIM1;
@@ -13027,66 +13044,66 @@ test_storage_size(hid_t fapl)
     max_dims[0] = H5S_UNLIMITED;
     max_dims[1] = H5S_UNLIMITED;
     if ((sid = H5Screate_simple(2, dims, max_dims)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create chunked dataset, w/early allocation */
     if ((dsid = H5Dcreate2(fid, "dset4a", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl2, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize buffer to zeroes */
     HDmemset(wdata, 0, sizeof(wdata));
 
     /* write elements to dataset */
     if (H5Dwrite(dsid, H5T_NATIVE_INT, sid, sid, H5P_DEFAULT, wdata) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 6 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Extend dataset's dimensions */
     new_dims[0] = STORAGE_SIZE_DIM1 * 2;
     new_dims[1] = STORAGE_SIZE_DIM2 * 2;
     if (H5Dset_extent(dsid, new_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 15 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset & dataspace */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Copy the dataset */
     if (H5Ocopy(fid, "dset4a", fid, "dset4a_copy", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the copied dataset */
     if ((dsid = H5Dopen2(fid, "dset4a_copy", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the storage size */
     if (0 == (ssize = H5Dget_storage_size(dsid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sizeof(int) * 15 * STORAGE_SIZE_CHUNK_DIM1 * STORAGE_SIZE_CHUNK_DIM2) != ssize)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close copied dataset */
     if (H5Dclose(dsid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close rest */
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -13140,7 +13157,7 @@ test_power2up(hid_t fapl)
 
     /* Create file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set dims[1] to ((2^63) -1) */
     dims[0]     = 0;
@@ -13150,16 +13167,16 @@ test_power2up(hid_t fapl)
 
     /* Create dataset creation property list */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set chunk size */
     chunk_dims[0] = chunk_dims[1] = 1;
     if (H5Pset_chunk(dcpl, 2, chunk_dims) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create chunked dataset */
     if ((did = H5Dcreate2(fid, "dset", H5T_NATIVE_INT64, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     ext_dims[0] = 1;
     ext_dims[1] = dims[1] + 5;
@@ -13171,17 +13188,17 @@ test_power2up(hid_t fapl)
     }
     H5E_END_TRY;
     if (status >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -13276,7 +13293,7 @@ test_scatter(void)
 
     /* Create dataspace */
     if ((sid = H5Screate_simple(3, dim, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize src_buf */
     for (i = 0; i < (int)(sizeof(src_buf) / sizeof(src_buf[0])); i++)
@@ -13290,10 +13307,10 @@ test_scatter(void)
     count[1] = 1;
     count[2] = 8;
     if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-            /* Initialize dst_buf and expect_dst_buf */
-            (void) HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
+    /* Initialize dst_buf and expect_dst_buf */
+    (void)HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
     for (i = 0; i < 8; i++)
         expect_dst_buf[0][0][i] = src_buf[i];
 
@@ -13309,7 +13326,7 @@ test_scatter(void)
 
         /* Scatter data */
         if (H5Dscatter((H5D_scatter_func_t)scatter_cb, &scatter_info, H5T_NATIVE_INT, sid, dst_buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify data */
         TEST_SCATTER_CHECK_ARR(dst_buf, expect_dst_buf)
@@ -13326,10 +13343,10 @@ test_scatter(void)
     count[1] = 3;
     count[2] = 2;
     if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-            /* Initialize expect_dst_buf */
-            (void) HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
+    /* Initialize expect_dst_buf */
+    (void)HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
     src_i = 0;
     for (i = 3; i < 5; i++)
         for (j = 2; j < 5; j++)
@@ -13348,7 +13365,7 @@ test_scatter(void)
 
         /* Scatter data */
         if (H5Dscatter((H5D_scatter_func_t)scatter_cb, &scatter_info, H5T_NATIVE_INT, sid, dst_buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify data */
         TEST_SCATTER_CHECK_ARR(dst_buf, expect_dst_buf)
@@ -13371,13 +13388,13 @@ test_scatter(void)
     block[1]  = 3;
     block[2]  = 2;
     if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-            /* Initialize expect_dst_buf */
-            /* Iterate over block containing selection, checking if each element is in
-             * selection.  Note that the algorithm used here (if statement) would not
-             * work for overlapping hyperslabs. */
-            (void) HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
+    /* Initialize expect_dst_buf */
+    /* Iterate over block containing selection, checking if each element is in
+     * selection.  Note that the algorithm used here (if statement) would not
+     * work for overlapping hyperslabs. */
+    (void)HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
     src_i = 0;
     for (i = 1; i < 8; i++)
         for (j = 1; j < 4; j++)
@@ -13402,7 +13419,7 @@ test_scatter(void)
 
         /* Scatter data */
         if (H5Dscatter((H5D_scatter_func_t)scatter_cb, &scatter_info, H5T_NATIVE_INT, sid, dst_buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify data */
         TEST_SCATTER_CHECK_ARR(dst_buf, expect_dst_buf)
@@ -13419,7 +13436,7 @@ test_scatter(void)
     count[1] = 3;
     count[2] = 2;
     if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     start2[0] = 1;
     start2[1] = 2;
     start2[2] = 2;
@@ -13427,12 +13444,12 @@ test_scatter(void)
     count2[1] = 2;
     count2[2] = 2;
     if (H5Sselect_hyperslab(sid, H5S_SELECT_XOR, start2, NULL, count2, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-            /* Initialize expect_dst_buf */
-            /* Iterate over block containing selection, checking if each element is in
-             * selection. */
-            (void) HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
+    /* Initialize expect_dst_buf */
+    /* Iterate over block containing selection, checking if each element is in
+     * selection. */
+    (void)HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
     src_i = 0;
     for (i = 1; i < 4; i++)
         for (j = 1; j < 4; j++)
@@ -13457,7 +13474,7 @@ test_scatter(void)
 
         /* Scatter data */
         if (H5Dscatter((H5D_scatter_func_t)scatter_cb, &scatter_info, H5T_NATIVE_INT, sid, dst_buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify data */
         TEST_SCATTER_CHECK_ARR(dst_buf, expect_dst_buf)
@@ -13468,12 +13485,12 @@ test_scatter(void)
      */
     /* Select hyperslabs */
     if (H5Sselect_elements(sid, H5S_SELECT_SET, sizeof(point) / sizeof(point[0]), (hsize_t *)point) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-            /* Initialize expect_dst_buf */
-            /* Iterate over block containing selection, checking if each element is in
-             * selection. */
-            (void) HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
+    /* Initialize expect_dst_buf */
+    /* Iterate over block containing selection, checking if each element is in
+     * selection. */
+    (void)HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
     for (i = 0; i < (int)(sizeof(point) / sizeof(point[0])); i++)
         expect_dst_buf[point[i][0]][point[i][1]][point[i][2]] = src_buf[i];
 
@@ -13489,7 +13506,7 @@ test_scatter(void)
 
         /* Scatter data */
         if (H5Dscatter((H5D_scatter_func_t)scatter_cb, &scatter_info, H5T_NATIVE_INT, sid, dst_buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify data */
         TEST_SCATTER_CHECK_ARR(dst_buf, expect_dst_buf)
@@ -13497,7 +13514,7 @@ test_scatter(void)
 
     /* Close everything */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -13546,24 +13563,24 @@ gather_cb(const void *dst_buf, size_t dst_buf_bytes_used, void *_gather_info)
 
     /* Make sure the number of bytes is a multiple of the number of elements */
     if (nelmts * sizeof(gather_info->expect_dst_buf[0]) != dst_buf_bytes_used)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make sure we weren't passed more data than we requested to be passed at
      * once */
     if (nelmts > gather_info->max_nelmts)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* If we were passed less data than requested, make sure this is the last
      * time the callback was called */
     if (gather_info->last_call)
-        TEST_ERROR
+        TEST_ERROR;
     if (nelmts < gather_info->max_nelmts)
         gather_info->last_call = TRUE;
 
     /* Compare data and expected data */
     for (i = 0; i < (int)nelmts; i++)
         if (((const int *)dst_buf)[i] != *((gather_info->expect_dst_buf)++))
-            TEST_ERROR
+            TEST_ERROR;
 
     return SUCCEED;
 
@@ -13594,7 +13611,7 @@ test_gather(void)
 
     /* Create dataspace */
     if ((sid = H5Screate_simple(3, dim, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize src_buf */
     for (i = 0; i < (int)(sizeof(src_buf) / sizeof(src_buf[0])); i++)
@@ -13611,10 +13628,10 @@ test_gather(void)
     count[1] = 1;
     count[2] = 8;
     if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-            /* Initialize expect_dst_buf */
-            (void) HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
+    /* Initialize expect_dst_buf */
+    (void)HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
     for (i = 0; i < 8; i++)
         expect_dst_buf[i] = src_buf[0][0][i];
 
@@ -13631,11 +13648,11 @@ test_gather(void)
         /* Gather data */
         if (H5Dgather(sid, src_buf, H5T_NATIVE_INT, dst_buf_size * sizeof(dst_buf[0]), dst_buf, gather_cb,
                       &gather_info) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify that all data has been gathered (and verified) */
         if (gather_info.expect_dst_buf - expect_dst_buf != 8)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Test without a callback */
@@ -13647,12 +13664,12 @@ test_gather(void)
         /* Gather data */
         if (H5Dgather(sid, src_buf, H5T_NATIVE_INT, dst_buf_size * sizeof(dst_buf[0]), dst_buf, NULL, NULL) <
             0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify data */
         for (i = 0; i < (int)(sizeof(dst_buf) / sizeof(dst_buf[0])); i++)
             if (dst_buf[i] != expect_dst_buf[i])
-                TEST_ERROR
+                TEST_ERROR;
     } /* end for */
 
     /* Test with a dst_buf_size that is not a multiple of the datatype size */
@@ -13668,11 +13685,11 @@ test_gather(void)
     /* Gather data */
     if (H5Dgather(sid, src_buf, H5T_NATIVE_INT, dst_buf_size * sizeof(dst_buf[0]) - 1, dst_buf, gather_cb,
                   &gather_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that all data has been gathered (and verified) */
     if (gather_info.expect_dst_buf - expect_dst_buf != 8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 2: Single block in dataset
@@ -13685,10 +13702,10 @@ test_gather(void)
     count[1] = 3;
     count[2] = 2;
     if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-            /* Initialize expect_dst_buf */
-            (void) HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
+    /* Initialize expect_dst_buf */
+    (void)HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
     dst_i = 0;
     for (i = 3; i < 5; i++)
         for (j = 2; j < 5; j++)
@@ -13708,11 +13725,11 @@ test_gather(void)
         /* Gather data */
         if (H5Dgather(sid, src_buf, H5T_NATIVE_INT, dst_buf_size * sizeof(dst_buf[0]), dst_buf, gather_cb,
                       &gather_info) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify that all data has been gathered (and verified) */
         if (gather_info.expect_dst_buf - expect_dst_buf != 12)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /*
@@ -13732,13 +13749,13 @@ test_gather(void)
     block[1]  = 3;
     block[2]  = 2;
     if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-            /* Initialize expect_dst_buf */
-            /* Iterate over block containing selection, checking if each element is in
-             * selection.  Note that the algorithm used here (if statement) would not
-             * work for overlapping hyperslabs. */
-            (void) HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
+    /* Initialize expect_dst_buf */
+    /* Iterate over block containing selection, checking if each element is in
+     * selection.  Note that the algorithm used here (if statement) would not
+     * work for overlapping hyperslabs. */
+    (void)HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
     dst_i = 0;
     for (i = 1; i < 8; i++)
         for (j = 1; j < 4; j++)
@@ -13764,11 +13781,11 @@ test_gather(void)
         /* Gather data */
         if (H5Dgather(sid, src_buf, H5T_NATIVE_INT, dst_buf_size * sizeof(dst_buf[0]), dst_buf, gather_cb,
                       &gather_info) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify that all data has been gathered (and verified) */
         if (gather_info.expect_dst_buf - expect_dst_buf != 36)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /*
@@ -13782,7 +13799,7 @@ test_gather(void)
     count[1] = 3;
     count[2] = 2;
     if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     start2[0] = 1;
     start2[1] = 2;
     start2[2] = 2;
@@ -13790,12 +13807,12 @@ test_gather(void)
     count2[1] = 2;
     count2[2] = 2;
     if (H5Sselect_hyperslab(sid, H5S_SELECT_XOR, start2, NULL, count2, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-            /* Initialize expect_dst_buf */
-            /* Iterate over block containing selection, checking if each element is in
-             * selection. */
-            (void) HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
+    /* Initialize expect_dst_buf */
+    /* Iterate over block containing selection, checking if each element is in
+     * selection. */
+    (void)HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
     dst_i = 0;
     for (i = 1; i < 4; i++)
         for (j = 1; j < 4; j++)
@@ -13821,11 +13838,11 @@ test_gather(void)
         /* Gather data */
         if (H5Dgather(sid, src_buf, H5T_NATIVE_INT, dst_buf_size * sizeof(dst_buf[0]), dst_buf, gather_cb,
                       &gather_info) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify that all data has been gathered (and verified) */
         if (gather_info.expect_dst_buf - expect_dst_buf != 16)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /*
@@ -13833,12 +13850,12 @@ test_gather(void)
      */
     /* Select hyperslabs */
     if (H5Sselect_elements(sid, H5S_SELECT_SET, sizeof(point) / sizeof(point[0]), (hsize_t *)point) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-            /* Initialize expect_dst_buf */
-            /* Iterate over block containing selection, checking if each element is in
-             * selection. */
-            (void) HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
+    /* Initialize expect_dst_buf */
+    /* Iterate over block containing selection, checking if each element is in
+     * selection. */
+    (void)HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
     for (i = 0; i < (int)(sizeof(point) / sizeof(point[0])); i++)
         expect_dst_buf[i] = src_buf[point[i][0]][point[i][1]][point[i][2]];
 
@@ -13855,16 +13872,16 @@ test_gather(void)
         /* Gather data */
         if (H5Dgather(sid, src_buf, H5T_NATIVE_INT, dst_buf_size * sizeof(dst_buf[0]), dst_buf, gather_cb,
                       &gather_info) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify that all data has been gathered (and verified) */
         if (gather_info.expect_dst_buf - expect_dst_buf != 4)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Close everything */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -13956,7 +13973,7 @@ test_scatter_error(void)
 
     /* Create dataspace */
     if ((sid = H5Screate_simple(1, dim, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize src_buf */
     for (i = 0; i < (int)(sizeof(src_buf) / sizeof(src_buf[0])); i++)
@@ -13964,14 +13981,14 @@ test_scatter_error(void)
 
     /* Select hyperslab */
     if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that base configuration passes */
     scatter_info.src_buf = src_buf;
     scatter_info.block   = sizeof(src_buf) / sizeof(src_buf[0]);
     scatter_info.size    = 6;
     if (H5Dscatter((H5D_scatter_func_t)scatter_cb, &scatter_info, H5T_NATIVE_INT, sid, dst_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test invalid parameters
@@ -13984,7 +14001,7 @@ test_scatter_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     scatter_info.src_buf = src_buf;
     scatter_info.size    = 6;
@@ -13994,7 +14011,7 @@ test_scatter_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     scatter_info.src_buf = src_buf;
     scatter_info.size    = 6;
@@ -14005,7 +14022,7 @@ test_scatter_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     scatter_info.src_buf = src_buf;
     scatter_info.size    = 6;
@@ -14015,7 +14032,7 @@ test_scatter_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test returning too many elements in callback
@@ -14028,7 +14045,7 @@ test_scatter_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test callback returns failure
@@ -14042,7 +14059,7 @@ test_scatter_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test callback returns NULL buffer
@@ -14056,7 +14073,7 @@ test_scatter_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test callback returns 0 for src_buf_bytes_used
@@ -14069,7 +14086,7 @@ test_scatter_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test callback returns src_buf_bytes_used that is not a multiple of
@@ -14083,7 +14100,7 @@ test_scatter_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     cb_unalign_nbytes = sizeof(src_buf[0]) + 1;
     H5E_BEGIN_TRY
@@ -14093,11 +14110,11 @@ test_scatter_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close everything */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -14151,7 +14168,7 @@ test_gather_error(void)
 
     /* Create dataspace */
     if ((sid = H5Screate_simple(1, dim, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize src_buf */
     for (i = 0; i < (int)(sizeof(src_buf) / sizeof(src_buf[0])); i++)
@@ -14159,10 +14176,10 @@ test_gather_error(void)
 
     /* Select hyperslab */
     if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-            /* Initialize expect_dst_buf */
-            (void) HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
+    /* Initialize expect_dst_buf */
+    (void)HDmemset(expect_dst_buf, 0, sizeof(expect_dst_buf));
     for (i = 0; i < 6; i++)
         expect_dst_buf[i] = src_buf[i + 2];
 
@@ -14171,7 +14188,7 @@ test_gather_error(void)
     gather_info.max_nelmts     = 6;
     gather_info.last_call      = FALSE;
     if (H5Dgather(sid, src_buf, H5T_NATIVE_INT, 6 * sizeof(dst_buf[0]), dst_buf, gather_cb, &gather_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test invalid parameters
@@ -14185,7 +14202,7 @@ test_gather_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     gather_info.expect_dst_buf = expect_dst_buf;
     gather_info.last_call      = FALSE;
@@ -14195,7 +14212,7 @@ test_gather_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     gather_info.expect_dst_buf = expect_dst_buf;
     gather_info.last_call      = FALSE;
@@ -14205,7 +14222,7 @@ test_gather_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     gather_info.expect_dst_buf = expect_dst_buf;
     gather_info.last_call      = FALSE;
@@ -14215,7 +14232,7 @@ test_gather_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     gather_info.expect_dst_buf = expect_dst_buf;
     gather_info.last_call      = FALSE;
@@ -14225,7 +14242,7 @@ test_gather_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     gather_info.expect_dst_buf = expect_dst_buf;
     gather_info.last_call      = FALSE;
@@ -14235,7 +14252,7 @@ test_gather_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     gather_info.expect_dst_buf = expect_dst_buf;
     gather_info.last_call      = FALSE;
@@ -14245,7 +14262,7 @@ test_gather_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test callback returns failure
@@ -14259,11 +14276,11 @@ test_gather_error(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close everything */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -14383,43 +14400,43 @@ dls_01_setup_file(hid_t fid)
 
     sid = H5Screate_simple(ndims, initial_shape, max_shape);
     if (sid <= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     tid = H5Tcopy(H5T_C_S1);
     if (tid <= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     status = H5Tset_size(tid, DLS_01_STR_SIZE);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dcpl = H5Pcreate(H5P_DATASET_CREATE);
     if (dcpl <= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     status = H5Pset_chunk(dcpl, ndims, chunks);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     did = H5Dcreate2(fid, DLS_01_DATASET, tid, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT);
     if (did <= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     status = H5Dclose(did);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     status = H5Pclose(dcpl);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     status = H5Tclose(tid);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     status = H5Sclose(sid);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return SUCCEED;
 
@@ -14436,31 +14453,31 @@ dls_01_write_data(hid_t fid, char *buffer)
 
     did = H5Dopen2(fid, DLS_01_DATASET, H5P_DEFAULT);
     if (did <= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     tid = H5Dget_type(did);
     if (tid <= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     status = H5Dset_extent(did, extent);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     status = H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     status = H5Fflush(fid, H5F_SCOPE_LOCAL);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     status = H5Tclose(tid);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     status = H5Dclose(did);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return SUCCEED;
 
@@ -14477,15 +14494,15 @@ dls_01_read_stuff(hid_t fid)
 
     did = H5Dopen2(fid, DLS_01_DATASET, H5P_DEFAULT);
     if (did <= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     status = H5Oget_info3(did, &info, H5O_INFO_BASIC);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     status = H5Dclose(did);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return SUCCEED;
 
@@ -14505,11 +14522,11 @@ dls_01_main(void)
     TESTING("Testing DLS bugfix 1");
 
     if (NULL == h5_fixname(FILENAME[23], H5P_DEFAULT, filename, sizeof(filename)))
-        TEST_ERROR
+        TEST_ERROR;
 
     buffer = (char *)HDcalloc(DLS_01_DIMS, DLS_01_STR_SIZE);
     if (NULL == buffer)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDstrcpy(buffer, strings[0]);
     HDstrcpy(buffer + DLS_01_STR_SIZE, strings[1]);
@@ -14518,15 +14535,15 @@ dls_01_main(void)
 
     fapl = H5Pcreate(H5P_FILE_ACCESS);
     if (fapl <= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     status = H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
     if (fid <= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (0 != dls_01_setup_file(fid))
         goto error;
@@ -14536,22 +14553,22 @@ dls_01_main(void)
 
     status = H5Fclose(fid);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl);
     if (fid <= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (0 != dls_01_read_stuff(fid))
         goto error;
 
     status = H5Fclose(fid);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     status = H5Pclose(fapl);
     if (status != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDfree(buffer);
 
@@ -14601,7 +14618,7 @@ test_compact_open_close_dirty(hid_t fapl)
     /* Create a file */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize data */
     for (i = 0; i < 10; i++)
@@ -14609,28 +14626,28 @@ test_compact_open_close_dirty(hid_t fapl)
 
     /* Create dataspace */
     if ((sid = H5Screate_simple(1, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set compact layout */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_layout(dcpl, H5D_COMPACT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_alloc_time(dcpl, H5D_ALLOC_TIME_EARLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a compact dataset */
     if ((did = H5Dcreate2(fid, DSET_COMPACT_MAX_NAME, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Write to the dataset */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, wbuf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the repeated open/close of the dataset will not fail */
     for (i = 0; i < 20; i++) {
@@ -14640,38 +14657,38 @@ test_compact_open_close_dirty(hid_t fapl)
         }
         H5E_END_TRY;
         if (did < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Dclose(did) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* Open the dataset */
     if ((did = H5Dopen2(fid, DSET_COMPACT_MAX_NAME, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve the "dirty" flag from the compact dataset layout */
     if (H5D__layout_compact_dirty_test(did, &dirty) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the "dirty" flag is false */
     if (dirty)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset creation property list */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -14731,7 +14748,7 @@ test_versionbounds(void)
 
     /* Create a copy of file access property list */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     h5_fixname(VDS_FNAME1, fapl, vfilename1, sizeof vfilename1);
     h5_fixname(VDS_FNAME2, fapl, vfilename2, sizeof vfilename2);
@@ -14739,23 +14756,23 @@ test_versionbounds(void)
 
     /* Create DCPL */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create source dataspace */
     if ((srcspace = H5Screate_simple(1, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create virtual dataspace */
     if ((vspace = H5Screate_simple(1, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace, srcfilename, SRC_DSET, srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop through all the combinations of low/high library format bounds */
     /* Create a source file and a dataset in it.  Create a virtual file and
@@ -14776,14 +14793,14 @@ test_versionbounds(void)
 
             /* Create a source file and dataset */
             if ((srcfile = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if ((srcdset = H5Dcreate2(srcfile, SRC_DSET, H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                       H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create a virtual file */
             if ((vfile = H5Fcreate(vfilename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create the virtual dataset */
             H5E_BEGIN_TRY
@@ -14798,22 +14815,22 @@ test_versionbounds(void)
                 VERIFY(high >= H5F_LIBVER_V110, TRUE, "virtual dataset");
 
                 if (H5Dclose(vdset) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 vdset = -1;
             }
 
             /* Close virtual file */
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             vfile = -1;
 
             /* Close srcdset and srcfile */
             if (H5Dclose(srcdset) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             srcdset = -1;
 
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             srcfile = -1;
 
         } /* for high */
@@ -14821,16 +14838,16 @@ test_versionbounds(void)
 
     /* Close dataspaces and properties */
     if (H5Sclose(srcspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     srcspace = -1;
     if (H5Sclose(vspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     vspace = -1;
     if (H5Pclose(fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     fapl = -1;
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     dcpl = -1;
     PASSED();
     return SUCCEED;
@@ -14862,8 +14879,6 @@ error:
  *
  * Programmer: Jacob Smith
  *             2018 August 15
- *
- * Changes:    None.
  *-----------------------------------------------------------------------------
  */
 static herr_t
@@ -14882,88 +14897,93 @@ test_object_header_minimization_dcpl(void)
     /*********/
 
     if (NULL == h5_fixname(OHMIN_FILENAME_A, H5P_DEFAULT, filename, sizeof(filename)))
-        TEST_ERROR
+        TEST_ERROR;
 
     file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
     if (file_id == H5I_INVALID_HID)
-        TEST_ERROR
+        TEST_ERROR;
 
     dcpl_id = H5Pcreate(H5P_DATASET_CREATE);
     if (dcpl_id == H5I_INVALID_HID)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*********/
     /* TESTS */
     /*********/
 
-    /* default value (not set explicitly)
-     */
+    /* Default value (not set explicitly) */
     if (H5Pget_dset_no_attrs_hint(dcpl_id, &minimize) == FAIL)
-        TEST_ERROR
+        TEST_ERROR;
     if (FALSE != minimize)
-        TEST_ERROR
+        TEST_ERROR;
 
-    /* FALSE-set value
-     */
+    /* FALSE-set value */
     if (H5Pset_dset_no_attrs_hint(dcpl_id, FALSE) == FAIL)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_dset_no_attrs_hint(dcpl_id, &minimize) == FAIL)
-        TEST_ERROR
+        TEST_ERROR;
     if (FALSE != minimize)
-        TEST_ERROR
+        TEST_ERROR;
 
-    /* TRUE-set value
-     */
+    /* TRUE-set value */
     if (H5Pset_dset_no_attrs_hint(dcpl_id, TRUE) == FAIL)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_dset_no_attrs_hint(dcpl_id, &minimize) == FAIL)
-        TEST_ERROR
+        TEST_ERROR;
     if (TRUE != minimize)
-        TEST_ERROR
+        TEST_ERROR;
 
-    /* error cases
-     */
+    /***************/
+    /* Error cases */
+    /***************/
+
+    /* Invalid DCPL ID should fail */
     H5E_BEGIN_TRY
     {
-        ret = H5Pget_dset_no_attrs_hint(-1, &minimize);
+        ret = H5Pget_dset_no_attrs_hint(H5I_INVALID_HID, &minimize);
     }
     H5E_END_TRY;
     if (ret == SUCCEED)
-        TEST_ERROR /* Invalid DCPL ID should fail */
+        TEST_ERROR;
 
-            H5E_BEGIN_TRY
-        {
-            ret = H5Pset_dset_no_attrs_hint(-1, FALSE);
-        }
+    /* Invalid DCPL ID should fail */
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_dset_no_attrs_hint(H5I_INVALID_HID, FALSE);
+    }
     H5E_END_TRY;
     if (ret == SUCCEED)
-        TEST_ERROR /* Invalid DCPL ID should fail */
+        TEST_ERROR;
 
-            H5E_BEGIN_TRY
-        {
-            ret = H5Pset_dset_no_attrs_hint(-1, TRUE);
-        }
+    /* Invalid DCPL ID should fail */
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pset_dset_no_attrs_hint(H5I_INVALID_HID, TRUE);
+    }
     H5E_END_TRY;
     if (ret == SUCCEED)
-        TEST_ERROR /* Invalid DCPL ID should fail */
+        TEST_ERROR;
 
-            H5E_BEGIN_TRY
-        {
-            ret = H5Pget_dset_no_attrs_hint(dcpl_id, NULL);
-        }
+    /* NULL out pointer should fail */
+    H5E_BEGIN_TRY
+    {
+        ret = H5Pget_dset_no_attrs_hint(dcpl_id, NULL);
+    }
     H5E_END_TRY;
     if (ret == SUCCEED)
-        TEST_ERROR /* NULL out pointer should fail */
+        TEST_ERROR;
 
-            /************/
-            /* TEARDOWN */
-            /************/
+    /************/
+    /* TEARDOWN */
+    /************/
 
-            if (H5Fclose(file_id) == FAIL) TEST_ERROR
+    if (H5Fclose(file_id) == FAIL)
+        TEST_ERROR;
 
-            if (H5Pclose(dcpl_id) == FAIL) TEST_ERROR
+    if (H5Pclose(dcpl_id) == FAIL)
+        TEST_ERROR;
 
-            PASSED();
+    PASSED();
     return SUCCEED;
 
 error:
@@ -15009,14 +15029,14 @@ test_h5s_block(void)
     /* SETUP */
     /*********/
     if (NULL == h5_fixname(FILENAME[27], H5P_DEFAULT, filename, sizeof(filename)))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5I_INVALID_HID == (file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((file_space_id = H5Screate_simple(1, dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dset_id = H5Dcreate2(file_id, "dset", H5T_NATIVE_INT, file_space_id, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     for (u = 0; u < 20; u++)
         buf[u] = (int)u;
@@ -15032,55 +15052,55 @@ test_h5s_block(void)
     }
     H5E_END_TRY;
     if (ret == SUCCEED)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Write the entire dataset */
     if (H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_BLOCK, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reset the memory buffer */
     HDmemset(buf, 0, sizeof(buf));
 
     /* Read the entire dataset */
     if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_BLOCK, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the data read in */
     for (u = 0; u < 20; u++)
         if (buf[u] != (int)u)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Read a hyperslab from the file to the first 10 elements of the buffer */
     if (H5Sselect_hyperslab(file_space_id, H5S_SELECT_SET, &start, NULL, &count, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_BLOCK, file_space_id, H5P_DEFAULT, buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the data read in */
     for (u = 0; u < count; u++)
         if (buf[u] != (int)(u + start))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Verify that reading 0 elements is handled correctly and doesn't modify buffer */
     if (H5Sselect_none(file_space_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_BLOCK, file_space_id, H5P_DEFAULT, buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the data read in */
     for (u = 0; u < count; u++)
         if (buf[u] != (int)(u + start))
-            TEST_ERROR
+            TEST_ERROR;
 
     /************/
     /* TEARDOWN */
     /************/
     if (FAIL == H5Sclose(file_space_id))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (FAIL == H5Dclose(dset_id))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (FAIL == H5Fclose(file_id))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -15137,16 +15157,16 @@ test_h5s_plist(void)
     /* SETUP */
     /*********/
     if (NULL == h5_fixname(FILENAME[28], H5P_DEFAULT, filename, sizeof(filename)))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5I_INVALID_HID == (file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((file_space_id = H5Screate_simple(1, dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dset_id = H5Dcreate2(file_id, "dset", H5T_NATIVE_INT, file_space_id, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     for (u = 0; u < 20; u++)
         buf[u] = (int)u;
@@ -15164,7 +15184,7 @@ test_h5s_plist(void)
     }
     H5E_END_TRY;
     if (ret == SUCCEED)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         /* Bad selection operator */
@@ -15173,7 +15193,7 @@ test_h5s_plist(void)
     }
     H5E_END_TRY;
     if (ret == SUCCEED)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         /* Bad start pointer */
@@ -15182,7 +15202,7 @@ test_h5s_plist(void)
     }
     H5E_END_TRY;
     if (ret == SUCCEED)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         /* Bad stride value (stride of NULL is OK) */
@@ -15193,7 +15213,7 @@ test_h5s_plist(void)
     }
     H5E_END_TRY;
     if (ret == SUCCEED)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         /* Bad count pointer */
@@ -15202,7 +15222,7 @@ test_h5s_plist(void)
     }
     H5E_END_TRY;
     if (ret == SUCCEED)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Block pointer is allowed to be NULL */
 
@@ -15213,23 +15233,23 @@ test_h5s_plist(void)
     }
     H5E_END_TRY;
     if (ret == SUCCEED)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Write the entire dataset */
     if (H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_BLOCK, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reset the memory buffer */
     HDmemset(buf, 0, sizeof(buf));
 
     /* Read the entire dataset */
     if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_BLOCK, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the data read in */
     for (u = 0; u < 20; u++)
         if (buf[u] != (int)u)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Reset the memory buffer */
     HDmemset(buf, 0, sizeof(buf));
@@ -15237,32 +15257,32 @@ test_h5s_plist(void)
     /* Set valid selection in DXPL */
     if (H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_SET, &start, &stride, &count, &block) <
         0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read a hyperslab from the file to the first 10 elements of the buffer */
     if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_BLOCK, H5S_PLIST, dxpl_id, buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the data read in */
     for (u = 0; u < count; u++)
         if (buf[u] != (int)(u + start))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Reset the memory buffer */
     HDmemset(buf, 0, sizeof(buf));
 
     /* Check for copying property list w/selection */
     if ((dxpl_id_copy = H5Pcopy(dxpl_id)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read a hyperslab from the file to the first 10 elements of the buffer */
     if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_BLOCK, H5S_PLIST, dxpl_id_copy, buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the data read in */
     for (u = 0; u < count; u++)
         if (buf[u] != (int)(u + start))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Attempt to 'OR' block with invalid dimensions into the selection */
     H5E_BEGIN_TRY
@@ -15272,55 +15292,55 @@ test_h5s_plist(void)
     }
     H5E_END_TRY;
     if (ret == SUCCEED)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set new valid selection in DXPL */
     if (H5Pset_dataset_io_hyperslab_selection(dxpl_id_copy, 1, H5S_SELECT_SET, &start, &stride, &count,
                                               &block) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read a hyperslab from the file to the first 10 elements of the buffer */
     if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_BLOCK, H5S_PLIST, dxpl_id_copy, buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the data read in */
     for (u = 0; u < count; u++)
         if (buf[u] != (int)(u + start))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Close the copy */
     if (FAIL == H5Pclose(dxpl_id_copy))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     dxpl_id_copy = H5I_INVALID_HID;
 
     /* 'OR' valid block into the existing selection in original DXPL */
     if (H5Pset_dataset_io_hyperslab_selection(dxpl_id, 1, H5S_SELECT_OR, &start2, &stride, &count2, &block) <
         0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read a disjoint hyperslab from the file to the first 10 elements of the buffer */
     if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_BLOCK, H5S_PLIST, dxpl_id, buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the data read in */
     for (u = 0; u < count; u++)
         if (buf[u] != (int)(u + start))
-            TEST_ERROR
+            TEST_ERROR;
     for (u = 0; u < count2; u++)
         if (buf[u + count] != (int)(u + start2))
-            TEST_ERROR
+            TEST_ERROR;
 
     /************/
     /* TEARDOWN */
     /************/
     if (FAIL == H5Pclose(dxpl_id))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (FAIL == H5Sclose(file_space_id))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (FAIL == H5Dclose(dset_id))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (FAIL == H5Fclose(file_id))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -15373,11 +15393,11 @@ test_0sized_dset_metadata_alloc(hid_t fapl_id)
     /*********/
 
     if (NULL == h5_fixname(FILENAME[26], fapl_id, filename, sizeof(filename)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create DCPL for the dataset */
     if ((dcpl_id = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*************/
     /* RUN TESTS */
@@ -15390,20 +15410,20 @@ test_0sized_dset_metadata_alloc(hid_t fapl_id)
 
         /* Copy the file access property list */
         if ((fapl_id_copy = H5Pcopy(fapl_id)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set the "use the latest version of the format" bounds for creating objects in the file */
         if (new_format)
             if (H5Pset_libver_bounds(fapl_id_copy, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
         /* Create test file */
         if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id_copy)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close the copy of the FAPL */
         if (H5Pclose(fapl_id_copy) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Iterate over combinations of testing parameters */
         for (layout = H5D_COMPACT; layout <= H5D_CHUNKED; layout++) {
@@ -15424,37 +15444,37 @@ test_0sized_dset_metadata_alloc(hid_t fapl_id)
 
                 /* Set up DCPL */
                 if ((dcpl_id_copy = H5Pcopy(dcpl_id)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5Pset_alloc_time(dcpl_id_copy, alloc_time) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5Pset_layout(dcpl_id_copy, layout) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5D_CHUNKED == layout)
                     if (H5Pset_chunk(dcpl_id_copy, 1, chunk_dims) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                 /* Create the dataspace for the dataset */
                 if ((dset_space_id = H5Screate_simple(1, dims, (H5D_CHUNKED == layout ? max_dims : NULL))) <
                     0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Create the dataset with the appropriate parameters */
                 if ((dset_id = H5Dcreate2(file_id, dset_name, H5T_NATIVE_INT, dset_space_id, H5P_DEFAULT,
                                           dcpl_id_copy, H5P_DEFAULT)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Close objects used to create dataset */
                 if (H5Pclose(dcpl_id_copy) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5Sclose(dset_space_id) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Retrieve & verify the dataset's index info */
                 HDmemset(&nat_info, 0, sizeof(nat_info));
                 if (H5Oget_native_info(dset_id, &nat_info, H5O_NATIVE_INFO_META_SIZE) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (0 != nat_info.meta_size.obj.index_size)
-                    FAIL_PUTS_ERROR("dataset index allocation size is non-zero")
+                    FAIL_PUTS_ERROR("dataset index allocation size is non-zero");
 
                 /* If chunked, try extending and verify that the index is allocated */
                 if (H5D_CHUNKED == layout) {
@@ -15465,46 +15485,46 @@ test_0sized_dset_metadata_alloc(hid_t fapl_id)
 
                     /* Extend dataset */
                     if (H5Dset_extent(dset_id, new_dims) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Get the dataspace for the dataset & set single point selection */
                     if ((dset_space_id = H5Dget_space(dset_id)) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
                     if (H5Sselect_elements(dset_space_id, H5S_SELECT_SET, (size_t)1,
                                            (const hsize_t *)&coord) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Create memory dataspace, with only one element */
                     if ((buf_space_id = H5Screate_simple(1, mem_dims, NULL)) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Write the data to the dataset */
                     if (H5Dwrite(dset_id, H5T_NATIVE_INT, buf_space_id, dset_space_id, H5P_DEFAULT, &val) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Close objects used to perform I/O */
                     if (H5Sclose(dset_space_id) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
                     if (H5Sclose(buf_space_id) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Retrieve & verify the dataset's index info */
                     HDmemset(&nat_info, 0, sizeof(nat_info));
                     if (H5Oget_native_info(dset_id, &nat_info, H5O_NATIVE_INFO_META_SIZE) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
                     if (0 == nat_info.meta_size.obj.index_size)
-                        FAIL_PUTS_ERROR("dataset index allocation size is zero")
+                        FAIL_PUTS_ERROR("dataset index allocation size is zero");
                 } /* end if */
 
                 /* Close dataset */
                 if (H5Dclose(dset_id) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
             } /* end for */
         }     /* end for */
 
         /* Close test file */
         if (H5Fclose(file_id) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /************/
@@ -15512,7 +15532,7 @@ test_0sized_dset_metadata_alloc(hid_t fapl_id)
     /************/
 
     if (H5Pclose(dcpl_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -15622,21 +15642,21 @@ main(void)
 
     /* Copy the file access property list */
     if ((fapl2 = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set the "use the latest version of the format" bounds for creating objects in the file */
     if (H5Pset_libver_bounds(fapl2, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create a file creation property list */
     if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fcpl2 = H5Pcopy(fcpl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set file space strategy to paged aggregation and persisting free-space */
     if (H5Pset_file_space_strategy(fcpl2, H5F_FSPACE_STRATEGY_PAGE, TRUE, (hsize_t)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
@@ -15783,11 +15803,11 @@ main(void)
 
     /* Close property lists */
     if (H5Pclose(fapl2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(fcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(fcpl2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Tests that do not use files */
     nerrors += (test_scatter() < 0 ? 1 : 0);

--- a/test/dt_arith.c
+++ b/test/dt_arith.c
@@ -915,7 +915,7 @@ test_derived_flt(void)
     }
 
     if ((tid1 = H5Topen2(file, "new float type 1", H5P_DEFAULT)) < 0)
-        FAIL_PUTS_ERROR("Can't open datatype")
+        FAIL_PUTS_ERROR("Can't open datatype");
     if (H5Tget_fields(tid1, &spos, &epos, &esize, &mpos, &msize) < 0) {
         H5_FAILED();
         HDprintf("Can't get fields\n");
@@ -1075,7 +1075,7 @@ test_derived_flt(void)
     }
 
     if ((tid2 = H5Topen2(file, "new float type 2", H5P_DEFAULT)) < 0)
-        FAIL_PUTS_ERROR("Can't open datatype")
+        FAIL_PUTS_ERROR("Can't open datatype");
     if (H5Tget_fields(tid2, &spos, &epos, &esize, &mpos, &msize) < 0) {
         H5_FAILED();
         HDprintf("Can't get fields\n");
@@ -1351,7 +1351,7 @@ test_derived_integer(void)
     }
 
     if ((tid1 = H5Topen2(file, "new integer type 1", H5P_DEFAULT)) < 0)
-        FAIL_PUTS_ERROR("Can't open datatype")
+        FAIL_PUTS_ERROR("Can't open datatype");
     if (H5Tget_precision(tid1) != 24) {
         H5_FAILED();
         HDprintf("Can't get precision or wrong precision\n");
@@ -1412,7 +1412,7 @@ test_derived_integer(void)
     }
 
     if ((tid2 = H5Topen2(file, "new integer type 2", H5P_DEFAULT)) < 0)
-        FAIL_PUTS_ERROR("Can't open datatype")
+        FAIL_PUTS_ERROR("Can't open datatype");
     if (H5Tget_precision(tid2) != 48) {
         H5_FAILED();
         HDprintf("Can't get precision or wrong precision\n");

--- a/test/dtransform.c
+++ b/test/dtransform.c
@@ -142,16 +142,16 @@ const int transformData[ROWS][COLS] = {{36, 31, 25, 19, 13, 7, 1, 5, 11, 16, 22,
             TEST_ERROR;                                                                                      \
                                                                                                              \
         if ((dt_nn = H5Tcopy(HDF_TYPE)) < 0)                                                                 \
-            TEST_ERROR                                                                                       \
+            TEST_ERROR;                                                                                      \
         if ((order = H5Tget_order(dt_nn)) == H5T_ORDER_ERROR)                                                \
-            TEST_ERROR                                                                                       \
+            TEST_ERROR;                                                                                      \
         if (H5Tset_order(dt_nn, order == H5T_ORDER_LE ? H5T_ORDER_BE : H5T_ORDER_LE) < 0)                    \
-            TEST_ERROR                                                                                       \
+            TEST_ERROR;                                                                                      \
         if ((dset_nn = H5Dcreate2(file_id, "/nonnative_transformtest_" TEST_STR, dt_nn, dataspace,           \
                                   H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)                               \
-            TEST_ERROR                                                                                       \
+            TEST_ERROR;                                                                                      \
         if (H5Tclose(dt_nn) < 0)                                                                             \
-            TEST_ERROR                                                                                       \
+            TEST_ERROR;                                                                                      \
                                                                                                              \
         if (SIGNED) {                                                                                        \
             if ((dxpl_id_f_to_c = H5Pcreate(H5P_DATASET_XFER)) < 0)                                          \
@@ -178,7 +178,7 @@ const int transformData[ROWS][COLS] = {{36, 31, 25, 19, 13, 7, 1, 5, 11, 16, 22,
                 TEST_ERROR;                                                                                  \
         }                                                                                                    \
                                                                                                              \
-        TESTING("contiguous, no data type conversion (" TEST_STR "->" TEST_STR ")")                          \
+        TESTING("contiguous, no data type conversion (" TEST_STR "->" TEST_STR ")");                         \
                                                                                                              \
         if (H5Dread(dset, HDF_TYPE, H5S_ALL, H5S_ALL, XFORM, array) < 0)                                     \
             TEST_ERROR;                                                                                      \
@@ -187,7 +187,7 @@ const int transformData[ROWS][COLS] = {{36, 31, 25, 19, 13, 7, 1, 5, 11, 16, 22,
         else                                                                                                 \
             UCOMPARE(TYPE, array->arr, COMPARE_DATA, 4)                                                      \
                                                                                                              \
-        TESTING("contiguous, byte order conversion (" TEST_STR "->" TEST_STR ")")                            \
+        TESTING("contiguous, byte order conversion (" TEST_STR "->" TEST_STR ")");                           \
                                                                                                              \
         if (H5Dread(dset_nn, HDF_TYPE, H5S_ALL, H5S_ALL, XFORM, array) < 0)                                  \
             TEST_ERROR;                                                                                      \
@@ -197,7 +197,7 @@ const int transformData[ROWS][COLS] = {{36, 31, 25, 19, 13, 7, 1, 5, 11, 16, 22,
             UCOMPARE(TYPE, array->arr, COMPARE_DATA, 4)                                                      \
                                                                                                              \
         if (SIGNED) {                                                                                        \
-            TESTING("contiguous, with type conversion (float->" TEST_STR ")")                                \
+            TESTING("contiguous, with type conversion (float->" TEST_STR ")");                               \
                                                                                                              \
             if (H5Dread(dset_id_float, HDF_TYPE, H5S_ALL, H5S_ALL, XFORM, array) < 0)                        \
                 TEST_ERROR;                                                                                  \
@@ -243,9 +243,9 @@ const int transformData[ROWS][COLS] = {{36, 31, 25, 19, 13, 7, 1, 5, 11, 16, 22,
                                      H5P_DEFAULT, cparms, H5P_DEFAULT)) < 0)                                 \
             TEST_ERROR;                                                                                      \
         if ((filespace = H5Dget_space(dset_chunk)) < 0)                                                      \
-            TEST_ERROR                                                                                       \
+            TEST_ERROR;                                                                                      \
         if ((memspace = H5Screate_simple(2, dim, NULL)) < 0)                                                 \
-            TEST_ERROR                                                                                       \
+            TEST_ERROR;                                                                                      \
         if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, offset, NULL, dim, NULL) < 0)                     \
             TEST_ERROR;                                                                                      \
                                                                                                              \
@@ -272,7 +272,7 @@ const int transformData[ROWS][COLS] = {{36, 31, 25, 19, 13, 7, 1, 5, 11, 16, 22,
                 TEST_ERROR;                                                                                  \
         }                                                                                                    \
                                                                                                              \
-        TESTING("chunked, no data type conversion (" TEST_STR "->" TEST_STR ")")                             \
+        TESTING("chunked, no data type conversion (" TEST_STR "->" TEST_STR ")");                            \
                                                                                                              \
         if (H5Dread(dset_chunk, HDF_TYPE, memspace, filespace, XFORM, array) < 0)                            \
             TEST_ERROR;                                                                                      \
@@ -282,7 +282,7 @@ const int transformData[ROWS][COLS] = {{36, 31, 25, 19, 13, 7, 1, 5, 11, 16, 22,
             UCOMPARE(TYPE, array->arr, COMPARE_DATA, 4)                                                      \
                                                                                                              \
         if (SIGNED) {                                                                                        \
-            TESTING("chunked, with type conversion (float->" TEST_STR ")")                                   \
+            TESTING("chunked, with type conversion (float->" TEST_STR ")");                                  \
                                                                                                              \
             if (H5Dread(dset_id_float_chunk, HDF_TYPE, memspace, filespace, XFORM, array) < 0)               \
                 TEST_ERROR;                                                                                  \
@@ -462,65 +462,65 @@ init_test(hid_t file_id)
     hsize_t offset[2]      = {0, 0};
 
     if ((dxpl_id_f_to_c = H5Pcreate(H5P_DATASET_XFER)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dxpl_id_utrans = H5Pcreate(H5P_DATASET_XFER)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pset_data_transform(dxpl_id_f_to_c, f_to_c) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_data_transform(dxpl_id_utrans, utrans) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     cparms = H5Pcreate(H5P_DATASET_CREATE);
     if (H5Pset_chunk(cparms, 2, dim) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((dataspace = H5Screate_simple(2, dim, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
-    TESTING("Initializing test...")
+    TESTING("Initializing test...");
 
     if ((dset_id_int = H5Dcreate2(file_id, "/default_int", H5T_NATIVE_INT, dataspace, H5P_DEFAULT,
                                   H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dset_id_int, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, dxpl_id_f_to_c, windchillFfloat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((dset_id_float = H5Dcreate2(file_id, "/default_float", H5T_NATIVE_FLOAT, dataspace, H5P_DEFAULT,
                                     H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dset_id_float, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, dxpl_id_f_to_c, windchillFfloat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((dset_id_int_chunk = H5Dcreate2(file_id, "/default_chunk_int", H5T_NATIVE_INT, dataspace, H5P_DEFAULT,
                                         cparms, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((filespace = H5Dget_space(dset_id_int_chunk)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, offset, NULL, dim, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dset_id_int_chunk, H5T_NATIVE_FLOAT, dataspace, filespace, dxpl_id_f_to_c, windchillFfloat) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((dset_id_float_chunk = H5Dcreate2(file_id, "/default_chunk_float", H5T_NATIVE_FLOAT, dataspace,
                                           H5P_DEFAULT, cparms, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dset_id_float_chunk, H5T_NATIVE_FLOAT, dataspace, filespace, dxpl_id_f_to_c,
                  windchillFfloat) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pclose(cparms) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dxpl_id_f_to_c) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dxpl_id_utrans) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(dataspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -555,9 +555,9 @@ test_poly(const hid_t dxpl_id_polynomial)
             polyflres[row][col] = ((2.0F + (float)windchillC) * (((float)windchillC - 8.0F) / 2.0F));
         }
 
-    TESTING("data transform, polynomial transform (int->float)")
+    TESTING("data transform, polynomial transform (int->float)");
     if (H5Dread(dset_id_int, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, dxpl_id_polynomial, polyflread) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     COMPARE(float, polyflread, polyflres, 2.0F)
 
@@ -567,9 +567,9 @@ test_poly(const hid_t dxpl_id_polynomial)
             polyflres[row][col] = (float)((2 + windchillC) * ((windchillC - 8) / 2));
         }
 
-    TESTING("data transform, polynomial transform (float->int)")
+    TESTING("data transform, polynomial transform (float->int)");
     if (H5Dread(dset_id_float, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, dxpl_id_polynomial, polyintread) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     COMPARE(int, polyintread, polyflres, 4)
 
@@ -595,10 +595,10 @@ test_specials(hid_t file)
     const char *special6 = "2e+1*x";
     const char *special7 = "x";
 
-    TESTING("data transform of some special cases")
+    TESTING("data transform of some special cases");
 
     if ((dataspace = H5Screate_simple(2, dim, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
         TEST_ERROR;
@@ -615,16 +615,16 @@ test_specials(hid_t file)
 
     if ((dset_id = H5Dcreate2(file, "/special1", H5T_NATIVE_INT, dataspace, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, dxpl_id, transformData) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     COMPARE_INT(read_buf, data_res)
 
     if (H5Dclose(dset_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*-----------------------------
      * Operation 2: 100-x
@@ -638,16 +638,16 @@ test_specials(hid_t file)
 
     if ((dset_id = H5Dcreate2(file, "/special2", H5T_NATIVE_INT, dataspace, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, dxpl_id, transformData) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     COMPARE_INT(read_buf, data_res)
 
     if (H5Dclose(dset_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*-----------------------------
      * Operation 3: 1000/x
@@ -661,16 +661,16 @@ test_specials(hid_t file)
 
     if ((dset_id = H5Dcreate2(file, "/special3", H5T_NATIVE_INT, dataspace, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, dxpl_id, transformData) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     COMPARE_INT(read_buf, data_res)
 
     if (H5Dclose(dset_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*-----------------------------
      * Operation 4: -x
@@ -684,16 +684,16 @@ test_specials(hid_t file)
 
     if ((dset_id = H5Dcreate2(file, "/special4", H5T_NATIVE_INT, dataspace, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, dxpl_id, transformData) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     COMPARE_INT(read_buf, data_res)
 
     if (H5Dclose(dset_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*-----------------------------
      * Operation 5: +x
@@ -707,16 +707,16 @@ test_specials(hid_t file)
 
     if ((dset_id = H5Dcreate2(file, "/special5", H5T_NATIVE_INT, dataspace, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, dxpl_id, transformData) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     COMPARE_INT(read_buf, data_res)
 
     if (H5Dclose(dset_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*-----------------------------
      * Operation 6: 2e+1*x
@@ -730,16 +730,16 @@ test_specials(hid_t file)
 
     if ((dset_id = H5Dcreate2(file, "/special6", H5T_NATIVE_INT, dataspace, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, dxpl_id, transformData) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     COMPARE_INT(read_buf, data_res)
 
     if (H5Dclose(dset_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*-----------------------------
      * Operation 7: x
@@ -756,21 +756,21 @@ test_specials(hid_t file)
 
     if ((dset_id = H5Dcreate2(file, "/special7", H5T_NATIVE_INT, dataspace, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, dxpl_id, transformData) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     COMPARE_INT(read_buf, data_res)
 
     if (H5Dclose(dset_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pclose(dxpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(dataspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -794,15 +794,15 @@ test_copy(const hid_t dxpl_id_c_to_f_copy, const hid_t dxpl_id_polynomial_copy)
             polyflres[row][col] = (float)((2 + windchillC) * ((windchillC - 8) / 2));
         }
 
-    TESTING("data transform, linear transform w/ copied property")
+    TESTING("data transform, linear transform w/ copied property");
     if (H5Dread(dset_id_float, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, dxpl_id_c_to_f_copy, windchillFintread) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     COMPARE(int, windchillFintread, windchillFfloat, 2)
 
-    TESTING("data transform, polynomial transform w/ copied property")
+    TESTING("data transform, polynomial transform w/ copied property");
     if (H5Dread(dset_id_float, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, dxpl_id_polynomial_copy, polyintread) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     COMPARE(int, polyintread, polyflres, 2)
 
@@ -819,9 +819,9 @@ test_trivial(const hid_t dxpl_id_simple)
     int   windchillFintread[ROWS][COLS];
     int   row, col;
 
-    TESTING("data transform, trivial transform, without type conversion")
+    TESTING("data transform, trivial transform, without type conversion");
     if (H5Dread(dset_id_float, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, dxpl_id_simple, windchillFfloatread) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     for (row = 0; row < ROWS; row++)
         for (col = 0; col < COLS; col++) {
             if ((windchillFfloatread[row][col] - 4.8F) > FLOAT_TOL)
@@ -830,13 +830,13 @@ test_trivial(const hid_t dxpl_id_simple)
 
     PASSED();
 
-    TESTING("data transform, trivial transform, with type conversion")
+    TESTING("data transform, trivial transform, with type conversion");
     if (H5Dread(dset_id_float, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, dxpl_id_simple, windchillFintread) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     for (row = 0; row < ROWS; row++)
         for (col = 0; col < COLS; col++) {
             if (windchillFintread[row][col] != 4)
-                FAIL_PUTS_ERROR("    ERROR: Conversion failed to match computed data\n")
+                FAIL_PUTS_ERROR("    ERROR: Conversion failed to match computed data\n");
         }
 
     PASSED();
@@ -856,45 +856,45 @@ test_getset(const hid_t dxpl_id_c_to_f)
     const char *c_to_f     = "(9/5.0)*x + 32";
     char *      ptrgetTest = NULL;
 
-    TESTING("H5Pget_data_transform")
+    TESTING("H5Pget_data_transform");
 
     if (NULL == (ptrgetTest = (char *)HDmalloc(HDstrlen(simple) + 1)))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pget_data_transform(dxpl_id_c_to_f, ptrgetTest, HDstrlen(c_to_f) + 1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(c_to_f, ptrgetTest) != 0)
-        FAIL_PUTS_ERROR("    ERROR: Data transform failed to match what was set\n")
+        FAIL_PUTS_ERROR("    ERROR: Data transform failed to match what was set\n");
 
     PASSED();
 
     HDfree(ptrgetTest);
     ptrgetTest = NULL;
 
-    TESTING("data transform, read after resetting of transform property")
+    TESTING("data transform, read after resetting of transform property");
 
     if (H5Pset_data_transform(dxpl_id_c_to_f, simple) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dread(dset_id_float, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, dxpl_id_c_to_f, windchillFfloatread) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     for (row = 0; row < ROWS; row++)
         for (col = 0; col < COLS; col++) {
             if ((windchillFfloatread[row][col] - 4.8F) > FLOAT_TOL)
-                FAIL_PUTS_ERROR("    ERROR: Conversion failed to match computed data\n")
+                FAIL_PUTS_ERROR("    ERROR: Conversion failed to match computed data\n");
         }
 
     PASSED();
 
-    TESTING("H5Pget_data_transform, after resetting transform property")
+    TESTING("H5Pget_data_transform, after resetting transform property");
 
     if (NULL == (ptrgetTest = (char *)HDcalloc((size_t)1, HDstrlen(simple) + 1)))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_data_transform(dxpl_id_c_to_f, ptrgetTest, HDstrlen(simple) + 1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(simple, ptrgetTest) != 0)
-        FAIL_PUTS_ERROR("    ERROR: Data transform failed to match what was set\n")
+        FAIL_PUTS_ERROR("    ERROR: Data transform failed to match what was set\n");
 
     PASSED();
 
@@ -918,13 +918,13 @@ test_set(void)
     const char *str        = "(9/5.0)*x + 32";
     char *      ptrgetTest = NULL;
 
-    TESTING("H5Pget_data_transform (get before set)")
+    TESTING("H5Pget_data_transform (get before set)");
 
     if (NULL == (ptrgetTest = (char *)HDmalloc(HDstrlen(str) + 1)))
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test get before set */
     H5Eget_auto2(H5E_DEFAULT, &func, NULL);
@@ -942,34 +942,34 @@ test_set(void)
     TESTING("H5Pset_data_transform (set with NULL transform)");
     INVALID_SET_TEST(NULL);
 
-    TESTING("H5Pset_data_transform (set with invalid transform 1)")
+    TESTING("H5Pset_data_transform (set with invalid transform 1)");
     INVALID_SET_TEST("\0");
 
-    TESTING("H5Pset_data_transform (set with invalid transform 2)")
+    TESTING("H5Pset_data_transform (set with invalid transform 2)");
     INVALID_SET_TEST("     ");
 
-    TESTING("H5Pset_data_transform (set with invalid transform 3)")
+    TESTING("H5Pset_data_transform (set with invalid transform 3)");
     INVALID_SET_TEST("x+");
 
-    TESTING("H5Pset_data_transform (set with invalid transform 4)")
+    TESTING("H5Pset_data_transform (set with invalid transform 4)");
     INVALID_SET_TEST("(x+5");
 
-    TESTING("H5Pset_data_transform (set with invalid transform 5)")
+    TESTING("H5Pset_data_transform (set with invalid transform 5)");
     INVALID_SET_TEST("+");
 
-    TESTING("H5Pset_data_transform (set with invalid transform 6)")
+    TESTING("H5Pset_data_transform (set with invalid transform 6)");
     INVALID_SET_TEST("(9/5)*x + x**2");
 
-    TESTING("H5Pset_data_transform (set with invalid transform 7)")
+    TESTING("H5Pset_data_transform (set with invalid transform 7)");
     INVALID_SET_TEST("(9/5)x");
 
-    TESTING("H5Pset_data_transform (set with invalid transform 8)")
+    TESTING("H5Pset_data_transform (set with invalid transform 8)");
     INVALID_SET_TEST("(9/5)*x + x^2");
 
     H5Eset_auto2(H5E_DEFAULT, func, NULL);
 
     if (H5Pclose(dxpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 

--- a/test/dtypes.c
+++ b/test/dtypes.c
@@ -64,16 +64,18 @@
  * the soft conversion list.  One must call reset_hdf5() after this.
  */
 #define CHECK_NMEMBS(NMEMBS, SRC_ID, DST_ID)                                                                 \
-    if (H5Tunregister(H5T_PERS_SOFT, NULL, SRC_ID, DST_ID, NULL) < 0)                                        \
-        FAIL_STACK_ERROR                                                                                     \
-    if (H5Tclose(SRC_ID) < 0 || ((SRC_ID) != (DST_ID) && H5Tclose(DST_ID) < 0))                              \
-        FAIL_STACK_ERROR                                                                                     \
-    if ((NMEMBS) != H5I_nmembers(H5I_DATATYPE)) {                                                            \
-        H5_FAILED();                                                                                         \
-        HDprintf("    #dtype ids expected: %lld; found: %lld\n", (long long)(NMEMBS),                        \
-                 (long long)H5I_nmembers(H5I_DATATYPE));                                                     \
-        goto error;                                                                                          \
-    }
+    do {                                                                                                     \
+        if (H5Tunregister(H5T_PERS_SOFT, NULL, SRC_ID, DST_ID, NULL) < 0)                                    \
+            FAIL_STACK_ERROR;                                                                                \
+        if (H5Tclose(SRC_ID) < 0 || ((SRC_ID) != (DST_ID) && H5Tclose(DST_ID) < 0))                          \
+            FAIL_STACK_ERROR;                                                                                \
+        if ((NMEMBS) != H5I_nmembers(H5I_DATATYPE)) {                                                        \
+            H5_FAILED();                                                                                     \
+            HDprintf("    #dtype ids expected: %lld; found: %lld\n", (long long)(NMEMBS),                    \
+                     (long long)H5I_nmembers(H5I_DATATYPE));                                                 \
+            goto error;                                                                                      \
+        }                                                                                                    \
+    } while (0)
 
 const char *FILENAME[] = {"dtypes0", "dtypes1", "dtypes2", "dtypes3", "dtypes4",  "dtypes5",
                           "dtypes6", "dtypes7", "dtypes8", "dtypes9", "dtypes10", NULL};
@@ -198,84 +200,84 @@ test_classes(void)
      *  Check class of some atomic types.
      *-----------------------------------------------------------*/
     if ((tcls = H5Tget_class(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_INTEGER != tcls)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((tcls = H5Tget_class(H5T_NATIVE_DOUBLE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_FLOAT != tcls)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a VL datatype of char.  It should be a VL, not a string class. */
     if ((vlc_id = H5Tvlen_create(H5T_NATIVE_CHAR)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that the correct classes can be detected */
     if ((tcls = H5Tget_class(vlc_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_VLEN != tcls)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that an incorrect class is not detected */
     if (H5T_STRING == tcls)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a VL string.  It should be a string, not a VL class. */
     if ((vls_id = H5Tcopy(H5T_C_S1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_size(vls_id, H5T_VARIABLE) < 0)
         TEST_ERROR;
 
     /* Make certain that the correct classes can be detected */
     if ((tcls = H5Tget_class(vls_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_STRING != tcls)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that an incorrect class is not detected */
     if (H5T_VLEN == tcls)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*-------------------------------------------------------------
      *  Check class for member types of compound type.
      *-----------------------------------------------------------*/
     /* Create a compound datatype and insert some complex types */
     if ((cmpd_id = H5Tcreate(H5T_COMPOUND, sizeof(struct complex))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(cmpd_id, "vl_c", HOFFSET(struct complex, vl_c), vlc_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(cmpd_id, "vl_s", HOFFSET(struct complex, vl_s), vls_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((nmembs = H5Tget_nmembers(cmpd_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     for (u = 0; u < (unsigned)nmembs; u++) {
         /* Get member type ID */
         if ((memb_id = H5Tget_member_type(cmpd_id, u)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get member type class */
         if ((memb_cls = H5Tget_member_class(cmpd_id, u)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify member class */
         if (H5Tdetect_class(memb_id, memb_cls) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close member type ID */
         if (H5Tclose(memb_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Close datatypes */
     if (H5Tclose(cmpd_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(vlc_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(vls_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -381,175 +383,175 @@ test_detect(void)
      *------------------------------------------------------------------------------*/
     /* Native integers should be in the integer class */
     if (H5Tdetect_class(H5T_NATIVE_INT, H5T_INTEGER) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Native integers should _not_ be in other classes */
     if (H5Tdetect_class(H5T_NATIVE_INT, H5T_FLOAT) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(H5T_NATIVE_INT, H5T_ARRAY) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(H5T_NATIVE_INT, H5T_ENUM) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*--------------------------------------------------------------------------------
      *  Test class of a compound type with some atomic types as fields.
      *------------------------------------------------------------------------------*/
     /* Create a compound datatype and insert some atomic types */
     if ((atom_cmpd_id = H5Tcreate(H5T_COMPOUND, sizeof(struct atomic))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(atom_cmpd_id, "i", HOFFSET(struct atomic, i), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(atom_cmpd_id, "f", HOFFSET(struct atomic, f), H5T_NATIVE_FLOAT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(atom_cmpd_id, "c", HOFFSET(struct atomic, c), H5T_NATIVE_CHAR) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(atom_cmpd_id, "d", HOFFSET(struct atomic, d), H5T_NATIVE_DOUBLE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(atom_cmpd_id, "s", HOFFSET(struct atomic, s), H5T_NATIVE_SHORT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that the correct classes can be detected */
     if (H5Tdetect_class(atom_cmpd_id, H5T_COMPOUND) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(atom_cmpd_id, H5T_INTEGER) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(atom_cmpd_id, H5T_FLOAT) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that an incorrect class is not detected */
     if (H5Tdetect_class(atom_cmpd_id, H5T_VLEN) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*--------------------------------------------------------------------------------
      *  Test class of some complex types.
      *------------------------------------------------------------------------------*/
     /* Create an array datatype with an atomic base type */
     if ((atom_arr_id = H5Tarray_create2(H5T_STD_REF_OBJ, rank, dims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that the correct classes can be detected */
     if (H5Tdetect_class(atom_arr_id, H5T_ARRAY) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(atom_arr_id, H5T_REFERENCE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that an incorrect class is not detected */
     if (H5Tdetect_class(atom_arr_id, H5T_VLEN) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(atom_arr_id, H5T_FLOAT) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(atom_arr_id, H5T_INTEGER) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a VL datatype with an atomic base type of float*/
     if ((atom_vlf_id = H5Tvlen_create(H5T_NATIVE_FLOAT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that the correct classes can be detected */
     if (H5Tdetect_class(atom_vlf_id, H5T_VLEN) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(atom_vlf_id, H5T_FLOAT) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that an incorrect class is not detected */
     if (H5Tdetect_class(atom_vlf_id, H5T_COMPOUND) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(atom_vlf_id, H5T_INTEGER) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a VL datatype with an atomic base type of char.  It should be a VL
      * but not a string class. */
     if ((atom_vlc_id = H5Tvlen_create(H5T_NATIVE_CHAR)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that the correct classes can be detected */
     if (H5Tdetect_class(atom_vlc_id, H5T_VLEN) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(atom_vlc_id, H5T_INTEGER) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that an incorrect class is not detected */
     if (H5Tdetect_class(atom_vlc_id, H5T_STRING) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a VL string.  It should be a string, not a VL class. */
     if ((atom_vls_id = H5Tcopy(H5T_C_S1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_size(atom_vls_id, H5T_VARIABLE) < 0)
         TEST_ERROR;
 
     /* Make certain that the correct classes can be detected */
     if (H5Tdetect_class(atom_vls_id, H5T_STRING) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that an incorrect class is not detected */
     if (H5Tdetect_class(atom_vls_id, H5T_VLEN) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*--------------------------------------------------------------------------------
      *  Test class of a compound type with some complex types as fields.
      *------------------------------------------------------------------------------*/
     /* Create a compound datatype and insert some complex types */
     if ((cplx_cmpd_id = H5Tcreate(H5T_COMPOUND, sizeof(struct complex))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(cplx_cmpd_id, "arr_r", HOFFSET(struct complex, arr_r), atom_arr_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(cplx_cmpd_id, "i", HOFFSET(struct complex, i), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(cplx_cmpd_id, "vl_f", HOFFSET(struct complex, vl_f), atom_vlf_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(cplx_cmpd_id, "vl_s", HOFFSET(struct complex, vl_s), atom_vls_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(cplx_cmpd_id, "c", HOFFSET(struct complex, c), H5T_NATIVE_CHAR) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(cplx_cmpd_id, "s", HOFFSET(struct complex, s), H5T_NATIVE_SHORT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that the correct classes can be detected */
     if (H5Tdetect_class(cplx_cmpd_id, H5T_COMPOUND) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(cplx_cmpd_id, H5T_ARRAY) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(cplx_cmpd_id, H5T_REFERENCE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(cplx_cmpd_id, H5T_INTEGER) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(cplx_cmpd_id, H5T_FLOAT) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(cplx_cmpd_id, H5T_STRING) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(cplx_cmpd_id, H5T_VLEN) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that an incorrect class is not detected */
     if (H5Tdetect_class(cplx_cmpd_id, H5T_TIME) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tdetect_class(cplx_cmpd_id, H5T_ENUM) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close complex compound datatype */
     if (H5Tclose(cplx_cmpd_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close atomic VL datatype of float */
     if (H5Tclose(atom_vlf_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close atomic VL datatype of char */
     if (H5Tclose(atom_vlc_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close atomic VL string datatype  */
     if (H5Tclose(atom_vls_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close atomic array datatype */
     if (H5Tclose(atom_arr_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close atomic compound datatype */
     if (H5Tclose(atom_cmpd_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -778,7 +780,7 @@ test_compound_2(void)
     TESTING("compound element reordering");
 
     if ((nmembs = H5I_nmembers(H5I_DATATYPE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Sizes should be the same, but be careful just in case */
     if (NULL == (buf = (unsigned char *)HDmalloc(nelmts * MAX(sizeof(struct st), sizeof(struct dt)))))
@@ -846,7 +848,7 @@ test_compound_2(void)
     HDfree(buf);
     HDfree(bkg);
     HDfree(orig);
-    CHECK_NMEMBS(nmembs, st, dt)
+    CHECK_NMEMBS(nmembs, st, dt);
 
     PASSED();
 
@@ -905,7 +907,7 @@ test_compound_3(void)
     TESTING("compound subset conversions");
 
     if ((nmembs = H5I_nmembers(H5I_DATATYPE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize */
     if (NULL == (buf = (unsigned char *)HDmalloc(nelmts * MAX(sizeof(struct st), sizeof(struct dt)))))
@@ -970,7 +972,7 @@ test_compound_3(void)
     HDfree(buf);
     HDfree(bkg);
     HDfree(orig);
-    CHECK_NMEMBS(nmembs, st, dt)
+    CHECK_NMEMBS(nmembs, st, dt);
 
     PASSED();
 
@@ -1032,7 +1034,7 @@ test_compound_4(void)
     TESTING("compound element shrinking & reordering");
 
     if ((nmembs = H5I_nmembers(H5I_DATATYPE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Sizes should be the same, but be careful just in case */
     if (NULL == (buf = (unsigned char *)HDmalloc(nelmts * MAX(sizeof(struct st), sizeof(struct dt)))))
@@ -1100,7 +1102,7 @@ test_compound_4(void)
     HDfree(buf);
     HDfree(bkg);
     HDfree(orig);
-    CHECK_NMEMBS(nmembs, st, dt)
+    CHECK_NMEMBS(nmembs, st, dt);
 
     PASSED();
 
@@ -1260,7 +1262,7 @@ test_compound_6(void)
     TESTING("compound element growing");
 
     if ((nmembs = H5I_nmembers(H5I_DATATYPE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Sizes should be the same, but be careful just in case */
     if (NULL == (buf = (unsigned char *)HDmalloc(nelmts * MAX(sizeof(struct st), sizeof(struct dt)))))
@@ -1314,7 +1316,7 @@ test_compound_6(void)
     HDfree(buf);
     HDfree(bkg);
     HDfree(orig);
-    CHECK_NMEMBS(nmembs, st, dt)
+    CHECK_NMEMBS(nmembs, st, dt);
 
     PASSED();
 
@@ -1857,7 +1859,7 @@ test_compound_9(void)
     } /* end if */
 
     if ((cmpd_tid = H5Topen2(file, "compound", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((dup_tid = H5Tcopy(cmpd_tid)) < 0) {
         H5_FAILED();
@@ -2270,45 +2272,45 @@ test_compound_11(void)
 
     /* Create variable string type for use in both structs */
     if ((var_string_tid = H5Tcopy(H5T_C_S1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_size(var_string_tid, H5T_VARIABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create type for 'big' struct */
     if ((big_tid = H5Tcreate(H5T_COMPOUND, sizeof(big_t))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Tinsert(big_tid, "d1", HOFFSET(big_t, d1), H5T_NATIVE_DOUBLE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(big_tid, "i1", HOFFSET(big_t, i1), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(big_tid, "s1", HOFFSET(big_t, s1), var_string_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(big_tid, "i2", HOFFSET(big_t, i2), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(big_tid, "d2", HOFFSET(big_t, d2), H5T_NATIVE_DOUBLE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(big_tid, "d3", HOFFSET(big_t, d3), H5T_NATIVE_DOUBLE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create type for 'little' struct (with "out of order" inserts) */
     if ((little_tid = H5Tcreate(H5T_COMPOUND, sizeof(little_t))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Tinsert(little_tid, "d1", HOFFSET(little_t, d1), H5T_NATIVE_DOUBLE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(little_tid, "s1", HOFFSET(little_t, s1), var_string_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(little_tid, "i1", HOFFSET(little_t, i1), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate buffers */
     if ((buf = HDmalloc(sizeof(big_t) * NTESTELEM)) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
     if ((buf_orig = HDmalloc(sizeof(big_t) * NTESTELEM)) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
     if ((bkg = HDmalloc(sizeof(big_t) * NTESTELEM)) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize buffer */
     for (u = 0; u < NTESTELEM; u++) {
@@ -2319,7 +2321,7 @@ test_compound_11(void)
         ((big_t *)buf)[u].i2 = (int)(u * 5);
         ((big_t *)buf)[u].s1 = (char *)HDmalloc((size_t)32);
         if (!((big_t *)buf)[u].s1)
-            TEST_ERROR
+            TEST_ERROR;
         HDsprintf(((big_t *)buf)[u].s1, "%u", (unsigned)u);
     } /* end for */
 
@@ -2338,35 +2340,35 @@ test_compound_11(void)
      * conversion routine doesn't use the same ones this time and next time
      */
     if ((big_tid2 = H5Tcopy(big_tid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((little_tid2 = H5Tcopy(little_tid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Convert buffer from 'big' to 'little' struct */
     if (H5Tconvert(big_tid2, little_tid2, (size_t)NTESTELEM, buf, bkg, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify converted buffer is correct */
     for (u = 0; u < NTESTELEM; u++) {
         if (!H5_DBL_ABS_EQUAL(((big_t *)buf_orig)[u].d1, ((little_t *)buf)[u].d1)) {
             HDprintf("Error, line #%d: buf_orig[%u].d1=%f, buf[%u].d1=%f\n", __LINE__, (unsigned)u,
                      ((big_t *)buf_orig)[u].d1, (unsigned)u, ((little_t *)buf)[u].d1);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
         if (((big_t *)buf_orig)[u].i1 != ((little_t *)buf)[u].i1) {
             HDprintf("Error, line #%d: buf_orig[%u].i1=%d, buf[%u].i1=%d\n", __LINE__, (unsigned)u,
                      ((big_t *)buf_orig)[u].i1, (unsigned)u, ((little_t *)buf)[u].i1);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
         if (((big_t *)buf_orig)[u].s1 == NULL || ((little_t *)buf)[u].s1 == NULL) {
             HDprintf("Error, line #%d: buf_orig[%u].s1=%s, buf[%u].s1=%s\n", __LINE__, (unsigned)u,
                      ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
         else if (HDstrcmp(((big_t *)buf_orig)[u].s1, ((little_t *)buf)[u].s1) != 0) {
             HDprintf("Error, line #%d: buf_orig[%u].s1=%s, buf[%u].s1=%s\n", __LINE__, (unsigned)u,
                      ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
     }     /* end for */
     if (H5Treclaim(little_tid2, space_id, H5P_DEFAULT, buf) < 0) {
@@ -2378,46 +2380,46 @@ test_compound_11(void)
 
     /* Build source and destination types for conversion routine */
     if ((opaq_src_tid = H5Tcreate(H5T_OPAQUE, (size_t)4)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_tag(opaq_src_tid, "opaque source type") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((opaq_dst_tid = H5Tcreate(H5T_OPAQUE, (size_t)4)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_tag(opaq_dst_tid, "opaque destination type") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Register new type conversion routine */
     if (H5Tregister(H5T_PERS_HARD, "opaq_test", opaq_src_tid, opaq_dst_tid, convert_opaque) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Recover the original buffer information */
     HDmemcpy(buf, buf_orig, sizeof(big_t) * NTESTELEM);
 
     /* Convert buffer from 'big' to 'little' struct */
     if (H5Tconvert(big_tid, little_tid, (size_t)NTESTELEM, buf, bkg, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify converted buffer is correct */
     for (u = 0; u < NTESTELEM; u++) {
         if (!H5_DBL_ABS_EQUAL(((big_t *)buf_orig)[u].d1, ((little_t *)buf)[u].d1)) {
             HDprintf("Error, line #%d: buf_orig[%u].d1=%f, buf[%u].d1=%f\n", __LINE__, (unsigned)u,
                      ((big_t *)buf_orig)[u].d1, (unsigned)u, ((little_t *)buf)[u].d1);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
         if (((big_t *)buf_orig)[u].i1 != ((little_t *)buf)[u].i1) {
             HDprintf("Error, line #%d: buf_orig[%u].i1=%d, buf[%u].i1=%d\n", __LINE__, (unsigned)u,
                      ((big_t *)buf_orig)[u].i1, (unsigned)u, ((little_t *)buf)[u].i1);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
         if (((big_t *)buf_orig)[u].s1 == NULL || ((little_t *)buf)[u].s1 == NULL) {
             HDprintf("Error, line #%d: buf_orig[%u].s1=%s, buf[%u].s1=%s\n", __LINE__, (unsigned)u,
                      ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
         else if (HDstrcmp(((big_t *)buf_orig)[u].s1, ((little_t *)buf)[u].s1) != 0) {
             HDprintf("Error, line #%d: buf_orig[%u].s1=%s, buf[%u].s1=%s\n", __LINE__, (unsigned)u,
                      ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
     }     /* end for */
     if (H5Treclaim(little_tid, space_id, H5P_DEFAULT, buf) < 0) {
@@ -2429,36 +2431,36 @@ test_compound_11(void)
 
     /* Unregister the conversion routine */
     if (H5Tunregister(H5T_PERS_HARD, "opaq_test", opaq_src_tid, opaq_dst_tid, convert_opaque) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Recover the original buffer information */
     HDmemcpy(buf, buf_orig, sizeof(big_t) * NTESTELEM);
 
     /* Convert buffer from 'big' to 'little' struct */
     if (H5Tconvert(big_tid, little_tid, (size_t)NTESTELEM, buf, bkg, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify converted buffer is correct */
     for (u = 0; u < NTESTELEM; u++) {
         if (!H5_DBL_ABS_EQUAL(((big_t *)buf_orig)[u].d1, ((little_t *)buf)[u].d1)) {
             HDprintf("Error, line #%d: buf_orig[%u].d1=%f, buf[%u].d1=%f\n", __LINE__, (unsigned)u,
                      ((big_t *)buf_orig)[u].d1, (unsigned)u, ((little_t *)buf)[u].d1);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
         if (((big_t *)buf_orig)[u].i1 != ((little_t *)buf)[u].i1) {
             HDprintf("Error, line #%d: buf_orig[%u].i1=%d, buf[%u].i1=%d\n", __LINE__, (unsigned)u,
                      ((big_t *)buf_orig)[u].i1, (unsigned)u, ((little_t *)buf)[u].i1);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
         if (((big_t *)buf_orig)[u].s1 == NULL || ((little_t *)buf)[u].s1 == NULL) {
             HDprintf("Error, line #%d: buf_orig[%u].s1=%s, buf[%u].s1=%s\n", __LINE__, (unsigned)u,
                      ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
         else if (HDstrcmp(((big_t *)buf_orig)[u].s1, ((little_t *)buf)[u].s1) != 0) {
             HDprintf("Error, line #%d: buf_orig[%u].s1=%s, buf[%u].s1=%s\n", __LINE__, (unsigned)u,
                      ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
     }     /* end for */
     if (H5Treclaim(little_tid, space_id, H5P_DEFAULT, buf) < 0) {
@@ -2472,21 +2474,21 @@ test_compound_11(void)
     for (u = 0; u < NTESTELEM; u++)
         HDfree(((big_t *)buf_orig)[u].s1);
     if (H5Sclose(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(opaq_dst_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(opaq_src_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(little_tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(big_tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(little_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(big_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(var_string_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     retval = 0;
@@ -2641,89 +2643,89 @@ test_compound_13(void)
      * compound datatype format.
      */
     if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open file and get root group. */
     h5_fixname(FILENAME[4], H5P_DEFAULT, filename, sizeof filename);
     if ((fileid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((grpid = H5Gopen2(fileid, "/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a compound type. */
     if ((dtypeid = H5Tcreate(H5T_COMPOUND, sizeof(struct s1))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((array1_tid = H5Tarray_create2(H5T_NATIVE_UCHAR, 1, dims)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(dtypeid, "x", HOFFSET(struct s1, x), array1_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(dtypeid, "y", HOFFSET(struct s1, y), H5T_NATIVE_FLOAT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a space. */
     if ((spaceid = H5Screate(H5S_SCALAR)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create an attribute of this compound type. */
     if ((attid = H5Acreate2(grpid, COMPOUND13_ATTR_NAME, dtypeid, spaceid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write some data. */
     if (H5Awrite(attid, dtypeid, &data_out) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Release all resources. */
     if (H5Aclose(attid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(array1_tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(dtypeid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(spaceid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(grpid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fileid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(fapl_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Now open the file and read it. */
     if ((fileid = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((grpid = H5Gopen2(fileid, "/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((attid = H5Aopen(grpid, COMPOUND13_ATTR_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dtypeid = H5Aget_type(attid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tget_class(dtypeid) != H5T_COMPOUND)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HOFFSET(struct s1, x) != H5Tget_member_offset(dtypeid, 0))
-        TEST_ERROR
+        TEST_ERROR;
     if (HOFFSET(struct s1, y) != H5Tget_member_offset(dtypeid, 1))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aread(attid, dtypeid, &data_in) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check the data. */
     for (u = 0; u < COMPOUND13_ARRAY_SIZE + 1; u++)
         if (data_out.x[u] != data_in.x[u])
-            TEST_ERROR
+            TEST_ERROR;
     if (!H5_FLT_ABS_EQUAL(data_out.y, data_in.y))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Release all resources. */
     if (H5Aclose(attid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(dtypeid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(grpid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fileid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -3403,38 +3405,38 @@ test_compound_16(void)
     /* Create File */
     h5_fixname(FILENAME[3], H5P_DEFAULT, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Copy and commit integer datatype */
     if ((int_id = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(file, "int", int_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file compound datatype */
     if ((cmpd_f_tid = H5Tcreate(H5T_COMPOUND, 2 * sizeof(int) + 2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(cmpd_f_tid, "i1", (size_t)0, int_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(cmpd_f_tid, "i2", sizeof(int) + 1, int_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create memory compound datatype */
     if ((cmpd_m_tid = H5Tcreate(H5T_COMPOUND, sizeof(struct cmpd_struct))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(cmpd_m_tid, "i1", HOFFSET(struct cmpd_struct, i1), int_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(cmpd_m_tid, "i2", HOFFSET(struct cmpd_struct, i2), int_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create space, dataset, write wdata1 */
     if ((space_id = H5Screate_simple(1, dim1, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dset_id = H5Dcreate2(file, "Dataset", cmpd_f_tid, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dset_id, cmpd_m_tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, &wdata1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check behavior of H5Fget_obj_count */
     if ((obj_count = H5Fget_obj_count(file, H5F_OBJ_DATATYPE)) != 1) {
@@ -3446,7 +3448,7 @@ test_compound_16(void)
 
     /* Check behavior of H5Fget_obj_ids */
     if (H5Fget_obj_ids(file, H5F_OBJ_DATATYPE, (size_t)2, open_dtypes) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (open_dtypes[1]) {
         H5_FAILED();
         AT();
@@ -3456,17 +3458,17 @@ test_compound_16(void)
 
     /* Close */
     if (H5Dclose(dset_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(cmpd_f_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(cmpd_m_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(int_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -3507,31 +3509,31 @@ test_compound_17(void)
     /* Create inner compound datatype.  This type will be "packed" according
      * to the internal field, but will have trailing space at the end. */
     if ((cmpd_int = H5Tcreate(H5T_COMPOUND, (size_t)4)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(cmpd_int, "c", (size_t)0, H5T_NATIVE_CHAR) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create inner array datatype */
     if ((arr_int = H5Tarray_create2(cmpd_int, 1, dims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create outer compound datatype.  This type will be truly packed, with no
      * trailing space.  However, the internal compound contained within is not
      * packed. */
     if ((cmpd_ext = H5Tcreate(H5T_COMPOUND, (size_t)8)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(cmpd_ext, "arr", (size_t)0, arr_int) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create outer array datatype */
     if ((arr_ext = H5Tarray_create2(cmpd_ext, 1, dims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try packing the internal array.  Size should be 2 after packing. */
     if ((tmp_dt = H5Tcopy(arr_int)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tpack(tmp_dt) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (2 != H5Tget_size(tmp_dt)) {
         H5_FAILED();
         AT();
@@ -3539,13 +3541,13 @@ test_compound_17(void)
         goto error;
     }
     if (H5Tclose(tmp_dt) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try packing the external array.  Size should be 4 after packing. */
     if ((tmp_dt = H5Tcopy(arr_ext)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tpack(tmp_dt) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (4 != H5Tget_size(tmp_dt)) {
         H5_FAILED();
         AT();
@@ -3553,48 +3555,48 @@ test_compound_17(void)
         goto error;
     }
     if (H5Tclose(tmp_dt) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now we will commit arr_int and arr_ext to a file, and verify that they
      * are still packed correctly after opening them from the file */
     /* Create File */
     h5_fixname(FILENAME[3], H5P_DEFAULT, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Commit the datatypes.  Note that they are still unpacked. */
     if (H5Tcommit2(file, "arr_int", arr_int, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(file, "arr_ext", arr_ext, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close IDs */
     if (H5Tclose(cmpd_int) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(arr_int) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(cmpd_ext) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(arr_ext) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reopen file */
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open committed array datatypes */
     if ((arr_int = H5Topen2(file, "arr_int", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((arr_ext = H5Topen2(file, "arr_ext", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try packing the internal array.  Size should be 2 after packing. */
     if ((tmp_dt = H5Tcopy(arr_int)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tpack(tmp_dt) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (2 != H5Tget_size(tmp_dt)) {
         H5_FAILED();
         AT();
@@ -3602,13 +3604,13 @@ test_compound_17(void)
         goto error;
     }
     if (H5Tclose(tmp_dt) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try packing the external array.  Size should be 4 after packing. */
     if ((tmp_dt = H5Tcopy(arr_ext)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tpack(tmp_dt) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (4 != H5Tget_size(tmp_dt)) {
         H5_FAILED();
         AT();
@@ -3616,15 +3618,15 @@ test_compound_17(void)
         goto error;
     }
     if (H5Tclose(tmp_dt) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close IDs */
     if (H5Tclose(arr_int) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(arr_ext) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -3671,7 +3673,7 @@ test_compound_18(void)
     /* Create File */
     h5_fixname(FILENAME[3], H5P_DEFAULT, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataspace to use */
     sid = H5Screate_simple(1, &dim, NULL);
@@ -3685,7 +3687,7 @@ test_compound_18(void)
     H5E_END_TRY;
     if (did > 0) {
         H5Dclose(did);
-        FAIL_PUTS_ERROR("created dataset with bad compound datatype")
+        FAIL_PUTS_ERROR("created dataset with bad compound datatype");
     } /* end if */
 
     /* Create a group */
@@ -3700,7 +3702,7 @@ test_compound_18(void)
     H5E_END_TRY;
     if (aid > 0) {
         H5Aclose(aid);
-        FAIL_PUTS_ERROR("created attribute with bad compound datatype")
+        FAIL_PUTS_ERROR("created attribute with bad compound datatype");
     } /* end if */
 
     /* Commit the datatype */
@@ -3710,24 +3712,24 @@ test_compound_18(void)
     }
     H5E_END_TRY;
     if (ret >= 0) {
-        FAIL_PUTS_ERROR("committed named datatype with bad compound datatype")
+        FAIL_PUTS_ERROR("committed named datatype with bad compound datatype");
     } /* end if */
 
     /* Close IDs */
     if (H5Tclose(tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!h5_driver_uses_modified_filename()) {
         /* Open Generated File */
         /* (generated with gen_bad_compound.c) */
         if ((file = H5Fopen(testfile, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Try to open the datatype */
         H5E_BEGIN_TRY
@@ -3737,7 +3739,7 @@ test_compound_18(void)
         H5E_END_TRY;
         if (tid > 0) {
             H5Tclose(tid);
-            FAIL_PUTS_ERROR("opened named datatype with bad compound datatype")
+            FAIL_PUTS_ERROR("opened named datatype with bad compound datatype");
         } /* end if */
 
         /* Try to open the dataset */
@@ -3748,12 +3750,12 @@ test_compound_18(void)
         H5E_END_TRY;
         if (did > 0) {
             H5Dclose(did);
-            FAIL_PUTS_ERROR("opened dataset with bad compound datatype")
+            FAIL_PUTS_ERROR("opened dataset with bad compound datatype");
         } /* end if */
 
         /* Open the group with the attribute */
         if ((gid = H5Gopen2(file, "group", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Try to open the dataset */
         H5E_BEGIN_TRY
@@ -3763,14 +3765,14 @@ test_compound_18(void)
         H5E_END_TRY;
         if (aid > 0) {
             H5Aclose(aid);
-            FAIL_PUTS_ERROR("opened attribute with bad compound datatype")
+            FAIL_PUTS_ERROR("opened attribute with bad compound datatype");
         } /* end if */
 
         /* Close IDs */
         if (H5Gclose(gid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
 
     PASSED();
@@ -3930,9 +3932,9 @@ test_query(void)
 
     /* Open the dataytpe for query */
     if ((tid1 = H5Topen2(file, compnd_type, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((tid2 = H5Topen2(file, enum_type, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Query member number and member index by name, for compound type */
     if (H5Tget_nmembers(tid1) != 4) {
@@ -4305,7 +4307,7 @@ test_named(hid_t fapl)
     if (H5Tclose(type) < 0)
         goto error;
     if ((type = H5Topen2(file, "native-int", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((status = H5Tcommitted(type)) < 0)
         goto error;
     if (!status) {
@@ -5046,19 +5048,19 @@ test_conv_str_3(void)
     } /* end for */
 
     if (H5Tget_precision(type) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tget_size(type) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_pad(type, H5T_PAD_ZERO, H5T_PAD_ONE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tget_cset(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tget_strpad(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tset_offset(type, (size_t)0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tget_order(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -5698,11 +5700,11 @@ opaque_long(void)
 
     /* Build opaque type */
     if ((dt = H5Tcreate(H5T_OPAQUE, (size_t)4)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create long tag */
     if (NULL == (long_tag = (char *)HDmalloc((size_t)(16384 + 1))))
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(long_tag, 'a', (size_t)16384);
     long_tag[16384] = '\0';
 
@@ -5713,11 +5715,11 @@ opaque_long(void)
     }
     H5E_END_TRY;
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close datatype */
     if (H5Tclose(dt) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Release memory for tag */
     HDfree(long_tag);
@@ -5759,9 +5761,9 @@ opaque_funcs(void)
 
     /* Build opaque type */
     if ((type = H5Tcreate(H5T_OPAQUE, (size_t)4)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_tag(type, "opaque source type") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((size = H5Tget_size(type)) == 0)
         goto error;
@@ -5773,7 +5775,7 @@ opaque_funcs(void)
     H5E_END_TRY;
     if (ret >= 0) {
         HDprintf("Operation not allowed for this type.\n");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     H5E_BEGIN_TRY
@@ -5783,7 +5785,7 @@ opaque_funcs(void)
     H5E_END_TRY;
     if (ret >= 0) {
         HDprintf("Operation not allowed for this type.\n");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     H5E_BEGIN_TRY
@@ -5793,7 +5795,7 @@ opaque_funcs(void)
     H5E_END_TRY;
     if (size > 0) {
         HDprintf("Operation not allowed for this type.\n");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     H5E_BEGIN_TRY
@@ -5803,7 +5805,7 @@ opaque_funcs(void)
     H5E_END_TRY;
     if (inpad > -1) {
         HDprintf("Operation not allowed for this type.\n");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     H5E_BEGIN_TRY
@@ -5813,7 +5815,7 @@ opaque_funcs(void)
     H5E_END_TRY;
     if (cset > -1) {
         HDprintf("Operation not allowed for this type.\n");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     H5E_BEGIN_TRY
@@ -5823,7 +5825,7 @@ opaque_funcs(void)
     H5E_END_TRY;
     if (strpad > -1) {
         HDprintf("Operation not allowed for this type.\n");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     H5E_BEGIN_TRY
@@ -5833,7 +5835,7 @@ opaque_funcs(void)
     H5E_END_TRY;
     if (ret >= 0) {
         HDprintf("Operation not allowed for this type.\n");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     H5E_BEGIN_TRY
@@ -5843,7 +5845,7 @@ opaque_funcs(void)
     H5E_END_TRY;
     if (sign > -1) {
         HDprintf("Operation not allowed for this type.\n");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     H5E_BEGIN_TRY
@@ -5853,12 +5855,12 @@ opaque_funcs(void)
     H5E_END_TRY;
     if (super >= 0) {
         HDprintf("Operation not allowed for this type.\n");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Close datatype */
     if (H5Tclose(type) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     return 0;
 
 error:
@@ -6026,7 +6028,7 @@ test_encode(void)
 
     /* Decode from the compound buffer and return an object handle */
     if ((decoded_tid1 = H5Tdecode(cmpd_buf)) < 0)
-        FAIL_PUTS_ERROR("Can't decode compound type\n")
+        FAIL_PUTS_ERROR("Can't decode compound type\n");
 
     /* Verify that the datatype was copied exactly */
     if (H5Tequal(decoded_tid1, tid1) <= 0) {
@@ -6187,11 +6189,11 @@ test_encode(void)
 
     /* Open the dataytpe for query */
     if ((tid1 = H5Topen2(file, compnd_type, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((tid2 = H5Topen2(file, enum_type, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((tid3 = H5Topen2(file, vlstr_type, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*-----------------------------------------------------------------------
      * Test encoding and decoding compound, enumerate, and vl string datatypes
@@ -6215,7 +6217,7 @@ test_encode(void)
 
     /* Decode from the compound buffer and return an object handle */
     if ((decoded_tid1 = H5Tdecode(cmpd_buf)) < 0)
-        FAIL_PUTS_ERROR("Can't decode compound type\n")
+        FAIL_PUTS_ERROR("Can't decode compound type\n");
 
     /* Verify that the datatype was copied exactly */
     if (H5Tequal(decoded_tid1, tid1) <= 0) {
@@ -6476,141 +6478,141 @@ test_latest(void)
 
     /* Create a compound datatype */
     if ((tid1 = H5Tcreate(H5T_COMPOUND, sizeof(struct s1))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(tid1, "a", HOFFSET(struct s1, a), H5T_NATIVE_INT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(tid1, "b", HOFFSET(struct s1, b), H5T_NATIVE_FLOAT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(tid1, "c", HOFFSET(struct s1, c), H5T_NATIVE_LONG) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(tid1, "d", HOFFSET(struct s1, d), H5T_NATIVE_DOUBLE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create file using default FAPL */
     h5_fixname(FILENAME[5], H5P_DEFAULT, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make a copy of the datatype, to commit */
     if ((tid2 = H5Tcopy(tid1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Commit compound datatype */
     if (H5Tcommit2(file, compnd_type, tid2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get information about datatype on disk */
     if (H5Oget_native_info_by_name(file, compnd_type, &oi, H5O_NATIVE_INFO_HDR, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     old_dtype_oh_size = oi.hdr.space.total;
 
     /* Close datatype */
     if (H5Tclose(tid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that datatype has been encoded/decoded correctly */
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataytpe for query */
     if ((tid2 = H5Topen2(file, compnd_type, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the datatype was encoded/decoded correctly */
     if (H5Tequal(tid1, tid2) <= 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get information about datatype on disk */
     if (H5Oget_native_info_by_name(file, compnd_type, &oi, H5O_NATIVE_INFO_HDR, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that the object header info is still the same */
     if (old_dtype_oh_size != oi.hdr.space.total)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close datatype */
     if (H5Tclose(tid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the 'use the latest format' bounds in the FAPL */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create file using default FAPL */
     h5_fixname(FILENAME[5], fapl, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make a copy of the datatype, to commit */
     if ((tid2 = H5Tcopy(tid1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Commit compound datatype */
     if (H5Tcommit2(file, compnd_type, tid2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get information about datatype on disk */
     if (H5Oget_native_info_by_name(file, compnd_type, &oi, H5O_NATIVE_INFO_HDR, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     new_dtype_oh_size = oi.hdr.space.total;
 
     /* Check that the new format is smaller than the old format */
     if (old_dtype_oh_size <= new_dtype_oh_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close datatype */
     if (H5Tclose(tid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that datatype has been encoded/decoded correctly */
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataytpe for query */
     if ((tid2 = H5Topen2(file, compnd_type, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the datatype was encoded/decoded correctly */
     if (H5Tequal(tid1, tid2) <= 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get information about datatype on disk */
     if (H5Oget_native_info_by_name(file, compnd_type, &oi, H5O_NATIVE_INFO_HDR, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that the object header info is still the same */
     if (new_dtype_oh_size != oi.hdr.space.total)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close datatype */
     if (H5Tclose(tid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close FAPL */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close datatype */
     if (H5Tclose(tid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -6702,113 +6704,113 @@ test_int_float_except(void)
 #if H5_SIZEOF_INT == 4 && H5_SIZEOF_FLOAT == 4
     /* Create dataset transfer property list */
     if ((dxpl = H5Pcreate(H5P_DATASET_XFER)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set the conversion exception handler in the DXPL */
     if (H5Pset_type_conv_cb(dxpl, conv_except, &e) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Convert buffer */
     HDmemset(&e, 0, sizeof(except_info_t));
     if (H5Tconvert(H5T_NATIVE_FLOAT, H5T_NATIVE_INT, (size_t)CONVERT_SIZE, buf, NULL, dxpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the buffer after conversion, as integers */
     for (u = 0; u < CONVERT_SIZE; u++) {
         intp = (int *)&buf[u];
         if (*intp != buf_int[u])
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for proper exceptions */
     if (e.num_range_hi != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (e.num_range_low != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (e.num_precision != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (e.num_truncate != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (e.num_other != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Convert buffer */
     HDmemset(&e, 0, sizeof(except_info_t));
     if (H5Tconvert(H5T_NATIVE_INT, H5T_NATIVE_FLOAT, (size_t)CONVERT_SIZE, buf, NULL, dxpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the buffer after conversion, as floats */
     for (u = 0; u < CONVERT_SIZE; u++) {
         floatp = (float *)&buf[u];
         if (!H5_FLT_ABS_EQUAL(*floatp, buf_float[u]))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for proper exceptions */
     if (e.num_range_hi != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (e.num_range_low != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (e.num_precision != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (e.num_truncate != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (e.num_other != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Work on second buffer */
 
     /* Convert second buffer */
     HDmemset(&e, 0, sizeof(except_info_t));
     if (H5Tconvert(H5T_NATIVE_INT, H5T_NATIVE_FLOAT, (size_t)CONVERT_SIZE, buf2, NULL, dxpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the buffer after conversion, as floats */
     for (u = 0; u < CONVERT_SIZE; u++) {
         floatp = (float *)&buf2[u];
         if (!H5_FLT_ABS_EQUAL(*floatp, buf2_float[u]))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for proper exceptions */
     if (e.num_range_hi != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (e.num_range_low != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (e.num_precision != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (e.num_truncate != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (e.num_other != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Convert buffer */
     HDmemset(&e, 0, sizeof(except_info_t));
     if (H5Tconvert(H5T_NATIVE_FLOAT, H5T_NATIVE_INT, (size_t)CONVERT_SIZE, buf2, NULL, dxpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the buffer after conversion, as integers */
     for (u = 0; u < CONVERT_SIZE; u++) {
         intp = (int *)&buf2[u];
         if (*intp != buf2_int[u])
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for proper exceptions */
     if (e.num_range_hi != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (e.num_range_low != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (e.num_precision != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (e.num_truncate != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (e.num_other != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close DXPL */
     if (H5Pclose(dxpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 #else  /* H5_SIZEOF_INT==4 && H5_SIZEOF_FLOAT==4 */
@@ -6854,60 +6856,60 @@ test_set_order(void)
 
     /* Integer */
     if ((dtype = H5Tcopy(H5T_STD_I32BE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_BE != H5Tget_order(dtype))
         TEST_ERROR;
     H5E_BEGIN_TRY
     ret = H5Tset_order(dtype, H5T_ORDER_NONE);
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_order(dtype, H5T_ORDER_LE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_LE != H5Tget_order(dtype))
         TEST_ERROR;
     if (H5Tclose(dtype) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Float */
     if ((dtype = H5Tcopy(H5T_IEEE_F64LE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_LE != H5Tget_order(dtype))
         TEST_ERROR;
     H5E_BEGIN_TRY
     ret = H5Tset_order(dtype, H5T_ORDER_NONE);
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_order(dtype, H5T_ORDER_BE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_BE != H5Tget_order(dtype))
         TEST_ERROR;
     if (H5Tclose(dtype) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Time */
     if ((dtype = H5Tcopy(H5T_UNIX_D64BE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_BE != H5Tget_order(dtype))
         TEST_ERROR;
     H5E_BEGIN_TRY
     ret = H5Tset_order(dtype, H5T_ORDER_NONE);
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_order(dtype, H5T_ORDER_LE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_LE != H5Tget_order(dtype))
         TEST_ERROR;
     if (H5Tclose(dtype) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fixed length string */
     if ((dtype = H5Tcopy(H5T_C_S1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_size(dtype, (size_t)5) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_NONE != H5Tget_order(dtype))
         TEST_ERROR;
     if (H5Tset_order(dtype, H5T_ORDER_NONE) < 0)
@@ -6917,68 +6919,68 @@ test_set_order(void)
 
     /* Variable length string */
     if (H5Tset_size(dtype, H5T_VARIABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     ret = H5Tset_order(dtype, H5T_ORDER_NONE);
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_order(dtype, H5T_ORDER_BE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_BE != H5Tget_order(dtype))
         TEST_ERROR;
     if (H5Tclose(dtype) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Bitfield */
     if ((dtype = H5Tcopy(H5T_STD_B16LE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_LE != H5Tget_order(dtype))
         TEST_ERROR;
     H5E_BEGIN_TRY
     ret = H5Tset_order(dtype, H5T_ORDER_NONE);
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_order(dtype, H5T_ORDER_BE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_BE != H5Tget_order(dtype))
         TEST_ERROR;
     if (H5Tclose(dtype) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Opaque - No effect on the order */
     if ((dtype = H5Tcreate(H5T_OPAQUE, (size_t)96)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_NONE != H5Tget_order(dtype))
         TEST_ERROR;
     if (H5Tset_order(dtype, H5T_ORDER_NONE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_order(dtype, H5T_ORDER_BE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_NONE != H5Tget_order(dtype))
         TEST_ERROR;
     if (H5Tclose(dtype) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compound */
     if ((dtype = H5Tcreate(H5T_COMPOUND, (size_t)48)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     ret = H5Tset_order(dtype, H5T_ORDER_BE);
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((order = H5Tget_order(dtype)) == H5T_ORDER_ERROR)
-        TEST_ERROR
+        TEST_ERROR;
     if (order != H5T_ORDER_NONE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(dtype) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Object reference */
     if ((dtype = H5Tcopy(H5T_STD_REF_OBJ)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_NONE != H5Tget_order(dtype))
         TEST_ERROR;
     if (H5Tset_order(dtype, H5T_ORDER_NONE) < 0)
@@ -6986,11 +6988,11 @@ test_set_order(void)
     if (H5T_ORDER_NONE != H5Tget_order(dtype))
         TEST_ERROR;
     if (H5Tclose(dtype) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Region reference */
     if ((dtype = H5Tcopy(H5T_STD_REF_DSETREG)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_NONE != H5Tget_order(dtype))
         TEST_ERROR;
     if (H5Tset_order(dtype, H5T_ORDER_NONE) < 0)
@@ -6998,58 +7000,58 @@ test_set_order(void)
     if (H5T_ORDER_NONE != H5Tget_order(dtype))
         TEST_ERROR;
     if (H5Tclose(dtype) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Enum */
     if ((dtype = H5Tenum_create(H5T_STD_I16BE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_BE != H5Tget_order(dtype))
         TEST_ERROR;
     H5E_BEGIN_TRY
     ret = H5Tset_order(dtype, H5T_ORDER_NONE);
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_order(dtype, H5T_ORDER_LE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_LE != H5Tget_order(dtype))
         TEST_ERROR;
     if (H5Tclose(dtype) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Vlen */
     if ((dtype = H5Tvlen_create(H5T_STD_U64LE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_LE != H5Tget_order(dtype))
         TEST_ERROR;
     H5E_BEGIN_TRY
     ret = H5Tset_order(dtype, H5T_ORDER_NONE);
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_order(dtype, H5T_ORDER_BE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_BE != H5Tget_order(dtype))
         TEST_ERROR;
     if (H5Tclose(dtype) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Array */
     if ((dtype = H5Tarray_create2(H5T_IEEE_F64BE, 2, dims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_BE != H5Tget_order(dtype))
         TEST_ERROR;
     H5E_BEGIN_TRY
     ret = H5Tset_order(dtype, H5T_ORDER_NONE);
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_order(dtype, H5T_ORDER_LE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5T_ORDER_LE != H5Tget_order(dtype))
         TEST_ERROR;
     if (H5Tclose(dtype) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -7102,19 +7104,19 @@ test_set_order_compound(hid_t fapl)
     TESTING("H5Tset/get_order for compound type");
 
     if ((memb_cmpd = H5Tcreate(H5T_COMPOUND, sizeof(atomic_cmpd))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(memb_cmpd, "i", HOFFSET(atomic_cmpd, i), H5T_NATIVE_INT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(memb_cmpd, "c", HOFFSET(atomic_cmpd, c), H5T_NATIVE_CHAR) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(memb_cmpd, "s", HOFFSET(atomic_cmpd, s), H5T_NATIVE_SHORT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(memb_cmpd, "f", HOFFSET(atomic_cmpd, f), H5T_NATIVE_FLOAT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the order to little-endian. */
     if (H5Tset_order(memb_cmpd, H5T_ORDER_BE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the array datatypes */
     memb_array1 = H5Tarray_create2(H5T_NATIVE_DOUBLE, 2, dims);
@@ -7122,96 +7124,96 @@ test_set_order_compound(hid_t fapl)
 
     /* Set the order to big-endian. */
     if (H5Tset_order(memb_array1, H5T_ORDER_LE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a variable-length datatype */
     if ((vl_id = H5Tvlen_create(H5T_NATIVE_UINT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a compound type using the types above. */
     if ((cmpd = H5Tcreate(H5T_COMPOUND, sizeof(complex_cmpd))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(cmpd, "a", HOFFSET(complex_cmpd, a), memb_cmpd) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(cmpd, "vl_type", HOFFSET(complex_cmpd, vl), vl_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(cmpd, "b", HOFFSET(complex_cmpd, b), memb_array1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(cmpd, "d", HOFFSET(complex_cmpd, d), memb_array2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* The order should be mixed now. */
     if (H5Tget_order(cmpd) != H5T_ORDER_MIXED)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create an array of the compound type above */
     cmpd_array = H5Tarray_create2(cmpd, 2, dims);
 
     /* The order of the array type should be the same as the compound type */
     if (H5Tget_order(cmpd_array) != H5T_ORDER_MIXED)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the order can't be 'none'. */
     H5E_BEGIN_TRY
     ret = H5Tset_order(cmpd, H5T_ORDER_NONE);
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the order can't be 'mixed'. */
     H5E_BEGIN_TRY
     ret = H5Tset_order(cmpd, H5T_ORDER_MIXED);
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Change the order of the compound type to big-endian*/
     if (H5Tset_order(cmpd, H5T_ORDER_BE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the order of the compound type is big-endian */
     if (H5Tget_order(cmpd) != H5T_ORDER_BE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Change the order of the array type to little-endian*/
     if (H5Tset_order(cmpd_array, H5T_ORDER_LE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the order of the array type is little-endian */
     if (H5Tget_order(cmpd_array) != H5T_ORDER_LE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create file */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
 
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Commit the data type */
     if (H5Tcommit2(file, "compound", cmpd, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that committed type can't change order */
     H5E_BEGIN_TRY
     ret = H5Tset_order(cmpd, H5T_ORDER_LE);
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Tclose(memb_cmpd) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb_array1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(memb_array2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(vl_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(cmpd) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(cmpd_array) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -7258,9 +7260,9 @@ test_named_indirect_reopen(hid_t fapl)
     /* Create file, dataspace */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((space = H5Screate_simple(1, dims, dims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Compound
@@ -7268,43 +7270,43 @@ test_named_indirect_reopen(hid_t fapl)
 
     /* Create compound type */
     if ((strtype = H5Tcopy(H5T_C_S1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_size(strtype, H5T_VARIABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((type = H5Tcreate(H5T_COMPOUND, sizeof(char *))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(type, "vlstr", (size_t)0, strtype) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(strtype) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get size of compound type */
     if ((dt_size = H5Tget_size(type)) == 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Commit compound type and verify the size doesn't change */
     if (H5Tcommit2(file, "cmpd_type", type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (dt_size != H5Tget_size(type))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataset with compound type */
     if ((dset = H5Dcreate2(file, "cmpd_dset", type, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Indirectly reopen type and verify that the size doesn't change */
     if ((reopened_type = H5Dget_type(dset)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (dt_size != H5Tget_size(reopened_type))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close types and dataset */
     if (H5Tclose(type) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(reopened_type) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Enum
@@ -7312,41 +7314,41 @@ test_named_indirect_reopen(hid_t fapl)
 
     /* Create enum type */
     if ((type = H5Tenum_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     enum_value = 0;
     if (H5Tenum_insert(type, "val1", &enum_value) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     enum_value = 1;
     if (H5Tenum_insert(type, "val2", &enum_value) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get size of enum type */
     if ((dt_size = H5Tget_size(type)) == 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Commit enum type and verify the size doesn't change */
     if (H5Tcommit2(file, "enum_type", type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (dt_size != H5Tget_size(type))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataset with enum type */
     if ((dset = H5Dcreate2(file, "enum_dset", type, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Indirectly reopen type and verify that the size doesn't change */
     if ((reopened_type = H5Dget_type(dset)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (dt_size != H5Tget_size(reopened_type))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close types and dataset */
     if (H5Tclose(type) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(reopened_type) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Vlen
@@ -7354,35 +7356,35 @@ test_named_indirect_reopen(hid_t fapl)
 
     /* Create vlen type */
     if ((type = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get size of vlen type */
     if ((dt_size = H5Tget_size(type)) == 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Commit vlen type and verify the size doesn't change */
     if (H5Tcommit2(file, "vlen_type", type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (dt_size != H5Tget_size(type))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataset with vlen type */
     if ((dset = H5Dcreate2(file, "vlen_dset", type, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Indirectly reopen type and verify that the size doesn't change */
     if ((reopened_type = H5Dget_type(dset)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (dt_size != H5Tget_size(reopened_type))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close types and dataset */
     if (H5Tclose(type) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(reopened_type) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Opaque
@@ -7390,49 +7392,49 @@ test_named_indirect_reopen(hid_t fapl)
 
     /* Create opaque type */
     if ((type = H5Tcreate(H5T_OPAQUE, (size_t)13)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_tag(type, tag) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get size of opaque type */
     if ((dt_size = H5Tget_size(type)) == 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Commit opaque type and verify the size and tag don't change */
     if (H5Tcommit2(file, "opaque_type", type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (dt_size != H5Tget_size(type))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (tag_ret = H5Tget_tag(type)))
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(tag, tag_ret) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5free_memory(tag_ret);
     tag_ret = NULL;
 
     /* Create dataset with opaque type */
     if ((dset = H5Dcreate2(file, "opaque_dset", type, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Indirectly reopen type and verify that the size and tag don't change */
     if ((reopened_type = H5Dget_type(dset)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (dt_size != H5Tget_size(reopened_type))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (tag_ret = H5Tget_tag(type)))
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(tag, tag_ret) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5free_memory(tag_ret);
     tag_ret = NULL;
 
     /* Close types and dataset */
     if (H5Tclose(type) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(reopened_type) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Array
@@ -7440,41 +7442,41 @@ test_named_indirect_reopen(hid_t fapl)
 
     /* Create array type */
     if ((type = H5Tarray_create2(H5T_NATIVE_INT, 1, dims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get size of array type */
     if ((dt_size = H5Tget_size(type)) == 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Commit array type and verify the size doesn't change */
     if (H5Tcommit2(file, "array_type", type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (dt_size != H5Tget_size(type))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataset with array type */
     if ((dset = H5Dcreate2(file, "array_dset", type, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Indirectly reopen type and verify that the size doesn't change */
     if ((reopened_type = H5Dget_type(dset)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (dt_size != H5Tget_size(reopened_type))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close types and dataset */
     if (H5Tclose(type) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(reopened_type) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file and dataspace */
     if (H5Sclose(space) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     PASSED();
     return 0;
 
@@ -7627,7 +7629,7 @@ test_delete_obj_named(hid_t fapl)
 
     /* Set up filenames & FAPLs */
     if ((fapl2 = H5Pcopy(fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     h5_fixname(FILENAME[8], fapl, filename, sizeof filename);
     h5_fixname(FILENAME[9], fapl2, filename2, sizeof filename2);
 
@@ -7645,62 +7647,62 @@ test_delete_obj_named(hid_t fapl)
 
             /* Test deleting dataset opened through different file ID */
             if ((filea1 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((filea2 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((dset = H5Dopen2(filea1, DEL_OBJ_NAMED_DATASET, H5P_DEFAULT)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Dclose(dset) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if (H5Fclose(filea1) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((fileb = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl2)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if (H5Ldelete(filea2, DEL_OBJ_NAMED_DATASET, H5P_DEFAULT) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if (H5Fclose(filea2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Fclose(fileb) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create test file, with attribute that uses committed datatype */
             create_del_obj_named_test_file(filename, fapl, low, high);
 
             /* Test deleting attribute opened through different file ID */
             if ((filea1 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((filea2 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((attr = H5Aopen_by_name(filea1, DEL_OBJ_NAMED_DATASET, DEL_OBJ_NAMED_ATTRIBUTE, H5P_DEFAULT,
                                         H5P_DEFAULT)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Aclose(attr) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if (H5Fclose(filea1) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((fileb = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl2)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if (H5Adelete_by_name(filea2, DEL_OBJ_NAMED_DATASET, DEL_OBJ_NAMED_ATTRIBUTE, H5P_DEFAULT) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if (H5Fclose(filea2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Fclose(fileb) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         } /* end high */
     }     /* end low */
 
     if (H5Pclose(fapl2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -7751,7 +7753,7 @@ test_delete_obj_named_fileid(hid_t fapl)
 
     /* Set up filenames & FAPLs */
     if ((fapl2 = H5Pcopy(fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     h5_fixname(FILENAME[8], fapl, filename, sizeof filename);
     h5_fixname(FILENAME[9], fapl2, filename2, sizeof filename2);
 
@@ -7768,138 +7770,138 @@ test_delete_obj_named_fileid(hid_t fapl)
 
             /* Test getting file ID for dataset opened through different file ID */
             if ((filea1 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((filea2 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((dset = H5Dopen2(filea1, DEL_OBJ_NAMED_DATASET, H5P_DEFAULT)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Verify file ID from dataset matches correct file */
             dset_fid = H5Iget_file_id(dset);
             if (!H5F__same_file_test(dset_fid, filea1))
-                TEST_ERROR
+                TEST_ERROR;
             H5Fclose(dset_fid);
 
             /* Verify file ID from datatype (from dataset) matches correct file */
             type     = H5Dget_type(dset);
             type_fid = H5Iget_file_id(type);
             if (!H5F__same_file_test(type_fid, filea1))
-                TEST_ERROR
+                TEST_ERROR;
             H5Fclose(type_fid);
             H5Tclose(type);
 
             if (H5Dclose(dset) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if (H5Fclose(filea1) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((fileb = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl2)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((filea1 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((dset = H5Dopen2(filea1, DEL_OBJ_NAMED_DATASET, H5P_DEFAULT)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Verify file ID from dataset matches correct file */
             dset_fid = H5Iget_file_id(dset);
             if (!H5F__same_file_test(dset_fid, filea1))
-                TEST_ERROR
+                TEST_ERROR;
             H5Fclose(dset_fid);
 
             /* Verify file ID from datatype (from dataset) matches correct file */
             type     = H5Dget_type(dset);
             type_fid = H5Iget_file_id(type);
             if (!H5F__same_file_test(type_fid, filea1))
-                TEST_ERROR
+                TEST_ERROR;
             H5Fclose(type_fid);
             H5Tclose(type);
 
             if (H5Dclose(dset) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if (H5Fclose(filea1) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Fclose(filea2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Fclose(fileb) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create test file, with attribute that uses committed datatype */
             create_del_obj_named_test_file(filename, fapl, low, high);
 
             /* Test getting file ID for attribute opened through different file ID */
             if ((filea1 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((filea2 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((attr = H5Aopen_by_name(filea1, DEL_OBJ_NAMED_DATASET, DEL_OBJ_NAMED_ATTRIBUTE, H5P_DEFAULT,
                                         H5P_DEFAULT)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Verify file ID from dataset matches correct file */
             attr_fid = H5Iget_file_id(attr);
             if (!H5F__same_file_test(attr_fid, filea1))
-                TEST_ERROR
+                TEST_ERROR;
             H5Fclose(attr_fid);
 
             /* Verify file ID from datatype (from dataset) matches correct file */
             type     = H5Aget_type(attr);
             type_fid = H5Iget_file_id(type);
             if (!H5F__same_file_test(type_fid, filea1))
-                TEST_ERROR
+                TEST_ERROR;
             H5Fclose(type_fid);
             H5Tclose(type);
 
             if (H5Aclose(attr) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if (H5Fclose(filea1) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((fileb = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl2)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((filea1 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((attr = H5Aopen_by_name(filea1, DEL_OBJ_NAMED_DATASET, DEL_OBJ_NAMED_ATTRIBUTE, H5P_DEFAULT,
                                         H5P_DEFAULT)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Verify file ID from dataset matches correct file */
             attr_fid = H5Iget_file_id(attr);
             if (!H5F__same_file_test(attr_fid, filea1))
-                TEST_ERROR
+                TEST_ERROR;
             H5Fclose(attr_fid);
 
             /* Verify file ID from datatype (from dataset) matches correct file */
             type     = H5Aget_type(attr);
             type_fid = H5Iget_file_id(type);
             if (!H5F__same_file_test(type_fid, filea1))
-                TEST_ERROR
+                TEST_ERROR;
             H5Fclose(type_fid);
             H5Tclose(type);
 
             if (H5Aclose(attr) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if (H5Fclose(filea1) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Fclose(filea2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Fclose(fileb) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         } /* end high */
     }     /* end low */
 
     if (H5Pclose(fapl2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -7955,18 +7957,18 @@ test_deprec(hid_t fapl)
     /* Create an array datatype with an atomic base type */
     /* (dimension permutations allowed, but not stored) */
     if ((type = H5Tarray_create1(H5T_NATIVE_INT, (int)rank, dims, perm)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain that the correct classes can be detected */
     if (H5Tdetect_class(type, H5T_ARRAY) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tdetect_class(type, H5T_INTEGER) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the array dimensions */
     /* (Query the dimension permutations, which is allowed, but ignored) */
     if (H5Tget_array_dims1(type, rdims, rperm) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check the array dimensions */
     dim_mismatch = FALSE;
@@ -7977,7 +7979,7 @@ test_deprec(hid_t fapl)
             dim_mismatch = TRUE;
         } /* end if */
     if (dim_mismatch)
-        FAIL_PUTS_ERROR("    Dimensions didn't match!")
+        FAIL_PUTS_ERROR("    Dimensions didn't match!");
 
     /* Check the array dimension permutations */
     dim_mismatch = FALSE;
@@ -7989,15 +7991,15 @@ test_deprec(hid_t fapl)
             dim_mismatch = TRUE;
         } /* end if */
     if (dim_mismatch)
-        FAIL_PUTS_ERROR("    Dimension permutations modified!")
+        FAIL_PUTS_ERROR("    Dimension permutations modified!");
 
     /* Close the datatype */
     if (H5Tclose(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Predefined types cannot be committed */
     H5E_BEGIN_TRY
@@ -8006,17 +8008,17 @@ test_deprec(hid_t fapl)
     }
     H5E_END_TRY;
     if (status >= 0)
-        FAIL_PUTS_ERROR("    Predefined types should not be committable!")
+        FAIL_PUTS_ERROR("    Predefined types should not be committable!");
 
     /* Copy a predefined datatype and commit the copy */
     if ((type = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tcommit1(file, "native-int", type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((status = H5Tcommitted(type)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (0 == status)
-        FAIL_PUTS_ERROR("    H5Tcommitted() returned false!")
+        FAIL_PUTS_ERROR("    H5Tcommitted() returned false!");
 
     /* We should not be able to modify a type after it has been committed. */
     H5E_BEGIN_TRY
@@ -8025,7 +8027,7 @@ test_deprec(hid_t fapl)
     }
     H5E_END_TRY;
     if (status >= 0)
-        FAIL_PUTS_ERROR("    Committed type is not constant!")
+        FAIL_PUTS_ERROR("    Committed type is not constant!");
 
     /* We should not be able to re-commit a committed type */
     H5E_BEGIN_TRY
@@ -8034,25 +8036,25 @@ test_deprec(hid_t fapl)
     }
     H5E_END_TRY;
     if (status >= 0)
-        FAIL_PUTS_ERROR("    Committed types should not be recommitted!")
+        FAIL_PUTS_ERROR("    Committed types should not be recommitted!");
 
     /*
      * Close the committed type and reopen it.  It should return a named type.
      */
     if (H5Tclose(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((type = H5Topen1(file, "native-int")) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((status = H5Tcommitted(type)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!status)
-        FAIL_PUTS_ERROR("    Opened named types should be named types!")
+        FAIL_PUTS_ERROR("    Opened named types should be named types!");
 
     /* Close */
     if (H5Tclose(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reopen file with read only access */
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
@@ -8130,25 +8132,25 @@ test_utf_ascii_conv(void)
      ************************************************/
     /* Create a variable-length string */
     if ((utf8_vtid = H5Tcopy(H5T_C_S1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((status = H5Tset_size(utf8_vtid, H5T_VARIABLE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the character set for the string to UTF-8 */
     if ((status = H5Tset_cset(utf8_vtid, H5T_CSET_UTF8)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a variable-length string */
     if ((ascii_vtid = H5Tcopy(H5T_C_S1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((status = H5Tset_size(ascii_vtid, H5T_VARIABLE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the character set for the string to ASCII (should already be so) */
     if ((status = H5Tset_cset(ascii_vtid, H5T_CSET_ASCII) < 0))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test conversion in memory */
     H5E_BEGIN_TRY
@@ -8157,24 +8159,24 @@ test_utf_ascii_conv(void)
     }
     H5E_END_TRY
     if (status >= 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a file */
     h5_fixname(FILENAME[10], H5P_DEFAULT, filename, sizeof filename);
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a scalar dataspace for the dataset */
     if ((sid = H5Screate(H5S_SCALAR)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataset of UTF8 string type */
     if ((did = H5Dcreate2(fid, UTF8_DATASET, utf8_vtid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write the UTF8 string, as UTF8 */
     if ((status = H5Dwrite(did, utf8_vtid, H5S_ALL, H5S_ALL, H5P_DEFAULT, &utf8_w)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read the UTF8 string, as ASCII, supposed to fail */
     H5E_BEGIN_TRY
@@ -8183,11 +8185,11 @@ test_utf_ascii_conv(void)
     }
     H5E_END_TRY
     if (status >= 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataset */
     if ((status = H5Dclose(did)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /************************************************
      * Test VL string conversion from ASCII to UTF8
@@ -8199,15 +8201,15 @@ test_utf_ascii_conv(void)
     }
     H5E_END_TRY
     if (status >= 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataset of ASCII string type */
     if ((did = H5Dcreate2(fid, ASCII_DATASET, ascii_vtid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write the ASCII string, as ASCII */
     if ((status = H5Dwrite(did, ascii_vtid, H5S_ALL, H5S_ALL, H5P_DEFAULT, &ascii_w)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read the ASCII string, as UTF8, supposed to fail */
     H5E_BEGIN_TRY
@@ -8216,44 +8218,44 @@ test_utf_ascii_conv(void)
     }
     H5E_END_TRY
     if (status >= 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataset */
     if ((status = H5Dclose(did)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the UTF8 VL-string datatype */
     if ((status = H5Tclose(utf8_vtid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the ASCII VL-string datatype */
     if ((status = H5Tclose(ascii_vtid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /**********************************************************
      * Test fixed-length string conversion from UTF8 to ASCII
      **********************************************************/
     /* Create a fixed-length UTF8 string */
     if ((utf8_tid = H5Tcopy(H5T_C_S1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((status = H5Tset_size(utf8_tid, 4)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the character set for the string to UTF-8 */
     if ((status = H5Tset_cset(utf8_tid, H5T_CSET_UTF8)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a fixed-length ASCII string */
     if ((ascii_tid = H5Tcopy(H5T_C_S1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((status = H5Tset_size(ascii_tid, 4)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the character set for the string to ASCII (should already be so) */
     if ((status = H5Tset_cset(ascii_tid, H5T_CSET_ASCII) < 0))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test conversion in memory */
     H5E_BEGIN_TRY
@@ -8262,15 +8264,15 @@ test_utf_ascii_conv(void)
     }
     H5E_END_TRY
     if (status >= 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataset */
     if ((did = H5Dcreate2(fid, UTF8_DATASET2, utf8_tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write the UTF8 string, as UTF8 */
     if ((status = H5Dwrite(did, utf8_tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, &utf8_w)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read the UTF8 string as ASCII, supposed to fail */
     H5E_BEGIN_TRY
@@ -8279,11 +8281,11 @@ test_utf_ascii_conv(void)
     }
     H5E_END_TRY
     if (status >= 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataset */
     if ((status = H5Dclose(did)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /**********************************************************
      * Test fixed-length string conversion from ASCII to UTF8
@@ -8295,15 +8297,15 @@ test_utf_ascii_conv(void)
     }
     H5E_END_TRY
     if (status >= 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataset */
     if ((did = H5Dcreate2(fid, ASCII_DATASET2, ascii_tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write the ASCII string, as ASCII */
     if ((status = H5Dwrite(did, ascii_tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, &ascii_w)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read the UTF8 string as ASCII, supposed to fail */
     H5E_BEGIN_TRY
@@ -8312,27 +8314,27 @@ test_utf_ascii_conv(void)
     }
     H5E_END_TRY
     if (status >= 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataset */
     if ((status = H5Dclose(did)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the UTF8 string datatype */
     if ((status = H5Tclose(utf8_tid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the ASCII string datatype */
     if ((status = H5Tclose(ascii_tid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataspace */
     if ((status = H5Sclose(sid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if ((status = H5Fclose(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -8382,7 +8384,7 @@ verify_version(hid_t dtype, H5F_libver_t low, unsigned *highest_version)
 
     dtypep = (H5T_t *)H5I_object(dtype);
     if (dtypep == NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Carry out the verification according to the class of the datatype.
        For compound datatype, its members will be verified, recursively.
@@ -8404,7 +8406,7 @@ verify_version(hid_t dtype, H5F_libver_t low, unsigned *highest_version)
             /* Get the base type's internal structure for version */
             base_dtypep = (H5T_t *)H5I_object(base_dtype);
             if (base_dtypep == NULL)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Reset highest version if this datatype has higher version than
                its outer type */
@@ -8416,11 +8418,11 @@ verify_version(hid_t dtype, H5F_libver_t low, unsigned *highest_version)
 
             /* Close the member datatype before checking for failure */
             if ((H5Tclose(base_dtype)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check if verify_version fails */
             if (ret < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             break;
         }
@@ -8428,19 +8430,19 @@ verify_version(hid_t dtype, H5F_libver_t low, unsigned *highest_version)
             H5T_t *mem_dtypep = NULL; /* Internal structure of a datatype */
             /* Get the number of members of this compound type */
             if ((nmembers = H5Tget_nmembers(dtype)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Go through all its member datatypes */
             for (i = 0; i < (unsigned)nmembers; i++) {
                 /* Get the member datatype to verify it recursively */
                 mem_dtype = H5Tget_member_type(dtype, i);
                 if (mem_dtype < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Get the member type's internal structure for version */
                 mem_dtypep = (H5T_t *)H5I_object(mem_dtype);
                 if (mem_dtypep == NULL)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Reset highest version if this datatype has higher version than
                    its outer type */
@@ -8452,11 +8454,11 @@ verify_version(hid_t dtype, H5F_libver_t low, unsigned *highest_version)
 
                 /* Close the member datatype before checking for failure */
                 if ((H5Tclose(mem_dtype)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check if verify_version fails */
                 if (ret < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             }
             /* If this compound datatype contains a datatype of higher version, it
                will be promoted to that version, thus, verify with highest version */
@@ -8482,7 +8484,7 @@ verify_version(hid_t dtype, H5F_libver_t low, unsigned *highest_version)
         case H5T_OPAQUE:
         case H5T_REFERENCE:
         default:
-            TEST_ERROR
+            TEST_ERROR;
     } /* end switch */
 
 error:
@@ -8571,114 +8573,114 @@ test_versionbounds(void)
 
     /* Create a file access property list */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a file creation property list */
     if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a scalar dataspace */
     if ((space = H5Screate(H5S_SCALAR)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a dataset creation property list */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an array datatype of chars */
     arr_chartype = H5Tarray_create2(H5T_NATIVE_CHAR, ARRAY_RANK, arr_dim);
     if (arr_chartype < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the simple compound datatype that has an integer and an
        array of chars */
     simple_cmp_type = H5Tcreate(H5T_COMPOUND, sizeof(simple_cmp_t));
     if (simple_cmp_type < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert integer field */
     ret = H5Tinsert(simple_cmp_type, "single_int", HOFFSET(simple_cmp_t, single_int), H5T_NATIVE_INT);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert array field */
     ret = H5Tinsert(simple_cmp_type, "char_arr", HOFFSET(simple_cmp_t, char_arr), arr_chartype);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an array datatype containing simple compound datatype */
     inner_arr_type = H5Tarray_create2(simple_cmp_type, ARRAY_RANK, arr_dim);
     if (inner_arr_type < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a VL datatype of floats */
     vlen_floattype = H5Tvlen_create(H5T_NATIVE_FLOAT);
     if (vlen_floattype < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the innermost compound datatype that houses inner_arr_type and vlen_floattype */
     inner_cmp_type = H5Tcreate(H5T_COMPOUND, sizeof(inner_cmp_t));
     if (inner_cmp_type < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert integer field */
     ret = H5Tinsert(inner_cmp_type, "inner_arr", HOFFSET(inner_cmp_t, inner_arr), inner_arr_type);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert integer field */
     ret = H5Tinsert(inner_cmp_type, "vlen_float", HOFFSET(inner_cmp_t, vlen_float), vlen_floattype);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a enumerate datatype */
     enum_type = H5Tcreate(H5T_ENUM, sizeof(color_t));
     if (enum_type < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     enum_val = E1_RED;
     ret      = H5Tenum_insert(enum_type, "RED", &enum_val);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     enum_val = E1_GREEN;
     ret      = H5Tenum_insert(enum_type, "GREEN", &enum_val);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     enum_val = E1_BLUE;
     ret      = H5Tenum_insert(enum_type, "BLUE", &enum_val);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     enum_val = E1_ORANGE;
     ret      = H5Tenum_insert(enum_type, "ORANGE", &enum_val);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     enum_val = E1_YELLOW;
     ret      = H5Tenum_insert(enum_type, "YELLOW", &enum_val);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the outer compound datatype that contains the inner compound datatype and the enum datatype */
     outer_cmp_type = H5Tcreate(H5T_COMPOUND, sizeof(outer_cmp_t));
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert integer field */
     ret = H5Tinsert(outer_cmp_type, "inner_cmp", HOFFSET(outer_cmp_t, inner_cmp), inner_cmp_type);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert enum field */
     ret = H5Tinsert(outer_cmp_type, "enum_color", HOFFSET(outer_cmp_t, enum_color), enum_type);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an array datatype containing the outer compound datatype */
     if ((outer_arr_type = H5Tarray_create2(outer_cmp_type, ARRAY_RANK, arr_dim)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop through all the combinations of low/high library format bounds,
        skipping invalid combinations */
@@ -8701,25 +8703,25 @@ test_versionbounds(void)
             /* Create a file */
             file = H5Fcreate(VERFNAME, H5F_ACC_TRUNC, fcpl, fapl);
             if (file < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Get the internal file pointer if the create succeeds */
             if ((filep = (H5F_t *)H5I_object(file)) == NULL)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create dataset using the array type */
             dset = H5Dcreate2(file, VERDSNAME, outer_arr_type, space, H5P_DEFAULT, dcpl, H5P_DEFAULT);
             if (dset < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Get the dataset's datatype */
             if ((dset_dtype = H5Dget_type(dset)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Get the version of this datatype */
             dtypep = (H5T_t *)H5I_object(dset_dtype);
             if (dtypep == NULL)
-                TEST_ERROR
+                TEST_ERROR;
             highest_version = dtypep->shared->version;
 
             /* Verify version of the datatype recursevily */
@@ -8727,24 +8729,24 @@ test_versionbounds(void)
 
             /* Close the dataset's datatype */
             if (H5Tclose(dset_dtype) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close dataset and file */
             if (H5Dclose(dset) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Fclose(file) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
         } /* for high */
     }     /* for low */
 
     /* Close dataspace and property lists */
     if (H5Sclose(space) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(fcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;

--- a/test/earray.c
+++ b/test/earray.c
@@ -291,15 +291,15 @@ create_file(unsigned flags, hid_t fapl, hid_t *file, H5F_t **f)
 {
     /* Create the file to work on */
     if ((*file = H5Fcreate(filename_g, flags, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (*f = (H5F_t *)H5VL_object(*file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(*f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Success */
     return (0);
@@ -328,44 +328,44 @@ check_stats(const H5EA_t *ea, const earray_state_t *state)
 
     /* Get statistics for extensible array and verify they are correct */
     if (H5EA_get_stats(ea, &earray_stats) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Compare information */
     if (earray_stats.stored.max_idx_set != state->max_idx_set) {
         HDfprintf(stdout,
                   "earray_stats.stored.max_idx_set = %" PRIuHSIZE ", state->max_idx_set = %" PRIuHSIZE "\n",
                   earray_stats.stored.max_idx_set, state->max_idx_set);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (earray_stats.stored.nelmts != state->nelmts) {
         HDfprintf(stdout, "earray_stats.stored.nelmts = %" PRIuHSIZE ", state->nelmts = %" PRIuHSIZE "\n",
                   earray_stats.stored.nelmts, state->nelmts);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (earray_stats.computed.hdr_size != state->hdr_size) {
         HDfprintf(stdout,
                   "earray_stats.computed.hdr_size = %" PRIuHSIZE ", state->hdr_size = %" PRIuHSIZE "\n",
                   earray_stats.computed.hdr_size, state->hdr_size);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (earray_stats.computed.nindex_blks != state->nindex_blks) {
         HDfprintf(stdout,
                   "earray_stats.computed.nindex_blks = %" PRIuHSIZE ", state->nindex_blks = %" PRIuHSIZE "\n",
                   earray_stats.computed.nindex_blks, state->nindex_blks);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (earray_stats.computed.index_blk_size != state->index_blk_size) {
         HDfprintf(stdout,
                   "earray_stats.computed.index_blk_size = %" PRIuHSIZE ", state->index_blk_size = %" PRIuHSIZE
                   "\n",
                   earray_stats.computed.index_blk_size, state->index_blk_size);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (earray_stats.stored.ndata_blks != state->ndata_blks) {
         HDfprintf(stdout,
                   "earray_stats.stored.ndata_blks = %" PRIuHSIZE ", state->ndata_blks = %" PRIuHSIZE "\n",
                   earray_stats.stored.ndata_blks, state->ndata_blks);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 /* Don't compare this currently, it's very hard to compute */
 #ifdef NOT_YET
@@ -374,14 +374,14 @@ check_stats(const H5EA_t *ea, const earray_state_t *state)
                   "earray_stats.stored.data_blk_size = %" PRIuHSIZE ", state->data_blk_size = %" PRIuHSIZE
                   "\n",
                   earray_stats.stored.data_blk_size, state->data_blk_size);
-        TEST_ERROR
+        TEST_ERROR;
     }  /* end if */
 #endif /* NOT_YET */
     if (earray_stats.stored.nsuper_blks != state->nsuper_blks) {
         HDfprintf(stdout,
                   "earray_stats.stored.nsuper_blks = %" PRIuHSIZE ", state->nsuper_blks = %" PRIuHSIZE "\n",
                   earray_stats.stored.nsuper_blks, state->nsuper_blks);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 /* Don't compare this currently, it's very hard to compute */
 #ifdef NOT_YET
@@ -390,7 +390,7 @@ check_stats(const H5EA_t *ea, const earray_state_t *state)
                   "earray_stats.stored.super_blk_size = %" PRIuHSIZE ", state->super_blk_size = %" PRIuHSIZE
                   "\n",
                   earray_stats.stored.super_blk_size, state->super_blk_size);
-        TEST_ERROR
+        TEST_ERROR;
     }  /* end if */
 #endif /* NOT_YET */
 
@@ -424,34 +424,34 @@ reopen_file(hid_t *file, H5F_t **f, hid_t fapl, H5EA_t **ea, haddr_t ea_addr,
         /* Close array, if given */
         if (ea && *ea) {
             if (H5EA_close(*ea) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             *ea = NULL;
         } /* end if */
 
         /* Close file */
         if (*file) {
             if (H5Fclose(*file) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             *file = (-1);
             *f    = NULL;
         } /* end if */
 
         /* Re-open the file */
         if ((*file = H5Fopen(filename_g, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (*f = (H5F_t *)H5VL_object(*file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Ignore metadata tags in the file's cache */
         if (H5AC_ignore_tags(*f) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Re-open array, if given */
         if (ea)
             if (NULL == (*ea = H5EA_open(*f, ea_addr, NULL)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
     } /* end if */
 
     /* Success */
@@ -482,22 +482,22 @@ create_array(H5F_t *f, const H5EA_create_t *cparam, H5EA_t **ea, haddr_t *ea_add
 
     /* Create array */
     if (NULL == (*ea = H5EA_create(f, cparam, cb)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check status of array */
     nelmts = (hsize_t)ULLONG_MAX;
     if (H5EA_get_nelmts(*ea, &nelmts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (nelmts > 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5EA_get_addr(*ea, ea_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(*ea_addr))
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(&state, 0, sizeof(state));
     state.hdr_size = EA_HDR_SIZE;
     if (check_stats(*ea, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return (0);
@@ -527,11 +527,11 @@ verify_cparam(const H5EA_t *ea, const H5EA_create_t *cparam)
     /* Retrieve creation parameters */
     HDmemset(&test_cparam, 0, sizeof(H5EA_create_t));
     if (H5EA__get_cparam_test(ea, &test_cparam) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify creation parameters */
     if (H5EA__cmp_cparam_test(cparam, &test_cparam))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return SUCCEED;
@@ -561,23 +561,23 @@ finish(hid_t file, hid_t fapl, H5F_t *f, H5EA_t *ea, haddr_t ea_addr)
 
     /* Close the extensible array */
     if (H5EA_close(ea) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete array */
     if (H5EA_delete(f, ea_addr, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename_g, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size_g)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return (0);
@@ -609,7 +609,7 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
 
     /* Create file & retrieve pointer to internal file object */
     if (create_file(H5F_ACC_TRUNC, fapl, &file, &f) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Display testing message
@@ -634,7 +634,7 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
             ea = NULL;
 
             /* Indicate error */
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
 
         /* Set invalid max. # of elements bits */
@@ -651,7 +651,7 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
             ea = NULL;
 
             /* Indicate error */
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
 
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
@@ -667,7 +667,7 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
             ea = NULL;
 
             /* Indicate error */
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
 
         /* Set invalid min. # of data block pointers in super blocks */
@@ -684,7 +684,7 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
             ea = NULL;
 
             /* Indicate error */
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
         test_cparam.sup_blk_min_data_ptrs = 1;
@@ -699,7 +699,7 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
             ea = NULL;
 
             /* Indicate error */
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
         test_cparam.sup_blk_min_data_ptrs = 6;
@@ -714,7 +714,7 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
             ea = NULL;
 
             /* Indicate error */
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
 
         /* Set invalid min. # of elements per data block */
@@ -731,7 +731,7 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
             ea = NULL;
 
             /* Indicate error */
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
 
         /* Set invalid max. # of elements per data block page bits */
@@ -750,7 +750,7 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
                 ea = NULL;
 
                 /* Indicate error */
-                TEST_ERROR
+                TEST_ERROR;
             } /* end if */
         }     /* end if */
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
@@ -767,7 +767,7 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
             ea = NULL;
 
             /* Indicate error */
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
         HDmemcpy(&test_cparam, cparam, sizeof(test_cparam));
         test_cparam.max_dblk_page_nelmts_bits = (uint8_t)(test_cparam.max_nelmts_bits + 1);
@@ -782,7 +782,7 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
             ea = NULL;
 
             /* Indicate error */
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
 
         PASSED();
@@ -799,7 +799,7 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
 
     /* Create array */
     if (create_array(f, cparam, &ea, &ea_addr, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -808,11 +808,11 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
 
     /* Verify the creation parameters */
     if (verify_cparam(ea, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close array, delete array, close file & verify file is empty */
     if (finish(file, fapl, f, ea, ea_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -854,7 +854,7 @@ test_reopen(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tparam)
 
     /* Create file & retrieve pointer to internal file object */
     if (create_file(H5F_ACC_TRUNC, fapl, &file, &f) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Display testing message
@@ -863,27 +863,27 @@ test_reopen(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tparam)
 
     /* Create array */
     if (create_array(f, cparam, &ea, &ea_addr, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the extensible array */
     if (H5EA_close(ea) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the file */
     if (reopen_file(&file, &f, fapl, NULL, HADDR_UNDEF, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the array */
     if (NULL == (ea = H5EA_open(f, ea_addr, NULL)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(ea, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close array, delete array, close file & verify file is empty */
     if (finish(file, fapl, f, ea, ea_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -928,7 +928,7 @@ test_open_twice(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tparam)
 
     /* Create file & retrieve pointer to internal file object */
     if (create_file(H5F_ACC_TRUNC, fapl, &file, &f) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Display testing message
@@ -937,46 +937,46 @@ test_open_twice(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tparam)
 
     /* Create array */
     if (create_array(f, cparam, &ea, &ea_addr, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the array again, through the first file handle */
     if (NULL == (ea2 = H5EA_open(f, ea_addr, NULL)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(ea, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (verify_cparam(ea2, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the second extensible array wrapper */
     if (H5EA_close(ea2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     ea2 = NULL;
 
     /* Check for closing & re-opening the file */
     if (reopen_file(&file, &f, fapl, &ea, ea_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file2 = H5Freopen(file)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f2 = (H5F_t *)H5VL_object(file2)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the extensible array through the second file handle */
     if (NULL == (ea2 = H5EA_open(f2, ea_addr, NULL)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(ea, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the first extensible array wrapper */
     if (H5EA_close(ea) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     ea = NULL;
 
     /* Close the first file */
@@ -984,11 +984,11 @@ test_open_twice(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tparam)
      *  shared file information)
      */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close array, delete array, close file & verify file is empty */
     if (finish(file2, fapl, f2, ea2, ea_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -1041,7 +1041,7 @@ test_open_twice_diff(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tpa
 
     /* Create file & retrieve pointer to internal file object */
     if (create_file(H5F_ACC_TRUNC, fapl, &file, &f) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Display testing message
@@ -1050,21 +1050,21 @@ test_open_twice_diff(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tpa
 
     /* Create array */
     if (create_array(f, cparam, &ea, &ea_addr, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the array again, through the first file handle */
     if (NULL == (ea2 = H5EA_open(f, ea_addr, NULL)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(ea, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (verify_cparam(ea2, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the second extensible array wrapper */
     if (H5EA_close(ea2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     ea2 = NULL;
 
     /* Re-open the file */
@@ -1072,19 +1072,19 @@ test_open_twice_diff(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tpa
      *  array is closed)
      */
     if ((file0 = H5Fopen(filename_g, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the file */
     if (reopen_file(&file, &f, fapl, &ea, ea_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(ea, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the first extensible array wrapper */
     if (H5EA_close(ea) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     ea = NULL;
 
     /* Close the first file */
@@ -1092,7 +1092,7 @@ test_open_twice_diff(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tpa
      *  shared file information)
      */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     file = -1;
 
     /* Open a different file */
@@ -1102,33 +1102,33 @@ test_open_twice_diff(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tpa
      */
     h5_fixname(FILENAME[1], fapl, filename_tmp, sizeof(filename_tmp));
     if ((file00 = H5Fcreate(filename_tmp, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file with the extensible array */
     if ((file2 = H5Fopen(filename_g, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f2 = (H5F_t *)H5VL_object(file2)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the extensible array through the second file handle */
     if (NULL == (ea2 = H5EA_open(f2, ea_addr, NULL)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(ea2, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the extra file handles */
     if (H5Fclose(file0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file00) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close array, delete array, close file & verify file is empty */
     if (finish(file2, fapl, f2, ea2, ea_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -1177,7 +1177,7 @@ test_delete_open(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tparam)
 
     /* Create file & retrieve pointer to internal file object */
     if (create_file(H5F_ACC_TRUNC, fapl, &file, &f) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Display testing message
@@ -1186,25 +1186,25 @@ test_delete_open(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tparam)
 
     /* Create array */
     if (create_array(f, cparam, &ea, &ea_addr, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the array again */
     if (NULL == (ea2 = H5EA_open(f, ea_addr, NULL)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Request that the array be deleted */
     if (H5EA_delete(f, ea_addr, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(ea, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (verify_cparam(ea2, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the second extensible array wrapper */
     if (H5EA_close(ea2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     ea2 = NULL;
 
     /* Try re-opening the array again (should fail, as array will be deleted) */
@@ -1218,17 +1218,17 @@ test_delete_open(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tparam)
         H5EA_close(ea2);
 
         /* Indicate error */
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Close the first extensible array wrapper */
     if (H5EA_close(ea) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     ea = NULL;
 
     /* Check for closing & re-opening the file */
     if (reopen_file(&file, &f, fapl, NULL, HADDR_UNDEF, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try re-opening the array again (should fail, as array is now deleted) */
     H5E_BEGIN_TRY
@@ -1241,20 +1241,20 @@ test_delete_open(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tparam)
         H5EA_close(ea);
 
         /* Indicate error */
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename_g, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size_g)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -2091,127 +2091,127 @@ test_set_elmts(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tparam, h
 
     /* Create file & retrieve pointer to internal file object */
     if (create_file(H5F_ACC_TRUNC, fapl, &file, &f) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create array */
     if (create_array(f, cparam, &ea, &ea_addr, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(ea, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the file */
     if (reopen_file(&file, &f, fapl, &ea, ea_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify high-water # of elements written */
     nelmts_written = (hsize_t)ULLONG_MAX;
     if (H5EA_get_nelmts(ea, &nelmts_written) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (nelmts_written != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify array state */
     HDmemset(&state, 0, sizeof(state));
     state.hdr_size = EA_HDR_SIZE;
     if (check_stats(ea, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get all elements from empty array */
 
     /* Initialize iterator */
     if (NULL == (eiter_info = tparam->eiter->init(cparam, tparam, nelmts)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get elements of array */
     for (cnt = 0; cnt < nelmts; cnt++) {
         /* Get the array index */
         if ((sidx = tparam->eiter->next(eiter_info)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         idx = (hsize_t)sidx;
 
         /* Retrieve element of array (not set yet) */
         relmt = (uint64_t)0;
         if (H5EA_get(ea, idx, &relmt) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify element is fill value for array */
         if (relmt != H5EA_TEST_FILL)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Shutdown iterator */
     if (tparam->eiter->term(eiter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set (& get) all elements from empty array */
 
     /* Initialize iterator */
     if (NULL == (eiter_info = tparam->eiter->init(cparam, tparam, nelmts)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set elements of array */
     for (cnt = 0; cnt < nelmts; cnt++) {
         /* Get the array index */
         if ((sidx = tparam->eiter->next(eiter_info)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         idx = (hsize_t)sidx;
 
         /* Retrieve element of array (not set yet) */
         relmt = (uint64_t)0;
         if (H5EA_get(ea, idx, &relmt) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify element is fill value for array */
         if (relmt != H5EA_TEST_FILL)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Set element of array */
         welmt = (uint64_t)7 + idx;
         if (H5EA_set(ea, idx, &welmt) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the max. array index */
         if ((smax = tparam->eiter->max_elem(eiter_info)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         max = (hsize_t)smax;
 
         /* Verify high-water # of elements written */
         nelmts_written = (hsize_t)ULLONG_MAX;
         if (H5EA_get_nelmts(ea, &nelmts_written) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (nelmts_written != (max + 1))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check if array state is available */
         if (tparam->eiter->state) {
             /* Get the extensible array state */
             if (tparam->eiter->state(eiter_info, cparam, tparam, &state, idx) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Verify array state */
             if (check_stats(ea, &state))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
 
         /* Retrieve element of array (set now) */
         relmt = (uint64_t)0;
         if (H5EA_get(ea, idx, &relmt) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify element is value written */
         if (relmt != welmt)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Shutdown iterator */
     if (tparam->eiter->term(eiter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close array, delete array, close file & verify file is empty */
     if (finish(file, fapl, f, ea, ea_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -2265,32 +2265,32 @@ test_skip_elmts(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tparam, 
 
     /* Create file & retrieve pointer to internal file object */
     if (create_file(H5F_ACC_TRUNC, fapl, &file, &f) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create array */
     if (create_array(f, cparam, &ea, &ea_addr, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(ea, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the file */
     if (reopen_file(&file, &f, fapl, &ea, ea_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify high-water # of elements written */
     nelmts_written = (hsize_t)ULLONG_MAX;
     if (H5EA_get_nelmts(ea, &nelmts_written) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (nelmts_written != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify array state */
     HDmemset(&state, 0, sizeof(state));
     state.hdr_size = EA_HDR_SIZE;
     if (check_stats(ea, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set (& get) element after skipping elements */
     idx = skip_elmts;
@@ -2298,23 +2298,23 @@ test_skip_elmts(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tparam, 
     /* Retrieve element of array (not set yet) */
     relmt = (uint64_t)0;
     if (H5EA_get(ea, idx, &relmt) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify element is fill value for array */
     if (relmt != H5EA_TEST_FILL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set element of array */
     welmt = (uint64_t)7 + idx;
     if (H5EA_set(ea, idx, &welmt) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify high-water # of elements written */
     nelmts_written = (hsize_t)ULLONG_MAX;
     if (H5EA_get_nelmts(ea, &nelmts_written) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (nelmts_written != (idx + 1))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set array state */
     HDmemset(&state, 0, sizeof(state));
@@ -2345,32 +2345,32 @@ test_skip_elmts(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t *tparam, 
 
     /* Verify array state */
     if (check_stats(ea, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve element of array (set now) */
     relmt = (uint64_t)0;
     if (H5EA_get(ea, idx, &relmt) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify element is value written */
     if (relmt != welmt)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get unset elements of array */
     for (cnt = 0; cnt < skip_elmts; cnt++) {
         /* Retrieve element of array (not set yet) */
         relmt = (uint64_t)0;
         if (H5EA_get(ea, cnt, &relmt) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify element is fill value for array */
         if (relmt != H5EA_TEST_FILL)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Close array, delete array, close file & verify file is empty */
     if (finish(file, fapl, f, ea, ea_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -2427,7 +2427,7 @@ main(void)
 
     /* Push API context */
     if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = TRUE;
 
     /* Seed random #'s */
@@ -2439,15 +2439,15 @@ main(void)
         hid_t file; /* File ID */
 
         if ((file = H5Fcreate(filename_g, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of a file w/no array */
         if ((empty_size_g = h5_get_file_size(filename_g, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* Initialize extensible array creation parameters */
@@ -2590,7 +2590,7 @@ main(void)
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = FALSE;
 
     if (nerrors)

--- a/test/efc.c
+++ b/test/efc.c
@@ -70,15 +70,15 @@ test_single(void)
      * a file pointer to H5F__efc_open containing the EFC.
      */
     if (H5Pset_elink_file_cache_size(fapl_id, 3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open parent file */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Disable EFC for child files */
     if (H5Pset_elink_file_cache_size(fapl_id, 0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test 1: Open file 1 through EFC, close, then open normally, verify ref
      * count = 2, release EFC, verify ref count = 1. Verifies a file can be
@@ -86,39 +86,39 @@ test_single(void)
      */
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(ftmp1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 2: Verify that subsequent efc_open requests return the cached top
      * level file pointer.  Open file 1 through EFC, close, open again, verify
      * file pointers are the same. */
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     ftmp1 = f1;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1 != ftmp1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 3: Verify LRU functionality.  Add four files to the EFC and verify
      * that the one added first is evicted.  Then reopen files in a different
@@ -126,150 +126,150 @@ test_single(void)
      * to track ref counts. */
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL ==
         (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL ==
         (f4 = H5F__efc_open(f0, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f4 = H5F_open(filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f4->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL == (ftmp3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f4->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL == (ftmp2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f4->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL == (ftmp1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f4->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL == (ftmp4 = H5F__efc_open(f0, filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f4->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f4->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(f4, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 4: Verify that files kept open through the EFC are not evicted by
      * H5F__efc_release(). */
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(ftmp1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 5: Verify that files kept open through the EFC are not evicted by
      * filling up the cache.  Open 4 files while holding the first open.  Verify
@@ -277,73 +277,73 @@ test_single(void)
      * second, and verify that the first file is evicted. */
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared != f1->shared)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL ==
         (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL ==
         (f4 = H5F__efc_open(f0, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(ftmp1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(ftmp2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 6: Verify that having a full EFC filled only with open files
      * prevents further files from being cached.  Open and hold open 3 files
@@ -351,107 +351,107 @@ test_single(void)
      * the EFC. */
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared != f1->shared)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp2->shared != f2->shared)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL ==
         (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp3->shared != f3->shared)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL ==
         (f4 = H5F__efc_open(f0, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp4 = H5F_open(filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp4->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp4->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(ftmp1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(ftmp2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(ftmp3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(ftmp4, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 7: Test multiple file opens.  Open a file twice, close it once, then
      * verify that it is not evicted by H5F__efc_release(). */
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(ftmp1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close parent file */
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -495,7 +495,7 @@ test_graph_nocycle(void)
      * because we don't test the EFC becoming too large in this test.
      */
     if (H5Pset_elink_file_cache_size(fapl_id, 8) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test 1: Simple 3 file chain. Open file 1 through file 0, then open file
      * 2 through file 1. Release file 0's EFC and verify that file 2 gets its
@@ -503,107 +503,107 @@ test_graph_nocycle(void)
      * opening order reversed.
      */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(ftmp2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F__efc_open(ftmp1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id,
                                     fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(ftmp1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(ftmp2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 2: 5 file chain.  The parent file has 2 child files, each of which
      * has their own child file.  Verifies that releasing the parent's EFC
      * closes all 4 children. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL ==
         (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f4 = H5F__efc_open(f3, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, f4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp4 = H5F_open(filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp4->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp4->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(ftmp2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(ftmp4, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 3: Simple "inverted" tree.  Two parent files share a child file,
      * which has its own child file.  Verify that the child's child is not
@@ -611,170 +611,170 @@ test_graph_nocycle(void)
      * parent, then reopen through that parent and release the other, then
      * re-release the first parent. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL == (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F__efc_release(f1->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(ftmp3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 4: Simple "diamond" tree.  The parent file has two children, which
      * shared the same child.  Verify that releasing the parent file closes all
      * files. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp3->shared->nrefs != 3)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(ftmp3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 5: Dense 5 file graph.  f0 caches f1, f2, f3 and f4.  f1 and f2
      * each cache f3 and f4.  f3 caches f4.  Verify that releasing f0 closes all
      * files. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f4 = H5F__efc_open(f0, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f4 = H5F__efc_open(f1, filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f4 = H5F__efc_open(f2, filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f4 = H5F__efc_open(f3, filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, f4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp4 = H5F_open(filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp4->shared->nrefs != 5)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp4->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (ftmp2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(ftmp1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(ftmp2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(ftmp3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(ftmp4, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -819,1814 +819,1814 @@ test_graph_cycle(void)
      * because we don't test the EFC becoming too large in this test.
      */
     if (H5Pset_elink_file_cache_size(fapl_id, 8) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test 1: File caches itself. Verify that closing the file causes it to be
      * actually closed, and there is no other unexpected behavior.
      */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f0, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL == (ftmp0 = H5F__efc_open(f0, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 2: Indirectly referenced file caches itself.  Same as above except
      * the file is part of another file's EFC. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f1, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f1, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 3: Simple 2 file cycle */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 4: Simple 2 file cycle (indirectly referenced) */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 5: Parallel double cycle */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f2, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 3)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 6: Parallel double cycle with release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f2, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 3)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 7: Chained parallel double cycle */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f3, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 8: Chained parallel double cycle with release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f3, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 9: Simple 2 file cycle, extra ID on root */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F_open(filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared != ftmp0->shared)
-        TEST_ERROR
+        TEST_ERROR;
     if (f0->shared->nrefs != 3)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(ftmp0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 10: Simple 2 file cycle, extra ID on second file */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(ftmp1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 11: Parallel double cycle, extra ID on a child file */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f2, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 3)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 3)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(ftmp2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 12: Parallel double cycle, extra ID on a child file, with release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f2, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 3)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(ftmp2->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(ftmp2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 13: Chained parallel double cycle, extra ID on a child file */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f3, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(ftmp3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 14: Chained parallel double cycle, extra ID on a child file, with
      * release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f3, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(ftmp3->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(ftmp3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 15: One local and one remote cycle */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f3, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 16: One local and one remote cycle, with release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f3, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 17: One local and one remote cycle, remote cycle held open */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f3, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(ftmp3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 18: One local and one remote cycle, remote cycle held open, with
      * release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f3, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (ftmp3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f2->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5F__efc_release(ftmp3->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ftmp3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(ftmp3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 19: "Diamond" shape with links moving from bottom (root) to top.
      * Also cycle between bottom (root) and top and cycles on the sides. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f3, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f4 = H5F__efc_open(f1, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f4, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f4, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f5 = H5F__efc_open(f2, filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f5, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f5, ftmp2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f5) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f4 = H5F_open(filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f4->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f4, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f5 = H5F_open(filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f5->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f5, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 20: "Diamond" shape with links moving from bottom (root) to top.
      * Also cycle between bottom (root) and top, cycles on the sides, and
      * release the files instead of closing. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f3, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f4 = H5F__efc_open(f1, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f4, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f4, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f5 = H5F__efc_open(f2, filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f5, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f5, ftmp2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f5) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f4 = H5F_open(filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f4->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f4, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f5 = H5F_open(filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f5->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f5, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 21: "Diamond" shape with links moving from bottom (root) to top.
      * Also cycle between bottom (root) and top, cycles on sides held open. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f3, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f4 = H5F__efc_open(f1, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f4, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f4, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f4 = H5F_open(filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f5 = H5F__efc_open(f2, filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f5, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f5, ftmp2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f5) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f5 = H5F_open(filename[5], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f4->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f5->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f4->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f5->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(f4, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f5->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f5->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5F_try_close(f5, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f4 = H5F_open(filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f4->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f4, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f5 = H5F_open(filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f5->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f5, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 22: "Diamond" shape with links moving from bottom (root) to top.
      * Also cycle between bottom (root) and top, cycles on sides held open.
      * Also release the files instead of closing. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f3, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f4 = H5F__efc_open(f1, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f4, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f4, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f4 = H5F_open(filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f5 = H5F__efc_open(f2, filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f5, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f5, ftmp2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f5) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f5 = H5F_open(filename[5], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f4->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f5->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f4->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f5->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f3->shared->nrefs != 3)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5F__efc_release(f4->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f4->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f5->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5F__efc_release(f5->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f4->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f5->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(f4, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(f5, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 23: Dense "ball" of files.  4 files each cache all files (including
      * itself). */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f0, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f1, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (NULL == (ftmp0 = H5F__efc_open(f2, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f2, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (NULL == (ftmp0 = H5F__efc_open(f3, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f3, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f3, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F__efc_open(f3, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 24: Dense "ball" of files.  4 files each cache all files (including
      * itself).  Release the files instead of closing. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f0, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f1, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (NULL == (ftmp0 = H5F__efc_open(f2, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f2, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (NULL == (ftmp0 = H5F__efc_open(f3, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f3, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f3, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F__efc_open(f3, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 25: File held open by EFC client interrupts cycle, with release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 26: File held open by EFC does not interrupt cycle, with release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 27: File held open by EFC client through non-parent file does not
      * interrupt cycle, but parent file does (no valid way around it) */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5F_efc_close(f1, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5F_efc_close(f2, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 3)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f3->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 28: File held open by EFC client through non-parent file does not
      * interrupt cycle, but parent file does (no valid way around it), with
      * release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f1->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f0->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F__efc_release(f2->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_efc_close(f1, f3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F__efc_release(f2->shared->efc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f3->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f3, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 29: File without EFC interrupts cycle */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_elink_file_cache_size(fapl_id, 0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_elink_file_cache_size(fapl_id, 8) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 30: File without EFC does not interrupt cycle */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL ==
         (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_elink_file_cache_size(fapl_id, 0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL ==
         (f2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_elink_file_cache_size(fapl_id, 8) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f1->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f1, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (f2->shared->nrefs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5F_try_close(f2, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2679,7 +2679,7 @@ main(void)
 
     /* Push API context */
     if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = TRUE;
 
     /* Get the VOL info from the fapl */
@@ -2698,14 +2698,14 @@ main(void)
 
     /* Close property lists */
     if (H5Pclose(fcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify symbol table messages are cached */
     nerrors += (h5_verify_cached_stabs(FILENAME, fapl_id) < 0 ? 1 : 0);
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = FALSE;
 
     if (nerrors)

--- a/test/enc_dec_plist.c
+++ b/test/enc_dec_plist.c
@@ -33,11 +33,11 @@ test_encode_decode(hid_t orig_pl, H5F_libver_t low, H5F_libver_t high, hbool_t s
 
     /* Create file access property list */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set library version bounds */
     if (H5Pset_libver_bounds(fapl, low, high) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -53,23 +53,23 @@ test_encode_decode(hid_t orig_pl, H5F_libver_t low, H5F_libver_t high, hbool_t s
 
         /* Allocate the buffer for encoding */
         if (NULL == (temp_buf = (void *)HDmalloc(temp_size)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Encode the property list to the buffer */
         if (H5Pencode2(orig_pl, temp_buf, &temp_size, fapl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Decode the buffer */
         if ((pl = H5Pdecode(temp_buf)) < 0)
-            STACK_ERROR
+            STACK_ERROR;
 
         /* Check if the original and the decoded property lists are equal */
         if (!H5Pequal(orig_pl, pl))
-            PUTS_ERROR("encoding-decoding cycle failed\n")
+            PUTS_ERROR("encoding-decoding cycle failed\n");
 
         /* Close the decoded property list */
         if ((H5Pclose(pl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free the buffer */
         if (temp_buf)
@@ -80,22 +80,22 @@ test_encode_decode(hid_t orig_pl, H5F_libver_t low, H5F_libver_t high, hbool_t s
 
         /* first call to encode returns only the size of the buffer needed */
         if (H5Pencode1(orig_pl, NULL, &temp_size) < 0)
-            STACK_ERROR
+            STACK_ERROR;
 
         if (NULL == (temp_buf = (void *)HDmalloc(temp_size)))
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Pencode1(orig_pl, temp_buf, &temp_size) < 0)
-            STACK_ERROR
+            STACK_ERROR;
 
         if ((pl = H5Pdecode(temp_buf)) < 0)
-            STACK_ERROR
+            STACK_ERROR;
 
         if (!H5Pequal(orig_pl, pl))
-            PUTS_ERROR("encoding-decoding cycle failed\n")
+            PUTS_ERROR("encoding-decoding cycle failed\n");
 
         if ((H5Pclose(pl)) < 0)
-            STACK_ERROR
+            STACK_ERROR;
 
         if (temp_buf)
             HDfree(temp_buf);
@@ -103,7 +103,7 @@ test_encode_decode(hid_t orig_pl, H5F_libver_t low, H5F_libver_t high, hbool_t s
     }
 
     if ((H5Pclose(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return (0);
@@ -209,367 +209,367 @@ main(void)
             /******* ENCODE/DECODE DCPLS *****/
             TESTING("Default DCPL Encoding/Decoding");
             if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding default property list */
             if (test_encode_decode(dcpl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("Default DCPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("Default DCPL encoding/decoding failed\n");
 
             PASSED();
 
             TESTING("DCPL Encoding/Decoding");
 
             if ((H5Pset_chunk(dcpl, 2, chunk_size)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_alloc_time(dcpl, H5D_ALLOC_TIME_LATE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_fill_value(dcpl, H5T_NATIVE_DOUBLE, &fill)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_dset_no_attrs_hint(dcpl, FALSE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             max_size[0] = 100;
             if ((H5Pset_external(dcpl, "ext1.data", (off_t)0, (hsize_t)(max_size[0] * sizeof(int) / 4))) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_external(dcpl, "ext2.data", (off_t)0, (hsize_t)(max_size[0] * sizeof(int) / 4))) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_external(dcpl, "ext3.data", (off_t)0, (hsize_t)(max_size[0] * sizeof(int) / 4))) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_external(dcpl, "ext4.data", (off_t)0, (hsize_t)(max_size[0] * sizeof(int) / 4))) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding property list */
             if (test_encode_decode(dcpl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("DCPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("DCPL encoding/decoding failed\n");
 
             /* release resource */
             if ((H5Pclose(dcpl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             PASSED();
 
             /******* ENCODE/DECODE DCPLS *****/
             TESTING("DCPL Encoding/Decoding for virtual layout");
             if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Set virtual layout */
             if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create source dataspace */
             if ((srcspace = H5Screate_simple(1, dims, NULL)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create virtual dataspace */
             if ((vspace = H5Screate_simple(1, dims, NULL)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Add virtual layout mapping */
             if (H5Pset_virtual(dcpl, vspace, SRC_FNAME, SRC_DSET, srcspace) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             if (test_encode_decode(dcpl, low, high, TRUE) < 0)
-                FAIL_PUTS_ERROR("DCPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("DCPL encoding/decoding failed\n");
 
             /* release resource */
             if ((H5Pclose(dcpl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /******* ENCODE/DECODE DAPLS *****/
             TESTING("Default DAPL Encoding/Decoding");
             if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding default property list */
             if (test_encode_decode(dapl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("Default DAPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("Default DAPL encoding/decoding failed\n");
 
             PASSED();
 
             TESTING("DAPL Encoding/Decoding");
 
             if ((H5Pset_chunk_cache(dapl, nslots, nbytes, w0)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding property list */
             if (test_encode_decode(dapl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("DAPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("DAPL encoding/decoding failed\n");
 
             /* release resource */
             if ((H5Pclose(dapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             PASSED();
 
             /******* ENCODE/DECODE OCPLS *****/
             TESTING("Default OCPL Encoding/Decoding");
             if ((ocpl = H5Pcreate(H5P_OBJECT_CREATE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding default property list */
             if (test_encode_decode(ocpl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("Default OCPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("Default OCPL encoding/decoding failed\n");
 
             PASSED();
 
             TESTING("OCPL Encoding/Decoding");
 
             if ((H5Pset_attr_creation_order(ocpl, (H5P_CRT_ORDER_TRACKED | H5P_CRT_ORDER_INDEXED))) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_attr_phase_change(ocpl, 110, 105)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_filter(ocpl, H5Z_FILTER_FLETCHER32, 0, (size_t)0, NULL)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding property list */
             if (test_encode_decode(ocpl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("OCPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("OCPL encoding/decoding failed\n");
 
             /* release resource */
             if ((H5Pclose(ocpl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             PASSED();
 
             /******* ENCODE/DECODE DXPLS *****/
             TESTING("Default DXPL Encoding/Decoding");
             if ((dxpl = H5Pcreate(H5P_DATASET_XFER)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding default property list */
             if (test_encode_decode(dxpl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("Default DXPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("Default DXPL encoding/decoding failed\n");
 
             PASSED();
 
             TESTING("DXPL Encoding/Decoding");
 
             if ((H5Pset_btree_ratios(dxpl, 0.2, 0.6, 0.2)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_hyper_vector_size(dxpl, 5)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
 #ifdef H5_HAVE_PARALLEL
             if ((H5Pset_dxpl_mpio(dxpl, H5FD_MPIO_COLLECTIVE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_dxpl_mpio_collective_opt(dxpl, H5FD_MPIO_INDIVIDUAL_IO)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_dxpl_mpio_chunk_opt(dxpl, H5FD_MPIO_CHUNK_MULTI_IO)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_dxpl_mpio_chunk_opt_ratio(dxpl, 30)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_dxpl_mpio_chunk_opt_num(dxpl, 40)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 #endif /* H5_HAVE_PARALLEL */
             if ((H5Pset_edc_check(dxpl, H5Z_DISABLE_EDC)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_data_transform(dxpl, c_to_f)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding property list */
             if (test_encode_decode(dxpl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("DXPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("DXPL encoding/decoding failed\n");
 
             /* release resource */
             if ((H5Pclose(dxpl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             PASSED();
 
             /******* ENCODE/DECODE GCPLS *****/
             TESTING("Default GCPL Encoding/Decoding");
             if ((gcpl = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding default property list */
             if (test_encode_decode(gcpl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("Default GCPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("Default GCPL encoding/decoding failed\n");
 
             PASSED();
 
             TESTING("GCPL Encoding/Decoding");
 
             if ((H5Pset_local_heap_size_hint(gcpl, 256)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_link_phase_change(gcpl, 2, 2)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Query the group creation properties */
             if ((H5Pget_link_phase_change(gcpl, &max_compact, &min_dense)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_est_link_info(gcpl, 3, 9)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_link_creation_order(gcpl, (H5P_CRT_ORDER_TRACKED | H5P_CRT_ORDER_INDEXED))) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding property list */
             if (test_encode_decode(gcpl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("GCPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("GCPL encoding/decoding failed\n");
 
             /* release resource */
             if ((H5Pclose(gcpl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             PASSED();
 
             /******* ENCODE/DECODE LCPLS *****/
             TESTING("Default LCPL Encoding/Decoding");
             if ((lcpl = H5Pcreate(H5P_LINK_CREATE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding default property list */
             if (test_encode_decode(lcpl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("Default LCPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("Default LCPL encoding/decoding failed\n");
 
             PASSED();
 
             TESTING("LCPL Encoding/Decoding");
 
             if ((H5Pset_create_intermediate_group(lcpl, TRUE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding property list */
             if (test_encode_decode(lcpl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("LCPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("LCPL encoding/decoding failed\n");
 
             /* release resource */
             if ((H5Pclose(lcpl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             PASSED();
 
             /******* ENCODE/DECODE LAPLS *****/
             TESTING("Default LAPL Encoding/Decoding");
             if ((lapl = H5Pcreate(H5P_LINK_ACCESS)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding default property list */
             if (test_encode_decode(lapl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("Default LAPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("Default LAPL encoding/decoding failed\n");
 
             PASSED();
 
             TESTING("LAPL Encoding/Decoding");
 
             if ((H5Pset_nlinks(lapl, (size_t)134)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_elink_acc_flags(lapl, H5F_ACC_RDONLY)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_elink_prefix(lapl, "/tmpasodiasod")) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create FAPL for the elink FAPL */
             if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_alignment(fapl, 2, 1024)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_elink_fapl(lapl, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Close the elink's FAPL */
             if ((H5Pclose(fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding property list */
             if (test_encode_decode(lapl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("LAPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("LAPL encoding/decoding failed\n");
 
             /* release resource */
             if ((H5Pclose(lapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             PASSED();
 
             /******* ENCODE/DECODE OCPYPLS *****/
             TESTING("Default OCPYPL Encoding/Decoding");
             if ((ocpypl = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding default property list */
             if (test_encode_decode(ocpypl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("Default OCPYPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("Default OCPYPL encoding/decoding failed\n");
 
             PASSED();
 
             TESTING("OCPYPL Encoding/Decoding");
 
             if ((H5Pset_copy_object(ocpypl, H5O_COPY_EXPAND_EXT_LINK_FLAG)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Padd_merge_committed_dtype_path(ocpypl, "foo")) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Padd_merge_committed_dtype_path(ocpypl, "bar")) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding property list */
             if (test_encode_decode(ocpypl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("OCPYPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("OCPYPL encoding/decoding failed\n");
 
             /* release resource */
             if ((H5Pclose(ocpypl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             PASSED();
 
             /******* ENCODE/DECODE FAPLS *****/
             TESTING("Default FAPL Encoding/Decoding");
             if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding default property list */
             if (test_encode_decode(fapl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("Default FAPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("Default FAPL encoding/decoding failed\n");
 
             PASSED();
 
             TESTING("FAPL Encoding/Decoding");
 
             if ((H5Pset_family_offset(fapl, 1024)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_meta_block_size(fapl, 2098452)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_sieve_buf_size(fapl, 1048576)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_alignment(fapl, 2, 1024)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_cache(fapl, 1024, 128, 10485760, 0.3)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_elink_file_cache_size(fapl, 10485760)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_gc_references(fapl, 1)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_small_data_block_size(fapl, 2048)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_fclose_degree(fapl, H5F_CLOSE_WEAK)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_multi_type(fapl, H5FD_MEM_GHEAP)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_mdc_config(fapl, &my_cache_config)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pset_mdc_image_config(fapl, &my_cache_image_config)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding property list */
             if (test_encode_decode(fapl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("FAPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("FAPL encoding/decoding failed\n");
 
             /* release resource */
             if ((H5Pclose(fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             PASSED();
 
@@ -577,44 +577,44 @@ main(void)
             TESTING("Default FCPL Encoding/Decoding");
 
             if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding default property list */
             if (test_encode_decode(fcpl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("Default FCPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("Default FCPL encoding/decoding failed\n");
 
             PASSED();
 
             TESTING("FCPL Encoding/Decoding");
 
             if ((H5Pset_userblock(fcpl, 1024) < 0))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_istore_k(fcpl, 3) < 0))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_sym_k(fcpl, 4, 5) < 0))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_shared_mesg_nindexes(fcpl, 8) < 0))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_shared_mesg_index(fcpl, 1, H5O_SHMESG_SDSPACE_FLAG, 32) < 0))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_shared_mesg_phase_change(fcpl, 60, 20) < 0))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if ((H5Pset_sizes(fcpl, 8, 4) < 0))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding property list */
             if (test_encode_decode(fcpl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("FCPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("FCPL encoding/decoding failed\n");
 
             /* release resource */
             if ((H5Pclose(fcpl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             PASSED();
 
@@ -622,26 +622,26 @@ main(void)
             TESTING("Default STRCPL Encoding/Decoding");
 
             if ((strcpl = H5Pcreate(H5P_STRING_CREATE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding default property list */
             if (test_encode_decode(strcpl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("Default STRCPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("Default STRCPL encoding/decoding failed\n");
 
             PASSED();
 
             TESTING("STRCPL Encoding/Decoding");
 
             if ((H5Pset_char_encoding(strcpl, H5T_CSET_UTF8) < 0))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding property list */
             if (test_encode_decode(strcpl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("STRCPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("STRCPL encoding/decoding failed\n");
 
             /* release resource */
             if ((H5Pclose(strcpl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             PASSED();
 
@@ -649,26 +649,26 @@ main(void)
             TESTING("Default ACPL Encoding/Decoding");
 
             if ((acpl = H5Pcreate(H5P_ATTRIBUTE_CREATE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding default property list */
             if (test_encode_decode(acpl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("Default ACPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("Default ACPL encoding/decoding failed\n");
 
             PASSED();
 
             TESTING("ACPL Encoding/Decoding");
 
             if ((H5Pset_char_encoding(acpl, H5T_CSET_UTF8) < 0))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Test encoding & decoding property list */
             if (test_encode_decode(acpl, low, high, FALSE) < 0)
-                FAIL_PUTS_ERROR("ACPL encoding/decoding failed\n")
+                FAIL_PUTS_ERROR("ACPL encoding/decoding failed\n");
 
             /* release resource */
             if ((H5Pclose(acpl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             PASSED();
 

--- a/test/enc_dec_plist_cross_platform.c
+++ b/test/enc_dec_plist_cross_platform.c
@@ -33,121 +33,121 @@ main(void)
     /******* ENCODE/DECODE DCPLS *****/
     TESTING("Default DCPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/def_dcpl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     TESTING("DCPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/dcpl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /******* ENCODE/DECODE DAPLS *****/
     TESTING("Default DAPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/def_dapl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     TESTING("DAPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/dapl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /******* ENCODE/DECODE DXPLS *****/
     TESTING("Default DXPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/def_dxpl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     TESTING("DXPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/dxpl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /******* ENCODE/DECODE GCPLS *****/
     TESTING("Default GCPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/def_gcpl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     TESTING("GCPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/gcpl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /******* ENCODE/DECODE LCPLS *****/
     TESTING("Default LCPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/def_lcpl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     TESTING("LCPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/lcpl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /******* ENCODE/DECODE LAPLS *****/
     TESTING("Default LAPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/def_lapl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     TESTING("LAPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/lapl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /******* ENCODE/DECODE OCPLS *****/
     TESTING("Default OCPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/def_ocpl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     TESTING("OCPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/ocpl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /******* ENCODE/DECODE OCPYPLS *****/
     TESTING("Default OCPYPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/def_ocpypl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     TESTING("OCPYPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/ocpypl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /******* ENCODE/DECODE FCPLS *****/
     TESTING("Default FCPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/def_fcpl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     TESTING("FCPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/fcpl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /******* ENCODE/DECODE FAPLS *****/
     TESTING("Default FAPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/def_fapl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     TESTING("FAPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/fapl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /******* ENCODE/DECODE STRCPLS *****/
     TESTING("Default STRCPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/def_strcpl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     TESTING("STRCPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/strcpl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /******* ENCODE/DECODE ACPLS *****/
     TESTING("Default ACPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/def_acpl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     TESTING("ACPL Encoding/Decoding");
     if (test_plists("testfiles/plist_files/acpl_") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     return 0;
@@ -173,50 +173,50 @@ test_plists(const char *filename_prefix)
             /* Generate filename for file 1 */
             if (HDsnprintf(filename, sizeof(filename), "%s%s%s", filename_prefix,
                            config_1 & CONFIG_64 ? "64" : "32", config_1 & CONFIG_LE ? "le" : "be") < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Read file 1 */
             testfile = H5_get_srcdir_filename(filename);
             if ((fd_1 = HDopen(testfile, O_RDONLY)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             size_1 = (size_t)HDlseek(fd_1, (HDoff_t)0, SEEK_END);
             HDlseek(fd_1, (HDoff_t)0, SEEK_SET);
             buf_1 = (void *)HDmalloc(size_1);
             if (HDread(fd_1, buf_1, size_1) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             HDclose(fd_1);
 
             /* Generate filename for file 2 */
             if (HDsnprintf(filename, sizeof(filename), "%s%s%s", filename_prefix,
                            config_2 & CONFIG_64 ? "64" : "32", config_2 & CONFIG_LE ? "le" : "be") < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Read file 1 */
             testfile = H5_get_srcdir_filename(filename);
             if ((fd_2 = HDopen(testfile, O_RDONLY)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             size_2 = (size_t)HDlseek(fd_2, (HDoff_t)0, SEEK_END);
             HDlseek(fd_2, (HDoff_t)0, SEEK_SET);
             buf_2 = (void *)HDmalloc(size_2);
             if (HDread(fd_2, buf_2, size_2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             HDclose(fd_2);
 
             /* Decode property lists */
             if ((plist_1 = H5Pdecode(buf_1)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((plist_2 = H5Pdecode(buf_2)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Compare decoded property lists */
             if (!H5Pequal(plist_1, plist_2))
-                FAIL_PUTS_ERROR("PLIST encoding/decoding comparison failed\n")
+                FAIL_PUTS_ERROR("PLIST encoding/decoding comparison failed\n");
 
             /* Close */
             if ((H5Pclose(plist_1)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((H5Pclose(plist_2)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             HDfree(buf_1);
             HDfree(buf_2);

--- a/test/enum.c
+++ b/test/enum.c
@@ -47,70 +47,70 @@ test_named(hid_t file)
 
     TESTING("named enumeration types");
     if ((cwg = H5Gcreate2(file, "test_named", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* A native integer */
     if ((type = H5Tcreate(H5T_ENUM, sizeof(c_e1))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "RED", CPTR(val, E1_RED)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "GREEN", CPTR(val, E1_GREEN)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "BLUE", CPTR(val, E1_BLUE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "WHITE", CPTR(val, E1_WHITE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "BLACK", CPTR(val, E1_BLACK)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tcommit2(cwg, "e1_a", type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* A smaller type */
     if ((type = H5Tcreate(H5T_ENUM, (size_t)1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "RED", CPTR(val8, E1_RED)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "GREEN", CPTR(val8, E1_GREEN)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "BLUE", CPTR(val8, E1_BLUE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "WHITE", CPTR(val8, E1_WHITE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "BLACK", CPTR(val8, E1_BLACK)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tcommit2(cwg, "e1_b", type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* A non-native type */
     if (H5T_ORDER_BE == H5Tget_order(H5T_NATIVE_INT)) {
         if ((type = H5Tenum_create(H5T_STD_U8LE)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     else {
         if ((type = H5Tenum_create(H5T_STD_U8BE)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     if (H5Tenum_insert(type, "RED", CPTR(val8, E1_RED)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "GREEN", CPTR(val8, E1_GREEN)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "BLUE", CPTR(val8, E1_BLUE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "WHITE", CPTR(val8, E1_WHITE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "BLACK", CPTR(val8, E1_BLACK)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tcommit2(cwg, "e1_c", type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Gclose(cwg) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -161,36 +161,36 @@ test_conv(hid_t file)
     TESTING("enumeration conversions");
 
     if ((cwg = H5Gcreate2(file, "test_conv", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((type = H5Tcreate(H5T_ENUM, sizeof(c_e1))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "RED", CPTR(val, E1_RED)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "GREEN", CPTR(val, E1_GREEN)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "BLUE", CPTR(val, E1_BLUE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "WHITE", CPTR(val, E1_WHITE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "BLACK", CPTR(val, E1_BLACK)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((space = H5Screate_simple(1, ds_size, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /***************************************
      *    Dataset of enumeration type
      ***************************************/
     /* Create a dataset of enum type and write enum data to it */
     if ((dset = H5Dcreate2(cwg, "color_table1", type, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dwrite(dset, type, space, space, H5P_DEFAULT, data1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test reading back the data with no conversion */
     if (H5Dread(dset, type, space, space, H5P_DEFAULT, data2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     for (i = 0; i < (size_t)ds_size[0]; i++)
         if (data1[i] != data2[i]) {
@@ -202,7 +202,7 @@ test_conv(hid_t file)
 
     /* Test converting the data to integer. Read enum data back as integer */
     if (H5Dread(dset, H5T_NATIVE_SHORT, space, space, H5P_DEFAULT, data_short) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     for (i = 0; i < (size_t)ds_size[0]; i++)
         if ((short)data1[i] != data_short[i]) {
@@ -214,7 +214,7 @@ test_conv(hid_t file)
 
     /* Test converting the data to floating number. Read enum data back as floating number */
     if (H5Dread(dset, H5T_NATIVE_DOUBLE, space, space, H5P_DEFAULT, data_double) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     for (i = 0; i < (size_t)ds_size[0]; i++)
         if ((int)data1[i] != (int)data_double[i]) {
@@ -225,7 +225,7 @@ test_conv(hid_t file)
         } /* end if */
 
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /***************************************
      *    Dataset of integer type
@@ -233,14 +233,14 @@ test_conv(hid_t file)
     /* Create a dataset of native integer and write enum data to it */
     if ((dset = H5Dcreate2(cwg, "color_table2", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT,
                            H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dwrite(dset, type, space, space, H5P_DEFAULT, data1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test reading back the data with no conversion */
     if (H5Dread(dset, H5T_NATIVE_INT, space, space, H5P_DEFAULT, data_int) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     for (i = 0; i < (size_t)ds_size[0]; i++)
         if ((int)data1[i] != data_int[i]) {
@@ -251,7 +251,7 @@ test_conv(hid_t file)
         } /* end if */
 
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /***************************************
      *    Dataset of double type
@@ -259,14 +259,14 @@ test_conv(hid_t file)
     /* Create a dataset of native double and write enum data to it */
     if ((dset = H5Dcreate2(cwg, "color_table3", H5T_NATIVE_DOUBLE, space, H5P_DEFAULT, H5P_DEFAULT,
                            H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dwrite(dset, type, space, space, H5P_DEFAULT, data1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test reading back the data with no conversion */
     if (H5Dread(dset, H5T_NATIVE_DOUBLE, space, space, H5P_DEFAULT, data_double) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     for (i = 0; i < (size_t)ds_size[0]; i++)
         if ((int)data1[i] != (int)data_double[i]) {
@@ -277,14 +277,14 @@ test_conv(hid_t file)
         } /* end if */
 
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(cwg) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -335,42 +335,42 @@ test_tr1(hid_t file)
     TESTING("O(1) conversions");
 
     if ((cwg = H5Gcreate2(file, "test_tr1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((m_type = H5Tcreate(H5T_ENUM, sizeof(c_e1))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(m_type, "RED", CPTR(eval, E1_RED)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(m_type, "GREEN", CPTR(eval, E1_GREEN)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(m_type, "BLUE", CPTR(eval, E1_BLUE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(m_type, "WHITE", CPTR(eval, E1_WHITE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(m_type, "BLACK", CPTR(eval, E1_BLACK)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((f_type = H5Tcreate(H5T_ENUM, sizeof(c_e1))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(f_type, "RED", CPTR(ival, 105)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(f_type, "GREEN", CPTR(ival, 104)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(f_type, "BLUE", CPTR(ival, 103)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(f_type, "WHITE", CPTR(ival, 102)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(f_type, "BLACK", CPTR(ival, 101)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((space = H5Screate_simple(1, ds_size, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dset = H5Dcreate2(cwg, "color_table", f_type, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dwrite(dset, m_type, space, space, H5P_DEFAULT, data1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dread(dset, m_type, space, space, H5P_DEFAULT, data2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     for (i = 0; i < (size_t)ds_size[0]; i++)
         if (data1[i] != data2[i]) {
@@ -381,15 +381,15 @@ test_tr1(hid_t file)
         }
 
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(m_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(f_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(cwg) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -439,42 +439,42 @@ test_tr2(hid_t file)
     TESTING("O(log N) conversions");
 
     if ((cwg = H5Gcreate2(file, "test_tr2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((m_type = H5Tcreate(H5T_ENUM, sizeof(c_e1))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(m_type, "RED", CPTR(val1, E1_RED)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(m_type, "GREEN", CPTR(val1, E1_GREEN)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(m_type, "BLUE", CPTR(val1, E1_BLUE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(m_type, "WHITE", CPTR(val1, E1_WHITE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(m_type, "BLACK", CPTR(val1, E1_BLACK)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((f_type = H5Tcreate(H5T_ENUM, sizeof(int))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(f_type, "RED", CPTR(val2, 1050)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(f_type, "GREEN", CPTR(val2, 1040)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(f_type, "BLUE", CPTR(val2, 1030)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(f_type, "WHITE", CPTR(val2, 1020)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(f_type, "BLACK", CPTR(val2, 1010)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((space = H5Screate_simple(1, ds_size, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dset = H5Dcreate2(cwg, "color_table", f_type, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dwrite(dset, m_type, space, space, H5P_DEFAULT, data1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dread(dset, m_type, space, space, H5P_DEFAULT, data2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     for (i = 0; i < (size_t)ds_size[0]; i++)
         if (data1[i] != data2[i]) {
@@ -485,15 +485,15 @@ test_tr2(hid_t file)
         }
 
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(m_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(f_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(cwg) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -641,28 +641,28 @@ test_funcs(void)
 
     /* A native integer */
     if ((type = H5Tcreate(H5T_ENUM, sizeof(c_e1))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "RED", CPTR(val, E1_RED)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "GREEN", CPTR(val, E1_GREEN)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "BLUE", CPTR(val, E1_BLUE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "WHITE", CPTR(val, E1_WHITE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tenum_insert(type, "BLACK", CPTR(val, E1_BLACK)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Tget_precision(type) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tget_size(type) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tget_offset(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tget_sign(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tget_super(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     H5E_BEGIN_TRY
     {

--- a/test/error_test.c
+++ b/test/error_test.c
@@ -186,9 +186,9 @@ init_error(void)
     H5E_type_t msg_type;
 
     if (NULL == (cls_name = (char *)HDmalloc(HDstrlen(ERR_CLS_NAME) + 1)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (msg = (char *)HDmalloc(HDstrlen(ERR_MIN_SUBROUTINE_MSG) + 1)))
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((ERR_CLS = H5Eregister_class(ERR_CLS_NAME, PROG_NAME, PROG_VERS)) < 0)
         TEST_ERROR;
@@ -467,12 +467,12 @@ test_create(void)
 
     /* Create an empty error stack */
     if ((estack_id = H5Ecreate_stack()) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the number of errors on stack */
     err_num = H5Eget_num(estack_id);
     if (err_num != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Push an error with a long description */
     if (H5Epush(estack_id, __FILE__, err_func, __LINE__, ERR_CLS, ERR_MAJ_TEST, ERR_MIN_SUBROUTINE, "%s",
@@ -482,20 +482,20 @@ test_create(void)
     /* Check the number of errors on stack */
     err_num = H5Eget_num(estack_id);
     if (err_num != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Clear the error stack */
     if (H5Eclear2(estack_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the number of errors on stack */
     err_num = H5Eget_num(estack_id);
     if (err_num != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close error stack */
     if (H5Eclose_stack(estack_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -530,30 +530,30 @@ test_copy(void)
     /* Check the number of errors on stack */
     err_num = H5Eget_num(H5E_DEFAULT);
     if (err_num != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Copy error stack, which clears the original */
     if ((estack_id = H5Eget_current_stack()) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the number of errors on stack copy */
     err_num = H5Eget_num(estack_id);
     if (err_num != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the number of errors on original stack */
     err_num = H5Eget_num(H5E_DEFAULT);
     if (err_num != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Put the stack copy as the default.  It closes the stack copy, too. */
     if (H5Eset_current_stack(estack_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the number of errors on default stack */
     err_num = H5Eget_num(H5E_DEFAULT);
     if (err_num != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try to close error stack copy.  Should fail because
      * the current H5Eset_current_stack closes the stack to be set.
@@ -564,7 +564,7 @@ test_copy(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -600,21 +600,21 @@ test_append(void)
 
     /* Copy error stack, which clears the original */
     if ((estack_id1 = H5Eget_current_stack()) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the number of errors on stack #1 */
     err_num = H5Eget_num(estack_id1);
     if (err_num != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create another stack, from scratch */
     if ((estack_id2 = H5Ecreate_stack()) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the number of errors on stack #2 */
     err_num = H5Eget_num(estack_id2);
     if (err_num != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Push an error on stack #2 */
     if (H5Epush(estack_id2, __FILE__, err_func, __LINE__, ERR_CLS, ERR_MAJ_IO, ERR_MIN_CREATE, "%s",
@@ -624,7 +624,7 @@ test_append(void)
     /* Check the number of errors on stack #2 */
     err_num = H5Eget_num(estack_id2);
     if (err_num != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try to append bad error stack IDs */
     H5E_BEGIN_TRY
@@ -633,39 +633,39 @@ test_append(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         ret = H5Eappend_stack(estack_id1, H5E_DEFAULT, FALSE);
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         ret = H5Eappend_stack(H5E_DEFAULT, estack_id2, FALSE);
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Append error stack #2 to error stack #1, without closing stack #2 */
     if (H5Eappend_stack(estack_id1, estack_id2, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the number of errors on stack #1 */
     err_num = H5Eget_num(estack_id1);
     if (err_num != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the number of errors on stack #2 */
     err_num = H5Eget_num(estack_id2);
     if (err_num != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Append error stack #2 to error stack #1, and close stack #2 */
     if (H5Eappend_stack(estack_id1, estack_id2, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try to close error stack #2.  Should fail because H5Eappend_stack
      * should have already closed it.
@@ -676,12 +676,12 @@ test_append(void)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the number of errors on stack #1 */
     err_num = H5Eget_num(estack_id1);
     if (err_num != 3)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -760,10 +760,10 @@ test_filter_error(const char *fname, hid_t fapl)
 
     /* Close/release resources */
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 

--- a/test/event_set.c
+++ b/test/event_set.c
@@ -334,40 +334,40 @@ test_es_get_requests(void)
 
     /* Create an event set */
     if ((es_id = H5EScreate()) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get number of requests in event set */
     count = 3;
     if (H5ESget_requests(es_id, H5_ITER_NATIVE, NULL, NULL, 0, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get only connector IDs */
     count            = 3;
     connector_ids[0] = H5I_INVALID_HID;
     connector_ids[1] = H5I_INVALID_HID;
     if (H5ESget_requests(es_id, H5_ITER_NATIVE, connector_ids, NULL, 2, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[0] != H5I_INVALID_HID)
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[1] != H5I_INVALID_HID)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get only requests */
     count       = 3;
     requests[0] = NULL;
     requests[1] = NULL;
     if (H5ESget_requests(es_id, H5_ITER_NATIVE, NULL, requests, 2, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[0] != NULL)
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[1] != NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get both */
     count            = 3;
@@ -376,54 +376,54 @@ test_es_get_requests(void)
     requests[0]      = NULL;
     requests[1]      = NULL;
     if (H5ESget_requests(es_id, H5_ITER_NATIVE, connector_ids, requests, 2, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[0] != H5I_INVALID_HID)
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[1] != H5I_INVALID_HID)
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[0] != NULL)
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[1] != NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert event into event set */
     if (H5ESinsert_request(es_id, connector_ids_g[0], &req_targets[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get number of requests in event set */
     count = 0;
     if (H5ESget_requests(es_id, H5_ITER_NATIVE, NULL, NULL, 0, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get only connector IDs */
     count            = 0;
     connector_ids[0] = H5I_INVALID_HID;
     connector_ids[1] = H5I_INVALID_HID;
     if (H5ESget_requests(es_id, H5_ITER_NATIVE, connector_ids, NULL, 2, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[0] != connector_ids_g[0])
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[1] != H5I_INVALID_HID)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get only requests */
     count       = 0;
     requests[0] = NULL;
     requests[1] = NULL;
     if (H5ESget_requests(es_id, H5_ITER_NATIVE, NULL, requests, 2, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[0] != &req_targets[0])
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[1] != NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get both */
     count            = 0;
@@ -432,80 +432,80 @@ test_es_get_requests(void)
     requests[0]      = NULL;
     requests[1]      = NULL;
     if (H5ESget_requests(es_id, H5_ITER_NATIVE, connector_ids, requests, 2, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[0] != connector_ids_g[0])
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[1] != H5I_INVALID_HID)
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[0] != &req_targets[0])
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[1] != NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert second event into event set */
     if (H5ESinsert_request(es_id, connector_ids_g[1], &req_targets[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get number of requests in event set */
     count = 0;
     if (H5ESget_requests(es_id, H5_ITER_NATIVE, NULL, NULL, 0, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get only connector IDs */
     count            = 0;
     connector_ids[0] = H5I_INVALID_HID;
     connector_ids[1] = H5I_INVALID_HID;
     if (H5ESget_requests(es_id, H5_ITER_INC, connector_ids, NULL, 2, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[0] != connector_ids_g[0])
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[1] != connector_ids_g[1])
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try with H5_ITER_DEC */
     count            = 0;
     connector_ids[0] = H5I_INVALID_HID;
     connector_ids[1] = H5I_INVALID_HID;
     if (H5ESget_requests(es_id, H5_ITER_DEC, connector_ids, NULL, 2, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[0] != connector_ids_g[1])
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[1] != connector_ids_g[0])
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get only requests */
     count       = 0;
     requests[0] = NULL;
     requests[1] = NULL;
     if (H5ESget_requests(es_id, H5_ITER_INC, NULL, requests, 2, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[0] != &req_targets[0])
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[1] != &req_targets[1])
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try with H5_ITER_DEC */
     count       = 0;
     requests[0] = NULL;
     requests[1] = NULL;
     if (H5ESget_requests(es_id, H5_ITER_DEC, NULL, requests, 2, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[0] != &req_targets[1])
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[1] != &req_targets[0])
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get both */
     count            = 0;
@@ -514,17 +514,17 @@ test_es_get_requests(void)
     requests[0]      = NULL;
     requests[1]      = NULL;
     if (H5ESget_requests(es_id, H5_ITER_INC, connector_ids, requests, 2, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[0] != connector_ids_g[0])
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[1] != connector_ids_g[1])
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[0] != &req_targets[0])
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[1] != &req_targets[1])
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try with H5_ITER_DEC */
     count            = 0;
@@ -533,69 +533,69 @@ test_es_get_requests(void)
     requests[0]      = NULL;
     requests[1]      = NULL;
     if (H5ESget_requests(es_id, H5_ITER_DEC, connector_ids, requests, 2, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[0] != connector_ids_g[1])
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[1] != connector_ids_g[0])
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[0] != &req_targets[1])
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[1] != &req_targets[0])
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get only first connector ID */
     count            = 0;
     connector_ids[0] = H5I_INVALID_HID;
     connector_ids[1] = H5I_INVALID_HID;
     if (H5ESget_requests(es_id, H5_ITER_INC, connector_ids, NULL, 1, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[0] != connector_ids_g[0])
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[1] != H5I_INVALID_HID)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try with H5_ITER_DEC */
     count            = 0;
     connector_ids[0] = H5I_INVALID_HID;
     connector_ids[1] = H5I_INVALID_HID;
     if (H5ESget_requests(es_id, H5_ITER_DEC, connector_ids, NULL, 1, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[0] != connector_ids_g[1])
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[1] != H5I_INVALID_HID)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get only first request */
     count       = 0;
     requests[0] = NULL;
     requests[1] = NULL;
     if (H5ESget_requests(es_id, H5_ITER_INC, NULL, requests, 1, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[0] != &req_targets[0])
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[1] != NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try with H5_ITER_DEC */
     count       = 0;
     requests[0] = NULL;
     requests[1] = NULL;
     if (H5ESget_requests(es_id, H5_ITER_DEC, NULL, requests, 1, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (count != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[0] != &req_targets[1])
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[1] != NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get only first of both */
     count            = 0;
@@ -604,15 +604,15 @@ test_es_get_requests(void)
     requests[0]      = NULL;
     requests[1]      = NULL;
     if (H5ESget_requests(es_id, H5_ITER_INC, connector_ids, requests, 1, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[0] != connector_ids_g[0])
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[1] != H5I_INVALID_HID)
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[0] != &req_targets[0])
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[1] != NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try with H5_ITER_DEC */
     count            = 0;
@@ -621,21 +621,21 @@ test_es_get_requests(void)
     requests[0]      = NULL;
     requests[1]      = NULL;
     if (H5ESget_requests(es_id, H5_ITER_DEC, connector_ids, requests, 1, &count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[0] != connector_ids_g[1])
-        TEST_ERROR
+        TEST_ERROR;
     if (connector_ids[1] != H5I_INVALID_HID)
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[0] != &req_targets[1])
-        TEST_ERROR
+        TEST_ERROR;
     if (requests[1] != NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the event set */
     if (H5ESwait(es_id, 10000000, &count, &op_failed) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5ESclose(es_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -676,7 +676,7 @@ main(void)
     /* Register dummy connector IDs */
     for (i = 0; i < EVENT_SET_NUM_CONNECTOR_IDS; i++)
         if ((connector_ids_g[i] = H5VLregister_connector(&fake_wait_vol_g, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Tests */
     nerrors += test_es_create();
@@ -686,7 +686,7 @@ main(void)
     /* Unregister dummy connectors */
     for (i = 0; i < EVENT_SET_NUM_CONNECTOR_IDS; i++)
         if (H5VLunregister_connector(connector_ids_g[i]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Cleanup */
     h5_cleanup(FILENAME, fapl_id);

--- a/test/evict_on_close.c
+++ b/test/evict_on_close.c
@@ -186,7 +186,7 @@ generate_eoc_test_file(hid_t fapl_id)
         /* Create the group name */
         HDmemset(subgroup_name, '\0', SUBGROUP_NAME_SIZE);
         if (HDsnprintf(subgroup_name, (size_t)(SUBGROUP_NAME_SIZE - 1), "%d", i) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if ((gid2 = H5Gcreate2(gid1, subgroup_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
@@ -281,7 +281,7 @@ generate_eoc_test_file(hid_t fapl_id)
         /* Create the group name */
         HDmemset(subgroup_name, '\0', SUBGROUP_NAME_SIZE);
         if (HDsnprintf(subgroup_name, (size_t)(SUBGROUP_NAME_SIZE - 1), "%d", i) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if ((gid2 = H5Gcreate2(gid1, subgroup_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
@@ -622,7 +622,7 @@ check_group_layout(hid_t fid, const char *group_name)
         /* Create the group name */
         HDmemset(subgroup_name, '\0', SUBGROUP_NAME_SIZE);
         if (HDsnprintf(subgroup_name, (size_t)(SUBGROUP_NAME_SIZE - 1), "%d", i) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if ((gid2 = H5Gopen2(gid1, subgroup_name, H5P_DEFAULT)) < 0)
             TEST_ERROR;

--- a/test/external.c
+++ b/test/external.c
@@ -115,23 +115,23 @@ test_non_extendible(hid_t file)
 
     /* Create the dataset and close */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_external(dcpl, "ext1.data", (off_t)0, (hsize_t)(max_size[0] * sizeof(int))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((space = H5Screate_simple(1, cur_size, max_size)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dset = H5Dcreate2(file, "dset1", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read dataset creation information */
     if ((dset = H5Dopen2(file, "dset1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test dataset address.  Should be undefined. */
     H5E_BEGIN_TRY
@@ -140,13 +140,13 @@ test_non_extendible(hid_t file)
     }
     H5E_END_TRY;
     if (dset_addr != HADDR_UNDEF)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check external count */
     if ((dcpl = H5Dget_create_plist(dset)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((n = H5Pget_external_count(dcpl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (1 != n) {
         H5_FAILED();
         HDputs("    Returned external count is wrong.");
@@ -156,7 +156,7 @@ test_non_extendible(hid_t file)
 
     /* Verify external file settings */
     if (H5Pget_external(dcpl, 0, 0, NULL, &file_offset, &file_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (file_offset != 0) {
         H5_FAILED();
         HDputs("    Wrong file offset.");
@@ -172,9 +172,9 @@ test_non_extendible(hid_t file)
 
     /* Done (dataspace was previously closed) */
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     return 0;
 
@@ -215,12 +215,12 @@ test_too_small(hid_t file)
     TESTING("external storage is too small");
 
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_external(dcpl, "ext1.data", (off_t)0, (hsize_t)(max_size[0] * sizeof(int) - 1)) <
         0) /* note -1 */
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((space = H5Screate_simple(1, cur_size, max_size)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -230,9 +230,9 @@ test_too_small(hid_t file)
     if (dset >= 0)
         FAIL_PUTS_ERROR("    Small external file succeeded instead of failing.");
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -275,20 +275,20 @@ test_large_enough_current_eventual(hid_t file)
     TESTING("extendible dataspace, exact external size");
 
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_external(dcpl, "ext1.data", (off_t)0, (hsize_t)(max_size[0] * sizeof(int))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((space = H5Screate_simple(1, cur_size, max_size)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dset = H5Dcreate2(file, "dset3", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -330,12 +330,12 @@ test_large_enough_current_not_eventual(hid_t file)
     TESTING("extendible dataspace, external storage is too small");
 
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_external(dcpl, "ext1.data", (off_t)0, (hsize_t)(max_size[0] * sizeof(int) - 1)) <
         0) /* note -1 */
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((space = H5Screate_simple(1, cur_size, max_size)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -346,9 +346,9 @@ test_large_enough_current_not_eventual(hid_t file)
         FAIL_PUTS_ERROR("    Small external file succeeded instead of failing.");
 
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -394,28 +394,28 @@ test_unlimited(hid_t file)
 
     /* Create dataset */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_external(dcpl, "ext1.data", (off_t)0, H5F_UNLIMITED) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((space = H5Screate_simple(1, cur_size, max_size)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dset = H5Dcreate2(file, "dset5", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read dataset creation information */
     if ((dset = H5Dopen2(file, "dset5", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dcpl = H5Dget_create_plist(dset)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((n = H5Pget_external_count(dcpl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (1 != n) {
         H5_FAILED();
         HDputs("    Returned external count is wrong.");
@@ -424,7 +424,7 @@ test_unlimited(hid_t file)
     } /* end if */
 
     if (H5Pget_external(dcpl, 0, 0, NULL, &file_offset, &file_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (file_offset != 0) {
         H5_FAILED();
         HDputs("    Wrong file offset.");
@@ -439,9 +439,9 @@ test_unlimited(hid_t file)
     }
 
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -523,7 +523,7 @@ test_multiple_files(hid_t file)
     TESTING("multiple external files");
 
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     max_ext_size = (hsize_t)(sizeof(int) * max_size[0] / n_external_files);
 
@@ -532,22 +532,22 @@ test_multiple_files(hid_t file)
     }
 
     if ((space = H5Screate_simple(1, cur_size, max_size)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((dset = H5Dcreate2(file, "dset6", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Re-use space below */
 
     /* ----------------------------------------------
      * Verify that too-small external files will fail
      */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     max_ext_size -= 1;
 
@@ -564,9 +564,9 @@ test_multiple_files(hid_t file)
         FAIL_PUTS_ERROR("    Small external files succeeded instead of failing.");
 
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -606,9 +606,9 @@ test_add_to_unlimited(void)
     TESTING("external file following unlimited file");
 
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_external(dcpl, "ext1.data", (off_t)0, H5F_UNLIMITED) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -619,12 +619,12 @@ test_add_to_unlimited(void)
         FAIL_PUTS_ERROR("    H5Pset_external() succeeded when it should have failed.");
 
     if ((n = H5Pget_external_count(dcpl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (1 != n)
         FAIL_PUTS_ERROR("    Wrong external file count returned.");
 
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     return 0;
 
@@ -660,9 +660,9 @@ test_overflow(void)
     TESTING("address overflow in external files");
 
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_external(dcpl, "ext1.data", (off_t)0, H5F_UNLIMITED - 1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -673,7 +673,7 @@ test_overflow(void)
         FAIL_PUTS_ERROR("    H5Pset_external() succeeded when it should have failed.");
 
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -720,11 +720,11 @@ test_read_file_set(hid_t fapl)
     TESTING("read external dataset");
 
     if (HDsetenv("HDF5_EXTFILE_PREFIX", "", 1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reset the raw data files */
     if (reset_raw_data_files(FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the file and an initial group.  This causes messages about
      * debugging to be emitted before we start playing games with what the
@@ -732,34 +732,34 @@ test_read_file_set(hid_t fapl)
      */
     h5_fixname(EXT_FNAME[1], fapl, filename, sizeof(filename));
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((grp = H5Gcreate2(file, "emit-diagnostics", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(grp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dcpl */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     for (i = 0; i < N_EXT_FILES; i++) {
         HDsnprintf(filename, sizeof(filename), "extern_%dr.raw", (int)i + 1);
         if (H5Pset_external(dcpl, filename, (off_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
 
     /* Create the dataspace */
     cur_size = TOTAL_SIZE;
     if ((space = H5Screate_simple(1, &cur_size, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dataset */
     if ((dset = H5Dcreate2(file, "dset1", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read the entire dataset */
     HDmemset(whole, 0, sizeof(whole));
     if (H5Dread(dset, H5T_NATIVE_INT, space, space, H5P_DEFAULT, whole) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Compare data */
     for (i = 0; i < TOTAL_SIZE; i++)
@@ -770,14 +770,14 @@ test_read_file_set(hid_t fapl)
 
     /* Set up dataspace */
     if ((hs_space = H5Scopy(space)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sselect_hyperslab(hs_space, H5S_SELECT_SET, &hs_start, NULL, &hs_count, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read */
     HDmemset(whole, 0, sizeof(whole));
     if (H5Dread(dset, H5T_NATIVE_INT, hs_space, hs_space, H5P_DEFAULT, whole) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify data */
     for (i = (size_t)hs_start; i < (size_t)(hs_start + hs_count); i++) {
@@ -786,15 +786,15 @@ test_read_file_set(hid_t fapl)
     } /* end for */
 
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(hs_space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     return 0;
 
@@ -845,16 +845,16 @@ test_write_file_set(hid_t fapl)
     TESTING("write external dataset");
 
     if (HDsetenv("HDF5_EXTFILE_PREFIX", "", 1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create another file */
     h5_fixname(EXT_FNAME[2], fapl, filename, sizeof(filename));
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dcpl and external file list */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     for (i = 0; i < N_EXT_FILES; i++) {
         hsize_t size;
 
@@ -866,61 +866,61 @@ test_write_file_set(hid_t fapl)
             size = H5F_UNLIMITED;
 
         if (H5Pset_external(dcpl, filename, (off_t)(i * GARBAGE_PER_FILE), size) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Reset the raw data files */
     if (reset_raw_data_files(FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the dataset */
     if ((mem_space = H5Screate_simple(1, &cur_size, &max_size)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((file_space = H5Scopy(mem_space)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dset = H5Dcreate2(file, "dset1", H5T_NATIVE_INT, file_space, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write the entire dataset and compare with the original */
     for (i = 0; i < cur_size; i++)
         whole[i] = (int)i;
     if (H5Dwrite(dset, H5T_NATIVE_INT, mem_space, file_space, H5P_DEFAULT, whole) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     for (i = 0; i < N_EXT_FILES; i++) {
         char name1[64], name2[64];
 
         HDsnprintf(name1, sizeof(name1), "extern_%dr.raw", i + 1);
         HDsnprintf(name2, sizeof(name2), "extern_%dw.raw", i + 1);
         if (!files_have_same_contents(name1, name2))
-            FAIL_PUTS_ERROR("   Output differs from expected value.")
+            FAIL_PUTS_ERROR("   Output differs from expected value.");
     } /* end for */
 
     /* Extend the dataset by another 100 elements */
     if (H5Dset_extent(dset, &max_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(file_space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((file_space = H5Dget_space(dset)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write second half of dataset */
     for (i = 0; i < hs_count; i++)
         whole[i] = 100 + (int)i;
     if (H5Sselect_hyperslab(file_space, H5S_SELECT_SET, &hs_start, NULL, &hs_count, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dwrite(dset, H5T_NATIVE_INT, mem_space, file_space, H5P_DEFAULT, whole) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(mem_space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(file_space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -973,17 +973,17 @@ test_path_absolute(hid_t fapl)
 
     h5_fixname(EXT_FNAME[3], fapl, filename, sizeof(filename));
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reset the raw data files */
     if (reset_raw_data_files(FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the dcpl */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == HDgetcwd(cwdpath, sizeof(cwdpath)))
-        TEST_ERROR
+        TEST_ERROR;
     for (i = 0; i < N_EXT_FILES; i++) {
         HDsnprintf(filename, sizeof(filename), "%s%sextern_%zur.raw", cwdpath, H5_DIR_SEPS, i + 1);
 #if defined(H5_HAVE_WINDOW_PATH)
@@ -992,34 +992,34 @@ test_path_absolute(hid_t fapl)
             HDsnprintf(filename, sizeof(filename), "%s%sextern_%zur.raw", cwdpath + 2, H5_DIR_SEPS, i + 1);
 #endif
         if (H5Pset_external(dcpl, filename, (off_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* create the dataspace */
     cur_size = TOTAL_SIZE;
     if ((space = H5Screate_simple(1, &cur_size, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* create the dataset */
     if ((dset = H5Dcreate2(file, "dset1", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read the entire dataset and compare with the original */
     HDmemset(whole, 0, sizeof(whole));
     if (H5Dread(dset, H5T_NATIVE_INT, space, space, H5P_DEFAULT, whole) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     for (i = 0; i < TOTAL_SIZE; i++)
         if (whole[i] != (signed)i)
             FAIL_PUTS_ERROR("Incorrect value(s) read.");
 
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     return 0;
 
@@ -1066,7 +1066,7 @@ test_path_relative(hid_t fapl)
     TESTING("filenames relative to current directory for external file");
 
     if (HDsetenv("HDF5_EXTFILE_PREFIX", "", 1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (HDmkdir("extern_dir", (mode_t)0755) < 0 && errno != EEXIST)
         TEST_ERROR;
@@ -1077,39 +1077,39 @@ test_path_relative(hid_t fapl)
 
     /* Reset the raw data files */
     if (reset_raw_data_files(FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the dataset */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     for (i = 0; i < N_EXT_FILES; i++) {
         HDsnprintf(filename, sizeof(filename), "extern_%dr.raw", (int)i + 1);
         if (H5Pset_external(dcpl, filename, (off_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     cur_size = TOTAL_SIZE;
     if ((space = H5Screate_simple(1, &cur_size, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dset = H5Dcreate2(file, "dset1", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read the entire dataset and compare with the original */
     HDmemset(whole, 0, sizeof(whole));
     if (H5Dread(dset, H5T_NATIVE_INT, space, space, H5P_DEFAULT, whole) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     for (i = 0; i < TOTAL_SIZE; i++)
         if (whole[i] != (signed)i)
             FAIL_PUTS_ERROR("Incorrect value(s) read.");
 
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     return 0;
 
@@ -1163,7 +1163,7 @@ test_path_relative_cwd(hid_t fapl)
     TESTING("filenames relative to HDF5 file for external file");
 
     if (HDsetenv("HDF5_EXTFILE_PREFIX", "", 1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (HDmkdir("extern_dir", (mode_t)0755) < 0 && errno != EEXIST)
         TEST_ERROR;
@@ -1174,42 +1174,42 @@ test_path_relative_cwd(hid_t fapl)
 
     /* Reset the raw data files */
     if (reset_raw_data_files(FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the dataset */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     for (i = 0; i < N_EXT_FILES; i++) {
         HDsnprintf(filename, sizeof(filename), "..%sextern_%dr.raw", H5_DIR_SEPS, (int)i + 1);
         if (H5Pset_external(dcpl, filename, (off_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     cur_size = TOTAL_SIZE;
     if ((space = H5Screate_simple(1, &cur_size, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_efile_prefix(dapl, "${ORIGIN}") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pget_efile_prefix(dapl, buffer, sizeof(buffer)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(buffer, "${ORIGIN}") != 0)
         FAIL_PUTS_ERROR("efile prefix not set correctly");
     if ((dapl2 = H5Pcopy(dapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataset */
     if ((dset = H5Dcreate2(file, "dset1", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, dapl2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reopen dataset with same efile_prefix property */
     if ((dset2 = H5Dopen2(file, "dset1", dapl2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reopen dataset with different efile_prefix property */
     if (H5Pset_efile_prefix(dapl, "//") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     H5E_BEGIN_TRY
     {
         dset3 = H5Dopen2(file, "dset1", dapl);
@@ -1221,32 +1221,32 @@ test_path_relative_cwd(hid_t fapl)
     /* Read the entire dataset and compare with the original */
     HDmemset(whole, 0, sizeof(whole));
     if (H5Dread(dset, H5T_NATIVE_INT, space, space, H5P_DEFAULT, whole) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     for (i = 0; i < TOTAL_SIZE; i++)
         if (whole[i] != (signed)i)
             FAIL_PUTS_ERROR("Incorrect value(s) read.");
 
     /* Close dataset */
     if (H5Dclose(dset2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open dataset (use a different prefix than for create.
      * This works because the dataset was closed.
      */
     if (H5Pset_efile_prefix(dapl2, "${ORIGIN}/.") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dset = H5Dopen2(file, "dset1", dapl2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reopen dataset with same efile_prefix property */
     if ((dset2 = H5Dopen2(file, "dset1", dapl2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reopen dataset with different efile_prefix property */
     if (H5Pset_efile_prefix(dapl, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     H5E_BEGIN_TRY
     {
         dset3 = H5Dopen2(file, "dset1", dapl);
@@ -1258,25 +1258,25 @@ test_path_relative_cwd(hid_t fapl)
     /* Read the entire dataset and compare with the original */
     HDmemset(whole, 0, sizeof(whole));
     if (H5Dread(dset, H5T_NATIVE_INT, space, space, H5P_DEFAULT, whole) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     for (i = 0; i < TOTAL_SIZE; i++)
         if (whole[i] != (signed)i)
             FAIL_PUTS_ERROR("Incorrect value(s) read.");
 
     if (H5Dclose(dset2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dapl2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
     return 0;
 
@@ -1324,64 +1324,64 @@ test_h5d_get_access_plist(hid_t fapl_id)
     TESTING("H5Dget_access_plist() returns correct prefix");
 
     if (HDsetenv("HDF5_EXTFILE_PREFIX", "", 1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reset the raw data files */
     if (reset_raw_data_files(FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the file */
     h5_fixname(EXT_FNAME[5], fapl_id, filename, sizeof(filename));
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dcpl and set external storage */
     if ((dcpl_id = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_external(dcpl_id, "extern_1r.raw", (off_t)0, (hsize_t)0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dapl and set the prefix */
     if ((dapl_id = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_efile_prefix(dapl_id, "someprefix") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dataset */
     if ((sid = H5Screate_simple(1, &dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did = H5Dcreate2(fid, "dset1", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl_id, dapl_id)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dapl */
     if (H5Pclose(dapl_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     dapl_id = -1;
 
     /* Get a data access property list from the dataset */
     if ((dapl_id = H5Dget_access_plist(did)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check the value for the external prefix */
     if ((buffer = (char *)HDcalloc((size_t)64, sizeof(char))) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_efile_prefix(dapl_id, buffer, (size_t)64) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(buffer, "someprefix") != 0)
         FAIL_PUTS_ERROR("external file prefix from dapl incorrect");
 
     /* Close everything */
     HDfree(buffer);
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dapl_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -1432,9 +1432,9 @@ main(void)
 
     /* Copy and set up a fapl for the latest file format */
     if ((fapl_id_new = H5Pcopy(fapl_id_old)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_libver_bounds(fapl_id_new, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* The file format doesn't matter for this test */
     nerrors += test_h5d_get_access_plist(fapl_id_new);
@@ -1456,13 +1456,13 @@ main(void)
 
         /* Create the common file used by some of the tests */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, current_fapl_id)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create a group that will be used in the file set read test */
         if ((gid = H5Gcreate2(fid, "emit-diagnostics", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Gclose(gid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* These tests use a common file */
         nerrors += test_non_extendible(fid);
@@ -1488,7 +1488,7 @@ main(void)
 
         /* Close the common file */
         if (H5Fclose(fid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
     } /* end for old and new format */
 
@@ -1497,7 +1497,7 @@ main(void)
 
     /* Close the new ff fapl. h5_cleanup will take care of the old ff fapl */
     if (H5Pclose(fapl_id_new) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDputs("All external storage tests passed.");
 

--- a/test/external_env.c
+++ b/test/external_env.c
@@ -61,57 +61,57 @@ test_path_env(hid_t fapl)
 
     h5_fixname(EXT_ENV_FNAME[0], fapl, filename, sizeof(filename));
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reset the raw data files */
     if (reset_raw_data_files(TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the dataset */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     for (i = 0; i < N_EXT_FILES; i++) {
         HDsnprintf(filename, sizeof(filename), "..%sextern_env_%dr.raw", H5_DIR_SEPS, (int)i + 1);
         if (H5Pset_external(dcpl, filename, (off_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     cur_size = TOTAL_SIZE;
     if ((space = H5Screate_simple(1, &cur_size, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set prefix to a nonexistent directory, will be overwritten by environment variable */
     if (H5Pset_efile_prefix(dapl, "someprefix") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pget_efile_prefix(dapl, buffer, sizeof(buffer)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(buffer, "someprefix") != 0)
         FAIL_PUTS_ERROR("efile prefix not set correctly");
 
     /* Create dataset */
     if ((dset = H5Dcreate2(file, "dset1", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, dapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read the entire dataset and compare with the original */
     HDmemset(whole, 0, sizeof(whole));
     if (H5Dread(dset, H5T_NATIVE_INT, space, space, H5P_DEFAULT, whole) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     for (i = 0; i < TOTAL_SIZE; i++)
         if (whole[i] != (signed)i)
             FAIL_PUTS_ERROR("Incorrect value(s) read.");
 
     if (H5Dclose(dset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -158,9 +158,9 @@ main(void)
 
     /* Copy and set up a fapl for the latest file format */
     if ((fapl_id_new = H5Pcopy(fapl_id_old)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_libver_bounds(fapl_id_new, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test with old & new format groups */
     for (latest_format = FALSE; latest_format <= TRUE; latest_format++) {
@@ -184,7 +184,7 @@ main(void)
 
     /* Close the new ff fapl. h5_cleanup will take care of the old ff fapl */
     if (H5Pclose(fapl_id_new) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDputs("All external storage tests passed.");
 

--- a/test/farray.c
+++ b/test/farray.c
@@ -174,25 +174,25 @@ check_stats(const H5FA_t *fa, const farray_state_t *state)
 
     /* Get statistics for fixed array and verify they are correct */
     if (H5FA_get_stats(fa, &farray_stats) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Compare information */
     if (farray_stats.hdr_size != state->hdr_size) {
         HDfprintf(stdout, "farray_stats.hdr_size = %" PRIuHSIZE ", state->hdr_size = %" PRIuHSIZE "\n",
                   farray_stats.hdr_size, state->hdr_size);
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (farray_stats.dblk_size != state->dblk_size) {
         HDfprintf(stdout, "farray_stats.dblk_size = %" PRIuHSIZE ", state->dblk_size = %" PRIuHSIZE "\n",
                   farray_stats.dblk_size, state->dblk_size);
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (farray_stats.nelmts != state->nelmts) {
         HDfprintf(stdout, "farray_stats.nelmts = %" PRIuHSIZE ", state->nelmts = %" PRIuHSIZE "\n",
                   farray_stats.nelmts, state->nelmts);
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* Success */
@@ -259,21 +259,21 @@ reopen_file(hid_t *fid, H5F_t **f, hid_t fapl_id, H5FA_t **fa, haddr_t fa_addr,
         /* Close array, if given */
         if (fa && *fa) {
             if (H5FA_close(*fa) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             *fa = NULL;
         }
 
         /* Close file */
         if (*fid) {
             if (H5Fclose(*fid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             *fid = H5I_INVALID_HID;
             *f   = NULL;
         }
 
         /* Re-open the file */
         if ((*fid = H5Fopen(filename_g, H5F_ACC_RDWR, fapl_id)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (*f = (H5F_t *)H5VL_object(*fid)))
@@ -281,12 +281,12 @@ reopen_file(hid_t *fid, H5F_t **f, hid_t fapl_id, H5FA_t **fa, haddr_t fa_addr,
 
         /* Ignore metadata tags in the file's cache */
         if (H5AC_ignore_tags(*f) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Re-open array, if given */
         if (fa)
             if (NULL == (*fa = H5FA_open(*f, fa_addr, NULL)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
     }
 
     /* Success */
@@ -312,20 +312,20 @@ create_array(H5F_t *f, const H5FA_create_t *cparam, H5FA_t **fa, haddr_t *fa_add
 
     /* Create array */
     if (NULL == (*fa = H5FA_create(f, cparam, NULL)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check status of array */
     if (H5FA_get_addr(*fa, fa_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(*fa_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check array stats */
     HDmemset(&state, 0, sizeof(state));
     state.hdr_size = FA_HDR_SIZE;
     state.nelmts   = cparam->nelmts;
     if (check_stats(*fa, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return SUCCEED;
@@ -351,11 +351,11 @@ verify_cparam(const H5FA_t *fa, const H5FA_create_t *cparam)
     /* Retrieve creation parameters */
     HDmemset(&test_cparam, 0, sizeof(H5FA_create_t));
     if (H5FA__get_cparam_test(fa, &test_cparam) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify creation parameters */
     if (H5FA__cmp_cparam_test(cparam, &test_cparam))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return SUCCEED;
@@ -381,23 +381,23 @@ finish(hid_t fid, hid_t fapl_id, H5F_t *f, H5FA_t *fa, haddr_t fa_addr)
 
     /* Close the fixed array */
     if (H5FA_close(fa) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete array */
     if (H5FA_delete(f, fa_addr, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename_g, fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size_g)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return SUCCEED;
@@ -426,7 +426,7 @@ test_create(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t H5_ATTR_UNUSE
 
     /* Create file & retrieve pointer to internal file object */
     if (create_file(fapl, &file, &f) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Display testing message
@@ -451,7 +451,7 @@ test_create(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t H5_ATTR_UNUSE
             fa = NULL;
 
             /* Indicate error */
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
 
         /* Set invalid max. # of elements bits */
@@ -468,7 +468,7 @@ test_create(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t H5_ATTR_UNUSE
             fa = NULL;
 
             /* Indicate error */
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
 
         /* Set invalid max. # of elements */
@@ -485,7 +485,7 @@ test_create(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t H5_ATTR_UNUSE
             fa = NULL;
 
             /* Indicate error */
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
 
         PASSED();
@@ -502,7 +502,7 @@ test_create(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t H5_ATTR_UNUSE
 
     /* Create array */
     if (create_array(f, cparam, &fa, &fa_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -511,11 +511,11 @@ test_create(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t H5_ATTR_UNUSE
 
     /* Verify the creation parameters */
     if (verify_cparam(fa, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close array, delete array, close file & verify file is empty */
     if (finish(file, fapl, f, fa, fa_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -554,7 +554,7 @@ test_reopen(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t *tparam)
 
     /* Create file & retrieve pointer to internal file object */
     if (create_file(fapl, &file, &f) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Display testing message
@@ -563,27 +563,27 @@ test_reopen(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t *tparam)
 
     /* Create array */
     if (create_array(f, cparam, &fa, &fa_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fixed array */
     if (H5FA_close(fa) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the file */
     if (reopen_file(&file, &f, fapl, NULL, HADDR_UNDEF, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the array */
     if (NULL == (fa = H5FA_open(f, fa_addr, NULL)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(fa, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close array, delete array, close file & verify file is empty */
     if (finish(file, fapl, f, fa, fa_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -625,37 +625,37 @@ test_open_twice(hid_t fapl_id, H5FA_create_t *cparam, farray_test_param_t *tpara
 
     /* Create file & retrieve pointer to internal file object */
     if (create_file(fapl_id, &fid, &f) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Display testing message */
     TESTING("open fixed array twice");
 
     /* Create array */
     if (create_array(f, cparam, &fa, &fa_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the array again, through the first file handle */
     if (NULL == (fa2 = H5FA_open(f, fa_addr, NULL)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(fa, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (verify_cparam(fa2, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the second fixed array wrapper */
     if (H5FA_close(fa2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fa2 = NULL;
 
     /* Check for closing & re-opening the file */
     if (reopen_file(&fid, &f, fapl_id, &fa, fa_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((fid2 = H5Freopen(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f2 = (H5F_t *)H5VL_object(fid2)))
@@ -663,15 +663,15 @@ test_open_twice(hid_t fapl_id, H5FA_create_t *cparam, farray_test_param_t *tpara
 
     /* Open the fixed array through the second file handle */
     if (NULL == (fa2 = H5FA_open(f2, fa_addr, NULL)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(fa, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the first extensible array wrapper */
     if (H5FA_close(fa) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fa = NULL;
 
     /* Close the first file */
@@ -679,11 +679,11 @@ test_open_twice(hid_t fapl_id, H5FA_create_t *cparam, farray_test_param_t *tpara
      *  shared file information)
      */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close array, delete array, close file & verify file is empty */
     if (finish(fid2, fapl_id, f2, fa2, fa_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -739,25 +739,25 @@ test_open_twice_diff(hid_t fapl_id, H5FA_create_t *cparam, farray_test_param_t *
 
     /* Create file & retrieve pointer to internal file object */
     if (create_file(fapl_id, &fid, &f) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create array */
     if (create_array(f, cparam, &fa, &fa_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the array again, through the first file handle */
     if (NULL == (fa2 = H5FA_open(f, fa_addr, NULL)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(fa, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (verify_cparam(fa2, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the second fixed array wrapper */
     if (H5FA_close(fa2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fa2 = NULL;
 
     /* Re-open the file */
@@ -765,15 +765,15 @@ test_open_twice_diff(hid_t fapl_id, H5FA_create_t *cparam, farray_test_param_t *
      *  array is closed)
      */
     if ((fid0 = H5Fopen(filename_g, H5F_ACC_RDWR, fapl_id)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the file */
     if (reopen_file(&fid, &f, fapl_id, &fa, fa_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the first fixed array wrapper */
     if (H5FA_close(fa) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fa = NULL;
 
     /* Close the first file */
@@ -781,7 +781,7 @@ test_open_twice_diff(hid_t fapl_id, H5FA_create_t *cparam, farray_test_param_t *
      *  shared file information)
      */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fid = H5I_INVALID_HID;
 
     /* Open a different file */
@@ -791,11 +791,11 @@ test_open_twice_diff(hid_t fapl_id, H5FA_create_t *cparam, farray_test_param_t *
      */
     h5_fixname(FILENAME[1], fapl_id, filename_tmp, sizeof(filename_tmp));
     if ((fid00 = H5Fcreate(filename_tmp, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file with the fixed array */
     if ((fid2 = H5Fopen(filename_g, H5F_ACC_RDWR, fapl_id)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f2 = (H5F_t *)H5VL_object(fid2)))
@@ -803,21 +803,21 @@ test_open_twice_diff(hid_t fapl_id, H5FA_create_t *cparam, farray_test_param_t *
 
     /* Open the fixed array through the second file handle */
     if (NULL == (fa2 = H5FA_open(f2, fa_addr, NULL)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(fa2, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the extra file handles */
     if (H5Fclose(fid0) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid00) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close array, delete array, close file & verify file is empty */
     if (finish(fid2, fapl_id, f2, fa2, fa_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -863,7 +863,7 @@ test_delete_open(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t *tparam)
 
     /* Create file & retrieve pointer to internal file object */
     if (create_file(fapl, &file, &f) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Display testing message
@@ -872,25 +872,25 @@ test_delete_open(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t *tparam)
 
     /* Create array */
     if (create_array(f, cparam, &fa, &fa_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the array again */
     if (NULL == (fa2 = H5FA_open(f, fa_addr, NULL)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Request that the array be deleted */
     if (H5FA_delete(f, fa_addr, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(fa, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (verify_cparam(fa2, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the second fixed array wrapper */
     if (H5FA_close(fa2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fa2 = NULL;
 
     /* Try re-opening the array again (should fail, as array will be deleted) */
@@ -904,17 +904,17 @@ test_delete_open(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t *tparam)
         H5FA_close(fa2);
 
         /* Indicate error */
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Close the first fixed array wrapper */
     if (H5FA_close(fa) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fa = NULL;
 
     /* Check for closing & re-opening the file */
     if (reopen_file(&file, &f, fapl, NULL, HADDR_UNDEF, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try re-opening the array again (should fail, as array is now deleted) */
     H5E_BEGIN_TRY
@@ -927,20 +927,20 @@ test_delete_open(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t *tparam)
         H5FA_close(fa);
 
         /* Indicate error */
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename_g, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size_g)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -1316,11 +1316,11 @@ check_elmt(void *_relmt, void *_welmt)
 
     if (welmt == NULL) { /* check for fill value */
         if (*relmt != H5FA_TEST_FILL)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else {
         if (*relmt != *welmt)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end else */
 
     return (0);
@@ -1365,25 +1365,25 @@ test_set_elmts(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t *tparam, h
 
     /* Create file & retrieve pointer to internal file object */
     if (create_file(fapl, &file, &f) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create array */
     if (create_array(f, cparam, &fa, &fa_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(fa, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the file */
     if (reopen_file(&file, &f, fapl, &fa, fa_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5FA_get_nelmts(fa, &fa_nelmts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (nelmts > fa_nelmts)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify array state */
     HDmemset(&state, 0, sizeof(state));
@@ -1391,84 +1391,84 @@ test_set_elmts(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t *tparam, h
     state.nelmts    = cparam->nelmts;
     state.dblk_size = 0;
     if (check_stats(fa, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get all elements from empty array */
 
     /* Initialize iterator */
     if (NULL == (fiter_info = tparam->fiter->init(cparam, tparam, nelmts)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get elements of array */
     for (cnt = 0; cnt < nelmts; cnt++) {
         /* Get the array index */
         if ((sidx = tparam->fiter->next(fiter_info)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         idx = (hsize_t)sidx;
 
         /* Retrieve element of array (not set yet) */
         relmt = (uint64_t)0;
         if (H5FA_get(fa, idx, &relmt) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify that the retrieved is correct */
         if (check_elmt(&relmt, NULL))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Shutdown iterator */
     if (tparam->fiter->term(fiter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set (& get) all elements from empty array */
 
     /* Initialize iterator */
     if (NULL == (fiter_info = tparam->fiter->init(cparam, tparam, nelmts)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set elements of array */
     for (cnt = 0; cnt < nelmts; cnt++) {
         /* Get the array index */
         if ((sidx = tparam->fiter->next(fiter_info)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         idx = (hsize_t)sidx;
 
         relmt = (uint64_t)0;
         if (H5FA_get(fa, idx, &relmt) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify that the retrieved element is correct */
         if (check_elmt(&relmt, NULL))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Set element of array */
         welmt = (uint64_t)7 + idx;
         if (H5FA_set(fa, idx, &welmt) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Retrieve element of array (set now) */
         relmt = (uint64_t)0;
         if (H5FA_get(fa, idx, &relmt) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify that the retrieved element is correct */
         if (check_elmt(&relmt, &welmt))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Verify array state */
     HDmemset(&state, 0, sizeof(state));
     set_fa_state(cparam, &state);
     if (check_stats(fa, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Shutdown iterator */
     if (tparam->fiter->term(fiter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close array, delete array, close file & verify file is empty */
     if (finish(file, fapl, f, fa, fa_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -1520,25 +1520,25 @@ test_skip_elmts(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t *tparam, 
 
     /* Create file & retrieve pointer to internal file object */
     if (create_file(fapl, &file, &f) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create array */
     if (create_array(f, cparam, &fa, &fa_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the creation parameters */
     if (verify_cparam(fa, cparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the file */
     if (reopen_file(&file, &f, fapl, &fa, fa_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5FA_get_nelmts(fa, &fa_nelmts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (skip_elmts >= fa_nelmts)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify array state */
     HDmemset(&state, 0, sizeof(state));
@@ -1546,7 +1546,7 @@ test_skip_elmts(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t *tparam, 
     state.nelmts    = cparam->nelmts;
     state.dblk_size = 0;
     if (check_stats(fa, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set (& get) element after skipping elements */
     idx = skip_elmts;
@@ -1554,31 +1554,31 @@ test_skip_elmts(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t *tparam, 
     /* Retrieve element of array (not set yet) */
     relmt = (uint64_t)0;
     if (H5FA_get(fa, idx, &relmt) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the retrieved is correct */
     if (check_elmt(&relmt, NULL))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set element of array */
     welmt = (uint64_t)7 + idx;
     if (H5FA_set(fa, idx, &welmt) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify array state */
     HDmemset(&state, 0, sizeof(state));
     set_fa_state(cparam, &state);
     if (check_stats(fa, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve element of array (set now) */
     relmt = (uint64_t)0;
     if (H5FA_get(fa, idx, &relmt) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the retrieved is correct */
     if (check_elmt(&relmt, &welmt))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (check_rest) {
         /* Get unset elements of array */
@@ -1586,17 +1586,17 @@ test_skip_elmts(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t *tparam, 
             /* Retrieve element of array (not set yet) */
             relmt = (uint64_t)0;
             if (H5FA_get(fa, cnt, &relmt) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Verify that the retrieved is correct */
             if (check_elmt(&relmt, NULL))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
     }     /* end if */
 
     /* Close array, delete array, close file & verify file is empty */
     if (finish(file, fapl, f, fa, fa_addr) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -1650,7 +1650,7 @@ main(void)
 
     /* Push API context */
     if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = TRUE;
 
     /* Seed random #'s */
@@ -1662,15 +1662,15 @@ main(void)
         hid_t file; /* File ID */
 
         if ((file = H5Fcreate(filename_g, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of a file w/no array */
         if ((empty_size_g = h5_get_file_size(filename_g, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* Iterate over the testing parameters */
@@ -1783,7 +1783,7 @@ main(void)
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = FALSE;
 
     if (nerrors)

--- a/test/fheap.c
+++ b/test/fheap.c
@@ -270,48 +270,48 @@ check_stats(const H5HF_t *fh, const fheap_heap_state_t *state)
 
     /* Get statistics for heap and verify they are correct */
     if (H5HF_stat_info(fh, &heap_stats) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (heap_stats.man_nobjs != state->man_nobjs) {
         HDfprintf(stdout, "heap_stats.man_nobjs = %" PRIuHSIZE ", state->man_nobjs = %zu\n",
                   heap_stats.man_nobjs, state->man_nobjs);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (heap_stats.man_size != state->man_size) {
         HDfprintf(stdout, "heap_stats.man_size = %" PRIuHSIZE ", state->man_size = %" PRIuHSIZE "\n",
                   heap_stats.man_size, state->man_size);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (heap_stats.man_alloc_size != state->man_alloc_size) {
         HDfprintf(stdout,
                   "heap_stats.man_alloc_size = %" PRIuHSIZE ", state->man_alloc_size = %" PRIuHSIZE "\n",
                   heap_stats.man_alloc_size, state->man_alloc_size);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (heap_stats.man_free_space != state->man_free_space) {
         HDfprintf(stdout,
                   "heap_stats.man_free_space = %" PRIuHSIZE ", state->man_free_space = %" PRIuHSIZE "\n",
                   heap_stats.man_free_space, state->man_free_space);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (heap_stats.huge_nobjs != state->huge_nobjs) {
         HDfprintf(stdout, "heap_stats.huge_nobjs = %" PRIuHSIZE ", state->huge_nobjs = %zu\n",
                   heap_stats.huge_nobjs, state->huge_nobjs);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (heap_stats.huge_size != state->huge_size) {
         HDfprintf(stdout, "heap_stats.huge_size = %" PRIuHSIZE ", state->huge_size = %" PRIuHSIZE "\n",
                   heap_stats.huge_size, state->huge_size);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (heap_stats.tiny_nobjs != state->tiny_nobjs) {
         HDfprintf(stdout, "heap_stats.tiny_nobjs = %" PRIuHSIZE ", state->tiny_nobjs = %zu\n",
                   heap_stats.tiny_nobjs, state->tiny_nobjs);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (heap_stats.tiny_size != state->tiny_size) {
         HDfprintf(stdout, "heap_stats.tiny_size = %" PRIuHSIZE ", state->tiny_size = %" PRIuHSIZE "\n",
                   heap_stats.tiny_size, state->tiny_size);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* All tests passed */
@@ -384,14 +384,14 @@ add_obj(H5HF_t *fh, size_t obj_off, size_t obj_size, fheap_heap_state_t *state, 
 
     /* Get information about heap ID lengths */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > MAX_HEAP_ID_LEN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object */
     HDmemset(heap_id, 0, id_len);
     if (H5HF_insert(fh, obj_size, obj, heap_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for tracking the heap's state */
     if (state) {
@@ -400,7 +400,7 @@ add_obj(H5HF_t *fh, size_t obj_off, size_t obj_size, fheap_heap_state_t *state, 
 
         /* Check information about tiny objects */
         if (H5HF_get_tiny_info_test(fh, &tiny_max_len, &tiny_len_extended) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Adjust state of heap */
         if (obj_size <= tiny_max_len) {
@@ -414,18 +414,18 @@ add_obj(H5HF_t *fh, size_t obj_off, size_t obj_size, fheap_heap_state_t *state, 
 
         /* Check free space left in heap */
         if (check_stats(fh, state))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Read in object */
     if (H5HF_get_obj_len(fh, heap_id, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(obj, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* If the heap IDs are to be retained, append them to the list */
     if (keep_ids) {
@@ -438,15 +438,15 @@ add_obj(H5HF_t *fh, size_t obj_off, size_t obj_size, fheap_heap_state_t *state, 
             keep_ids->alloc_ids = MAX(1024, (keep_ids->alloc_ids * 2));
             if (NULL ==
                 (tmp_ids = (unsigned char *)H5MM_realloc(keep_ids->ids, id_len * keep_ids->alloc_ids)))
-                TEST_ERROR
+                TEST_ERROR;
             keep_ids->ids = tmp_ids;
             if (NULL ==
                 (tmp_lens = (size_t *)H5MM_realloc(keep_ids->lens, sizeof(size_t) * keep_ids->alloc_ids)))
-                TEST_ERROR
+                TEST_ERROR;
             keep_ids->lens = tmp_lens;
             if (NULL ==
                 (tmp_offs = (size_t *)H5MM_realloc(keep_ids->offs, sizeof(size_t) * keep_ids->alloc_ids)))
-                TEST_ERROR
+                TEST_ERROR;
             keep_ids->offs = tmp_offs;
         } /* end if */
 
@@ -580,30 +580,30 @@ reopen_file(hid_t *file, H5F_t **f, const char *filename, hid_t fapl, H5HF_t **f
     if (tparam->reopen_heap) {
         /* Close heap */
         if (H5HF_close(*fh) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         *fh = NULL;
 
         /* Close file */
         if (H5Fclose(*file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         *file = (-1);
         *f    = NULL;
 
         /* Re-open the file */
         if ((*file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (*f = (H5F_t *)H5VL_object(*file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Ignore metadata tags in the file's cache */
         if (H5AC_ignore_tags(*f) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Re-open heap */
         if (NULL == (*fh = H5HF_open(*f, fh_addr)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Success */
@@ -639,82 +639,82 @@ open_heap(char *filename, hid_t fapl, const H5HF_create_t *cparam, const fheap_t
 
     /* Create the file to work on */
     if ((*file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for deleting the entire heap */
     if (tparam->del_dir != FHEAP_DEL_HEAP) {
         /* Get a pointer to the internal file object */
         if (NULL == (*f = (H5F_t *)H5VL_object(*file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Ignore metadata tags in the file's cache */
         if (H5AC_ignore_tags(*f) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create absolute heap */
         if (NULL == (*fh = H5HF_create(*f, cparam)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5HF_get_id_len(*fh, &id_len) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (id_len > tparam->actual_id_len)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5HF_get_heap_addr(*fh, fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (!H5F_addr_defined(*fh_addr))
-            TEST_ERROR
+            TEST_ERROR;
         HDmemset(state, 0, sizeof(fheap_heap_state_t));
         if (check_stats(*fh, state))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Prepare for querying the size of a file with an empty heap */
 
         /* Close (empty) heap */
         if (H5HF_close(*fh) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         *fh = NULL;
     } /* end if */
 
     /* Close file */
     if (H5Fclose(*file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of a file w/empty heap*/
     if ((*empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((*file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (*f = (H5F_t *)H5VL_object(*file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(*f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for deleting the entire heap */
     if (tparam->del_dir == FHEAP_DEL_HEAP) {
         /* Create absolute heap */
         if (NULL == (*fh = H5HF_create(*f, cparam)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5HF_get_id_len(*fh, &id_len) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (id_len > tparam->actual_id_len)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5HF_get_heap_addr(*fh, fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (!H5F_addr_defined(*fh_addr))
-            TEST_ERROR
+            TEST_ERROR;
         HDmemset(state, 0, sizeof(fheap_heap_state_t));
         if (check_stats(*fh, state))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else {
         /* Re-open heap */
         if (NULL == (*fh = H5HF_open(*f, *fh_addr)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end else */
 
     /* Success */
@@ -745,12 +745,12 @@ reopen_heap(H5F_t *f, H5HF_t **fh, haddr_t fh_addr, const fheap_test_param_t *tp
     if (tparam->reopen_heap) {
         /* Close (empty) heap */
         if (H5HF_close(*fh) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         *fh = NULL;
 
         /* Re-open heap */
         if (NULL == (*fh = H5HF_open(f, fh_addr)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Success */
@@ -781,42 +781,42 @@ close_heap(char *filename, hid_t fapl, fheap_test_param_t *tparam, hid_t file, H
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     if (check_stats(*fh, state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for deleting the objects in the heap */
     if (tparam->del_dir != FHEAP_DEL_HEAP) {
         /* Delete objects inserted (either forward or reverse order) */
         if (del_objs(f, fh, tparam, state, keep_ids))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Close the fractal heap */
     if (H5HF_close(*fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     *fh = NULL;
 
     /* Check for deleting the entire heap */
     if (tparam->del_dir == FHEAP_DEL_HEAP) {
         /* Delete heap */
         if (H5HF_delete(f, fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return (0);
@@ -857,14 +857,14 @@ del_objs_half_refill(H5F_t *f, H5HF_t **fh, fheap_test_param_t *tparam, fheap_he
     /* Check for closing & re-opening the heap */
     if (tparam->reopen_heap) {
         if (H5HF_get_heap_addr(*fh, &fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (!H5F_addr_defined(fh_addr))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Get information about heap ID lengths */
     if (H5HF_get_id_len(*fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove half of total objects from heap */
     if (tparam->del_dir == FHEAP_DEL_FORWARD)
@@ -875,11 +875,11 @@ del_objs_half_refill(H5F_t *f, H5HF_t **fh, fheap_test_param_t *tparam, fheap_he
     for (u = 0; u < half_nobjs; u++) {
         /* Remove object from heap */
         if (H5HF_remove(*fh, &keep_ids->ids[id_len * obj_idx]) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Adjust index of object to delete next */
         if (tparam->del_dir == FHEAP_DEL_FORWARD)
@@ -897,11 +897,11 @@ del_objs_half_refill(H5F_t *f, H5HF_t **fh, fheap_test_param_t *tparam, fheap_he
         /* Re-insert object */
         wobj = &shared_wobj_g[keep_ids->offs[obj_idx]];
         if (H5HF_insert(*fh, keep_ids->lens[obj_idx], wobj, &keep_ids->ids[id_len * obj_idx]) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Adjust index of object to delete next */
         if (tparam->del_dir == FHEAP_DEL_FORWARD)
@@ -949,19 +949,19 @@ del_objs(H5F_t *f, H5HF_t **fh, fheap_test_param_t *tparam, fheap_heap_state_t *
     /* Check for first deleting half of objects & then re-inserting them */
     if (tparam->drain_half == FHEAP_DEL_DRAIN_HALF)
         if (del_objs_half_refill(f, fh, tparam, keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (tparam->reopen_heap) {
         if (H5HF_get_heap_addr(*fh, &fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (!H5F_addr_defined(fh_addr))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Get information about heap ID lengths */
     if (H5HF_get_id_len(*fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove all objects from heap */
     if (tparam->del_dir == FHEAP_DEL_FORWARD)
@@ -971,11 +971,11 @@ del_objs(H5F_t *f, H5HF_t **fh, fheap_test_param_t *tparam, fheap_heap_state_t *
     for (u = 0; u < keep_ids->num_ids; u++) {
         /* Remove object from heap */
         if (H5HF_remove(*fh, &keep_ids->ids[id_len * obj_idx]) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Adjust index of object to delete next */
         if (tparam->del_dir == FHEAP_DEL_FORWARD)
@@ -989,7 +989,7 @@ del_objs(H5F_t *f, H5HF_t **fh, fheap_test_param_t *tparam, fheap_heap_state_t *
 
     /* Check up on heap... */
     if (check_stats(*fh, state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Operations succeeded */
     return (0);
@@ -1052,7 +1052,7 @@ fill_heap(H5HF_t *fh, unsigned block_row, size_t obj_size, fheap_heap_state_t *s
 
     /* Get information about heap ID lengths */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for some "magic" object sizes */
     if (obj_size == 0)
@@ -1070,13 +1070,13 @@ fill_heap(H5HF_t *fh, unsigned block_row, size_t obj_size, fheap_heap_state_t *s
             shared_alloc_ids_g = MAX(1024, (shared_alloc_ids_g * 2));
             if (NULL ==
                 (shared_ids_g = (unsigned char *)H5MM_realloc(shared_ids_g, id_len * shared_alloc_ids_g)))
-                TEST_ERROR
+                TEST_ERROR;
             if (NULL ==
                 (shared_lens_g = (size_t *)H5MM_realloc(shared_lens_g, sizeof(size_t) * shared_alloc_ids_g)))
-                TEST_ERROR
+                TEST_ERROR;
             if (NULL ==
                 (shared_offs_g = (size_t *)H5MM_realloc(shared_offs_g, sizeof(size_t) * shared_alloc_ids_g)))
-                TEST_ERROR
+                TEST_ERROR;
             curr_id_ptr  = &shared_ids_g[(num_ids - 1) * id_len];
             curr_len_ptr = &shared_lens_g[(num_ids - 1)];
             curr_off_ptr = &shared_offs_g[(num_ids - 1)];
@@ -1084,7 +1084,7 @@ fill_heap(H5HF_t *fh, unsigned block_row, size_t obj_size, fheap_heap_state_t *s
 
         /* Insert object */
         if (H5HF_insert(fh, obj_size, wobj, curr_id_ptr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         *curr_len_ptr = obj_size;
         *curr_off_ptr = obj_off;
 
@@ -1094,7 +1094,7 @@ fill_heap(H5HF_t *fh, unsigned block_row, size_t obj_size, fheap_heap_state_t *s
 
         /* Check stats for heap */
         if (check_stats(fh, state))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Adjust object & ID pointers */
         wobj++;
@@ -1124,13 +1124,13 @@ fill_heap(H5HF_t *fh, unsigned block_row, size_t obj_size, fheap_heap_state_t *s
             shared_alloc_ids_g = MAX(1024, (shared_alloc_ids_g * 2));
             if (NULL ==
                 (shared_ids_g = (unsigned char *)H5MM_realloc(shared_ids_g, id_len * shared_alloc_ids_g)))
-                TEST_ERROR
+                TEST_ERROR;
             if (NULL ==
                 (shared_lens_g = (size_t *)H5MM_realloc(shared_lens_g, sizeof(size_t) * shared_alloc_ids_g)))
-                TEST_ERROR
+                TEST_ERROR;
             if (NULL ==
                 (shared_offs_g = (size_t *)H5MM_realloc(shared_offs_g, sizeof(size_t) * shared_alloc_ids_g)))
-                TEST_ERROR
+                TEST_ERROR;
             curr_id_ptr  = &shared_ids_g[(num_ids - 1) * id_len];
             curr_len_ptr = &shared_lens_g[(num_ids - 1)];
             curr_off_ptr = &shared_offs_g[(num_ids - 1)];
@@ -1138,7 +1138,7 @@ fill_heap(H5HF_t *fh, unsigned block_row, size_t obj_size, fheap_heap_state_t *s
 
         /* Insert last object into the heap, using the remaining free space */
         if (H5HF_insert(fh, last_obj_len, wobj, curr_id_ptr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         *curr_len_ptr = last_obj_len;
         *curr_off_ptr = obj_off;
 
@@ -1148,7 +1148,7 @@ fill_heap(H5HF_t *fh, unsigned block_row, size_t obj_size, fheap_heap_state_t *s
 
         /* Verify that the heap is full */
         if (check_stats(fh, state))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else
         last_obj_len = obj_size; /* Normal sized last object */
@@ -1163,12 +1163,12 @@ fill_heap(H5HF_t *fh, unsigned block_row, size_t obj_size, fheap_heap_state_t *s
     for (u = 0; u < num_ids; u++) {
         /* Read in object */
         if (H5HF_read(fh, curr_id_ptr, shared_robj_g) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check that object is correct */
         wobj = &shared_wobj_g[*curr_off_ptr];
         if (HDmemcmp(wobj, shared_robj_g, *curr_len_ptr) != 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Adjust object & ID pointers */
         curr_id_ptr += id_len;
@@ -1183,13 +1183,13 @@ fill_heap(H5HF_t *fh, unsigned block_row, size_t obj_size, fheap_heap_state_t *s
             keep_ids->alloc_ids = MAX(1024, (keep_ids->alloc_ids * 2));
             if (NULL ==
                 (keep_ids->ids = (unsigned char *)H5MM_realloc(keep_ids->ids, id_len * keep_ids->alloc_ids)))
-                TEST_ERROR
+                TEST_ERROR;
             if (NULL == (keep_ids->lens =
                              (size_t *)H5MM_realloc(keep_ids->lens, sizeof(size_t) * keep_ids->alloc_ids)))
-                TEST_ERROR
+                TEST_ERROR;
             if (NULL == (keep_ids->offs =
                              (size_t *)H5MM_realloc(keep_ids->offs, sizeof(size_t) * keep_ids->alloc_ids)))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
 
         /* Append the IDs onto the array */
@@ -1294,7 +1294,7 @@ fill_root_row(H5HF_t *fh, unsigned row, size_t obj_size, fheap_heap_state_t *sta
 
         /* Fill a direct heap block up */
         if (fill_heap(fh, row, obj_size, state, keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Operations succeeded */
@@ -1339,7 +1339,7 @@ fill_partial_row(H5HF_t *fh, unsigned row, unsigned width, size_t obj_size, fhea
 
         /* Fill a direct heap block up */
         if (fill_heap(fh, row, obj_size, state, keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Operations succeeded */
@@ -1372,7 +1372,7 @@ fill_row(H5HF_t *fh, unsigned row, size_t obj_size, fheap_heap_state_t *state, f
 
     /* Fill the entire row (with the partial row fill routine) */
     if (fill_partial_row(fh, row, DTABLE_WIDTH(fh), obj_size, state, keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Operations succeeded */
     return (0);
@@ -1411,7 +1411,7 @@ fill_root_direct(H5HF_t *fh, size_t obj_size, fheap_heap_state_t *state, fheap_h
     /* Loop over rows */
     for (row = 0; row < max_dblock_rows; row++)
         if (fill_root_row(fh, row, obj_size, state, keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Operations succeeded */
     return (0);
@@ -1450,7 +1450,7 @@ fill_2nd_indirect(H5HF_t *fh, unsigned pos, size_t obj_size, fheap_heap_state_t 
     /* Loop over rows */
     for (row = 0; row < max_dblock_rows; row++)
         if (fill_row(fh, row, obj_size, state, keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Operations succeeded */
     return (0);
@@ -1487,7 +1487,7 @@ fill_all_direct(H5HF_t *fh, size_t obj_size, fheap_heap_state_t *state, fheap_he
     /* Loop over rows */
     for (row = 0; row < max_dblock_rows; row++)
         if (fill_row(fh, row, obj_size, state, keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Operations succeeded */
     return (0);
@@ -1525,7 +1525,7 @@ fill_2nd_indirect_row(H5HF_t *fh, unsigned pos, size_t obj_size, fheap_heap_stat
     /* Loop over row of indirect blocks */
     for (u = 0; u < width; u++)
         if (fill_2nd_indirect(fh, pos, obj_size, state, keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Operations succeeded */
     return (0);
@@ -1562,7 +1562,7 @@ fill_all_2nd_indirect_rows(H5HF_t *fh, size_t obj_size, fheap_heap_state_t *stat
     /* Loop over rows of 2nd level deep indirect blocks */
     for (u = 0; u < (H5VM_log2_of2(width) + 1); u++)
         if (fill_2nd_indirect_row(fh, (u + 1), obj_size, state, keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Operations succeeded */
     return (0);
@@ -1595,12 +1595,12 @@ fill_3rd_indirect(H5HF_t *fh, unsigned pos, size_t obj_size, fheap_heap_state_t 
 
     /* Fill all direct block rows in third level indirect block */
     if (fill_all_direct(fh, obj_size, state, keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows of recursive indirect blocks in third level indirect block */
     for (u = 0; u < pos; u++)
         if (fill_2nd_indirect_row(fh, (u + 1), obj_size, state, keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Operations succeeded */
     return (0);
@@ -1639,7 +1639,7 @@ fill_3rd_indirect_row(H5HF_t *fh, unsigned pos, size_t obj_size, fheap_heap_stat
     for (u = 0; u < width; u++)
         /* Fill third level indirect block */
         if (fill_3rd_indirect(fh, pos, obj_size, state, keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Operations succeeded */
     return (0);
@@ -1677,7 +1677,7 @@ fill_all_3rd_indirect_rows(H5HF_t *fh, size_t obj_size, fheap_heap_state_t *stat
     for (u = 0; u < (H5VM_log2_of2(width) + 1); u++)
         /* Fill row of 3rd level indirect blocks */
         if (fill_3rd_indirect_row(fh, (u + 1), obj_size, state, keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Operations succeeded */
     return (0);
@@ -1716,16 +1716,16 @@ fill_4th_indirect_row(H5HF_t *fh, unsigned pos, size_t obj_size, fheap_heap_stat
     for (u = 0; u < width; u++) {
         /* Fill all direct block rows in fourth level indirect block */
         if (fill_all_direct(fh, obj_size, state, keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Fill all rows of 2nd level deep indirect blocks in fourth level indirect block */
         if (fill_all_2nd_indirect_rows(fh, obj_size, state, keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Fill rows of third level indirect blocks in fourth level indirect block */
         for (v = 0; v < pos; v++)
             if (fill_3rd_indirect_row(fh, (v + 1), obj_size, state, keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
     } /* end for */
 
     /* Operations succeeded */
@@ -1764,7 +1764,7 @@ fill_all_4th_indirect_rows(H5HF_t *fh, size_t obj_size, fheap_heap_state_t *stat
     for (u = 0; u < (H5VM_log2_of2(width) + 1); u++) {
         /* Fill row of 4th level indirect blocks */
         if (fill_4th_indirect_row(fh, (u + 1), obj_size, state, keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Account for root indirect block doubling # of rows again */
         /* (From 16 rows to the max. # of rows: 22) */
@@ -1823,27 +1823,27 @@ test_create(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of a file w/empty heap*/
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Test fractal heap creation
@@ -1851,48 +1851,48 @@ test_create(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
     TESTING("fractal heap creation");
 
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
     PASSED();
 
     /* Query the type of address mapping */
     TESTING("query heap creation parameters");
     HDmemset(&test_cparam, 0, sizeof(H5HF_create_t));
     if (H5HF_get_cparam_test(fh, &test_cparam) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_cmp_cparam_test(cparam, &test_cparam))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Delete heap */
     if (H5HF_delete(f, fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -1943,30 +1943,30 @@ test_reopen(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of a file w/empty heap*/
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     if (f->shared->fs_strategy == H5F_FSPACE_STRATEGY_PAGE)
         page = TRUE;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Display testing message
@@ -1976,76 +1976,76 @@ test_reopen(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
 
     /* Create heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Check for closing & re-opening the file */
     if (tparam->reopen_heap) {
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Ignore metadata tags in the file's cache */
         if (H5AC_ignore_tags(f) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
     } /* end if */
 
     /* Re-open the heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Query the creation parameters */
     HDmemset(&test_cparam, 0, sizeof(H5HF_create_t));
     if (H5HF_get_cparam_test(fh, &test_cparam) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_cmp_cparam_test(cparam, &test_cparam))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Delete heap */
     if (H5HF_delete(f, fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (!page || (page && !tparam->reopen_heap))
         if (file_size != empty_size)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -2099,30 +2099,30 @@ test_open_twice(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of a file w/empty heap*/
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     if (f->shared->fs_strategy == H5F_FSPACE_STRATEGY_PAGE)
         page = TRUE;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Display testing message
@@ -2131,65 +2131,65 @@ test_open_twice(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
 
     /* Create heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the heap again, through the first file handle */
     if (NULL == (fh2 = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the creation parameters */
     HDmemset(&test_cparam, 0, sizeof(H5HF_create_t));
     if (H5HF_get_cparam_test(fh2, &test_cparam) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_cmp_cparam_test(cparam, &test_cparam))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the second fractal heap wrapper */
     if (H5HF_close(fh2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh2 = NULL;
 
     /* Check for closing & re-opening the heap & file */
     if (reopen_file(&file, &f, filename, fapl, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file2 = H5Freopen(file)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f2 = (H5F_t *)H5VL_object(file2)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the fractal heap through the second file handle */
     if (NULL == (fh2 = H5HF_open(f2, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the creation parameters */
     HDmemset(&test_cparam, 0, sizeof(H5HF_create_t));
     if (H5HF_get_cparam_test(fh2, &test_cparam) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_cmp_cparam_test(cparam, &test_cparam))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the first fractal heap wrapper */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the first file */
@@ -2197,29 +2197,29 @@ test_open_twice(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
      *  shared file information)
      */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the second fractal heap wrapper */
     if (H5HF_close(fh2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh2 = NULL;
 
     /* Delete heap */
     if (H5HF_delete(f2, fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the second file */
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (!page || (page && !tparam->reopen_heap))
         if (file_size != empty_size)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -2274,64 +2274,64 @@ test_delete_open(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of a file w/no heap*/
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Display test banner */
     TESTING("deleting open fractal heap");
 
     /* Create heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the heap again */
     if (NULL == (fh2 = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Request that the heap be deleted */
     if (H5HF_delete(f, fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the creation parameters */
     HDmemset(&test_cparam, 0, sizeof(H5HF_create_t));
     if (H5HF_get_cparam_test(fh2, &test_cparam) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_cmp_cparam_test(cparam, &test_cparam))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the second fractal heap wrapper */
     if (H5HF_close(fh2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh2 = NULL;
 
     /* Try re-opening the heap again (should fail, as heap will be deleted) */
@@ -2346,31 +2346,31 @@ test_delete_open(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
         fh2 = NULL;
 
         /* Indicate error */
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Close the first fractal heap wrapper */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Check for closing & re-opening the file */
     if (tparam->reopen_heap) {
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Ignore metadata tags in the file's cache */
         if (H5AC_ignore_tags(f) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
     } /* end if */
 
@@ -2386,20 +2386,20 @@ test_delete_open(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
         fh = NULL;
 
         /* Indicate error */
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -2451,18 +2451,18 @@ test_id_limits(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Display testing message */
-    TESTING("limits of heap ID lengths")
+    TESTING("limits of heap ID lengths");
 
     /* Copy heap creation properties */
     HDmemcpy(&tmp_cparam, cparam, sizeof(H5HF_create_t));
@@ -2472,27 +2472,27 @@ test_id_limits(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, &tmp_cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test ID length information for heap */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len != HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_tiny_info_test(fh, &tiny_max_len, &tiny_len_extended) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tiny_max_len != (HEAP_ID_LEN - 1))
-        TEST_ERROR
+        TEST_ERROR;
     if (tiny_len_extended != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5HF_get_huge_info_test(fh, NULL, &huge_ids_direct) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (huge_ids_direct != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Set the heap ID length to the size needed for directly accessing 'huge' objects */
@@ -2501,27 +2501,27 @@ test_id_limits(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, &tmp_cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test ID length information for heap */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len != 17)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_tiny_info_test(fh, &tiny_max_len, &tiny_len_extended) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tiny_max_len != 16)
-        TEST_ERROR
+        TEST_ERROR;
     if (tiny_len_extended != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5HF_get_huge_info_test(fh, NULL, &huge_ids_direct) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (huge_ids_direct != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Set the heap ID length to the size needed for directly accessing 'huge' objects */
@@ -2531,31 +2531,31 @@ test_id_limits(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
     /* Set an I/O filter for heap data */
     deflate_level = 6;
     if (H5Z_append(&tmp_cparam.pline, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, (size_t)1, &deflate_level) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, &tmp_cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test ID length information for heap */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len != 29)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_tiny_info_test(fh, &tiny_max_len, &tiny_len_extended) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tiny_max_len != 27)
-        TEST_ERROR
+        TEST_ERROR;
     if (tiny_len_extended != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5HF_get_huge_info_test(fh, NULL, &huge_ids_direct) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (huge_ids_direct != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Release the I/O pipeline filter information */
@@ -2571,7 +2571,7 @@ test_id_limits(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
     }
     H5E_END_TRY;
     if (NULL != fh)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the heap ID length a size that's large enough for 'tiny' & 'managed'
      *  objects, but too small for directly accessing 'huge' objects
@@ -2580,27 +2580,27 @@ test_id_limits(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, &tmp_cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test ID length information for heap */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len != 8)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_tiny_info_test(fh, &tiny_max_len, &tiny_len_extended) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tiny_max_len != 7)
-        TEST_ERROR
+        TEST_ERROR;
     if (tiny_len_extended != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5HF_get_huge_info_test(fh, NULL, &huge_ids_direct) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (huge_ids_direct != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Set the heap ID length a size that's large enough for directly
@@ -2610,27 +2610,27 @@ test_id_limits(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, &tmp_cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test ID length information for heap */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len != 17)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_tiny_info_test(fh, &tiny_max_len, &tiny_len_extended) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tiny_max_len != 16)
-        TEST_ERROR
+        TEST_ERROR;
     if (tiny_len_extended != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5HF_get_huge_info_test(fh, NULL, &huge_ids_direct) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (huge_ids_direct != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Set the heap ID length to the low side of the boundary condition for
@@ -2640,27 +2640,27 @@ test_id_limits(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, &tmp_cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test ID length information for heap */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len != 18)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_tiny_info_test(fh, &tiny_max_len, &tiny_len_extended) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tiny_max_len != 16)
-        TEST_ERROR
+        TEST_ERROR;
     if (tiny_len_extended != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5HF_get_huge_info_test(fh, NULL, &huge_ids_direct) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (huge_ids_direct != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Set the heap ID length to the high side of the boundary condition for
@@ -2670,27 +2670,27 @@ test_id_limits(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, &tmp_cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test ID length information for heap */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len != 19)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_tiny_info_test(fh, &tiny_max_len, &tiny_len_extended) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tiny_max_len != 17)
-        TEST_ERROR
+        TEST_ERROR;
     if (tiny_len_extended != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5HF_get_huge_info_test(fh, NULL, &huge_ids_direct) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (huge_ids_direct != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Set the heap ID length a size that's larger than what is needed for
@@ -2700,27 +2700,27 @@ test_id_limits(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, &tmp_cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test ID length information for heap */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len != 45)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_tiny_info_test(fh, &tiny_max_len, &tiny_len_extended) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tiny_max_len != 43)
-        TEST_ERROR
+        TEST_ERROR;
     if (tiny_len_extended != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5HF_get_huge_info_test(fh, NULL, &huge_ids_direct) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (huge_ids_direct != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Set the heap ID length to a size that's too large to encode the length
@@ -2735,11 +2735,11 @@ test_id_limits(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
     }
     H5E_END_TRY;
     if (NULL != fh)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -2787,18 +2787,18 @@ test_filtered_create(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Display testing message */
-    TESTING("creating heaps with I/O filters")
+    TESTING("creating heaps with I/O filters");
 
     /* Copy heap creation properties */
     HDmemcpy(&tmp_cparam, cparam, sizeof(H5HF_create_t));
@@ -2806,58 +2806,58 @@ test_filtered_create(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
     /* Set an I/O filter for heap data */
     deflate_level = 6;
     if (H5Z_append(&tmp_cparam.pline, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, (size_t)1, &deflate_level) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, &tmp_cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get heap's address */
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Query the heap creation parameters */
     HDmemset(&test_cparam, 0, sizeof(H5HF_create_t));
     if (H5HF_get_cparam_test(fh, &test_cparam) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_cmp_cparam_test(&tmp_cparam, &test_cparam))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Release the I/O pipeline filter information */
     H5O_msg_reset(H5O_PLINE_ID, &tmp_cparam.pline);
@@ -2909,98 +2909,98 @@ test_size(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Display testing message */
-    TESTING("querying heap statistics")
+    TESTING("querying heap statistics");
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get heap's address */
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get an empty heap's size */
     empty_heap_size = 0;
     if (H5HF_size(fh, &empty_heap_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (empty_heap_size == 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert an object */
     if (add_obj(fh, (size_t)0, (size_t)10, NULL, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the heap's size after inserting one object */
     one_heap_size = 0;
     if (H5HF_size(fh, &one_heap_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (one_heap_size <= empty_heap_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check the heap's size */
     heap_size = 0;
     if (H5HF_size(fh, &heap_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (heap_size != one_heap_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert another object */
     if (add_obj(fh, (size_t)1, (size_t)10, NULL, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the heap's size */
     heap_size = 0;
     if (H5HF_size(fh, &heap_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (heap_size != one_heap_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -3050,91 +3050,91 @@ test_reopen_hdr(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
 
     /* Create the file to work on */
     if ((file1 = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file1)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Display testing message */
-    TESTING("reopening header through different file")
+    TESTING("reopening header through different file");
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get heap's address */
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert an object */
     if (add_obj(fh, (size_t)0, (size_t)10, NULL, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file1 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file again */
     if ((file2 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object (file1) */
     if (NULL == (f = (H5F_t *)H5VL_object(file1)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file (file1) */
     if (H5Fclose(file1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object (file2) */
     if (NULL == (f = (H5F_t *)H5VL_object(file2)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reopen the heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check the heap's size */
     heap_size = 0;
     if (H5HF_size(fh, &heap_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file (file2) */
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -3184,34 +3184,34 @@ test_man_insert_weird(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpa
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test inserting "weird" sized objects into heap
@@ -3225,29 +3225,29 @@ test_man_insert_weird(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpa
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5Eclear2(H5E_DEFAULT);
 
     /* Insert a 1-sized object into heap (should be a 'tiny' object) */
     if (add_obj(fh, (size_t)10, (size_t)1, &state, NULL))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for correctly sized heap */
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -3297,34 +3297,34 @@ test_man_insert_first(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpa
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test inserting first (small) object into absolute heap
@@ -3334,23 +3334,23 @@ test_man_insert_first(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpa
     state.man_alloc_size = DBLOCK_SIZE(fh, 0);
     state.man_free_space = DBLOCK_FREE(fh, 0);
     if (add_obj(fh, (size_t)10, SMALL_OBJ_SIZE1, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for correctly sized heap */
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -3398,27 +3398,27 @@ test_man_insert_second(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tp
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -3429,23 +3429,23 @@ test_man_insert_second(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tp
     state.man_alloc_size = DBLOCK_SIZE(fh, 0);
     state.man_free_space = DBLOCK_FREE(fh, 0);
     if (add_obj(fh, (size_t)10, SMALL_OBJ_SIZE1, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert second object */
     if (add_obj(fh, (size_t)20, SMALL_OBJ_SIZE2, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -3495,27 +3495,27 @@ test_man_insert_root_mult(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t 
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -3531,19 +3531,19 @@ test_man_insert_root_mult(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t 
     state.man_alloc_size = DBLOCK_SIZE(fh, 0);
     state.man_free_space = DBLOCK_FREE(fh, 0);
     if (fill_heap(fh, 0, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -3594,27 +3594,27 @@ test_man_insert_force_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_test_par
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -3630,26 +3630,26 @@ test_man_insert_force_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_test_par
     state.man_alloc_size = DBLOCK_SIZE(fh, 0);
     state.man_free_space = DBLOCK_FREE(fh, 0);
     if (fill_heap(fh, 0, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert one more object, to force root indirect block creation */
     state.man_size = cparam->managed.width * DBLOCK_SIZE(fh, 0);
     state.man_alloc_size += DBLOCK_SIZE(fh, 0);
     state.man_free_space = (cparam->managed.width - 1) * DBLOCK_FREE(fh, 0);
     if (add_obj(fh, (size_t)10, SMALL_OBJ_SIZE1, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -3700,27 +3700,27 @@ test_man_insert_fill_second(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -3736,26 +3736,26 @@ test_man_insert_fill_second(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_
     state.man_alloc_size = DBLOCK_SIZE(fh, 0);
     state.man_free_space = DBLOCK_FREE(fh, 0);
     if (fill_heap(fh, 0, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill the second direct block heap up (also creates initial root indirect block) */
     state.man_size = cparam->managed.width * DBLOCK_SIZE(fh, 0);
     state.man_alloc_size += DBLOCK_SIZE(fh, 0);
     state.man_free_space = (cparam->managed.width - 1) * DBLOCK_FREE(fh, 0);
     if (fill_heap(fh, 0, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -3807,27 +3807,27 @@ test_man_insert_third_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -3843,31 +3843,31 @@ test_man_insert_third_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param
     state.man_alloc_size = DBLOCK_SIZE(fh, 0);
     state.man_free_space = DBLOCK_FREE(fh, 0);
     if (fill_heap(fh, 0, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill the second direct block heap up (also creates initial root indirect block) */
     state.man_size = cparam->managed.width * DBLOCK_SIZE(fh, 0);
     state.man_alloc_size += DBLOCK_SIZE(fh, 0);
     state.man_free_space = (cparam->managed.width - 1) * DBLOCK_FREE(fh, 0);
     if (fill_heap(fh, 0, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert one more object, to force creation of third direct block */
     state.man_alloc_size += DBLOCK_SIZE(fh, 0);
     if (add_obj(fh, (size_t)10, SMALL_OBJ_SIZE1, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -3918,27 +3918,27 @@ test_man_fill_first_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *t
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -3951,19 +3951,19 @@ test_man_fill_first_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *t
 
     /* Fill first row of [root] indirect block */
     if (fill_root_row(fh, 0, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -4014,27 +4014,27 @@ test_man_start_second_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t 
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -4047,26 +4047,26 @@ test_man_start_second_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t 
 
     /* Fill first root indirect row */
     if (fill_root_row(fh, 0, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert one more object, to force expanding root indirect block to two rows */
     state.man_size += cparam->managed.width * DBLOCK_SIZE(fh, 1);
     state.man_alloc_size += DBLOCK_SIZE(fh, 1);
     state.man_free_space = cparam->managed.width * DBLOCK_FREE(fh, 1);
     if (add_obj(fh, (size_t)10, SMALL_OBJ_SIZE1, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -4117,27 +4117,27 @@ test_man_fill_second_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -4150,23 +4150,23 @@ test_man_fill_second_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *
 
     /* Fill first root indirect row */
     if (fill_root_row(fh, 0, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill second root indirect row */
     if (fill_root_row(fh, 1, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -4218,27 +4218,27 @@ test_man_start_third_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -4251,15 +4251,15 @@ test_man_start_third_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *
 
     /* Fill first root indirect row */
     if (fill_root_row(fh, 0, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill second root indirect row */
     if (fill_root_row(fh, 1, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert one more object, to force expanding root indirect block to four rows */
     /* (Goes to four rows because it's doubling) */
@@ -4269,15 +4269,15 @@ test_man_start_third_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 2);
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 3);
     if (add_obj(fh, (size_t)10, SMALL_OBJ_SIZE1, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -4329,27 +4329,27 @@ test_man_fill_fourth_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -4363,19 +4363,19 @@ test_man_fill_fourth_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *
     /* Loop over rows */
     for (u = 0; u < 4; u++)
         if (fill_root_row(fh, u, fill_size, &state, NULL))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -4426,27 +4426,27 @@ test_man_fill_all_root_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_para
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -4459,19 +4459,19 @@ test_man_fill_all_root_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_para
 
     /* Fill all direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -4522,27 +4522,27 @@ test_man_first_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_test_
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -4555,24 +4555,24 @@ test_man_first_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_test_
 
     /* Fill direct blocks up */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert one more object, to force creation of first recursive indirect block */
     state.man_alloc_size += DBLOCK_SIZE(fh, 0);
     if (add_obj(fh, (size_t)10, SMALL_OBJ_SIZE1, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -4624,27 +4624,27 @@ test_man_second_direct_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fhe
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -4658,31 +4658,31 @@ test_man_second_direct_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fhe
 
     /* Fill direct blocks up */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill the first direct block in the recursive indirect block up */
     state.man_alloc_size += DBLOCK_SIZE(fh, 0);
     if (fill_heap(fh, 0, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert one more object, to force creation of second direct block in
      * first recursive indirect block
      */
     state.man_alloc_size += DBLOCK_SIZE(fh, 0);
     if (add_obj(fh, (size_t)10, SMALL_OBJ_SIZE1, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -4734,27 +4734,27 @@ test_man_fill_first_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -4768,23 +4768,23 @@ test_man_fill_first_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_
 
     /* Fill direct blocks up in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill first recursive indirect block */
     if (fill_2nd_indirect(fh, 1, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -4837,27 +4837,27 @@ test_man_second_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_test
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -4871,30 +4871,30 @@ test_man_second_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_test
 
     /* Fill direct blocks up in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill first recursive indirect block */
     if (fill_2nd_indirect(fh, 1, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert one more object, to force creation of second
      * recursive indirect block
      */
     state.man_alloc_size += DBLOCK_SIZE(fh, 0);
     if (add_obj(fh, (size_t)10, SMALL_OBJ_SIZE1, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -4948,27 +4948,27 @@ test_man_fill_second_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -4982,27 +4982,27 @@ test_man_fill_second_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap
 
     /* Fill direct blocks up in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill first recursive indirect block */
     if (fill_2nd_indirect(fh, 1, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill 2nd recursive indirect block */
     if (fill_2nd_indirect(fh, 1, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -5056,23 +5056,23 @@ test_man_fill_recursive_indirect_row(hid_t fapl, H5HF_create_t *cparam, fheap_te
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -5086,23 +5086,23 @@ test_man_fill_recursive_indirect_row(hid_t fapl, H5HF_create_t *cparam, fheap_te
 
     /* Fill direct blocks in root indirect block up */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill row of recursive indirect blocks */
     if (fill_2nd_indirect_row(fh, 1, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -5154,27 +5154,27 @@ test_man_start_2nd_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_t
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -5188,30 +5188,30 @@ test_man_start_2nd_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_t
 
     /* Fill direct blocks in root indirect block up */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill row of recursive indirect blocks */
     if (fill_2nd_indirect_row(fh, 1, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert one more object, to force creation of second
      * recursive indirect block
      */
     state.man_alloc_size += DBLOCK_SIZE(fh, 0);
     if (add_obj(fh, (size_t)10, SMALL_OBJ_SIZE1, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -5263,27 +5263,27 @@ test_man_recursive_indirect_two_deep(hid_t fapl, H5HF_create_t *cparam, fheap_te
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -5297,23 +5297,23 @@ test_man_recursive_indirect_two_deep(hid_t fapl, H5HF_create_t *cparam, fheap_te
 
     /* Fill direct blocks up in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -5366,27 +5366,27 @@ test_man_start_3rd_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_t
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -5400,30 +5400,30 @@ test_man_start_3rd_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_t
 
     /* Fill direct blocks up in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert one more object, to force creation of third level deep
      * recursive indirect block
      */
     state.man_alloc_size += DBLOCK_SIZE(fh, 0);
     if (add_obj(fh, (size_t)10, SMALL_OBJ_SIZE1, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -5476,27 +5476,27 @@ test_man_fill_first_3rd_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fh
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -5510,31 +5510,31 @@ test_man_fill_first_3rd_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fh
 
     /* Fill direct blocks up in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill all direct block rows in third level indirect block */
     if (fill_all_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill row of recursive indirect blocks in third level indirect block */
     if (fill_2nd_indirect_row(fh, 1, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -5587,27 +5587,27 @@ test_man_fill_3rd_recursive_indirect_row(hid_t fapl, H5HF_create_t *cparam, fhea
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -5622,27 +5622,27 @@ test_man_fill_3rd_recursive_indirect_row(hid_t fapl, H5HF_create_t *cparam, fhea
 
     /* Fill direct blocks up in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill 1st row of 3rd level indirect blocks */
     if (fill_3rd_indirect_row(fh, 1, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -5695,27 +5695,27 @@ test_man_fill_all_3rd_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fhea
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -5730,27 +5730,27 @@ test_man_fill_all_3rd_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fhea
 
     /* Fill direct blocks up in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 3rd level indirect blocks */
     if (fill_all_3rd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -5804,27 +5804,27 @@ test_man_start_4th_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_t
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -5838,34 +5838,34 @@ test_man_start_4th_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_t
 
     /* Fill direct blocks up in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill all rows of 3rd level indirect blocks */
     if (fill_all_3rd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert one more object, to force creation of four level deep
      * recursive indirect block
      */
     state.man_alloc_size += DBLOCK_SIZE(fh, 0);
     if (add_obj(fh, (size_t)10, SMALL_OBJ_SIZE1, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -5919,27 +5919,27 @@ test_man_fill_first_4th_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fh
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -5954,39 +5954,39 @@ test_man_fill_first_4th_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fh
 
     /* Fill direct blocks up in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill all rows of 3rd level indirect blocks */
     if (fill_all_3rd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill direct block rows in fourth level indirect block */
     if (fill_all_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill all rows of 2nd level deep indirect blocks in fourth level indirect block */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill first row of 3rd level deep indirect blocks in fourth level indirect block */
     if (fill_3rd_indirect_row(fh, 1, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -6040,27 +6040,27 @@ test_man_fill_4th_recursive_indirect_row(hid_t fapl, H5HF_create_t *cparam, fhea
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -6074,31 +6074,31 @@ test_man_fill_4th_recursive_indirect_row(hid_t fapl, H5HF_create_t *cparam, fhea
 
     /* Fill direct blocks up in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill all rows of 3rd level indirect blocks */
     if (fill_all_3rd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill 1st row of 4th level indirect blocks */
     if (fill_4th_indirect_row(fh, 1, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -6152,27 +6152,27 @@ test_man_fill_all_4th_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fhea
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -6186,31 +6186,31 @@ test_man_fill_all_4th_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fhea
 
     /* Fill direct blocks up in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill all rows of 3rd level indirect blocks */
     if (fill_all_3rd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 4th level indirect blocks */
     if (fill_all_4th_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -6266,27 +6266,27 @@ test_man_start_5th_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_t
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
     /*
@@ -6301,50 +6301,50 @@ test_man_start_5th_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_t
 
     /* Fill direct blocks up in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap & file */
     if (reopen_file(&file, &f, filename, fapl, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap & file */
     if (reopen_file(&file, &f, filename, fapl, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 3rd level indirect blocks */
     if (fill_all_3rd_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap & file */
     if (reopen_file(&file, &f, filename, fapl, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 4th level indirect blocks */
     if (fill_all_4th_indirect_rows(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap & file */
     if (reopen_file(&file, &f, filename, fapl, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert one more object, to force creation of five level deep
      * recursive indirect block
      */
     state.man_alloc_size += DBLOCK_SIZE(fh, 0);
     if (add_obj(fh, (size_t)10, (size_t)SMALL_OBJ_SIZE1, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -6398,34 +6398,34 @@ test_man_remove_bogus(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpa
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test removing bogus IDs from heap
@@ -6455,15 +6455,15 @@ HDfprintf(stderr, "Random # seed was: %lu\n", seed);
     }
     H5E_END_TRY;
     if (ret >= 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fill root direct blocks */
     if (fill_root_direct(fh, fill_size, &state, NULL))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get offset of random heap ID */
     if (H5HF_get_id_off_test(fh, heap_id, &obj_off) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make certain we can't accidentally use a valid heap ID */
     while (obj_off < state.man_size) {
@@ -6474,7 +6474,7 @@ HDfprintf(stderr, "Random # seed was: %lu\n", seed);
 
         /* Get offset of random heap ID */
         if (H5HF_get_id_off_test(fh, heap_id, &obj_off) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end while */
 
     /* Try removing bogus heap ID from heap w/objects */
@@ -6484,7 +6484,7 @@ HDfprintf(stderr, "Random # seed was: %lu\n", seed);
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5Eclear2(H5E_DEFAULT);
 
     /* Try reading bogus heap ID from heap w/objects */
@@ -6494,16 +6494,16 @@ HDfprintf(stderr, "Random # seed was: %lu\n", seed);
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5Eclear2(H5E_DEFAULT);
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -6557,60 +6557,60 @@ test_man_remove_one(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpara
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Prepare for querying the size of a file with an empty heap */
 
     /* Close (empty) heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of a file w/empty heap*/
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Re-open heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Test removing first (small) object from absolute heap
@@ -6623,11 +6623,11 @@ test_man_remove_one(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpara
 
     /* Insert object into heap */
     if (H5HF_insert(fh, sizeof(obj), obj, &heap_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.man_size       = DBLOCK_SIZE(fh, 0);
@@ -6635,15 +6635,15 @@ test_man_remove_one(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpara
     state.man_free_space = DBLOCK_FREE(fh, 0) - sizeof(obj);
     state.man_nobjs      = 1;
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove object from heap */
     if (H5HF_remove(fh, heap_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.man_size       = 0;
@@ -6651,24 +6651,24 @@ test_man_remove_one(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpara
     state.man_free_space = 0;
     state.man_nobjs      = 0;
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -6722,60 +6722,60 @@ test_man_remove_two(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpara
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Prepare for querying the size of a file with an empty heap */
 
     /* Close (empty) heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of a file w/empty heap*/
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Re-open heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Test removing two (small) objects from absolute heap
@@ -6788,11 +6788,11 @@ test_man_remove_two(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpara
 
     /* Insert first object into heap */
     if (H5HF_insert(fh, sizeof(obj), obj, &heap_id1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.man_size       = DBLOCK_SIZE(fh, 0);
@@ -6800,43 +6800,43 @@ test_man_remove_two(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpara
     state.man_free_space = DBLOCK_FREE(fh, 0) - sizeof(obj);
     state.man_nobjs      = 1;
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Insert second object into heap */
     if (H5HF_insert(fh, sizeof(obj), obj, &heap_id2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.man_free_space -= sizeof(obj);
     state.man_nobjs++;
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove first object from heap */
     if (H5HF_remove(fh, heap_id1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.man_free_space += sizeof(obj);
     state.man_nobjs--;
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove second object from heap */
     if (H5HF_remove(fh, heap_id2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.man_size       = 0;
@@ -6844,24 +6844,24 @@ test_man_remove_two(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpara
     state.man_free_space = 0;
     state.man_nobjs      = 0;
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -6916,60 +6916,60 @@ test_man_remove_one_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Prepare for querying the size of a file with an empty heap */
 
     /* Close (empty) heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of a file w/empty heap*/
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Re-open heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Test removing one larger object from absolute heap
@@ -6982,11 +6982,11 @@ test_man_remove_one_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t
 
     /* Insert object into heap */
     if (H5HF_insert(fh, obj_len, obj, &heap_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     for (u = 0; u < 4; u++) {
@@ -6997,15 +6997,15 @@ test_man_remove_one_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t
     state.man_free_space -= obj_len;
     state.man_nobjs = 1;
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove object from heap */
     if (H5HF_remove(fh, heap_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.man_size       = 0;
@@ -7013,24 +7013,24 @@ test_man_remove_one_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t
     state.man_free_space = 0;
     state.man_nobjs      = 0;
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -7086,68 +7086,68 @@ test_man_remove_two_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Prepare for querying the size of a file with an empty heap */
 
     /* Close (empty) heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of a file w/empty heap*/
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Re-open heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Test removing two larger objects from absolute heap
      */
     if (tparam->del_dir == FHEAP_DEL_FORWARD)
-        TESTING("removing two larger objects from absolute heap (forward)")
+        TESTING("removing two larger objects from absolute heap (forward)");
     else
-        TESTING("removing two larger objects from absolute heap (reverse)")
+        TESTING("removing two larger objects from absolute heap (reverse)");
 
     /* Set up first object to insert */
     obj_len = (size_t)DBLOCK_SIZE(fh, 2) + 1;
@@ -7155,11 +7155,11 @@ test_man_remove_two_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t
 
     /* Insert object into heap */
     if (H5HF_insert(fh, obj_len, obj, &heap_id1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     for (u = 0; u < 4; u++) {
@@ -7170,7 +7170,7 @@ test_man_remove_two_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t
     state.man_free_space -= obj_len;
     state.man_nobjs = 1;
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set up second object to insert */
     obj_len = (size_t)DBLOCK_SIZE(fh, 4) + 1;
@@ -7178,11 +7178,11 @@ test_man_remove_two_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t
 
     /* Insert object into heap */
     if (H5HF_insert(fh, obj_len, obj, &heap_id2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     /* (Goes to 8 rows because of doubling) */
@@ -7194,37 +7194,37 @@ test_man_remove_two_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t
     state.man_free_space -= obj_len;
     state.man_nobjs = 2;
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove objects in different orders */
     if (tparam->del_dir == FHEAP_DEL_FORWARD) {
         /* Remove first object from heap */
         if (H5HF_remove(fh, heap_id1) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check up on heap... */
         state.man_alloc_size -= DBLOCK_SIZE(fh, 3);
         state.man_free_space += DBLOCK_SIZE(fh, 2) + 1;
         state.man_nobjs = 1;
         if (check_stats(fh, &state))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Remove second object from heap */
         if (H5HF_remove(fh, heap_id2) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
     else {
         /* Remove second object from heap */
         if (H5HF_remove(fh, heap_id2) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check up on heap... */
         /* (Goes to 4 rows because of halving) */
@@ -7236,16 +7236,16 @@ test_man_remove_two_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t
         state.man_free_space += DBLOCK_SIZE(fh, 4) + 1;
         state.man_nobjs = 1;
         if (check_stats(fh, &state))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Remove first object from heap */
         if (H5HF_remove(fh, heap_id1) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end else */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.man_size       = 0;
@@ -7253,24 +7253,24 @@ test_man_remove_two_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t
     state.man_free_space = 0;
     state.man_nobjs      = 0;
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -7327,68 +7327,68 @@ test_man_remove_three_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Prepare for querying the size of a file with an empty heap */
 
     /* Close (empty) heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of a file w/empty heap*/
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Re-open heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Test removing three larger objects from absolute heap
      */
     if (tparam->del_dir == FHEAP_DEL_FORWARD)
-        TESTING("removing three larger objects from absolute heap (forward)")
+        TESTING("removing three larger objects from absolute heap (forward)");
     else
-        TESTING("removing three larger objects from absolute heap (reverse)")
+        TESTING("removing three larger objects from absolute heap (reverse)");
 
     /* Set up first object to insert */
     obj_len = (size_t)DBLOCK_SIZE(fh, 2) + 1;
@@ -7396,11 +7396,11 @@ test_man_remove_three_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param
 
     /* Insert object into heap */
     if (H5HF_insert(fh, obj_len, obj, &heap_id1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     for (u = 0; u < 4; u++) {
@@ -7411,7 +7411,7 @@ test_man_remove_three_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param
     state.man_free_space -= obj_len;
     state.man_nobjs = 1;
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set up second object to insert */
     obj_len = (size_t)DBLOCK_SIZE(fh, 4) + 1;
@@ -7419,11 +7419,11 @@ test_man_remove_three_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param
 
     /* Insert object into heap */
     if (H5HF_insert(fh, obj_len, obj, &heap_id2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     /* (Goes to 8 rows because of doubling) */
@@ -7435,7 +7435,7 @@ test_man_remove_three_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param
     state.man_free_space -= obj_len;
     state.man_nobjs = 2;
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set up third object to insert */
     obj_len = (size_t)DBLOCK_SIZE(fh, 7) + 1;
@@ -7443,11 +7443,11 @@ test_man_remove_three_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param
 
     /* Insert object into heap */
     if (H5HF_insert(fh, obj_len, obj, &heap_id3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     /* (Goes to 16 rows because of doubling) */
@@ -7459,52 +7459,52 @@ test_man_remove_three_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param
     state.man_free_space -= obj_len;
     state.man_nobjs = 3;
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove objects in different orders */
     if (tparam->del_dir == FHEAP_DEL_FORWARD) {
         /* Remove first object from heap */
         if (H5HF_remove(fh, heap_id1) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check up on heap... */
         state.man_alloc_size -= DBLOCK_SIZE(fh, 3);
         state.man_free_space += DBLOCK_SIZE(fh, 2) + 1;
         state.man_nobjs = 2;
         if (check_stats(fh, &state))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Remove second object from heap */
         if (H5HF_remove(fh, heap_id2) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check up on heap... */
         state.man_alloc_size -= DBLOCK_SIZE(fh, 5);
         state.man_free_space += DBLOCK_SIZE(fh, 4) + 1;
         state.man_nobjs = 1;
         if (check_stats(fh, &state))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Remove third object from heap */
         if (H5HF_remove(fh, heap_id3) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
     else {
         /* Remove third object from heap */
         if (H5HF_remove(fh, heap_id3) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check up on heap... */
         /* (Goes to 8 rows because of halving) */
@@ -7516,15 +7516,15 @@ test_man_remove_three_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param
         state.man_free_space += DBLOCK_SIZE(fh, 7) + 1;
         state.man_nobjs = 2;
         if (check_stats(fh, &state))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Remove second object from heap */
         if (H5HF_remove(fh, heap_id2) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check up on heap... */
         /* (Goes to 4 rows because of halving) */
@@ -7536,16 +7536,16 @@ test_man_remove_three_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param
         state.man_free_space += DBLOCK_SIZE(fh, 4) + 1;
         state.man_nobjs = 1;
         if (check_stats(fh, &state))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Remove first object from heap */
         if (H5HF_remove(fh, heap_id1) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end else */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.man_size       = 0;
@@ -7553,24 +7553,24 @@ test_man_remove_three_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param
     state.man_free_space = 0;
     state.man_nobjs      = 0;
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -7632,66 +7632,66 @@ test_man_incr_insert_remove(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, tparam->my_fcpl, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create absolute heap */
     if (NULL == (fh = H5HF_create(f, cparam)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > HEAP_ID_LEN)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!H5F_addr_defined(fh_addr))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Test incremental insert and removal
      */
-    TESTING("incremental object insertion and removal")
+    TESTING("incremental object insertion and removal");
 
     HDmemset(&obj1, 0, sizeof(obj1));
     HDmemset(&obj2, 0, sizeof(obj2));
     for (i = 0; i < 100; i++) {
         for (j = 0; j < i; j++) {
             if (H5HF_remove(fh, heap_id[j]) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             HDsprintf(obj2.b, "%s%2d", "ABCDEFGHIJKLMNOPQRSTUVWXYZ", j);
             if (H5HF_insert(fh, (sizeof(obj2)), &obj2, heap_id[j]) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         } /* end for */
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Insert object */
         HDmemset(heap_id[i], 0, id_len);
         HDsprintf(obj1.b, "%s%2d", "ABCDEFGHIJKLMNOPQRSTUVWXYZ", i);
         if (H5HF_insert(fh, (sizeof(obj1)), &obj1, heap_id[i]) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All tests passed */
     PASSED();
@@ -7748,22 +7748,22 @@ test_man_remove_root_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill the heap up */
     state.man_size       = DBLOCK_SIZE(fh, 0);
     state.man_alloc_size = DBLOCK_SIZE(fh, 0);
     state.man_free_space = DBLOCK_FREE(fh, 0);
     if (fill_heap(fh, 0, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -7821,37 +7821,37 @@ test_man_remove_two_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill the first block in heap */
     state.man_size       = DBLOCK_SIZE(fh, 0);
     state.man_alloc_size = DBLOCK_SIZE(fh, 0);
     state.man_free_space = DBLOCK_FREE(fh, 0);
     if (fill_heap(fh, 0, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill the second block in heap */
     state.man_size = cparam->managed.width * DBLOCK_SIZE(fh, 0);
     state.man_alloc_size += DBLOCK_SIZE(fh, 0);
     state.man_free_space = (cparam->managed.width - 1) * DBLOCK_FREE(fh, 0);
     if (fill_heap(fh, 0, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -7909,19 +7909,19 @@ test_man_remove_first_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t 
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill first row of direct blocks */
     if (fill_root_row(fh, 0, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -7979,21 +7979,21 @@ test_man_remove_first_two_rows(hid_t fapl, H5HF_create_t *cparam, fheap_test_par
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill first two rows of direct blocks */
     if (fill_root_row(fh, 0, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
     if (fill_root_row(fh, 1, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -8051,25 +8051,25 @@ test_man_remove_first_four_rows(hid_t fapl, H5HF_create_t *cparam, fheap_test_pa
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill first two rows of direct blocks */
     if (fill_root_row(fh, 0, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
     if (fill_root_row(fh, 1, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
     if (fill_root_row(fh, 2, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
     if (fill_root_row(fh, 3, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -8127,19 +8127,19 @@ test_man_remove_all_root_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_pa
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -8197,23 +8197,23 @@ test_man_remove_2nd_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_test_param
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -8271,27 +8271,27 @@ test_man_remove_3rd_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_test_param
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 3rd level indirect blocks */
     if (fill_all_3rd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -8352,11 +8352,11 @@ test_man_skip_start_block(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t 
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     obj_size       = (size_t)DBLOCK_SIZE(fh, 0) + 1;
     state.man_size = cparam->managed.width * DBLOCK_SIZE(fh, 0);
@@ -8367,11 +8367,11 @@ test_man_skip_start_block(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t 
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 1);
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 2);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -8431,11 +8431,11 @@ test_man_skip_start_block_add_back(hid_t fapl, H5HF_create_t *cparam, fheap_test
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object too large for starting block size */
     obj_size       = (size_t)DBLOCK_SIZE(fh, 0) + 1;
@@ -8447,29 +8447,29 @@ test_man_skip_start_block_add_back(hid_t fapl, H5HF_create_t *cparam, fheap_test
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 1);
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 2);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert an object to fill up the heap block just created */
     obj_size = (size_t)DBLOCK_FREE(fh, 2) - obj_size;
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert second "real" object, which should go in earlier direct block */
     state.man_alloc_size += DBLOCK_SIZE(fh, 0);
     if (add_obj(fh, (size_t)20, (size_t)SMALL_OBJ_SIZE2, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -8531,11 +8531,11 @@ test_man_skip_start_block_add_skipped(hid_t fapl, H5HF_create_t *cparam, fheap_t
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object too large for starting block size */
     obj_size       = (size_t)DBLOCK_SIZE(fh, 0) + 1;
@@ -8547,39 +8547,39 @@ test_man_skip_start_block_add_skipped(hid_t fapl, H5HF_create_t *cparam, fheap_t
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 1);
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 2);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert an object to fill up the heap block just created */
     obj_size = (size_t)DBLOCK_FREE(fh, 2) - obj_size;
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add rows of blocks to "backfill" direct blocks that were skipped */
     if (fill_row(fh, 0, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
     if (fill_row(fh, 1, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert another object, which should extend direct blocks, instead of backfill */
     state.man_alloc_size += DBLOCK_SIZE(fh, 2);
     if (add_obj(fh, (size_t)20, (size_t)SMALL_OBJ_SIZE2, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -8640,22 +8640,22 @@ test_man_skip_2nd_block(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *t
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert small object, to create root direct block */
     state.man_size       = DBLOCK_SIZE(fh, 0);
     state.man_alloc_size = DBLOCK_SIZE(fh, 0);
     state.man_free_space = DBLOCK_FREE(fh, 0);
     if (add_obj(fh, (size_t)10, (size_t)SMALL_OBJ_SIZE1, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped blocks that are too small to hold the second object
@@ -8669,11 +8669,11 @@ test_man_skip_2nd_block(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *t
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 1);
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 2);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -8739,22 +8739,22 @@ test_man_skip_2nd_block_add_skipped(hid_t fapl, H5HF_create_t *cparam, fheap_tes
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert small object, to create root direct block */
     state.man_size       = DBLOCK_SIZE(fh, 0);
     state.man_alloc_size = DBLOCK_SIZE(fh, 0);
     state.man_free_space = DBLOCK_FREE(fh, 0);
     if (add_obj(fh, (size_t)10, (size_t)SMALL_OBJ_SIZE1, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped blocks that are too small to hold the second object
@@ -8768,29 +8768,29 @@ test_man_skip_2nd_block_add_skipped(hid_t fapl, H5HF_create_t *cparam, fheap_tes
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 1);
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 2);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert an object to fill up the (smaller) heap block just created */
     obj_size = (size_t)DBLOCK_FREE(fh, 0) - SMALL_OBJ_SIZE1;
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill remainder of 2 * start size block */
     obj_size = (size_t)DBLOCK_FREE(fh, 2) - ((size_t)DBLOCK_SIZE(fh, 0) + 1);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert objects to fill remaining rows of the starting block size */
 
@@ -8798,25 +8798,25 @@ test_man_skip_2nd_block_add_skipped(hid_t fapl, H5HF_create_t *cparam, fheap_tes
     for (v = 0; v < (cparam->managed.width - 1); v++) {
         state.man_alloc_size += DBLOCK_SIZE(fh, 0);
         if (fill_heap(fh, 0, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Fill second row of direct blocks */
     if (fill_row(fh, 1, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert one more object, to create new 2 * start size direct block */
     state.man_alloc_size += DBLOCK_SIZE(fh, 2);
     if (add_obj(fh, (size_t)10, (size_t)SMALL_OBJ_SIZE1, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -8885,33 +8885,33 @@ test_man_fill_one_partial_skip_2nd_block_add_skipped(hid_t fapl, H5HF_create_t *
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill initial direct block */
     state.man_size       = DBLOCK_SIZE(fh, 0);
     state.man_alloc_size = DBLOCK_SIZE(fh, 0);
     state.man_free_space = DBLOCK_FREE(fh, 0);
     if (fill_heap(fh, 0, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert small object, to create root indirect block */
     state.man_size += (cparam->managed.width - 1) * DBLOCK_SIZE(fh, 0);
     state.man_alloc_size += DBLOCK_SIZE(fh, 0);
     state.man_free_space += (cparam->managed.width - 1) * DBLOCK_FREE(fh, 0);
     if (add_obj(fh, (size_t)10, (size_t)SMALL_OBJ_SIZE1, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped blocks that are too small to hold the large object
@@ -8925,66 +8925,66 @@ test_man_fill_one_partial_skip_2nd_block_add_skipped(hid_t fapl, H5HF_create_t *
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 2);
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 3);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert an object to fill up the (smaller) heap block just created */
     obj_size = (size_t)DBLOCK_FREE(fh, 0) - SMALL_OBJ_SIZE1;
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill remainder of 4 * start size block */
     obj_size = (size_t)DBLOCK_FREE(fh, 3) - ((size_t)DBLOCK_SIZE(fh, 2) + 1);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert objects to fill remaining heaps in first row */
     for (u = 0; u < (cparam->managed.width - 2); u++) {
         /* Fill a direct heap block up */
         state.man_alloc_size += DBLOCK_SIZE(fh, 0);
         if (fill_heap(fh, 0, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert objects to fill remaining heaps in second row */
     if (fill_row(fh, 1, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert objects to fill remaining heaps in third row */
     if (fill_row(fh, 2, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert one more object, to create new 4 * start size direct block */
     state.man_alloc_size += DBLOCK_SIZE(fh, 3);
     if (add_obj(fh, (size_t)10, (size_t)SMALL_OBJ_SIZE1, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -9050,19 +9050,19 @@ test_man_fill_row_skip_add_skipped(hid_t fapl, H5HF_create_t *cparam, fheap_test
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill first row of direct blocks */
     if (fill_root_row(fh, 0, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped blocks that are too small to hold the large object
@@ -9076,45 +9076,45 @@ test_man_fill_row_skip_add_skipped(hid_t fapl, H5HF_create_t *cparam, fheap_test
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 2);
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 3);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill remainder of 4 * start size block */
     obj_size = (size_t)DBLOCK_FREE(fh, 3) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert objects to fill remaining heaps in second row */
     if (fill_row(fh, 1, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert objects to fill remaining heaps in third row */
     if (fill_row(fh, 2, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert one more object, to create new 4 * start size direct block */
     state.man_alloc_size += DBLOCK_SIZE(fh, 3);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -9180,11 +9180,11 @@ test_man_skip_direct_skip_indirect_two_rows_add_skipped(hid_t fapl, H5HF_create_
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compute # direct block rows in root indirect block */
     num_direct_rows = DTABLE_MAX_DROWS(fh);
@@ -9202,7 +9202,7 @@ test_man_skip_direct_skip_indirect_two_rows_add_skipped(hid_t fapl, H5HF_create_
     obj_size = (size_t)DBLOCK_SIZE(fh, row - 2) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, row - 1);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compute heap size & free space when all direct blocks allocated */
     do {
@@ -9219,12 +9219,12 @@ test_man_skip_direct_skip_indirect_two_rows_add_skipped(hid_t fapl, H5HF_create_
     for (v = 0; v < cparam->managed.width; v++) {
         state.man_alloc_size += DBLOCK_SIZE(fh, num_direct_rows - 1);
         if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compute heap size & free space when root indirect block doubles again */
     do {
@@ -9239,11 +9239,11 @@ test_man_skip_direct_skip_indirect_two_rows_add_skipped(hid_t fapl, H5HF_create_
     obj_size = (size_t)DBLOCK_SIZE(fh, num_direct_rows - 2) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_direct_rows - 1);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -9306,19 +9306,19 @@ test_man_fill_direct_skip_indirect_start_block_add_skipped(hid_t fapl, H5HF_crea
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped blocks that are too small to hold the large object
@@ -9326,48 +9326,48 @@ test_man_fill_direct_skip_indirect_start_block_add_skipped(hid_t fapl, H5HF_crea
     obj_size = (size_t)DBLOCK_SIZE(fh, 2) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, 3);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add rows of blocks to "backfill" direct blocks that were skipped */
     if (fill_row(fh, 0, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
     if (fill_row(fh, 1, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert an object to fill up the (biggest) heap block created */
     obj_size = (size_t)DBLOCK_FREE(fh, 3) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill direct block heaps with 2 * initial block size in nested indirect block */
     if (fill_row(fh, 2, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert one more object, to create new 4 * start size direct block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, 3);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -9435,22 +9435,22 @@ test_man_fill_direct_skip_2nd_indirect_start_block_add_skipped(hid_t fapl, H5HF_
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve info about heap */
     num_first_indirect_rows = IBLOCK_MAX_DROWS(fh, 1);
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped (indirect) blocks that are too small to hold the large
@@ -9459,46 +9459,46 @@ test_man_fill_direct_skip_2nd_indirect_start_block_add_skipped(hid_t fapl, H5HF_
     obj_size = (size_t)DBLOCK_SIZE(fh, num_first_indirect_rows - 1) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill space in (large) block created */
     obj_size = (size_t)DBLOCK_FREE(fh, num_first_indirect_rows) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of direct blocks that are smaller than large object's block size */
     for (row = 0; row < num_first_indirect_rows; row++) {
         /* Fill rows of direct blocks in skipped indirect blocks */
         for (u = 0; u < cparam->managed.width; u++)
             if (fill_row(fh, row, fill_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Fill row of direct blocks in largest (i.e. non-skipped) indirect block */
         if (fill_row(fh, row, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add one more object, to create another "large" block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -9567,32 +9567,32 @@ test_man_fill_2nd_direct_less_one_wrap_start_block_add_skipped(hid_t fapl, H5HF_
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve info about heap */
     num_first_indirect_rows = IBLOCK_MAX_DROWS(fh, 1);
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill first row (except one) of 2nd level indirect blocks */
     for (u = 0; u < cparam->managed.width - 1; u++)
         /* Fill all rows of 2nd level indirect blocks in root block */
         if (fill_2nd_indirect(fh, 1, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped (indirect) blocks that are too small to hold the large
@@ -9601,20 +9601,20 @@ test_man_fill_2nd_direct_less_one_wrap_start_block_add_skipped(hid_t fapl, H5HF_
     obj_size = (size_t)DBLOCK_SIZE(fh, num_first_indirect_rows - 1) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill space in (large) block created */
     obj_size = (size_t)DBLOCK_FREE(fh, num_first_indirect_rows) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows skipped over in 2nd level indirect block's direct blocks
      * (and rows of next 2nd level indirect block's direct blocks)
@@ -9622,26 +9622,26 @@ test_man_fill_2nd_direct_less_one_wrap_start_block_add_skipped(hid_t fapl, H5HF_
     for (u = 0; u < num_first_indirect_rows; u++) {
         /* Direct block rows in skipped 2nd level indirect block */
         if (fill_row(fh, u, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Direct block row in current 2nd level indirect block */
         if (fill_row(fh, u, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add one more object, to create another "large" block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -9713,22 +9713,22 @@ test_man_fill_direct_skip_2nd_indirect_skip_2nd_block_add_skipped(hid_t fapl, H5
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve info about heap */
     num_first_indirect_rows = IBLOCK_MAX_DROWS(fh, 1);
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped (indirect) blocks that are too small to hold the large
@@ -9737,79 +9737,79 @@ test_man_fill_direct_skip_2nd_indirect_skip_2nd_block_add_skipped(hid_t fapl, H5
     obj_size = (size_t)DBLOCK_SIZE(fh, num_first_indirect_rows - 1) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill space in (large) block created */
     obj_size = (size_t)DBLOCK_FREE(fh, num_first_indirect_rows) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object too large for initial block size in skipped indirect blocks */
     obj_size = (size_t)DBLOCK_SIZE(fh, 3) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, 4);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill space in (medium) block just created */
     obj_size = (size_t)DBLOCK_FREE(fh, 4) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Finish off blocks in row of medium block size (just to make row filling easier below) */
     obj_size = (size_t)DBLOCK_FREE(fh, 4);
     for (u = 1; u < cparam->managed.width; u++) {
         state.man_alloc_size += DBLOCK_SIZE(fh, 4);
         if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of direct blocks that are smaller than large object's block size */
     for (row = 0; row < num_first_indirect_rows; row++) {
         /* Fill rows of direct blocks in skipped indirect blocks */
         for (u = 0; u < cparam->managed.width; u++)
             if (fill_row(fh, row, fill_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Fill row of direct blocks in largest (i.e. non-skipped) indirect block */
         /* (Skip the row of blocks filled above) */
         if (row != 4)
             if (fill_row(fh, row, fill_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
     } /* end while */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add one more object, to create another "large" block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -9876,11 +9876,11 @@ test_man_fill_direct_skip_indirect_two_rows_add_skipped(hid_t fapl, H5HF_create_
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve info about heap */
     num_first_indirect_rows = IBLOCK_MAX_DROWS(fh, 1);
@@ -9888,11 +9888,11 @@ test_man_fill_direct_skip_indirect_two_rows_add_skipped(hid_t fapl, H5HF_create_
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped blocks that are too small to hold the large object
@@ -9900,70 +9900,70 @@ test_man_fill_direct_skip_indirect_two_rows_add_skipped(hid_t fapl, H5HF_create_
     obj_size = (size_t)DBLOCK_SIZE(fh, max_dblock_rows - 2) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, max_dblock_rows - 1);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert an object to fill up the (biggest) heap block created */
     obj_size = (size_t)DBLOCK_FREE(fh, max_dblock_rows - 1) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows skipped over in indirect block's direct blocks */
     for (u = 0; u < num_first_indirect_rows; u++) {
         /* Direct block rows in first row of skipped 2nd level indirect blocks */
         for (v = 0; v < cparam->managed.width; v++)
             if (fill_row(fh, u, fill_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Direct block rows in second row of skipped 2nd level indirect blocks */
         for (v = 0; v < cparam->managed.width; v++)
             if (fill_row(fh, u, fill_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Direct block row in used 2nd level indirect block */
         if (fill_row(fh, u, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows in second row of skipped 2nd level indirect blocks (and used 2nd level block) */
 
     /* Direct block rows in skipped 2nd level indirect blocks */
     for (v = 0; v < cparam->managed.width; v++)
         if (fill_row(fh, num_first_indirect_rows, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Direct block row in used 2nd level indirect block */
     if (fill_row(fh, num_first_indirect_rows, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add one more object, to create another "large" block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, max_dblock_rows - 1);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -10033,11 +10033,11 @@ test_man_fill_direct_skip_indirect_two_rows_skip_indirect_row_add_skipped(hid_t 
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve info about heap */
     num_first_indirect_rows = IBLOCK_MAX_DROWS(fh, 1);
@@ -10045,11 +10045,11 @@ test_man_fill_direct_skip_indirect_two_rows_skip_indirect_row_add_skipped(hid_t 
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of two rows of indirect blocks and
      * range of skipped blocks that are too small to hold the large object
@@ -10057,20 +10057,20 @@ test_man_fill_direct_skip_indirect_two_rows_skip_indirect_row_add_skipped(hid_t 
     obj_size = (size_t)DBLOCK_SIZE(fh, max_dblock_rows - 2) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, max_dblock_rows - 1);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert an object to fill up the (biggest) heap block created */
     obj_size = (size_t)DBLOCK_FREE(fh, max_dblock_rows - 1) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object that can't fit in first row of indirect blocks
      * previously skipped, but is small enough to fit into second row of
@@ -10079,76 +10079,76 @@ test_man_fill_direct_skip_indirect_two_rows_skip_indirect_row_add_skipped(hid_t 
     obj_size = (size_t)DBLOCK_SIZE(fh, max_dblock_rows - 3) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, max_dblock_rows - 2);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert an object to fill up the (2nd biggest) heap block created */
     obj_size = (size_t)DBLOCK_FREE(fh, max_dblock_rows - 2) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows skipped over in indirect block's direct blocks */
     for (u = 0; u < num_first_indirect_rows; u++) {
         /* Direct block rows in first row of skipped 2nd level indirect blocks */
         for (v = 0; v < cparam->managed.width; v++)
             if (fill_row(fh, u, fill_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Direct block rows in second row of skipped 2nd level indirect blocks */
         for (v = 0; v < cparam->managed.width; v++)
             if (fill_row(fh, u, fill_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Direct block row in used 2nd level indirect block */
         if (fill_row(fh, u, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows in second row of skipped 2nd level indirect blocks (and used 2nd level block) */
 
     /* Finish blocks in partially used 2nd level indirect block */
     if (fill_partial_row(fh, num_first_indirect_rows, cparam->managed.width - 1, fill_size, &state,
                          &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Direct block rows in skipped 2nd level indirect blocks */
     /* (less the one indirect block already used) */
     for (v = 0; v < cparam->managed.width - 1; v++)
         if (fill_row(fh, num_first_indirect_rows, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Direct block row in used 3rd row 2nd level indirect block */
     if (fill_row(fh, num_first_indirect_rows, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add one more object, to create another "large" block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, max_dblock_rows - 1);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -10213,27 +10213,27 @@ test_man_fill_2nd_direct_skip_start_block_add_skipped(hid_t fapl, H5HF_create_t 
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped (indirect) blocks that are too small to hold the large
@@ -10242,42 +10242,42 @@ test_man_fill_2nd_direct_skip_start_block_add_skipped(hid_t fapl, H5HF_create_t 
     obj_size = (size_t)DBLOCK_SIZE(fh, 2) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, 3);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill space in (large) block created */
     obj_size = (size_t)DBLOCK_FREE(fh, 3) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows skipped over in 3rd level indirect block's direct blocks */
     if (fill_row(fh, 0, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
     if (fill_row(fh, 1, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
     if (fill_row(fh, 2, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add one more object, to create another "large" block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, 3);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -10345,35 +10345,35 @@ test_man_fill_2nd_direct_skip_2nd_indirect_start_block_add_skipped(hid_t fapl, H
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all direct block rows in third level indirect block */
     if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped (indirect) blocks that are too small to hold the large
@@ -10382,44 +10382,44 @@ test_man_fill_2nd_direct_skip_2nd_indirect_start_block_add_skipped(hid_t fapl, H
     obj_size = (size_t)DBLOCK_SIZE(fh, 2) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, 3);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill space in (large) block created */
     obj_size = (size_t)DBLOCK_FREE(fh, 3) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows skipped over in (3rd level indirect block's) 2nd level
      *  indirect block's direct blocks
      */
     if (fill_row(fh, 0, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
     if (fill_row(fh, 1, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
     if (fill_row(fh, 2, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add one more object, to create another "large" block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, 3);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -10489,38 +10489,38 @@ test_man_fill_2nd_direct_fill_direct_skip_3rd_indirect_start_block_add_skipped(h
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve info about heap */
     num_first_indirect_rows = IBLOCK_MAX_DROWS(fh, 1);
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all direct block rows in third level indirect block */
     if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped (indirect) blocks that are too small to hold the large
@@ -10529,20 +10529,20 @@ test_man_fill_2nd_direct_fill_direct_skip_3rd_indirect_start_block_add_skipped(h
     obj_size = (size_t)DBLOCK_SIZE(fh, num_first_indirect_rows - 1) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill space in (large) block created */
     obj_size = (size_t)DBLOCK_FREE(fh, num_first_indirect_rows) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows skipped over in (first 3rd level indirect block's) 2nd level
      *  indirect block's direct blocks
@@ -10552,26 +10552,26 @@ test_man_fill_2nd_direct_fill_direct_skip_3rd_indirect_start_block_add_skipped(h
         /* Direct block rows in 2nd level indirect blocks */
         for (v = 0; v < cparam->managed.width; v++)
             if (fill_row(fh, u, fill_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Direct block row in 3rd level indirect block */
         if (fill_row(fh, u, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add one more object, to create another "large" block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -10642,38 +10642,38 @@ test_man_fill_2nd_direct_fill_direct_skip2_3rd_indirect_start_block_add_skipped(
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve info about heap */
     num_first_indirect_rows = IBLOCK_MAX_DROWS(fh, 1);
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all direct block rows in third level indirect block */
     if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped (indirect) blocks that are too small to hold the large
@@ -10682,20 +10682,20 @@ test_man_fill_2nd_direct_fill_direct_skip2_3rd_indirect_start_block_add_skipped(
     obj_size = (size_t)DBLOCK_SIZE(fh, num_first_indirect_rows) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows + 1);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill space in (large) block created */
     obj_size = (size_t)DBLOCK_FREE(fh, num_first_indirect_rows + 1) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows skipped over in (first 3rd level indirect block's) 2nd level
      *  indirect block's direct blocks
@@ -10705,30 +10705,30 @@ test_man_fill_2nd_direct_fill_direct_skip2_3rd_indirect_start_block_add_skipped(
         /* Direct block rows in 2nd level indirect blocks */
         for (v = 0; v < cparam->managed.width; v++)
             if (fill_row(fh, u, fill_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Direct block row in 3rd level indirect block */
         if (fill_row(fh, u, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Fill row of direct blocks in second 3rd level indirect block */
     if (fill_row(fh, num_first_indirect_rows, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add one more object, to create another "large" block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows + 1);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -10800,48 +10800,48 @@ test_man_fill_3rd_direct_less_one_fill_direct_wrap_start_block_add_skipped(hid_t
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve info about heap */
     num_first_indirect_rows = IBLOCK_MAX_DROWS(fh, 1);
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks in root indirect block */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill first row (except one) of 3rd level indirect blocks */
     for (u = 0; u < cparam->managed.width - 1; u++)
         /* Fill 3rd level indirect block */
         if (fill_3rd_indirect(fh, 1, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all direct block rows in last third level indirect block */
     if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped (indirect) blocks that are too small to hold the large
@@ -10850,20 +10850,20 @@ test_man_fill_3rd_direct_less_one_fill_direct_wrap_start_block_add_skipped(hid_t
     obj_size = (size_t)DBLOCK_SIZE(fh, num_first_indirect_rows - 1) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill space in (large) block created */
     obj_size = (size_t)DBLOCK_FREE(fh, num_first_indirect_rows) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows skipped over in 2nd level indirect block's direct blocks
      * (and rows of next 3rd level indirect block's direct blocks)
@@ -10872,26 +10872,26 @@ test_man_fill_3rd_direct_less_one_fill_direct_wrap_start_block_add_skipped(hid_t
         /* Direct block rows in 2nd level indirect blocks */
         for (v = 0; v < cparam->managed.width; v++)
             if (fill_row(fh, u, fill_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Direct block row in current 3rd level indirect block */
         if (fill_row(fh, u, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add one more object, to create another "large" block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -10964,55 +10964,55 @@ test_man_fill_1st_row_3rd_direct_fill_2nd_direct_less_one_wrap_start_block_add_s
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve info about heap */
     num_first_indirect_rows = IBLOCK_MAX_DROWS(fh, 1);
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks in 4th level indirect block */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill first row of 3rd level indirect blocks */
     if (fill_3rd_indirect_row(fh, 1, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all direct block rows in 2nd row third level indirect block */
     if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill first row (except one) of 2nd level indirect blocks */
     for (u = 0; u < cparam->managed.width - 1; u++)
         if (fill_2nd_indirect(fh, 1, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped (indirect) blocks that are too small to hold the large
@@ -11021,20 +11021,20 @@ test_man_fill_1st_row_3rd_direct_fill_2nd_direct_less_one_wrap_start_block_add_s
     obj_size = (size_t)DBLOCK_SIZE(fh, num_first_indirect_rows - 1) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill space in (large) block created */
     obj_size = (size_t)DBLOCK_FREE(fh, num_first_indirect_rows) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows skipped over in 2nd level indirect block's direct blocks
      * (and rows of next 2nd level indirect block's direct blocks)
@@ -11042,26 +11042,26 @@ test_man_fill_1st_row_3rd_direct_fill_2nd_direct_less_one_wrap_start_block_add_s
     for (u = 0; u < num_first_indirect_rows; u++) {
         /* Direct block rows in skipped 2nd level indirect block */
         if (fill_row(fh, u, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Direct block row in current 2nd level indirect block */
         if (fill_row(fh, u, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add one more object, to create another "large" block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -11132,46 +11132,46 @@ test_man_fill_3rd_direct_fill_direct_skip_start_block_add_skipped(hid_t fapl, H5
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve info about heap */
     num_first_indirect_rows = IBLOCK_MAX_DROWS(fh, 1);
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 3rd level indirect blocks */
     if (fill_all_3rd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all direct block rows in fourth level indirect block */
     if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped (indirect) blocks that are too small to hold the large
@@ -11180,20 +11180,20 @@ test_man_fill_3rd_direct_fill_direct_skip_start_block_add_skipped(hid_t fapl, H5
     obj_size = (size_t)DBLOCK_SIZE(fh, num_first_indirect_rows - 1) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill space in (large) block created */
     obj_size = (size_t)DBLOCK_FREE(fh, num_first_indirect_rows) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows skipped over in (first 4th level indirect block's) 2nd level
      *  indirect block's direct blocks
@@ -11203,26 +11203,26 @@ test_man_fill_3rd_direct_fill_direct_skip_start_block_add_skipped(hid_t fapl, H5
         /* Direct block rows in 2nd level indirect blocks */
         for (v = 0; v < cparam->managed.width; v++)
             if (fill_row(fh, u, fill_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Direct block row in 2nd level indirect block */
         if (fill_row(fh, u, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add one more object, to create another "large" block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -11296,62 +11296,62 @@ test_man_fill_3rd_direct_fill_2nd_direct_fill_direct_skip_3rd_indirect_start_blo
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve info about heap */
     num_first_indirect_rows = IBLOCK_MAX_DROWS(fh, 1);
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 3rd level indirect blocks */
     if (fill_all_3rd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all direct block rows in fourth level indirect block */
     if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks in fourth level indirect block */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all direct block rows in fourth level indirect block's 3rd level indirect block */
     if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped (indirect) blocks that are too small to hold the large
@@ -11360,20 +11360,20 @@ test_man_fill_3rd_direct_fill_2nd_direct_fill_direct_skip_3rd_indirect_start_blo
     obj_size = (size_t)DBLOCK_SIZE(fh, num_first_indirect_rows - 1) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill space in (large) block created */
     obj_size = (size_t)DBLOCK_FREE(fh, num_first_indirect_rows) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows skipped over in (first 4th level indirect block's first 3rd
      *  level block's) 2nd level indirect block's direct blocks
@@ -11383,26 +11383,26 @@ test_man_fill_3rd_direct_fill_2nd_direct_fill_direct_skip_3rd_indirect_start_blo
         /* Direct block rows in 2nd level indirect blocks */
         for (v = 0; v < cparam->managed.width; v++)
             if (fill_row(fh, u, fill_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Direct block row in 3rd level indirect block */
         if (fill_row(fh, u, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add one more object, to create another "large" block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -11480,95 +11480,95 @@ test_man_fill_3rd_direct_fill_2nd_direct_fill_direct_skip_3rd_indirect_two_rows_
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve info about heap */
     num_first_indirect_rows = IBLOCK_MAX_DROWS(fh, 1);
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 3rd level indirect blocks */
     if (fill_all_3rd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill first row of 4th level indirect blocks */
     if (fill_4th_indirect_row(fh, 1, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
-        /* Account for root indirect block doubling # of rows again */
-        /* (From 16 rows to the max. # of rows: 22) */
-        /* (Note: this is tied to the particular doubling table/heap creation parameters) */
-        {
-            unsigned max_root_rows; /* Maximum # of rows in root indirect block */
-            unsigned row;           /* Row in heap */
+    /* Account for root indirect block doubling # of rows again */
+    /* (From 16 rows to the max. # of rows: 22) */
+    /* (Note: this is tied to the particular doubling table/heap creation parameters) */
+    {
+        unsigned max_root_rows; /* Maximum # of rows in root indirect block */
+        unsigned row;           /* Row in heap */
 
-            /* Get some information for the heap */
-            max_root_rows = HEAP_MAX_ROOT_ROWS(fh);
+        /* Get some information for the heap */
+        max_root_rows = HEAP_MAX_ROOT_ROWS(fh);
 
-            /* Increase heap size & free space */
-            for (row = 16; row < max_root_rows; row++) {
-                state.man_size += cparam->managed.width * DBLOCK_SIZE(fh, row);
-                state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, row);
-            } /* end for */
-        }     /* end if */
+        /* Increase heap size & free space */
+        for (row = 16; row < max_root_rows; row++) {
+            state.man_size += cparam->managed.width * DBLOCK_SIZE(fh, row);
+            state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, row);
+        } /* end for */
+    }     /* end if */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all direct block rows in 2nd row 4th level indirect block */
     if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks in 2nd row 4th level indirect block */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill first row of 3rd level indirect blocks in 2nd row 4th level indirect block */
     if (fill_3rd_indirect_row(fh, 1, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all direct block rows in 4th level indirect block's 2nd row of 3rd level indirect block */
     if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped (indirect) blocks that are too small to hold the large
@@ -11577,20 +11577,20 @@ test_man_fill_3rd_direct_fill_2nd_direct_fill_direct_skip_3rd_indirect_two_rows_
     obj_size = (size_t)DBLOCK_SIZE(fh, num_first_indirect_rows - 1) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill space in (large) block created */
     obj_size = (size_t)DBLOCK_FREE(fh, num_first_indirect_rows) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows skipped over in (first block in 2nd row  4th level indirect
      *  block's first 3rd level block's) 2nd level indirect block's direct
@@ -11600,26 +11600,26 @@ test_man_fill_3rd_direct_fill_2nd_direct_fill_direct_skip_3rd_indirect_two_rows_
         /* Direct block rows in 2nd level indirect blocks */
         for (v = 0; v < cparam->managed.width; v++)
             if (fill_row(fh, u, fill_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Direct block row in 3rd level indirect block */
         if (fill_row(fh, u, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add one more object, to create another "large" block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -11699,77 +11699,77 @@ test_man_fill_3rd_direct_fill_2nd_direct_fill_direct_skip_3rd_indirect_wrap_star
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve info about heap */
     num_first_indirect_rows = IBLOCK_MAX_DROWS(fh, 1);
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 3rd level indirect blocks */
     if (fill_all_3rd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all direct block rows in 4th level indirect block */
     if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks in 4th level indirect block */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill first row (except one) of 3rd level indirect blocks in 4th level indirect block */
     for (u = 0; u < cparam->managed.width - 1; u++) {
         /* Fill all direct block rows in 3rd level indirect block */
         if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Fill row of 2nd level indirect blocks in 3rd level indirect block */
         if (fill_2nd_indirect_row(fh, 1, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all direct block rows in 4th level indirect block's last 3rd level indirect block */
     if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped (indirect) blocks that are too small to hold the large
@@ -11778,20 +11778,20 @@ test_man_fill_3rd_direct_fill_2nd_direct_fill_direct_skip_3rd_indirect_wrap_star
     obj_size = (size_t)DBLOCK_SIZE(fh, num_first_indirect_rows - 1) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill space in (large) block created */
     obj_size = (size_t)DBLOCK_FREE(fh, num_first_indirect_rows) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows skipped over in (4th level indirect block's first 3rd level
      * block's) 2nd level indirect block's direct blocks (and rows of next 4th
@@ -11801,26 +11801,26 @@ test_man_fill_3rd_direct_fill_2nd_direct_fill_direct_skip_3rd_indirect_wrap_star
         /* Direct block rows in 2nd level indirect blocks */
         for (v = 0; v < cparam->managed.width; v++)
             if (fill_row(fh, u, fill_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Direct block row in 4th level indirect block */
         if (fill_row(fh, u, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add one more object, to create another "large" block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -11900,113 +11900,113 @@ test_man_fill_4th_direct_less_one_fill_2nd_direct_fill_direct_skip_3rd_indirect_
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve info about heap */
     num_first_indirect_rows = IBLOCK_MAX_DROWS(fh, 1);
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 3rd level indirect blocks */
     if (fill_all_3rd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill first row (except one) of 4th level indirect blocks */
     for (u = 0; u < cparam->managed.width - 1; u++) {
         /* Fill all direct block rows in 4th level indirect block */
         if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Fill all rows of 2nd level indirect blocks in 4th level indirect block */
         if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Fill row of 3rd level indirect blocks in 4th level indirect block */
         if (fill_3rd_indirect_row(fh, 1, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all direct block rows in 4th level indirect block */
     if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks in 4th level indirect block */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill row (except one) of 3rd level indirect blocks in 4th level indirect block */
     for (u = 0; u < cparam->managed.width - 1; u++) {
         /* Fill all direct block rows in 3rd level indirect block */
         if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Fill row of 2nd level indirect blocks in 3rd level indirect block */
         if (fill_2nd_indirect_row(fh, 1, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all direct block rows in 4th level indirect block's last 3rd level indirect block */
     if (fill_all_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
-        /* Account for root indirect block doubling # of rows again */
-        /* (From 16 rows to the max. # of rows: 22) */
-        /* (Note: this is tied to the particular doubling table/heap creation parameters) */
-        {
-            unsigned max_root_rows; /* Maximum # of rows in root indirect block */
-            unsigned row;           /* Row in heap */
+    /* Account for root indirect block doubling # of rows again */
+    /* (From 16 rows to the max. # of rows: 22) */
+    /* (Note: this is tied to the particular doubling table/heap creation parameters) */
+    {
+        unsigned max_root_rows; /* Maximum # of rows in root indirect block */
+        unsigned row;           /* Row in heap */
 
-            /* Get some information for the heap */
-            max_root_rows = HEAP_MAX_ROOT_ROWS(fh);
+        /* Get some information for the heap */
+        max_root_rows = HEAP_MAX_ROOT_ROWS(fh);
 
-            /* Increase heap size & free space */
-            for (row = 16; row < max_root_rows; row++) {
-                state.man_size += cparam->managed.width * DBLOCK_SIZE(fh, row);
-                state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, row);
-            } /* end for */
-        }     /* end if */
+        /* Increase heap size & free space */
+        for (row = 16; row < max_root_rows; row++) {
+            state.man_size += cparam->managed.width * DBLOCK_SIZE(fh, row);
+            state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, row);
+        } /* end for */
+    }     /* end if */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert large object, to force creation of indirect block and
      * range of skipped (indirect) blocks that are too small to hold the large
@@ -12015,20 +12015,20 @@ test_man_fill_4th_direct_less_one_fill_2nd_direct_fill_direct_skip_3rd_indirect_
     obj_size = (size_t)DBLOCK_SIZE(fh, num_first_indirect_rows - 1) + 1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object to fill space in (large) block created */
     obj_size = (size_t)DBLOCK_FREE(fh, num_first_indirect_rows) - obj_size;
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill rows skipped over in (4th level indirect block's first 3rd level
      * block's) 2nd level indirect block's direct blocks (and rows of next 4th
@@ -12038,26 +12038,26 @@ test_man_fill_4th_direct_less_one_fill_2nd_direct_fill_direct_skip_3rd_indirect_
         /* Direct block rows in 2nd level indirect blocks */
         for (v = 0; v < cparam->managed.width; v++)
             if (fill_row(fh, u, fill_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Direct block row in 4th level indirect block */
         if (fill_row(fh, u, fill_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add one more object, to create another "large" block */
     obj_size = SMALL_OBJ_SIZE1;
     state.man_alloc_size += DBLOCK_SIZE(fh, num_first_indirect_rows);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -12121,11 +12121,11 @@ test_man_frag_simple(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert objects small enough to fit into initial blocks, but not to
      * share them with other objects of the same size, until the next larger
@@ -12137,7 +12137,7 @@ test_man_frag_simple(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     for (u = 0; u < cparam->managed.width; u++) {
         state.man_alloc_size += DBLOCK_SIZE(fh, 0);
         if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
         if (u == 0) {
             state.man_size = cparam->managed.width * DBLOCK_SIZE(fh, 0);
             state.man_free_space += (cparam->managed.width - 1) * DBLOCK_FREE(fh, 0);
@@ -12148,12 +12148,12 @@ test_man_frag_simple(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     for (u = 0; u < cparam->managed.width; u++) {
         state.man_alloc_size += DBLOCK_SIZE(fh, 1);
         if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* (Account for doubling root indirect block for rows 3-4 */
     for (u = 0; u < 2; u++) {
@@ -12164,33 +12164,33 @@ test_man_frag_simple(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     /* Add one more object, to create a 2 * start_block_size block */
     state.man_alloc_size += DBLOCK_SIZE(fh, 2);
     if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Go back and fill in direct blocks of initial block size (which have large free space in them) */
     obj_size = (size_t)DBLOCK_FREE(fh, 0) - obj_size;
     for (u = 0; u < cparam->managed.width; u++)
         if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     for (u = 0; u < cparam->managed.width; u++)
         if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill in 2 * start_block_size block */
     obj_size = (size_t)DBLOCK_FREE(fh, 2) - ((size_t)DBLOCK_SIZE(fh, 0) / 2);
     if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -12253,11 +12253,11 @@ test_man_frag_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve # of direct rows in root indirect block */
     root_direct_rows = H5HF_get_dtable_max_drows_test(fh);
@@ -12272,7 +12272,7 @@ test_man_frag_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     for (u = 0; u < cparam->managed.width; u++) {
         state.man_alloc_size += DBLOCK_SIZE(fh, 0);
         if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
         if (u == 0) {
             state.man_size = cparam->managed.width * DBLOCK_SIZE(fh, 0);
             state.man_free_space += (cparam->managed.width - 1) * DBLOCK_FREE(fh, 0);
@@ -12284,12 +12284,12 @@ test_man_frag_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     for (u = 0; u < cparam->managed.width; u++) {
         state.man_alloc_size += DBLOCK_SIZE(fh, 1);
         if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* (Account for doubling root indirect block for rows 3-4 */
     for (u = 0; u < 2; u++) {
@@ -12303,13 +12303,13 @@ test_man_frag_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
         for (v = 0; v < cparam->managed.width; v++) {
             state.man_alloc_size += DBLOCK_SIZE(fh, u + 2);
             if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
     }     /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* (Account for doubling root indirect block for rows 5-8 */
     for (u = 0; u < 4; u++) {
@@ -12323,13 +12323,13 @@ test_man_frag_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
         for (v = 0; v < cparam->managed.width; v++) {
             state.man_alloc_size += DBLOCK_SIZE(fh, u + 4);
             if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
     }     /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* (Account for doubling root indirect block for rows 9-16 */
     for (u = 0; u < 8; u++) {
@@ -12342,24 +12342,24 @@ test_man_frag_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     for (v = 0; v < cparam->managed.width; v++) {
         state.man_alloc_size += DBLOCK_SIZE(fh, 8);
         if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Go back and backfill all root block's direct blocks */
     for (u = 0; u < root_direct_rows; u++) {
         obj_size = (size_t)DBLOCK_FREE(fh, u) - ((size_t)DBLOCK_SIZE(fh, u) / 2);
         for (v = 0; v < cparam->managed.width; v++)
             if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
     } /* end for */
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -12427,22 +12427,22 @@ test_man_frag_2nd_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compute # of bits used in first row */
     num_first_indirect_rows = IBLOCK_MAX_DROWS(fh, 1);
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert objects small enough to fit into each direct block, but not to
      * share them with other objects of the same size.
@@ -12452,25 +12452,25 @@ test_man_frag_2nd_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *
         for (v = 0; v < cparam->managed.width; v++) {
             state.man_alloc_size += DBLOCK_SIZE(fh, u);
             if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
     }     /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Go back and backfill all 2nd level indirect block's direct blocks */
     for (u = 0; u < num_first_indirect_rows; u++) {
         obj_size = (size_t)DBLOCK_FREE(fh, u) - ((size_t)DBLOCK_SIZE(fh, u) / 2);
         for (v = 0; v < cparam->managed.width; v++)
             if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
     } /* end for */
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -12539,30 +12539,30 @@ test_man_frag_3rd_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, &fill_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compute # of direct rows in root indirect block */
     root_direct_rows = DTABLE_MAX_DROWS(fh);
 
     /* Fill direct blocks in root indirect block */
     if (fill_root_direct(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fill all rows of 2nd level indirect blocks in root indirect block */
     if (fill_all_2nd_indirect_rows(fh, fill_size, &state, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert objects small enough to fit into each direct block, but not to
      * share them with other objects of the same size.
@@ -12572,25 +12572,25 @@ test_man_frag_3rd_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *
         for (v = 0; v < cparam->managed.width; v++) {
             state.man_alloc_size += DBLOCK_SIZE(fh, u);
             if (add_obj(fh, (size_t)10, obj_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
     }     /* end for */
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Go back and backfill all 3rd level indirect block's direct blocks */
     for (u = 0; u < root_direct_rows; u++) {
         obj_size = (size_t)DBLOCK_FREE(fh, u) - ((size_t)DBLOCK_SIZE(fh, u) / 2);
         for (v = 0; v < cparam->managed.width; v++)
             if (add_obj(fh, (size_t)20, obj_size, &state, &keep_ids))
-                TEST_ERROR
+                TEST_ERROR;
     } /* end for */
 
     /* Perform common file & heap close operations */
     if (close_heap(filename, fapl, tparam, file, f, &fh, fh_addr, &state, &keep_ids, empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -12653,92 +12653,92 @@ test_huge_insert_one(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate heap ID(s) */
     if (NULL == (heap_id = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that 'huge' object's heap IDs are correct size */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len != tparam->actual_id_len)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object too large for managed heap blocks */
     obj_size = SMALL_STAND_SIZE + 1;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_HUGE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.huge_size  = obj_size;
     state.huge_nobjs = 1;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in huge object */
     if (H5HF_get_obj_len(fh, heap_id, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
     if (tparam->del_dir != FHEAP_DEL_HEAP) {
         /* Remove object from heap */
         if (H5HF_remove(fh, heap_id) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check up on heap... */
         state.huge_size  = 0;
         state.huge_nobjs = 0;
         if (check_stats(fh, &state))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Check for deleting the entire heap */
     if (tparam->del_dir == FHEAP_DEL_HEAP) {
         /* Delete heap */
         if (H5HF_delete(f, fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(heap_id);
@@ -12804,169 +12804,169 @@ test_huge_insert_two(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate heap ID(s) */
     if (NULL == (heap_id = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (heap_id2 = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that 'huge' object's heap IDs are correct size */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len != tparam->actual_id_len)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object too large for managed heap blocks */
     obj_size = SMALL_STAND_SIZE + 1;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_HUGE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.huge_size  = obj_size;
     state.huge_nobjs = 1;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in huge object */
     if (H5HF_get_obj_len(fh, heap_id, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert second object too large for managed heap blocks */
     obj_size = SMALL_STAND_SIZE + 1;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id2, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_HUGE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.huge_size += obj_size;
     state.huge_nobjs = 2;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in second huge object */
     if (H5HF_get_obj_len(fh, heap_id2, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id2, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
     if (tparam->del_dir != FHEAP_DEL_HEAP) {
         if (tparam->del_dir == FHEAP_DEL_FORWARD) {
             /* Remove first object from heap */
             if (H5HF_remove(fh, heap_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size  = obj_size;
             state.huge_nobjs = 1;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove second object from heap */
             if (H5HF_remove(fh, heap_id2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size  = 0;
             state.huge_nobjs = 0;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
         else {
             /* Remove second object from heap */
             if (H5HF_remove(fh, heap_id2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size  = obj_size;
             state.huge_nobjs = 1;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove first object from heap */
             if (H5HF_remove(fh, heap_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size  = 0;
             state.huge_nobjs = 0;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end else */
     }     /* end if */
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Check for deleting the entire heap */
     if (tparam->del_dir == FHEAP_DEL_HEAP) {
         /* Delete heap */
         if (H5HF_delete(f, fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(heap_id);
@@ -13035,241 +13035,241 @@ test_huge_insert_three(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tp
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate heap ID(s) */
     if (NULL == (heap_id = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (heap_id2 = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (heap_id3 = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that 'huge' object's heap IDs are correct size */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len != tparam->actual_id_len)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert first object too large for managed heap blocks */
     obj_size = SMALL_STAND_SIZE + 1;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_HUGE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.huge_size  = obj_size;
     state.huge_nobjs = 1;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in first huge object */
     if (H5HF_get_obj_len(fh, heap_id, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert second object too large for managed heap blocks */
     obj_size = SMALL_STAND_SIZE + 2;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id2, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_HUGE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.huge_size += obj_size;
     state.huge_nobjs = 2;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in second huge object */
     if (H5HF_get_obj_len(fh, heap_id2, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id2, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert third object too large for managed heap blocks */
     obj_size = SMALL_STAND_SIZE + 3;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id3, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_HUGE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.huge_size += obj_size;
     state.huge_nobjs = 3;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in third huge object */
     if (H5HF_get_obj_len(fh, heap_id3, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id3, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
     if (tparam->del_dir != FHEAP_DEL_HEAP) {
         if (tparam->del_dir == FHEAP_DEL_FORWARD) {
             /* Remove first object from heap */
             if (H5HF_get_obj_len(fh, heap_id, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size -= robj_size;
             state.huge_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove second object from heap */
             if (H5HF_get_obj_len(fh, heap_id2, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size -= robj_size;
             state.huge_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove third object from heap */
             if (H5HF_get_obj_len(fh, heap_id3, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id3) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size -= robj_size;
             state.huge_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
         else {
             /* Remove third object from heap */
             if (H5HF_get_obj_len(fh, heap_id3, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id3) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size -= robj_size;
             state.huge_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove second object from heap */
             if (H5HF_get_obj_len(fh, heap_id2, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size -= robj_size;
             state.huge_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove first object from heap */
             if (H5HF_get_obj_len(fh, heap_id, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size -= robj_size;
             state.huge_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end else */
     }     /* end if */
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Check for deleting the entire heap */
     if (tparam->del_dir == FHEAP_DEL_HEAP) {
         /* Delete heap */
         if (H5HF_delete(f, fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(heap_id);
@@ -13342,132 +13342,132 @@ test_huge_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate heap ID(s) */
     if (NULL == (heap_id = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (heap_id2 = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (heap_id3 = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (heap_id4 = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (heap_id5 = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that 'huge' object's heap IDs are correct size */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len != tparam->actual_id_len)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert first object too large for managed heap blocks */
     obj_size = SMALL_STAND_SIZE + 1;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_HUGE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.huge_size += obj_size;
     state.huge_nobjs++;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in first huge object */
     if (H5HF_get_obj_len(fh, heap_id, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert second object too large for managed heap blocks */
     obj_size = SMALL_STAND_SIZE + 2;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id2, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_HUGE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.huge_size += obj_size;
     state.huge_nobjs++;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in second huge object */
     if (H5HF_get_obj_len(fh, heap_id2, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id2, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert third object too large for managed heap blocks */
     obj_size = SMALL_STAND_SIZE + 3;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id3, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_HUGE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.huge_size += obj_size;
     state.huge_nobjs++;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in third huge object */
     if (H5HF_get_obj_len(fh, heap_id3, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id3, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert fourth object small enough to fit into 'normal' heap blocks */
     obj_size = (size_t)DBLOCK_SIZE(fh, 0) + 1;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id4, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_MAN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.man_size = cparam->managed.width * DBLOCK_SIZE(fh, 0);
@@ -13480,31 +13480,31 @@ test_huge_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     state.man_free_space += (cparam->managed.width - 1) * DBLOCK_FREE(fh, 2);
     state.man_nobjs++;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in fourth ('normal') object */
     if (H5HF_get_obj_len(fh, heap_id4, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id4, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert fifth object small enough to fit into 'normal' heap blocks */
     obj_size = (size_t)DBLOCK_SIZE(fh, 3) + 1;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id5) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id5, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_MAN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     /* (account for doubling of root indirect block) */
@@ -13518,102 +13518,102 @@ test_huge_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 5);
     state.man_nobjs++;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in fifth ('normal') object */
     if (H5HF_get_obj_len(fh, heap_id5, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id5, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
     if (tparam->del_dir != FHEAP_DEL_HEAP) {
         if (tparam->del_dir == FHEAP_DEL_FORWARD) {
             /* Remove first object from heap */
             if (H5HF_get_obj_len(fh, heap_id, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size -= robj_size;
             state.huge_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove second object from heap */
             if (H5HF_get_obj_len(fh, heap_id2, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size -= robj_size;
             state.huge_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove third object from heap */
             if (H5HF_get_obj_len(fh, heap_id3, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id3) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size -= robj_size;
             state.huge_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove fourth ('normal') object from heap */
             if (H5HF_remove(fh, heap_id4) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove fifth ('normal') object from heap */
             if (H5HF_remove(fh, heap_id5) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
         else {
             /* Remove fifth ('normal') object from heap */
             if (H5HF_remove(fh, heap_id5) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove fourth ('normal') object from heap */
             if (H5HF_remove(fh, heap_id4) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Reset 'managed' object statistics after they are all removed  */
             state.man_nobjs      = 0;
@@ -13623,74 +13623,74 @@ test_huge_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
 
             /* Remove third object from heap */
             if (H5HF_get_obj_len(fh, heap_id3, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id3) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size -= robj_size;
             state.huge_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove second object from heap */
             if (H5HF_get_obj_len(fh, heap_id2, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size -= robj_size;
             state.huge_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove first object from heap */
             if (H5HF_remove(fh, heap_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end else */
 
         /* Check up on heap... */
         HDmemset(&state, 0, sizeof(fheap_heap_state_t));
         if (check_stats(fh, &state))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Check for deleting the entire heap */
     if (tparam->del_dir == FHEAP_DEL_HEAP) {
         /* Delete heap */
         if (H5HF_delete(f, fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(heap_id);
@@ -13770,7 +13770,7 @@ test_filtered_huge(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam
     /* Set an I/O filter for heap data */
     deflate_level = 6;
     if (H5Z_append(&tmp_cparam.pline, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, (size_t)1, &deflate_level) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     pline_init = TRUE;
 
     /* Adjust actual ID length, if asking for IDs that can directly access 'huge' objects */
@@ -13782,133 +13782,133 @@ test_filtered_huge(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, &tmp_cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate heap ID(s) */
     if (NULL == (heap_id = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that 'huge' object's heap IDs are correct form */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len != tparam->actual_id_len)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5HF_get_huge_info_test(fh, NULL, &huge_ids_direct) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (cparam->id_len == 1) {
         if (huge_ids_direct != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else if (tparam->actual_id_len >= 29) {
         if (huge_ids_direct != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else {
         if (huge_ids_direct != FALSE)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end else */
 
     /* Insert object too large for managed heap blocks */
     obj_size = SMALL_STAND_SIZE + 1;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_HUGE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #ifdef QAK
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Re-open the heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 #endif /* QAK */
 
     /* Check up on heap... */
     state.huge_size  = obj_size;
     state.huge_nobjs = 1;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in huge object */
     if (H5HF_get_obj_len(fh, heap_id, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
     if (tparam->del_dir != FHEAP_DEL_HEAP) {
         /* Remove object from heap */
         if (H5HF_remove(fh, heap_id) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check up on heap... */
         state.huge_size  = 0;
         state.huge_nobjs = 0;
         if (check_stats(fh, &state))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Check for deleting the entire heap */
     if (tparam->del_dir == FHEAP_DEL_HEAP) {
         /* Delete heap */
         if (H5HF_delete(f, fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reset actual ID length, if asking for IDs that can directly access 'huge' objects */
     if (cparam->id_len == 1)
@@ -13974,92 +13974,92 @@ test_tiny_insert_one(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate heap ID(s) */
     if (NULL == (heap_id = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that 'tiny' object's heap IDs are correct size */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len != tparam->actual_id_len)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object small enough to encode in heap ID */
     obj_size = tparam->actual_id_len - 2;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_TINY)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.tiny_size  = obj_size;
     state.tiny_nobjs = 1;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in tiny object */
     if (H5HF_get_obj_len(fh, heap_id, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
     if (tparam->del_dir != FHEAP_DEL_HEAP) {
         /* Remove object from heap */
         if (H5HF_remove(fh, heap_id) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check up on heap... */
         state.tiny_size  = 0;
         state.tiny_nobjs = 0;
         if (check_stats(fh, &state))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Check for deleting the entire heap */
     if (tparam->del_dir == FHEAP_DEL_HEAP) {
         /* Delete heap */
         if (H5HF_delete(f, fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(heap_id);
@@ -14125,169 +14125,169 @@ test_tiny_insert_two(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate heap ID(s) */
     if (NULL == (heap_id = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (heap_id2 = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that 'tiny' object's heap IDs are correct size */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len != tparam->actual_id_len)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object small enough to encode in heap ID */
     obj_size = tparam->actual_id_len - 2;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_TINY)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.tiny_size  = obj_size;
     state.tiny_nobjs = 1;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in tiny object */
     if (H5HF_get_obj_len(fh, heap_id, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert second object small enough to encode in heap ID */
     obj_size = tparam->actual_id_len - 2;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id2, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_TINY)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.tiny_size += obj_size;
     state.tiny_nobjs = 2;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in second tiny object */
     if (H5HF_get_obj_len(fh, heap_id2, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id2, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
     if (tparam->del_dir != FHEAP_DEL_HEAP) {
         if (tparam->del_dir == FHEAP_DEL_FORWARD) {
             /* Remove first object from heap */
             if (H5HF_remove(fh, heap_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.tiny_size  = obj_size;
             state.tiny_nobjs = 1;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove second object from heap */
             if (H5HF_remove(fh, heap_id2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.tiny_size  = 0;
             state.tiny_nobjs = 0;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
         else {
             /* Remove second object from heap */
             if (H5HF_remove(fh, heap_id2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.tiny_size  = obj_size;
             state.tiny_nobjs = 1;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove first object from heap */
             if (H5HF_remove(fh, heap_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.tiny_size  = 0;
             state.tiny_nobjs = 0;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end else */
     }     /* end if */
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Check for deleting the entire heap */
     if (tparam->del_dir == FHEAP_DEL_HEAP) {
         /* Delete heap */
         if (H5HF_delete(f, fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(heap_id);
@@ -14361,157 +14361,157 @@ test_tiny_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate heap ID(s) */
     if (NULL == (heap_id = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (heap_id2 = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (heap_id3 = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (heap_id4 = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (heap_id5 = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (heap_id6 = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (heap_id7 = (unsigned char *)H5MM_malloc(tparam->actual_id_len)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that 'tiny' object's heap IDs are correct size */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len != tparam->actual_id_len)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert first object too large for managed heap blocks */
     obj_size = SMALL_STAND_SIZE + 1;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_HUGE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.huge_size += obj_size;
     state.huge_nobjs++;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in first huge object */
     if (H5HF_get_obj_len(fh, heap_id, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check 'op' functionality on first huge object */
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_op(fh, heap_id, op_memcpy, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert second object too large for managed heap blocks */
     obj_size = SMALL_STAND_SIZE + 2;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id2, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_HUGE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.huge_size += obj_size;
     state.huge_nobjs++;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in second huge object */
     if (H5HF_get_obj_len(fh, heap_id2, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id2, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check 'op' functionality on second huge object */
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_op(fh, heap_id2, op_memcpy, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert third object too large for managed heap blocks */
     obj_size = SMALL_STAND_SIZE + 3;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id3, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_HUGE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.huge_size += obj_size;
     state.huge_nobjs++;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in third huge object */
     if (H5HF_get_obj_len(fh, heap_id3, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id3, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check 'op' functionality on third huge object */
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_op(fh, heap_id3, op_memcpy, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert fourth object small enough to fit into 'normal' heap blocks */
     obj_size = (size_t)DBLOCK_SIZE(fh, 0) + 1;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id4, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_MAN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.man_size = cparam->managed.width * DBLOCK_SIZE(fh, 0);
@@ -14524,38 +14524,38 @@ test_tiny_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     state.man_free_space += (cparam->managed.width - 1) * DBLOCK_FREE(fh, 2);
     state.man_nobjs++;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in fourth ('normal') object */
     if (H5HF_get_obj_len(fh, heap_id4, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id4, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check 'op' functionality on fourth ('normal') object */
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_op(fh, heap_id4, op_memcpy, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert fifth object small enough to fit into 'normal' heap blocks */
     obj_size = (size_t)DBLOCK_SIZE(fh, 3) + 1;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id5) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id5, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_MAN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     /* (account for doubling of root indirect block) */
@@ -14569,166 +14569,166 @@ test_tiny_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
     state.man_free_space += cparam->managed.width * DBLOCK_FREE(fh, 5);
     state.man_nobjs++;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in fifth ('normal') object */
     if (H5HF_get_obj_len(fh, heap_id5, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id5, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check 'op' functionality on fifth ('normal') object */
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_op(fh, heap_id5, op_memcpy, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert sixth object small enough to encode in heap ID */
     obj_size = tparam->actual_id_len - 2;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id6) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id6, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_TINY)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.tiny_size  = obj_size;
     state.tiny_nobjs = 1;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in tiny object */
     if (H5HF_get_obj_len(fh, heap_id6, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id6, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check 'op' functionality on sixth ('tiny') object */
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_op(fh, heap_id6, op_memcpy, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert seventh object small enough to encode in heap ID */
     obj_size = tparam->actual_id_len - 2;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id7) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id7, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_TINY)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check up on heap... */
     state.tiny_size += obj_size;
     state.tiny_nobjs++;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in tiny object */
     if (H5HF_get_obj_len(fh, heap_id7, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id7, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check 'op' functionality on seventh ('tiny') object */
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_op(fh, heap_id7, op_memcpy, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
     if (tparam->del_dir != FHEAP_DEL_HEAP) {
         if (tparam->del_dir == FHEAP_DEL_FORWARD) {
             /* Remove first object from heap */
             if (H5HF_get_obj_len(fh, heap_id, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size -= robj_size;
             state.huge_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove second object from heap */
             if (H5HF_get_obj_len(fh, heap_id2, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size -= robj_size;
             state.huge_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove third object from heap */
             if (H5HF_get_obj_len(fh, heap_id3, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id3) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size -= robj_size;
             state.huge_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove fourth ('normal') object from heap */
             if (H5HF_remove(fh, heap_id4) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove fifth ('normal') object from heap */
             if (H5HF_remove(fh, heap_id5) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Reset 'managed' object statistics after they are all removed  */
             state.man_nobjs      = 0;
@@ -14738,76 +14738,76 @@ test_tiny_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
 
             /* Remove sixth object from heap */
             if (H5HF_get_obj_len(fh, heap_id6, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id6) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.tiny_size -= robj_size;
             state.tiny_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove seventh object from heap */
             if (H5HF_remove(fh, heap_id7) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
         else {
             /* Remove seventh object from heap */
             if (H5HF_get_obj_len(fh, heap_id7, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id7) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.tiny_size -= robj_size;
             state.tiny_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove sixth object from heap */
             if (H5HF_get_obj_len(fh, heap_id6, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id6) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.tiny_size -= robj_size;
             state.tiny_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove fifth ('normal') object from heap */
             if (H5HF_remove(fh, heap_id5) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove fourth ('normal') object from heap */
             if (H5HF_remove(fh, heap_id4) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Reset 'managed' object statistics after they are all removed  */
             state.man_nobjs      = 0;
@@ -14817,74 +14817,74 @@ test_tiny_insert_mix(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpar
 
             /* Remove third object from heap */
             if (H5HF_get_obj_len(fh, heap_id3, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id3) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size -= robj_size;
             state.huge_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove second object from heap */
             if (H5HF_get_obj_len(fh, heap_id2, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check up on heap... */
             state.huge_size -= robj_size;
             state.huge_nobjs--;
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Remove first object from heap */
             if (H5HF_remove(fh, heap_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end else */
 
         /* Check up on heap... */
         HDmemset(&state, 0, sizeof(fheap_heap_state_t));
         if (check_stats(fh, &state))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Check for deleting the entire heap */
     if (tparam->del_dir == FHEAP_DEL_HEAP) {
         /* Delete heap */
         if (H5HF_delete(f, fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     H5MM_xfree(heap_id);
@@ -14966,53 +14966,53 @@ test_filtered_man_root_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_para
     /* Set an I/O filter for heap data */
     deflate_level = 6;
     if (H5Z_append(&tmp_cparam.pline, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, (size_t)1, &deflate_level) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, &tmp_cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object small enough to fit into direct heap block */
     obj_size = (size_t)DBLOCK_SIZE(fh, 0) / 2;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_MAN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check up on heap... */
     state.man_size       = DBLOCK_SIZE(fh, 0);
@@ -15020,62 +15020,62 @@ test_filtered_man_root_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_para
     state.man_free_space = DBLOCK_FREE(fh, 0) - obj_size;
     state.man_nobjs++;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in ('normal') object */
     if (H5HF_get_obj_len(fh, heap_id, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
     if (tparam->del_dir != FHEAP_DEL_HEAP) {
         /* Remove object from heap */
         if (H5HF_get_obj_len(fh, heap_id, &robj_size) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5HF_remove(fh, heap_id) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check up on heap... */
         HDmemset(&state, 0, sizeof(fheap_heap_state_t));
         if (check_stats(fh, &state))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Check for deleting the entire heap */
     if (tparam->del_dir == FHEAP_DEL_HEAP) {
         /* Delete heap */
         if (H5HF_delete(f, fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
 /* Needs file free space to be persistent */
 #ifdef NOT_YET
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 #endif /* NOT_YET */
 
     /* Free resources */
@@ -15140,62 +15140,62 @@ test_filtered_man_root_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_test_pa
     /* Set an I/O filter for heap data */
     deflate_level = 6;
     if (H5Z_append(&tmp_cparam.pline, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, (size_t)1, &deflate_level) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, &tmp_cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Perform common test initialization operations */
     if (begin_test(tparam, base_desc, &keep_ids, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object #1, small enough to fit into direct heap block */
     obj_size = (size_t)DBLOCK_SIZE(fh, 0) / 2;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id1, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_MAN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for closing & re-opening the heap */
     if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert object #2, small enough to fit into direct heap block */
     obj_size = (size_t)DBLOCK_SIZE(fh, 0) / 2;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, heap_id2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5HF_get_id_type_test(heap_id2, &obj_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5HF_ID_TYPE_MAN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check up on heap... */
     state.man_size       = cparam->managed.width * DBLOCK_SIZE(fh, 0);
@@ -15203,205 +15203,205 @@ test_filtered_man_root_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_test_pa
     state.man_free_space = (cparam->managed.width * DBLOCK_FREE(fh, 0)) - (obj_size * 2);
     state.man_nobjs += 2;
     if (check_stats(fh, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in ('normal') object #1 */
     if (H5HF_get_obj_len(fh, heap_id1, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id1, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read in ('normal') object #2 */
     if (H5HF_get_obj_len(fh, heap_id2, &robj_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_size != robj_size)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(shared_robj_g, 0, obj_size);
     if (H5HF_read(fh, heap_id2, shared_robj_g) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(shared_wobj_g, shared_robj_g, obj_size) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete individual objects, if we won't be deleting the entire heap later */
     if (tparam->del_dir != FHEAP_DEL_HEAP) {
         if (tparam->del_dir == FHEAP_DEL_FORWARD) {
             /* Remove object #1 from heap */
             if (H5HF_get_obj_len(fh, heap_id1, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id1) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Close the fractal heap */
             if (H5HF_close(fh) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             fh = NULL;
 
             /* Close the file */
             if (H5Fclose(file) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Re-open the file */
             if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Get a pointer to the internal file object */
             if (NULL == (f = (H5F_t *)H5VL_object(file)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Ignore metadata tags in the file's cache */
             if (H5AC_ignore_tags(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Re-open the heap */
             if (NULL == (fh = H5HF_open(f, fh_addr)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Remove object #2 from heap */
             if (H5HF_get_obj_len(fh, heap_id2, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check up on heap... */
             HDmemset(&state, 0, sizeof(fheap_heap_state_t));
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close the fractal heap */
             if (H5HF_close(fh) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             fh = NULL;
 
             /* Close the file */
             if (H5Fclose(file) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Re-open the file */
             if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Get a pointer to the internal file object */
             if (NULL == (f = (H5F_t *)H5VL_object(file)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Ignore metadata tags in the file's cache */
             if (H5AC_ignore_tags(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Re-open the heap */
             if (NULL == (fh = H5HF_open(f, fh_addr)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check up on heap... */
             HDmemset(&state, 0, sizeof(fheap_heap_state_t));
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
         else {
             /* Remove object #2 from heap */
             if (H5HF_get_obj_len(fh, heap_id2, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Close the fractal heap */
             if (H5HF_close(fh) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             fh = NULL;
 
             /* Close the file */
             if (H5Fclose(file) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Re-open the file */
             if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Get a pointer to the internal file object */
             if (NULL == (f = (H5F_t *)H5VL_object(file)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Ignore metadata tags in the file's cache */
             if (H5AC_ignore_tags(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Re-open the heap */
             if (NULL == (fh = H5HF_open(f, fh_addr)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Remove object #1 from heap */
             if (H5HF_get_obj_len(fh, heap_id1, &robj_size) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5HF_remove(fh, heap_id1) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check up on heap... */
             HDmemset(&state, 0, sizeof(fheap_heap_state_t));
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close the fractal heap */
             if (H5HF_close(fh) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             fh = NULL;
 
             /* Close the file */
             if (H5Fclose(file) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Re-open the file */
             if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Get a pointer to the internal file object */
             if (NULL == (f = (H5F_t *)H5VL_object(file)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Ignore metadata tags in the file's cache */
             if (H5AC_ignore_tags(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Re-open the heap */
             if (NULL == (fh = H5HF_open(f, fh_addr)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check up on heap... */
             HDmemset(&state, 0, sizeof(fheap_heap_state_t));
             if (check_stats(fh, &state))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end else */
     }     /* end if */
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Check for deleting the entire heap */
     if (tparam->del_dir == FHEAP_DEL_HEAP) {
         /* Delete heap */
         if (H5HF_delete(f, fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
 /* Needs file free space to be persistent */
 #ifdef NOT_YET
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 #endif /* NOT_YET */
 
     /* Free resources */
@@ -15474,18 +15474,18 @@ test_random(hsize_t size_limit, hid_t fapl, H5HF_create_t *cparam, fheap_test_pa
         deflate_level = 6;
         if (H5Z_append(&tmp_cparam.pline, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, (size_t)1, &deflate_level) <
             0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, &tmp_cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get information about heap ID lengths */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > MAX_HEAP_ID_LEN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Display testing message
@@ -15493,16 +15493,16 @@ test_random(hsize_t size_limit, hid_t fapl, H5HF_create_t *cparam, fheap_test_pa
     if (tparam->del_dir == FHEAP_DEL_HEAP) {
         if (tparam->comp == FHEAP_TEST_COMPRESS)
             TESTING("inserting random-sized objects in heap with compressed blocks, then remove all objects "
-                    "(all - deleting heap)")
+                    "(all - deleting heap)");
         else
-            TESTING("inserting random-sized objects, then remove all objects (all - deleting heap)")
+            TESTING("inserting random-sized objects, then remove all objects (all - deleting heap)");
     } /* end if */
     else {
         if (tparam->comp == FHEAP_TEST_COMPRESS)
             TESTING("inserting random-sized objects in heap with compressed blocks, then remove all objects "
-                    "(all - random)")
+                    "(all - random)");
         else
-            TESTING("inserting random-sized objects, then remove all objects (all - random)")
+            TESTING("inserting random-sized objects, then remove all objects (all - random)");
     } /* end else */
 
     /* Choose random # seed */
@@ -15522,11 +15522,11 @@ HDfprintf(stderr, "Random # seed was: %lu\n", seed);
 
         /* Insert object */
         if (add_obj(fh, obj_loc, obj_size, NULL, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Increment the amount of objects added */
         total_obj_added += obj_size;
@@ -15558,41 +15558,41 @@ HDfprintf(stderr, "Random # seed was: %lu\n", seed);
         for (u = 0; u < keep_ids.num_ids; u++) {
             /* Remove object from heap */
             if (H5HF_remove(fh, &keep_ids.ids[id_len * u]) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Check up on heap... */
         if (check_stats(fh, &state))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Check for deleting the entire heap */
     if (tparam->del_dir == FHEAP_DEL_HEAP) {
         /* Delete heap */
         if (H5HF_delete(f, fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     if (tparam->comp == FHEAP_TEST_COMPRESS)
@@ -15678,18 +15678,18 @@ test_random_pow2(hsize_t size_limit, hid_t fapl, H5HF_create_t *cparam, fheap_te
         deflate_level = 6;
         if (H5Z_append(&tmp_cparam.pline, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, (size_t)1, &deflate_level) <
             0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, &tmp_cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get information about heap ID lengths */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > MAX_HEAP_ID_LEN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Display testing message
@@ -15697,18 +15697,18 @@ test_random_pow2(hsize_t size_limit, hid_t fapl, H5HF_create_t *cparam, fheap_te
     if (tparam->del_dir == FHEAP_DEL_HEAP) {
         if (tparam->comp == FHEAP_TEST_COMPRESS)
             TESTING("inserting random-sized objects with power of 2 distribution in heap with compressed "
-                    "blocks, then remove all objects (all - deleting heap)")
+                    "blocks, then remove all objects (all - deleting heap)");
         else
             TESTING("inserting random-sized objects with power of 2 distribution, then remove all objects "
-                    "(all - deleting heap)")
+                    "(all - deleting heap)");
     } /* end if */
     else {
         if (tparam->comp == FHEAP_TEST_COMPRESS)
             TESTING("inserting random-sized objects with power of 2 distribution in heap with compressed "
-                    "blocks, then remove all objects (all - random)")
+                    "blocks, then remove all objects (all - random)");
         else
             TESTING("inserting random-sized objects with power of 2 distribution, then remove all objects "
-                    "(all - random)")
+                    "(all - random)");
     } /* end else */
 
     /* Choose random # seed */
@@ -15740,11 +15740,11 @@ HDfprintf(stderr, "Random # seed was: %lu\n", seed);
 
         /* Insert object */
         if (add_obj(fh, obj_loc, obj_size, NULL, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Increment the amount of objects added */
         total_obj_added += obj_size;
@@ -15776,41 +15776,41 @@ HDfprintf(stderr, "Random # seed was: %lu\n", seed);
         for (u = 0; u < keep_ids.num_ids; u++) {
             /* Remove object from heap */
             if (H5HF_remove(fh, &keep_ids.ids[id_len * u]) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Check for closing & re-opening the heap */
             if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Check up on heap... */
         if (check_stats(fh, &state))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Check for deleting the entire heap */
     if (tparam->del_dir == FHEAP_DEL_HEAP) {
         /* Delete heap */
         if (H5HF_delete(f, fh_addr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     if (tparam->comp == FHEAP_TEST_COMPRESS)
@@ -15895,9 +15895,9 @@ test_write(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
      * Display testing message
      */
     if (tparam->comp == FHEAP_TEST_COMPRESS)
-        TESTING("writing objects in heap with compressed blocks")
+        TESTING("writing objects in heap with compressed blocks");
     else
-        TESTING("writing objects in heap")
+        TESTING("writing objects in heap");
 
     /* Initialize the heap ID structure */
     HDmemset(&keep_ids, 0, sizeof(fheap_heap_ids_t));
@@ -15914,7 +15914,7 @@ test_write(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
         deflate_level = 6;
         if (H5Z_append(&tmp_cparam.pline, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, (size_t)1, &deflate_level) <
             0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Register and append custom filter */
         filter_class.version         = H5Z_CLASS_T_VERS;
@@ -15926,30 +15926,30 @@ test_write(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
         filter_class.set_local       = NULL;
         filter_class.filter          = test_write_filter;
         if (H5Zregister(&filter_class) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Z_append(&tmp_cparam.pline, H5Z_FILTER_RESERVED + 43, 0, (size_t)0, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         test_write_filter_called = FALSE;
     } /* end if */
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, &tmp_cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get information about heap ID lengths */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > MAX_HEAP_ID_LEN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create 'tiny' and 'huge' objects */
     obj_size = id_len / 2;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, tiny_heap_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     obj_size = tmp_cparam.max_man_size + 1;
     if (H5HF_insert(fh, obj_size, shared_wobj_g, huge_heap_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that writing to 'huge' objects works for un-filtered heaps */
     H5E_BEGIN_TRY
@@ -15960,11 +15960,11 @@ test_write(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
     HDassert(!id_changed);
     if (tparam->comp == FHEAP_TEST_COMPRESS) {
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else {
         if (ret < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end else */
 
     /* Verify that writing to 'tiny' objects return failure (for now) */
@@ -15975,40 +15975,40 @@ test_write(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
     H5E_END_TRY;
     HDassert(!id_changed);
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the custom filter has been applied for the huge object (if
      * applicable) */
     if (tparam->comp == FHEAP_TEST_COMPRESS) {
         if (!test_write_filter_called)
-            TEST_ERROR
+            TEST_ERROR;
         test_write_filter_called = FALSE;
     } /* end if */
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize data to overwrite with */
     rewrite_obj = (unsigned char *)H5MM_malloc(shared_obj_size_g);
@@ -16020,24 +16020,24 @@ test_write(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
     for (u = 0; u < 40; u++) {
         obj_loc = u;
         if (add_obj(fh, obj_loc, obj_size, NULL, &keep_ids))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for closing & re-opening the heap */
         if (reopen_heap(f, &fh, fh_addr, tparam) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Overwrite data just written */
         if (H5HF_write(fh, &keep_ids.ids[id_len * u], &id_changed, rewrite_obj) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         HDassert(!id_changed);
 
         /* Read data back in */
         if (H5HF_read(fh, &keep_ids.ids[id_len * u], shared_robj_g) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Compare data read in */
         if (HDmemcmp(rewrite_obj, shared_robj_g, obj_size) != 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Change size of data to write */
         if (u < 20)
@@ -16048,45 +16048,45 @@ test_write(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the custom filter has been applied to the managed objects (if
      * applicable) */
     if (tparam->comp == FHEAP_TEST_COMPRESS)
         if (!test_write_filter_called)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify changed objects */
     obj_size = 20;
     for (u = 0; u < 40; u++) {
         /* Read data back in */
         if (H5HF_read(fh, &keep_ids.ids[id_len * u], shared_robj_g) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Compare data read in */
         if (HDmemcmp(rewrite_obj, shared_robj_g, obj_size) != 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Change size of data to write */
         if (u < 20)
@@ -16097,12 +16097,12 @@ test_write(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Free resources */
     if (tparam->comp == FHEAP_TEST_COMPRESS)
@@ -16167,120 +16167,120 @@ test_bug1(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
     /*
      * Display testing message
      */
-    TESTING("bug1: inserting several objects & removing one, then re-inserting")
+    TESTING("bug1: inserting several objects & removing one, then re-inserting");
 
     /* Initialize the heap ID structure */
     HDmemset(&keep_ids, 0, sizeof(fheap_heap_ids_t));
 
     /* Perform common file & heap open operations */
     if (open_heap(filename, fapl, cparam, tparam, &file, &f, &fh, &fh_addr, &state, &empty_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get information about heap ID lengths */
     if (H5HF_get_id_len(fh, &id_len) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (id_len > MAX_HEAP_ID_LEN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert objects */
     obj_size = 44;
     obj_loc  = 1;
     if (add_obj(fh, obj_loc, obj_size, NULL, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     obj_size = 484;
     obj_loc  = 2;
     if (add_obj(fh, obj_loc, obj_size, NULL, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     obj_size = 168;
     obj_loc  = 3;
     if (add_obj(fh, obj_loc, obj_size, NULL, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     obj_size = 96;
     obj_loc  = 4;
     if (add_obj(fh, obj_loc, obj_size, NULL, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     obj_size = 568;
     obj_loc  = 5;
     if (add_obj(fh, obj_loc, obj_size, NULL, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     obj_size = 568;
     obj_loc  = 6;
     if (add_obj(fh, obj_loc, obj_size, NULL, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove one of the objects */
     if (H5HF_remove(fh, &keep_ids.ids[id_len * 4]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ignore metadata tags in the file's cache */
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the heap */
     if (NULL == (fh = H5HF_open(f, fh_addr)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Insert another object */
     obj_size = 208;
     obj_loc  = 6;
     if (add_obj(fh, obj_loc, obj_size, NULL, &keep_ids))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the fractal heap */
     if (H5HF_close(fh) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fh = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Free resources */
     H5MM_xfree(keep_ids.ids);
@@ -16378,7 +16378,7 @@ main(void)
 
     /* Push API context */
     if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = TRUE;
 
     /* Allocate space for the shared objects */
@@ -16388,13 +16388,13 @@ main(void)
 
     /* Create a copy def_fapl and enable page buffering */
     if ((pb_fapl = H5Pcopy(def_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_page_buffer_size(pb_fapl, PAGE_BUFFER_PAGE_SIZE, 0, 0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a file creation property list */
     if ((def_fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize the shared write buffer for objects */
     for (u = 0; u < shared_obj_size_g; u++)
@@ -16409,17 +16409,17 @@ main(void)
             break;
 
         if ((fcpl = H5Pcopy(def_fcpl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         switch (v) {
             case 0:
                 if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_FSM_AGGR, FALSE, (hsize_t)1) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 fapl = def_fapl;
                 break;
             case 1:
                 if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_FSM_AGGR, TRUE, (hsize_t)1) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 fapl = def_fapl;
                 /* This is a fix for the daily test failure from the checkin for libver bounds. */
                 /*
@@ -16447,26 +16447,26 @@ main(void)
                  *    message.
                  */
                 if (H5Pset_libver_bounds(fapl, H5F_LIBVER_V18, H5F_LIBVER_LATEST) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 break;
             case 2:
                 if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_PAGE, FALSE, (hsize_t)1) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 fapl = def_fapl;
                 break;
             case 3:
                 if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_PAGE, TRUE, (hsize_t)1) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 fapl = def_fapl;
                 break;
             case 4:
                 if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_PAGE, FALSE, (hsize_t)1) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 fapl = pb_fapl;
                 break;
             case 5:
                 if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_PAGE, TRUE, (hsize_t)1) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 fapl = pb_fapl;
                 break;
 
@@ -16874,7 +16874,7 @@ main(void)
         } /* end for */
 
         if (H5Pclose(fcpl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end num_pb_fs */
 
     /* Tests that address specific bugs */
@@ -16899,13 +16899,13 @@ main(void)
     H5MM_xfree(shared_offs_g);
 
     if (H5Pclose(def_fcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(pb_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = FALSE;
 
     /* Clean up file used */

--- a/test/file_image.c
+++ b/test/file_image.c
@@ -24,7 +24,7 @@
 #define VERIFY(condition, string)                                                                            \
     do {                                                                                                     \
         if (!(condition))                                                                                    \
-            FAIL_PUTS_ERROR(string)                                                                          \
+            FAIL_PUTS_ERROR(string);                                                                         \
     } while (0)
 
 /* Values for callback bit field */
@@ -104,18 +104,18 @@ test_properties(void)
      */
     size = (size_t)count * sizeof(char);
     if (NULL == (buffer = (char *)HDmalloc(size)))
-        TEST_ERROR
+        TEST_ERROR;
     for (i = 0; i < count - 1; i++)
         buffer[i] = (char)(65 + i);
     buffer[count - 1] = '\0';
 
     /* Create fapl */
     if ((fapl_1 = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file image stuff */
     if (H5Pget_file_image(fapl_1, (void **)&temp, &temp_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check default values */
     VERIFY(temp == NULL, "Default pointer is wrong");
@@ -123,11 +123,11 @@ test_properties(void)
 
     /* Set file image stuff */
     if (H5Pset_file_image(fapl_1, (void *)buffer, size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the same */
     if (H5Pget_file_image(fapl_1, (void **)&temp, &temp_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that sizes are the same, and that the buffers are identical but separate */
     VERIFY(temp != NULL, "temp is null!");
@@ -137,11 +137,11 @@ test_properties(void)
 
     /* Copy the fapl */
     if ((fapl_2 = H5Pcopy(fapl_1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get values from the new fapl */
     if (H5Pget_file_image(fapl_2, (void **)&temp2, &temp_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that sizes are the same, and that the buffers are identical but separate */
     VERIFY(temp_size == size, "Sizes of buffers don't match");
@@ -367,12 +367,12 @@ test_callbacks(void)
 
     /* Create fapl */
     if ((fapl_1 = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file image stuff */
     callbacks = real_callbacks;
     if (H5Pget_file_image_callbacks(fapl_1, &callbacks) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check default values */
     VERIFY(callbacks.image_malloc == NULL, "Default malloc callback is wrong");
@@ -386,12 +386,12 @@ test_callbacks(void)
     /* Set file image callbacks */
     callbacks = real_callbacks;
     if (H5Pset_file_image_callbacks(fapl_1, &callbacks) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file image callbacks */
     callbacks = null_callbacks;
     if (H5Pget_file_image_callbacks(fapl_1, &callbacks) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify values */
     VERIFY(callbacks.image_malloc == &malloc_cb, "malloc callback was not set or retrieved properly");
@@ -409,7 +409,7 @@ test_callbacks(void)
     /* Copy fapl */
     reset_udata(udata);
     if ((fapl_2 = H5Pcopy(fapl_1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the property's copy callback used the correct image callbacks */
     VERIFY(udata->used_callbacks == (UDATA_COPY), "Copying a fapl with no image used incorrect callbacks");
@@ -417,19 +417,19 @@ test_callbacks(void)
     /* Close fapl */
     reset_udata(udata);
     if (H5Pclose(fapl_2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the udata free callback was used */
     VERIFY(udata->used_callbacks == (UDATA_FREE), "Closing a fapl with no image used incorrect callbacks");
 
     /* Copy again */
     if ((fapl_2 = H5Pcopy(fapl_1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove property from fapl */
     reset_udata(udata);
     if (H5Premove(fapl_2, H5F_ACS_FILE_IMAGE_INFO_NAME) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the property's delete callback was called using the correct image callbacks */
     VERIFY(udata->used_callbacks == (UDATA_FREE),
@@ -437,12 +437,12 @@ test_callbacks(void)
 
     /* Close it again */
     if (H5Pclose(fapl_2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file image */
     reset_udata(udata);
     if (H5Pget_file_image(fapl_1, (void **)&temp_file_image, &temp_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the correct callbacks were used */
     VERIFY(udata->used_callbacks == 0,
@@ -451,7 +451,7 @@ test_callbacks(void)
     /* Set file image */
     reset_udata(udata);
     if (H5Pset_file_image(fapl_1, (void *)file_image, size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     VERIFY(udata->used_callbacks == (MALLOC | MEMCPY),
            "Setting a file image (first time) used incorrect callbacks");
@@ -463,7 +463,7 @@ test_callbacks(void)
     /* Copy fapl */
     reset_udata(udata);
     if ((fapl_2 = H5Pcopy(fapl_1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the property's copy callback used the correct image callbacks */
     VERIFY(udata->used_callbacks == (MALLOC | MEMCPY | UDATA_COPY),
@@ -474,7 +474,7 @@ test_callbacks(void)
     /* Close fapl */
     reset_udata(udata);
     if (H5Pclose(fapl_2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the udata free callback was used */
     VERIFY(udata->used_callbacks == (FREE | UDATA_FREE),
@@ -483,12 +483,12 @@ test_callbacks(void)
 
     /* Copy again */
     if ((fapl_2 = H5Pcopy(fapl_1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove property from fapl */
     reset_udata(udata);
     if (H5Premove(fapl_2, H5F_ACS_FILE_IMAGE_INFO_NAME) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the property's delete callback was called using the correct image callbacks */
     VERIFY(udata->used_callbacks == (FREE | UDATA_FREE),
@@ -497,12 +497,12 @@ test_callbacks(void)
 
     /* Close it again */
     if (H5Pclose(fapl_2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file image */
     reset_udata(udata);
     if (H5Pget_file_image(fapl_1, (void **)&temp_file_image, &temp_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the correct callbacks were used */
     VERIFY(udata->used_callbacks == (MALLOC | MEMCPY),
@@ -513,7 +513,7 @@ test_callbacks(void)
     /* Set file image */
     reset_udata(udata);
     if (H5Pset_file_image(fapl_1, (void *)file_image, size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     VERIFY(udata->used_callbacks == (FREE | MALLOC | MEMCPY),
            "Setting a file image (second time) used incorrect callbacks");
@@ -523,7 +523,7 @@ test_callbacks(void)
 
     /* Close stuff */
     if (H5Pclose(fapl_1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDfree(file_image);
     HDfree(temp_file_image);
     HDfree(udata);
@@ -670,13 +670,13 @@ test_core(void)
 
     /* Set file image in plist */
     if (H5Pset_file_image(fapl, file_image, size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test open with file image */
     if ((file = H5Fopen("dne.h5", H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Release resources */
     h5_clean_files(FILENAME, fapl);

--- a/test/filenotclosed.c
+++ b/test/filenotclosed.c
@@ -88,51 +88,51 @@ main(void)
 
     /* To exit from the file for SIGABRT signal */
     if (HDsignal(SIGABRT, catch_signal) == SIG_ERR)
-        TEST_ERROR
+        TEST_ERROR;
 
     fapl = h5_fileaccess();
     h5_fixname(FILENAME, fapl, filename, sizeof(filename));
 
     /* Set to latest format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the file  */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the dcpl and set the chunk size */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pset_chunk(dcpl, 1, chunk_dim) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the dataspace */
     if ((sid = H5Screate_simple(1, cur_dim, max_dim)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the dataset */
     if ((did = H5Dcreate2(fid, DATASET_NAME, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Write to the dataset */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the property lists */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* The file is not closed. */
     /* The library will call H5_term_library to shut down the library. */

--- a/test/fillval.c
+++ b/test/fillval.c
@@ -116,24 +116,24 @@ create_compound_vl_type(void)
 
     /* Create a string datatype */
     if ((str_id = H5Tcopy(H5T_C_S1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_size(str_id, H5T_VARIABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((ret_value = H5Tcreate(H5T_COMPOUND, sizeof(comp_vl_datatype))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(ret_value, "x", HOFFSET(comp_vl_datatype, x), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(ret_value, "a", HOFFSET(comp_vl_datatype, a), str_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(ret_value, "b", HOFFSET(comp_vl_datatype, b), str_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(ret_value, "y", HOFFSET(comp_vl_datatype, y), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close string datatype */
     if (H5Tclose(str_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return ret_value;
 
@@ -306,26 +306,26 @@ test_getset_vl(hid_t fapl)
 
     /* Create string type. */
     if ((dtypeid = H5Tcopy(H5T_C_S1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_size(dtypeid, H5T_VARIABLE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set up dataset creation property list, with fill value */
     if ((plistid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_fill_value(plistid, dtypeid, &f1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Modify original fill value string */
     fill_value[0] = 'b';
 
     /* Retrieve fill value from property */
     if (H5Pget_fill_value(plistid, dtypeid, &f2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the fill value is the original value */
     if (HDstrcmp(f2, orig_fill_value) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Release the fill value retrieved */
     HDfree(f2);
@@ -333,54 +333,54 @@ test_getset_vl(hid_t fapl)
     /* Open file. */
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
     if ((fileid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Write an dataset of this type. */
     if ((spaceid = H5Screate_simple(1, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((datasetid = H5Dcreate2(fileid, "Dataset", dtypeid, spaceid, H5P_DEFAULT, plistid, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close IDs (except datatype) */
     if (H5Dclose(datasetid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(plistid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(spaceid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fileid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open file, group & dataset */
     if ((fileid = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((datasetid = H5Dopen2(fileid, "Dataset", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get dataset's creation property list */
     if ((plistid = H5Dget_create_plist(datasetid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query fill value */
     if (H5Pget_fill_value(plistid, dtypeid, &f2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the fill value is the original value */
     if (HDstrcmp(f2, orig_fill_value) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Release the fill value retrieved */
     HDfree(f2);
 
     /* Close IDs */
     if (H5Dclose(datasetid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fileid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(plistid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(dtypeid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -1624,24 +1624,24 @@ test_extend_cases(hid_t file, hid_t _dcpl, const char *dset_name, const hsize_t 
 
     /* Make copy of dataset creation property list */
     if ((dcpl = H5Pcopy(_dcpl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #ifndef NO_FILLING
     if (H5Pset_fill_value(dcpl, dtype, fillval) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 #endif
 
     /* Get class of datatype */
     if ((dtype_class = H5Tget_class(dtype)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a dataspace */
     if ((fspace = H5Screate_simple(5, start_size, max_size)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataset */
     if ((dset = H5Dcreate2(file, dset_name, dtype, fspace, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set up pointers to elements */
     if (dtype_class == H5T_INTEGER) {
@@ -1672,7 +1672,7 @@ test_extend_cases(hid_t file, hid_t _dcpl, const char *dset_name, const hsize_t 
 
     /* Read some data and make sure it's the fill value */
     if ((mspace = H5Screate_simple(5, one, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     for (i = 0; i < 1000; i++) {
         /* Set offset for random element */
         for (j = 0; j < 5; j++)
@@ -1680,25 +1680,25 @@ test_extend_cases(hid_t file, hid_t _dcpl, const char *dset_name, const hsize_t 
 
         /* Select the random element */
         if (H5Sselect_hyperslab(fspace, H5S_SELECT_SET, hs_offset, NULL, one, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read the random element */
         if (H5Dread(dset, dtype, mspace, fspace, H5P_DEFAULT, val_rd) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the element read in */
         if (verify_rtn((unsigned)__LINE__, hs_offset, val_rd, fillval) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Release any VL components */
         if (H5Treclaim(dtype, mspace, H5P_DEFAULT, val_rd) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Clear the read buffer */
         HDmemset(val_rd, 0, val_size);
     } /* end for */
     if (H5Sclose(mspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize dataspace & hyperslab info */
     for (i = 0, nelmts = 1; i < 5; i++) {
@@ -1717,23 +1717,23 @@ test_extend_cases(hid_t file, hid_t _dcpl, const char *dset_name, const hsize_t 
 
     /* Create dataspace describing memory buffer */
     if ((mspace = H5Screate_simple(5, hs_size, hs_size)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select elements within file dataspace */
     if (H5Sselect_hyperslab(fspace, H5S_SELECT_SET, hs_offset, hs_stride, hs_size, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Write to all even data locations */
     if (H5Dwrite(dset, dtype, mspace, fspace, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close memory dataspace */
     if (H5Sclose(mspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read some data and make sure it's the right value */
     if ((mspace = H5Screate_simple(5, one, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     for (i = 0; i < 1000; i++) {
         /* Set offset for random element */
         for (j = 0, odd = 0; j < 5; j++) {
@@ -1743,42 +1743,42 @@ test_extend_cases(hid_t file, hid_t _dcpl, const char *dset_name, const hsize_t 
 
         /* Select the random element */
         if (H5Sselect_hyperslab(fspace, H5S_SELECT_SET, hs_offset, NULL, one, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read the random element */
         if (H5Dread(dset, dtype, mspace, fspace, H5P_DEFAULT, val_rd) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the element read in */
         should_be = odd ? odd_val : even_val;
         if (verify_rtn((unsigned)__LINE__, hs_offset, val_rd, should_be) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Release any VL components */
         if (H5Treclaim(dtype, mspace, H5P_DEFAULT, val_rd) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Clear the read buffer */
         HDmemset(val_rd, 0, val_size);
     } /* end for */
     if (H5Sclose(mspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Extend the dataset one element in each dimension */
     for (i = 0; i < 5; i++)
         extend_size[i] = start_size[i] + 1;
     if (H5Dset_extent(dset, extend_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open file dataspace */
     if (H5Sclose(fspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fspace = H5Dget_space(dset)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read some data and make sure it's the right value */
     if ((mspace = H5Screate_simple(5, one, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     for (i = 0; i < 1000; i++) {
         /* Set offset for random element */
         for (j = 0, odd = 0; j < 5; j++) {
@@ -1791,40 +1791,40 @@ test_extend_cases(hid_t file, hid_t _dcpl, const char *dset_name, const hsize_t 
 
         /* Select the random element */
         if (H5Sselect_hyperslab(fspace, H5S_SELECT_SET, hs_offset, NULL, one, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read the random element */
         if (H5Dread(dset, dtype, mspace, fspace, H5P_DEFAULT, val_rd) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the element read in */
         should_be = odd ? odd_val : even_val;
         if (verify_rtn((unsigned)__LINE__, hs_offset, val_rd, should_be) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Release any VL components */
         if (H5Treclaim(dtype, mspace, H5P_DEFAULT, val_rd) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Clear the read buffer */
         HDmemset(val_rd, 0, val_size);
     } /* end for */
     if (H5Sclose(mspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Extend the dataset to the maximum dimension sizes */
     if (H5Dset_extent(dset, max_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open file dataspace */
     if (H5Sclose(fspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fspace = H5Dget_space(dset)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read some data and make sure it's the right value */
     if ((mspace = H5Screate_simple(5, one, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     for (i = 0; i < 1000; i++) {
         /* Set offset for random element */
         for (j = 0, odd = 0; j < 5; j++) {
@@ -1837,42 +1837,42 @@ test_extend_cases(hid_t file, hid_t _dcpl, const char *dset_name, const hsize_t 
 
         /* Select the random element */
         if (H5Sselect_hyperslab(fspace, H5S_SELECT_SET, hs_offset, NULL, one, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read the random element */
         if (H5Dread(dset, dtype, mspace, fspace, H5P_DEFAULT, val_rd) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the element read in */
         should_be = odd ? odd_val : even_val;
         if (verify_rtn((unsigned)__LINE__, hs_offset, val_rd, should_be) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Release any VL components */
         if (H5Treclaim(dtype, mspace, H5P_DEFAULT, val_rd) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Clear the read buffer */
         HDmemset(val_rd, 0, val_size);
     } /* end for */
     if (H5Sclose(mspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Shrink the dataset to half of it's maximum size, plus 1/2 of a chunk */
     for (i = 0; i < 5; i++)
         extend_size[i] = (max_size[i] / 2) + (ch_size[i] / 2);
     if (H5Dset_extent(dset, extend_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open file dataspace */
     if (H5Sclose(fspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fspace = H5Dget_space(dset)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read some data and make sure it's the right value */
     if ((mspace = H5Screate_simple(5, one, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     for (i = 0; i < 1000; i++) {
         /* Set offset for random element */
         for (j = 0, odd = 0; j < 5; j++) {
@@ -1885,42 +1885,42 @@ test_extend_cases(hid_t file, hid_t _dcpl, const char *dset_name, const hsize_t 
 
         /* Select the random element */
         if (H5Sselect_hyperslab(fspace, H5S_SELECT_SET, hs_offset, NULL, one, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read the random element */
         if (H5Dread(dset, dtype, mspace, fspace, H5P_DEFAULT, val_rd) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the element read in */
         should_be = odd ? odd_val : even_val;
         if (verify_rtn((unsigned)__LINE__, hs_offset, val_rd, should_be) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Release any VL components */
         if (H5Treclaim(dtype, mspace, H5P_DEFAULT, val_rd) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Clear the read buffer */
         HDmemset(val_rd, 0, val_size);
     } /* end for */
     if (H5Sclose(mspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Extend the dataset's size by one element, in a dimension that won't
      *  cause additional chunks to be needed */
     extend_size[2] += 1;
     if (H5Dset_extent(dset, extend_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open file dataspace */
     if (H5Sclose(fspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fspace = H5Dget_space(dset)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace for single element sized buffer */
     if ((mspace = H5Screate_simple(5, one, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set location for "top-most" element in dataset to write */
     for (i = 0; i < 5; i++)
@@ -1928,7 +1928,7 @@ test_extend_cases(hid_t file, hid_t _dcpl, const char *dset_name, const hsize_t 
 
     /* Select the element */
     if (H5Sselect_hyperslab(fspace, H5S_SELECT_SET, hs_offset, NULL, one, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Write one element in a chunk that's 'partial' and overwrite a fill
      *  value that was initialized in the H5Dset_extent() routine.  This will
@@ -1937,23 +1937,23 @@ test_extend_cases(hid_t file, hid_t _dcpl, const char *dset_name, const hsize_t 
      *  fail.
      */
     if (H5Dwrite(dset, dtype, mspace, fspace, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read value back in */
     if (H5Dread(dset, dtype, mspace, fspace, H5P_DEFAULT, val_rd) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the element read in is the value written out */
     if (verify_rtn((unsigned)__LINE__, hs_offset, val_rd, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set the element back to fillval */
     if (H5Dwrite(dset, dtype, mspace, fspace, H5P_DEFAULT, fillval) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Release any VL components */
     if (H5Treclaim(dtype, mspace, H5P_DEFAULT, val_rd) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Clear the read buffer */
     HDmemset(val_rd, 0, val_size);
@@ -1963,19 +1963,19 @@ test_extend_cases(hid_t file, hid_t _dcpl, const char *dset_name, const hsize_t 
 
     /* Select the element */
     if (H5Sselect_hyperslab(fspace, H5S_SELECT_SET, hs_offset, NULL, one, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read value back in */
     if (H5Dread(dset, dtype, mspace, fspace, H5P_DEFAULT, val_rd) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the element read in is the fill-value */
     if (verify_rtn((unsigned)__LINE__, hs_offset, val_rd, fillval) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Release any VL components */
     if (H5Treclaim(dtype, mspace, H5P_DEFAULT, val_rd) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Clear the read buffer */
     HDmemset(val_rd, 0, val_size);
@@ -1993,26 +1993,26 @@ test_extend_cases(hid_t file, hid_t _dcpl, const char *dset_name, const hsize_t 
 
         /* Select the random element */
         if (H5Sselect_hyperslab(fspace, H5S_SELECT_SET, hs_offset, NULL, one, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read the random element */
         if (H5Dread(dset, dtype, mspace, fspace, H5P_DEFAULT, val_rd) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the element read in */
         should_be = odd ? odd_val : even_val;
         if (verify_rtn((unsigned)__LINE__, hs_offset, val_rd, should_be) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Release any VL components */
         if (H5Treclaim(dtype, mspace, H5P_DEFAULT, val_rd) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Clear the read buffer */
         HDmemset(val_rd, 0, val_size);
     } /* end for */
     if (H5Sclose(mspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Release elements & memory buffer */
     for (i = 0; i < nelmts; i++)
@@ -2024,11 +2024,11 @@ test_extend_cases(hid_t file, hid_t _dcpl, const char *dset_name, const hsize_t 
 
     /* Cleanup IDs */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(fspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -2084,9 +2084,9 @@ test_extend(hid_t fapl, const char *base_name, H5D_layout_t layout)
 
     /* Print testing message */
     if (H5D_CHUNKED == layout)
-        TESTING("chunked dataset extend")
+        TESTING("chunked dataset extend");
     else
-        TESTING("contiguous dataset extend")
+        TESTING("contiguous dataset extend");
 
     /* Set vl datatype fill value strings */
     fillval_c.a = HDstrdup("foo");
@@ -2094,10 +2094,10 @@ test_extend(hid_t fapl, const char *base_name, H5D_layout_t layout)
 
     /* Create dataset creation property list */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5D_CHUNKED == layout)
         if (H5Pset_chunk(dcpl, 5, ch_size) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
 #if 1
     /*
@@ -2157,27 +2157,27 @@ test_extend(hid_t fapl, const char *base_name, H5D_layout_t layout)
     /* Create a file and dataset */
     h5_fixname(base_name, fapl, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the compound+vl datatype */
     if ((cmpd_vl_tid = create_compound_vl_type()) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test integer datatype case */
     if (test_extend_cases(file, dcpl, "dset1", ch_size, start_size, max_size, H5T_NATIVE_INT, &fillval_i) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test compound+vl datatype datatype case */
     if (test_extend_cases(file, dcpl, "dset2", ch_size, start_size, max_size, cmpd_vl_tid, &fillval_c) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cleanup */
     if (H5Tclose(cmpd_vl_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDfree(fillval_c.a);
     HDfree(fillval_c.b);
@@ -2689,11 +2689,11 @@ main(int argc, char *argv[])
 
     /* Copy the file access property list */
     if ((fapl2 = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set the "use the latest version of the format" bounds for creating objects in the file */
     if (H5Pset_libver_bounds(fapl2, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop over using new group format */
     for (new_format = FALSE; new_format <= TRUE; new_format++) {

--- a/test/filter_fail.c
+++ b/test/filter_fail.c
@@ -127,33 +127,33 @@ test_filter_write(char *file_name, hid_t my_fapl, hbool_t cache_enabled)
 
     /* Create file */
     if ((file = H5Fcreate(file_name, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create the data space */
     if ((sid = H5Screate_simple(1, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dcpl and register the filter */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pset_chunk(dcpl, 1, chunk_dims) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Zregister(H5Z_FAIL_TEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the filter was registered */
     if (TRUE != H5Zfilter_avail(H5Z_FILTER_FAIL_TEST))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Enable the filter as mandatory */
     if (H5Pset_filter(dcpl, H5Z_FILTER_FAIL_TEST, 0, (size_t)0, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create a dataset */
     if ((dataset = H5Dcreate2(file, DSET_NAME, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize the write buffer */
     for (i = 0; i < DIM; i++)
@@ -163,7 +163,7 @@ test_filter_write(char *file_name, hid_t my_fapl, hbool_t cache_enabled)
      * disabled, H5Dwrite should fail. */
     if (cache_enabled) {
         if (H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, sid, H5P_DEFAULT, points) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else {
         /* Data writing should fail */
@@ -175,15 +175,15 @@ test_filter_write(char *file_name, hid_t my_fapl, hbool_t cache_enabled)
         if (ret >= 0) {
             H5_FAILED();
             HDputs("    Data writing is supposed to fail because the chunk can't be written to file.");
-            TEST_ERROR
+            TEST_ERROR;
         }
     }
 
     /* clean up objects used for this test */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset.  If the chunk cache is enabled, the flushing of chunks should fail
      * during H5Dclose.  If it is disabled, H5Dwrite should fail but H5Dclose should succeed. */
@@ -196,18 +196,18 @@ test_filter_write(char *file_name, hid_t my_fapl, hbool_t cache_enabled)
         if (ret >= 0) {
             H5_FAILED();
             HDputs("    Dataset is supposed to fail because the chunk can't be flushed to file.");
-            TEST_ERROR
+            TEST_ERROR;
         }
     }
     else {
         if (H5Dclose(dataset) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* Even though H5Dclose or H5Dwrite fails, it should release all resources.
      * So the file should close successfully. */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -263,23 +263,23 @@ test_filter_read(char *file_name, hid_t my_fapl)
 
     /* Open file */
     if ((file = H5Fopen(file_name, H5F_ACC_RDONLY, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open dataset */
     if ((dataset = H5Dopen2(file, DSET_NAME, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the storage size is equal to 4 chunks */
     if ((dset_size = H5Dget_storage_size(dataset)) == 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (dset_size != 4 * FILTER_CHUNK_DIM * sizeof(int))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read the chunks */
     HDmemset(rbuf, 0, DIM * sizeof(int));
     if (H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the values read are the same as the values written.
      * The last chunk should not be in the file. */
@@ -289,40 +289,40 @@ test_filter_read(char *file_name, hid_t my_fapl)
             HDprintf("    Read different values than written.\n");
             HDprintf("    At index %d\n", i);
             HDprintf("    rbuf[%d]=%d\n", i, rbuf[i]);
-            TEST_ERROR
+            TEST_ERROR;
         }
         else if (i >= DIM - 2 && rbuf[i] != 0) {
             H5_FAILED();
             HDprintf("    No value should be read.\n");
             HDprintf("    At index %d\n", i);
             HDprintf("    rbuf[%d]=%d\n", i, rbuf[i]);
-            TEST_ERROR
+            TEST_ERROR;
         }
     }
 
     /* Try to read in hyperslab simulating the h5dump's way of printing data */
     if ((sid = H5Dget_space(dataset)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDmemset(hs_offset, 0, sizeof(hs_offset));
     HDmemset(hs_size, 0, sizeof(hs_size));
     hs_size[0] = DIM / 2;
 
     if (H5Sselect_hyperslab(sid, H5S_SELECT_SET, hs_offset, stride, hs_size, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create the data space */
     if ((mspace = H5Screate_simple(1, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDmemset(zero, 0, sizeof zero);
 
     if (H5Sselect_hyperslab(mspace, H5S_SELECT_SET, zero, stride, &nelmts, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDmemset(rbuf, 0, DIM * sizeof(int));
     if (H5Dread(dataset, H5T_NATIVE_INT, H5S_ALL, sid, H5P_DEFAULT, rbuf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the values read are the same as the values written.
      * The last chunk should not be in the file. */
@@ -332,25 +332,25 @@ test_filter_read(char *file_name, hid_t my_fapl)
             HDprintf("    Read different values than written.\n");
             HDprintf("    At index %d\n", i);
             HDprintf("    rbuf[%d]=%d\n", i, rbuf[i]);
-            TEST_ERROR
+            TEST_ERROR;
         }
         else if (i >= DIM - 2 && rbuf[i] != 0) {
             H5_FAILED();
             HDprintf("    No value should be read.\n");
             HDprintf("    At index %d\n", i);
             HDprintf("    rbuf[%d]=%d\n", i, rbuf[i]);
-            TEST_ERROR
+            TEST_ERROR;
         }
     }
 
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(mspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -406,7 +406,7 @@ main(void)
     /* Disable the chunk cache so that the writing of data chunks happens
      * during H5Dwrite. */
     if (H5Pset_cache(fapl, mdc_nelmts, rdcc_nelmts, rdcc_nbytes, rdcc_w0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Run the test again. */
     nerrors += (test_filter_write(filename, fapl, FALSE) < 0 ? 1 : 0);
@@ -419,10 +419,10 @@ main(void)
 
     /* Make sure we can close the library */
     if (H5close() < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (nerrors)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDexit(EXIT_SUCCESS);
 

--- a/test/filter_plugin.c
+++ b/test/filter_plugin.c
@@ -602,7 +602,7 @@ test_read_data(hid_t did, int *origin_data)
     for (i = 0; i < sizes_g[0]; i++)
         for (j = 0; j < sizes_g[1]; j++) {
             if (*data_p != check[i][j])
-                TEST_ERROR
+                TEST_ERROR;
             data_p++;
         }
 
@@ -1038,7 +1038,7 @@ test_path_api_calls(void)
     H5E_END_TRY
 
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 

--- a/test/flush1.c
+++ b/test/flush1.c
@@ -71,25 +71,25 @@ create_file(const char *filename, hid_t fapl_id, hbool_t swmr)
     flags = H5F_ACC_TRUNC | (swmr ? H5F_ACC_SWMR_WRITE : 0);
 
     if ((fid = H5Fcreate(filename, flags, H5P_DEFAULT, fapl_id)) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Create a chunked dataset */
     if (add_dset_to_file(fid, FIRST_DSET_NAME) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create some groups */
     if ((top_gid = H5Gcreate2(fid, "top_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        STACK_ERROR
+        STACK_ERROR;
     for (i = 0; i < NGROUPS; i++) {
         HDsnprintf(group_name, sizeof(group_name), "group%02d", i);
         if ((gid = H5Gcreate2(top_gid, group_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            STACK_ERROR
+            STACK_ERROR;
         if (H5Gclose(gid) < 0)
-            STACK_ERROR
+            STACK_ERROR;
     } /* end for */
 
     if (H5Gclose(top_gid) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     return fid;
 
@@ -130,28 +130,28 @@ add_dset_to_file(hid_t fid, const char *dset_name)
 
     /* Create a chunked dataset */
     if ((dcpl_id = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        STACK_ERROR
+        STACK_ERROR;
     if (H5Pset_chunk(dcpl_id, NDIMS, chunk_dims) < 0)
-        STACK_ERROR
+        STACK_ERROR;
     if ((sid = H5Screate_simple(NDIMS, dims, NULL)) < 0)
-        STACK_ERROR
+        STACK_ERROR;
     if ((did = H5Dcreate2(fid, dset_name, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* Write some data */
     if (NULL == (data = (int *)HDcalloc((size_t)NELEMENTS, sizeof(int))))
-        STACK_ERROR
+        STACK_ERROR;
     for (i = 0; i < NELEMENTS; i++)
         data[i] = i;
     if (H5Dwrite(did, H5T_NATIVE_INT, sid, sid, H5P_DEFAULT, data) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     if (H5Pclose(dcpl_id) < 0)
-        STACK_ERROR
+        STACK_ERROR;
     if (H5Sclose(sid) < 0)
-        STACK_ERROR
+        STACK_ERROR;
     if (H5Dclose(did) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     HDfree(data);
 
@@ -198,7 +198,7 @@ main(void)
 
     h5_reset();
     if ((fapl_id = h5_fileaccess()) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the current VFD supports SWMR */
     driver            = HDgetenv(HDF5_DRIVER);
@@ -213,9 +213,9 @@ main(void)
     h5_fixname(FILENAME[0], fapl_id, filename, sizeof(filename));
     use_swmr = FALSE;
     if ((fid = create_file(filename, fapl_id, use_swmr)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fflush(fid, H5F_SCOPE_GLOBAL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /* Create a file and flush w/ SWMR I/O */
@@ -224,9 +224,9 @@ main(void)
         h5_fixname(FILENAME[1], fapl_id, filename, sizeof(filename));
         use_swmr = TRUE;
         if ((fid = create_file(filename, fapl_id, use_swmr)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Fflush(fid, H5F_SCOPE_GLOBAL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         PASSED();
     } /* end if */
     else
@@ -237,7 +237,7 @@ main(void)
     h5_fixname(FILENAME[2], fapl_id, filename, sizeof(filename));
     use_swmr = FALSE;
     if ((fid = create_file(filename, fapl_id, use_swmr)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     PASSED();
 
     /* Create a file which will not be flushed w/ SWMR I/O */
@@ -246,7 +246,7 @@ main(void)
         h5_fixname(FILENAME[3], fapl_id, filename, sizeof(filename));
         use_swmr = TRUE;
         if ((fid = create_file(filename, fapl_id, use_swmr)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         PASSED();
     } /* end if */
     else
@@ -257,13 +257,13 @@ main(void)
     h5_fixname(FILENAME[4], fapl_id, filename, sizeof(filename));
     use_swmr = FALSE;
     if ((fid = create_file(filename, fapl_id, use_swmr)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fflush(fid, H5F_SCOPE_GLOBAL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (add_dset_to_file(fid, SECOND_DSET_NAME) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fflush(fid, H5F_SCOPE_GLOBAL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /* Create a file, flush, add a dataset, flush w/ SWMR I/O */
@@ -272,13 +272,13 @@ main(void)
         h5_fixname(FILENAME[5], fapl_id, filename, sizeof(filename));
         use_swmr = TRUE;
         if ((fid = create_file(filename, fapl_id, use_swmr)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Fflush(fid, H5F_SCOPE_GLOBAL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (add_dset_to_file(fid, SECOND_DSET_NAME) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Fflush(fid, H5F_SCOPE_GLOBAL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         PASSED();
     } /* end if */
     else
@@ -289,11 +289,11 @@ main(void)
     h5_fixname(FILENAME[6], fapl_id, filename, sizeof(filename));
     use_swmr = FALSE;
     if ((fid = create_file(filename, fapl_id, use_swmr)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fflush(fid, H5F_SCOPE_GLOBAL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (add_dset_to_file(fid, SECOND_DSET_NAME) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     PASSED();
 
     /* Create a file, flush, add a dataset, (no flush) w/ SWMR I/O */
@@ -302,11 +302,11 @@ main(void)
         h5_fixname(FILENAME[7], fapl_id, filename, sizeof(filename));
         use_swmr = TRUE;
         if ((fid = create_file(filename, fapl_id, use_swmr)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Fflush(fid, H5F_SCOPE_GLOBAL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (add_dset_to_file(fid, SECOND_DSET_NAME) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         PASSED();
     } /* end if */
     else
@@ -321,7 +321,7 @@ main(void)
 
     /* DO NOT CLOSE FILE ID! */
     if (H5Pclose(fapl_id) < 0)
-        STACK_ERROR
+        STACK_ERROR;
 
     /* _exit() is necessary since we want a hard close of the library */
     HD_exit(EXIT_SUCCESS);

--- a/test/flush2.c
+++ b/test/flush2.c
@@ -248,7 +248,7 @@ main(void)
 
     h5_reset();
     if ((fapl_id = h5_fileaccess()) < 0)
-        PUTS_ERROR("bad vfd-dependent fapl")
+        PUTS_ERROR("bad vfd-dependent fapl");
 
     /* Check if the current VFD supports SWMR */
     driver            = HDgetenv(HDF5_DRIVER);
@@ -262,7 +262,7 @@ main(void)
     if (file_ok(filename, fapl_id, check_second_dset))
         PASSED();
     else
-        TEST_ERROR
+        TEST_ERROR;
 
     /* TEST 2 */
     /* Check the case where the file was flushed (w/SWMR) */
@@ -271,23 +271,23 @@ main(void)
         h5_fixname(FILENAME[1], fapl_id, filename, sizeof(filename));
         check_second_dset = FALSE;
         if (clear_status_flags(filename, fapl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (file_ok(filename, fapl_id, check_second_dset))
             PASSED();
         else
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else
-        SKIPPED()
+        SKIPPED();
 
     /* TEST 3 */
     /* Check the case where the file was not flushed */
     TESTING("H5Fflush (part2 without flush)");
     /* Turn the error stack off (failures expected) */
     if (H5Eget_auto2(H5E_DEFAULT, &func, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Eset_auto2(H5E_DEFAULT, NULL, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     h5_fixname(FILENAME[2], fapl_id, filename, sizeof(filename));
     check_second_dset = FALSE;
     if (file_ok(filename, fapl_id, check_second_dset)) {
@@ -295,14 +295,14 @@ main(void)
         SKIPPED();
         HDputs("   the DLL will flush the file even when calling _exit, skip this test temporarily");
 #else
-        TEST_ERROR
+        TEST_ERROR;
 #endif
     } /* end if */
     else
         PASSED();
     /* Turn the error stack back on */
     if (H5Eset_auto2(H5E_DEFAULT, func, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* TEST 4 */
     /* Check the case where the file was not flushed (w/SWMR) */
@@ -310,29 +310,29 @@ main(void)
     if (vfd_supports_swmr) {
         /* Turn the error stack off (failures expected) */
         if (H5Eget_auto2(H5E_DEFAULT, &func, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Eset_auto2(H5E_DEFAULT, NULL, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         h5_fixname(FILENAME[3], fapl_id, filename, sizeof(filename));
         check_second_dset = FALSE;
         if (clear_status_flags(filename, fapl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (file_ok(filename, fapl_id, check_second_dset)) {
 #if defined H5_HAVE_WIN32_API && !defined(hdf5_EXPORTS)
             SKIPPED();
             HDputs("   the DLL will flush the file even when calling _exit, skip this test temporarily");
 #else
-            TEST_ERROR
+            TEST_ERROR;
 #endif
         } /* end if */
         else
             PASSED();
         /* Turn the error stack back on */
         if (H5Eset_auto2(H5E_DEFAULT, func, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
     else
-        SKIPPED()
+        SKIPPED();
 
     /* TEST 5 */
     /* Check the case where the file was flushed, but more data was
@@ -344,7 +344,7 @@ main(void)
     if (file_ok(filename, fapl_id, check_second_dset))
         PASSED();
     else
-        TEST_ERROR
+        TEST_ERROR;
 
     /* TEST 6 */
     /* Check the case where the file was flushed, but more data was
@@ -355,14 +355,14 @@ main(void)
         check_second_dset = TRUE;
         h5_fixname(FILENAME[5], fapl_id, filename, sizeof(filename));
         if (clear_status_flags(filename, fapl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (file_ok(filename, fapl_id, check_second_dset))
             PASSED();
         else
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else
-        SKIPPED()
+        SKIPPED();
 
     /* TEST 7 */
     /* Check the case where the file was flushed, but more data was added
@@ -371,24 +371,24 @@ main(void)
     TESTING("H5Fflush (part2 with flush and later addition)");
     /* Turn the error stack off (failures expected) */
     if (H5Eget_auto2(H5E_DEFAULT, &func, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Eset_auto2(H5E_DEFAULT, NULL, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     h5_fixname(FILENAME[6], fapl_id, filename, sizeof(filename));
     check_second_dset = TRUE;
     if (file_ok(filename, fapl_id, check_second_dset)) {
 #if defined H5_HAVE_WIN32_API && !defined(hdf5_EXPORTS)
-        SKIPPED()
+        SKIPPED();
         HDputs("   the DLL will flush the file even when calling _exit, skip this test temporarily");
 #else
-        TEST_ERROR
+        TEST_ERROR;
 #endif
     } /* end if */
     else
         PASSED();
     /* Turn the error stack back on */
     if (H5Eset_auto2(H5E_DEFAULT, func, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* TEST 8 */
     /* Check the case where the file was flushed, but more data was added
@@ -398,29 +398,29 @@ main(void)
     if (vfd_supports_swmr) {
         /* Turn the error stack off (failures expected) */
         if (H5Eget_auto2(H5E_DEFAULT, &func, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Eset_auto2(H5E_DEFAULT, NULL, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         h5_fixname(FILENAME[7], fapl_id, filename, sizeof(filename));
         check_second_dset = TRUE;
         if (clear_status_flags(filename, fapl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (file_ok(filename, fapl_id, check_second_dset)) {
 #if defined H5_HAVE_WIN32_API && !defined(hdf5_EXPORTS)
             SKIPPED();
             HDputs("   the DLL will flush the file even when calling _exit, skip this test temporarily");
 #else
-            TEST_ERROR
+            TEST_ERROR;
 #endif
         } /* end if */
         else
             PASSED();
         /* Turn the error stack back on */
         if (H5Eset_auto2(H5E_DEFAULT, func, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
     else
-        SKIPPED()
+        SKIPPED();
 
     if (!vfd_supports_swmr)
         HDprintf("NOTE: Some tests were skipped since the current VFD lacks SWMR support\n");

--- a/test/freespace.c
+++ b/test/freespace.c
@@ -258,7 +258,7 @@ TEST_sect_merging(H5FS_section_info_t **_sect1, H5FS_section_info_t *_sect2, voi
 
     /* Get rid of second section */
     if (TEST_sect_free((H5FS_section_info_t *)sect2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 error:
     return ret_value;
 } /* TEST_sect_merging() */
@@ -316,7 +316,7 @@ TEST_sect_shrinking(H5FS_section_info_t **_sect, void *_udata)
     /* just free the section node */
     if (*can_shrink) {
         if (TEST_sect_free((H5FS_section_info_t *)*sect) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         *sect = NULL;
         return TRUE;
     } /* end if */
@@ -397,32 +397,32 @@ check_stats(const H5F_t *f, const H5FS_t *frsp, frspace_state_t *state)
 
     /* Get statistics for heap and verify they are correct */
     if (H5FS_stat_info(f, frsp, &frspace_stats) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (frspace_stats.tot_space != state->tot_space) {
         HDfprintf(stdout, "frspace_stats.tot_space = %" PRIuHSIZE ", state->tot_space = %" PRIuHSIZE "\n",
                   frspace_stats.tot_space, state->tot_space);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (frspace_stats.tot_sect_count != state->tot_sect_count) {
         HDfprintf(stdout,
                   "frspace_stats.tot_sect_count = %" PRIuHSIZE ", state->tot_sect_count = %" PRIuHSIZE "\n",
                   frspace_stats.tot_sect_count, state->tot_sect_count);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (frspace_stats.serial_sect_count != state->serial_sect_count) {
         HDfprintf(stdout,
                   "frspace_stats.serial_sect_count = %" PRIuHSIZE ", state->serial_sect_count = %" PRIuHSIZE
                   "\n",
                   frspace_stats.serial_sect_count, state->serial_sect_count);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (frspace_stats.ghost_sect_count != state->ghost_sect_count) {
         HDfprintf(stdout,
                   "frspace_stats.ghost_sect_count = %" PRIuHSIZE ", state->ghost_sect_count = %" PRIuHSIZE
                   "\n",
                   frspace_stats.ghost_sect_count, state->ghost_sect_count);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* All tests passed */
@@ -460,23 +460,23 @@ test_fs_create(hid_t fapl)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of a file w/empty heap*/
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* initialize creation parameters for free-space manager */
     init_cparam(&cparam);
@@ -487,59 +487,59 @@ test_fs_create(hid_t fapl)
 
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
     if (frsp->nclasses != nclasses)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     HDmemset(&test_cparam, 0, sizeof(H5FS_create_t));
     if (H5FS__get_cparam_test(frsp, &test_cparam) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5FS__cmp_cparam_test(&cparam, &test_cparam))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* reopen the free-space manager */
     if (NULL == (frsp = H5FS_open(f, fs_addr, nclasses, test_classes, NULL, (hsize_t)FSPACE_THRHD_DEF,
                                   (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
     if (frsp->nclasses != nclasses)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is the correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -603,23 +603,23 @@ test_fs_sect_add(hid_t fapl)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of a file w/empty heap*/
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_cparam(&cparam);
     nclasses = NELMTS(test_classes);
@@ -629,19 +629,19 @@ test_fs_sect_add(hid_t fapl)
 
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL == (sect_node = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node, (haddr_t)TEST_SECT_ADDR80, (hsize_t)TEST_SECT_SIZE20, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += sect_node->sect_info.size;
@@ -649,27 +649,27 @@ test_fs_sect_add(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     fr_meta_size = H5FS_HEADER_SIZE(f) + H5FS_SINFO_PREFIX_SIZE(f);
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     sect_node = NULL;
 
     if (h5_using_default_driver(NULL)) {
         /* Get the size of a file w/empty heap*/
         if ((tmp_file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (tmp_file_size <= (file_size + fr_meta_size))
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     PASSED();
@@ -678,15 +678,15 @@ test_fs_sect_add(hid_t fapl)
 
     /* Get the size of a file w/empty heap*/
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_cparam(&cparam);
     nclasses = NELMTS(test_classes);
@@ -694,20 +694,20 @@ test_fs_sect_add(hid_t fapl)
     init_flags = H5FS_CLS_GHOST_OBJ;
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create free list section node */
     if (NULL == (sect_node = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node, (haddr_t)TEST_SECT_ADDR80, (hsize_t)TEST_SECT_SIZE20, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node, 0, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += sect_node->sect_info.size;
@@ -715,26 +715,26 @@ test_fs_sect_add(hid_t fapl)
     state.ghost_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     fr_meta_size = H5FS_HEADER_SIZE(f);
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     sect_node = NULL;
 
     if (h5_using_default_driver(NULL)) {
         /* Get the size of a file w/empty heap*/
         if ((tmp_file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (tmp_file_size != (file_size + fr_meta_size))
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     PASSED();
@@ -743,23 +743,23 @@ test_fs_sect_add(hid_t fapl)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of a file w/empty heap*/
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     TEST_set_eoa((haddr_t)TEST_SECT_ADDR150); /* set end of file address for shrinking */
 
@@ -769,13 +769,13 @@ test_fs_sect_add(hid_t fapl)
     init_flags = 0;
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL == (sect_node = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Add section A
@@ -784,27 +784,27 @@ test_fs_sect_add(hid_t fapl)
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node, H5FS_ADD_RETURNED_SPACE, &can_shrink) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* nothing in free-space */
     HDmemset(&state, 0, sizeof(frspace_state_t));
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     sect_node = NULL;
 
     PASSED();
@@ -813,23 +813,23 @@ test_fs_sect_add(hid_t fapl)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of a file w/empty heap*/
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     TEST_set_eoa((haddr_t)TEST_SECT_ADDR150); /* set end of file address for shrinking */
 
@@ -839,13 +839,13 @@ test_fs_sect_add(hid_t fapl)
     init_flags = 0;
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (NULL == (sect_node = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Add section A
@@ -854,7 +854,7 @@ test_fs_sect_add(hid_t fapl)
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node, H5FS_ADD_DESERIALIZING, &can_shrink) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += sect_node->sect_info.size;
@@ -862,29 +862,29 @@ test_fs_sect_add(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5FS_sect_remove(f, frsp, (H5FS_section_info_t *)sect_node) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Free the section node(s) */
     if (TEST_sect_free((H5FS_section_info_t *)sect_node) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     sect_node = NULL;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     sect_node = NULL;
 
     PASSED();
@@ -948,11 +948,11 @@ test_fs_sect_find(hid_t fapl)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_cparam(&cparam);
     nclasses = NELMTS(test_classes);
@@ -962,28 +962,28 @@ test_fs_sect_find(hid_t fapl)
 
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((node_found = H5FS_sect_find(f, frsp, (hsize_t)TEST_SECT_SIZE30, (H5FS_section_info_t **)&node)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (node_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     PASSED();
@@ -993,24 +993,24 @@ test_fs_sect_find(hid_t fapl)
     /* reopen the free-space manager */
     if (NULL == (frsp = H5FS_open(f, fs_addr, nclasses, test_classes, NULL, (hsize_t)FSPACE_THRHD_DEF,
                                   (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
     if (frsp->nclasses != nclasses)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section A
      */
     if (NULL == (sect_node1 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR60, (hsize_t)TEST_SECT_SIZE30, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += sect_node1->sect_info.size;
@@ -1018,99 +1018,99 @@ test_fs_sect_find(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section C
      */
     if (NULL == (sect_node3 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node3, (haddr_t)(TEST_SECT_ADDR200), (hsize_t)TEST_SECT_SIZE50, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node3, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     state.tot_space += sect_node3->sect_info.size;
     state.tot_sect_count += 1;
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section B
      */
     if (NULL == (sect_node2 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     state.tot_space += sect_node2->sect_info.size;
     state.tot_sect_count += 1;
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section D
      */
     if (NULL == (sect_node4 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node4, (haddr_t)TEST_SECT_ADDR300, (hsize_t)TEST_SECT_SIZE80, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node4, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     state.tot_space += sect_node4->sect_info.size;
     state.tot_sect_count += 1;
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((node_found = H5FS_sect_find(f, frsp, (hsize_t)TEST_SECT_SIZE50, (H5FS_section_info_t **)&node)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!node_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((node->sect_info.addr != TEST_SECT_ADDR100) || (node->sect_info.size != TEST_SECT_SIZE50))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (TEST_sect_free((H5FS_section_info_t *)node) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* remove sections A, C and D */
     if (H5FS_sect_remove(f, frsp, (H5FS_section_info_t *)sect_node1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5FS_sect_remove(f, frsp, (H5FS_section_info_t *)sect_node3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5FS_sect_remove(f, frsp, (H5FS_section_info_t *)sect_node4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Free the section node(s) */
     if (TEST_sect_free((H5FS_section_info_t *)sect_node1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     sect_node1 = NULL;
     if (TEST_sect_free((H5FS_section_info_t *)sect_node3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     sect_node3 = NULL;
     if (TEST_sect_free((H5FS_section_info_t *)sect_node4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     sect_node4 = NULL;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     PASSED();
@@ -1120,24 +1120,24 @@ test_fs_sect_find(hid_t fapl)
     /* reopen the free-space manager */
     if (NULL == (frsp = H5FS_open(f, fs_addr, nclasses, test_classes, NULL, (hsize_t)FSPACE_THRHD_DEF,
                                   (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
     if (frsp->nclasses != nclasses)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section A
      */
     if (NULL == (sect_node1 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR60, (hsize_t)TEST_SECT_SIZE30, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += sect_node1->sect_info.size;
@@ -1145,51 +1145,51 @@ test_fs_sect_find(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section B
      */
     if (NULL == (sect_node2 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR200, (hsize_t)TEST_SECT_SIZE80, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     state.tot_space += sect_node2->sect_info.size;
     state.tot_sect_count += 1;
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((node_found = H5FS_sect_find(f, frsp, (hsize_t)TEST_SECT_SIZE50, (H5FS_section_info_t **)&node)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!node_found)
-        TEST_ERROR
+        TEST_ERROR;
     if ((node->sect_info.addr != TEST_SECT_ADDR200) || (node->sect_info.size < TEST_SECT_SIZE50))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (TEST_sect_free((H5FS_section_info_t *)node) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     node = NULL;
 
     /* remove sections A */
     if (H5FS_sect_remove(f, frsp, (H5FS_section_info_t *)sect_node1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Free the section node(s) */
     if (TEST_sect_free((H5FS_section_info_t *)sect_node1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     sect_node1 = NULL;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     PASSED();
@@ -1199,24 +1199,24 @@ test_fs_sect_find(hid_t fapl)
     /* reopen the free-space manager */
     if (NULL == (frsp = H5FS_open(f, fs_addr, nclasses, test_classes, NULL, (hsize_t)FSPACE_THRHD_DEF,
                                   (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
     if (frsp->nclasses != nclasses)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section A
      */
     if (NULL == (sect_node1 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR60, (hsize_t)TEST_SECT_SIZE30, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += sect_node1->sect_info.size;
@@ -1224,36 +1224,36 @@ test_fs_sect_find(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((node_found = H5FS_sect_find(f, frsp, (hsize_t)TEST_SECT_SIZE50, (H5FS_section_info_t **)&node)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (node_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* remove sections A */
     if (H5FS_sect_remove(f, frsp, (H5FS_section_info_t *)sect_node1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Free the section node(s) */
     if (TEST_sect_free((H5FS_section_info_t *)sect_node1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     sect_node1 = NULL;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1335,11 +1335,11 @@ test_fs_sect_merge(hid_t fapl)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_cparam(&cparam);
     nclasses = NELMTS(test_classes);
@@ -1349,22 +1349,22 @@ test_fs_sect_merge(hid_t fapl)
 
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section C
      */
     if (NULL == (sect_node1 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += TEST_SECT_SIZE50;
@@ -1372,90 +1372,90 @@ test_fs_sect_merge(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section B
      */
     if (NULL == (sect_node2 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE30, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* section B & C are merged */
     state.tot_space += TEST_SECT_SIZE30;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section A
      */
     if (NULL == (sect_node3 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node3, (haddr_t)TEST_SECT_ADDR60, (hsize_t)TEST_SECT_SIZE10, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node3, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* section A is merged with the merged section of B & C */
     state.tot_space += TEST_SECT_SIZE10;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section D
      */
     if (NULL == (sect_node4 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node4, (haddr_t)TEST_SECT_ADDR150, (hsize_t)TEST_SECT_SIZE80, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node4, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* section D is merged with the merged section of A & B & C */
     state.tot_space += TEST_SECT_SIZE80;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* should be able to find the merged section of A, B, C & D */
     if ((node_found = H5FS_sect_find(
              f, frsp, (hsize_t)(TEST_SECT_SIZE10 + TEST_SECT_SIZE30 + TEST_SECT_SIZE50 + TEST_SECT_SIZE80),
              (H5FS_section_info_t **)&node)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!node_found)
-        TEST_ERROR
+        TEST_ERROR;
     if ((node->sect_info.addr != TEST_SECT_ADDR60) ||
         (node->sect_info.size != (TEST_SECT_SIZE10 + TEST_SECT_SIZE30 + TEST_SECT_SIZE50 + TEST_SECT_SIZE80)))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (TEST_sect_free((H5FS_section_info_t *)node) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1466,11 +1466,11 @@ test_fs_sect_merge(hid_t fapl)
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_cparam(&cparam);
     nclasses = NELMTS(test_classes);
@@ -1478,22 +1478,22 @@ test_fs_sect_merge(hid_t fapl)
     init_flags = H5FS_CLS_SEPAR_OBJ;
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section A
      */
     if (NULL == (sect_node1 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE30, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += TEST_SECT_SIZE30;
@@ -1501,19 +1501,19 @@ test_fs_sect_merge(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section B
      */
     if (NULL == (sect_node2 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* section A & B are not merged because H5FS_CLS_SEPAR_OBJ is set */
     state.tot_space += TEST_SECT_SIZE50;
@@ -1521,44 +1521,44 @@ test_fs_sect_merge(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* should not be able to find the merged section of A & B */
     if ((node_found = H5FS_sect_find(f, frsp, (hsize_t)(TEST_SECT_SIZE30 + TEST_SECT_SIZE50),
                                      (H5FS_section_info_t **)&node)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (node_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* remove section A from free-space */
     if (H5FS_sect_remove(f, frsp, (H5FS_section_info_t *)sect_node1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* remove section B from free-space */
     if (H5FS_sect_remove(f, frsp, (H5FS_section_info_t *)sect_node2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Free the section node(s) */
     if (TEST_sect_free((H5FS_section_info_t *)sect_node1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     sect_node1 = NULL;
     if (TEST_sect_free((H5FS_section_info_t *)sect_node2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     sect_node2 = NULL;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1569,11 +1569,11 @@ test_fs_sect_merge(hid_t fapl)
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_cparam(&cparam);
     nclasses = NELMTS(test_classes);
@@ -1581,22 +1581,22 @@ test_fs_sect_merge(hid_t fapl)
     init_flags = 0; /* reset */
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section A
      */
     if (NULL == (sect_node1 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR60, (hsize_t)TEST_SECT_SIZE10, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += TEST_SECT_SIZE10;
@@ -1604,19 +1604,19 @@ test_fs_sect_merge(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section B
      */
     if (NULL == (sect_node2 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE30,
                    TEST_FSPACE_SECT_TYPE_NEW, H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* sections A & B are not merged because H5FS_CLS_MERGE_SYM is set & section class type is different */
     state.tot_space += TEST_SECT_SIZE30;
@@ -1624,37 +1624,37 @@ test_fs_sect_merge(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section C
      */
     if (NULL == (sect_node3 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node3, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50,
                    TEST_FSPACE_SECT_TYPE_NEW, H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node3, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* sections B & C are merged because H5FS_CLS_MERGE_SYM is set & section class type is the same */
     state.tot_space += TEST_SECT_SIZE50;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section D
      */
     if (NULL == (sect_node4 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node4, (haddr_t)TEST_SECT_ADDR150, (hsize_t)TEST_SECT_SIZE80, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node4, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * section D is not merged with the merged section of B & C because
@@ -1665,73 +1665,73 @@ test_fs_sect_merge(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* should not be able to find a merged section of A, B, C & D */
     if ((node_found = H5FS_sect_find(
              f, frsp, (hsize_t)(TEST_SECT_SIZE10 + TEST_SECT_SIZE30 + TEST_SECT_SIZE50 + TEST_SECT_SIZE80),
              (H5FS_section_info_t **)&node)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (node_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* should be able to find the merged section of B & C */
     if ((node_found = H5FS_sect_find(f, frsp, (hsize_t)(TEST_SECT_SIZE30 + TEST_SECT_SIZE50),
                                      (H5FS_section_info_t **)&node)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!node_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((node->sect_info.addr != TEST_SECT_ADDR70) ||
         (node->sect_info.size != (TEST_SECT_SIZE30 + TEST_SECT_SIZE50)))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (TEST_sect_free((H5FS_section_info_t *)node) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* should be able to find section A */
     if ((node_found = H5FS_sect_find(f, frsp, (hsize_t)(TEST_SECT_SIZE10), (H5FS_section_info_t **)&node)) <
         0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!node_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((node->sect_info.addr != TEST_SECT_ADDR60) || (node->sect_info.size != TEST_SECT_SIZE10))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (TEST_sect_free((H5FS_section_info_t *)node) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* should be able to find section D */
     if ((node_found = H5FS_sect_find(f, frsp, (hsize_t)(TEST_SECT_SIZE80), (H5FS_section_info_t **)&node)) <
         0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!node_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((node->sect_info.addr != TEST_SECT_ADDR150) || (node->sect_info.size != TEST_SECT_SIZE80))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (TEST_sect_free((H5FS_section_info_t *)node) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1811,11 +1811,11 @@ test_fs_sect_shrink(hid_t fapl)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_cparam(&cparam);
     nclasses = NELMTS(test_classes);
@@ -1827,23 +1827,23 @@ test_fs_sect_shrink(hid_t fapl)
 
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section A that allow shrinking but its section class type does not define "can_shrink"
      */
     if (NULL == (sect_node1 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50,
                    TEST_FSPACE_SECT_TYPE_NEW, H5FS_SECT_LIVE);
 
     can_shrink = FALSE;
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, &can_shrink) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += sect_node1->sect_info.size;
@@ -1851,62 +1851,62 @@ test_fs_sect_shrink(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* section A should still be there in free-space */
     if ((node_found = H5FS_sect_find(f, frsp, (hsize_t)(TEST_SECT_SIZE50), (H5FS_section_info_t **)&node)) <
         0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!node_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((node->sect_info.addr != TEST_SECT_ADDR100) || (node->sect_info.size != TEST_SECT_SIZE50))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (TEST_sect_free((H5FS_section_info_t *)node) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Re-add section A that allow shrinking and its section class type defines "can_shrink"
      */
     if (NULL == (sect_node1 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     can_shrink = FALSE;
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, &can_shrink) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* should have nothing in free-space */
     HDmemset(&state, 0, sizeof(frspace_state_t));
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* section A should not be there in free-space */
     if ((node_found = H5FS_sect_find(f, frsp, (hsize_t)(TEST_SECT_SIZE50), (H5FS_section_info_t **)&node)) <
         0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (node_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1914,11 +1914,11 @@ test_fs_sect_shrink(hid_t fapl)
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_cparam(&cparam);
     nclasses = NELMTS(test_classes);
@@ -1929,22 +1929,22 @@ test_fs_sect_shrink(hid_t fapl)
     init_flags = H5FS_CLS_SEPAR_OBJ;
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section A
      */
     if (NULL == (sect_node1 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR80, (hsize_t)TEST_SECT_SIZE20, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, &can_shrink) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += sect_node1->sect_info.size;
@@ -1952,62 +1952,62 @@ test_fs_sect_shrink(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section B
      */
     if (NULL == (sect_node2 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, &can_shrink) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* free-space should be the same since section B is shrunk */
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* section B should not be there in free-space */
     if ((node_found = H5FS_sect_find(f, frsp, (hsize_t)(TEST_SECT_SIZE50), (H5FS_section_info_t **)&node)) <
         0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (node_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* section A should still be there in free-space */
     if ((node_found = H5FS_sect_find(f, frsp, (hsize_t)(TEST_SECT_SIZE20), (H5FS_section_info_t **)&node)) <
         0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!node_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((node->sect_info.addr != TEST_SECT_ADDR80) || (node->sect_info.size != TEST_SECT_SIZE20))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (TEST_sect_free((H5FS_section_info_t *)node) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2015,11 +2015,11 @@ test_fs_sect_shrink(hid_t fapl)
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_cparam(&cparam);
     nclasses = NELMTS(test_classes);
@@ -2029,22 +2029,22 @@ test_fs_sect_shrink(hid_t fapl)
     init_flags = 0; /* reset */
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section A
      */
     if (NULL == (sect_node1 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE30, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, &can_shrink) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += sect_node1->sect_info.size;
@@ -2052,54 +2052,54 @@ test_fs_sect_shrink(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section B
      */
     if (NULL == (sect_node2 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, &can_shrink) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* section A & B are merged and then strunk, so there is nothing in free-space */
     HDmemset(&state, 0, sizeof(frspace_state_t));
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* section B should not be there in free-space */
     if ((node_found = H5FS_sect_find(f, frsp, (hsize_t)(TEST_SECT_SIZE50), (H5FS_section_info_t **)&node)) <
         0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (node_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* section A should not be there in free-space */
     if ((node_found = H5FS_sect_find(f, frsp, (hsize_t)(TEST_SECT_SIZE30), (H5FS_section_info_t **)&node)) <
         0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (node_found)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2156,11 +2156,11 @@ test_fs_sect_change_class(hid_t fapl)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_cparam(&cparam);
     nclasses = NELMTS(test_classes);
@@ -2171,22 +2171,22 @@ test_fs_sect_change_class(hid_t fapl)
     init_flags = H5FS_CLS_GHOST_OBJ;
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section A
      */
     if (NULL == (sect_node1 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR60, (hsize_t)TEST_SECT_SIZE30, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += TEST_SECT_SIZE30;
@@ -2194,65 +2194,65 @@ test_fs_sect_change_class(hid_t fapl)
     state.ghost_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section B
      */
     if (NULL == (sect_node2 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50,
                    TEST_FSPACE_SECT_TYPE_NONE, H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     state.tot_space += TEST_SECT_SIZE50;
     state.tot_sect_count += 1;
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5FS_sect_change_class(f, frsp, (H5FS_section_info_t *)sect_node1, TEST_FSPACE_SECT_TYPE_NONE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     state.serial_sect_count += 1;
     state.ghost_sect_count -= 1;
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5FS_sect_find(f, frsp, (hsize_t)TEST_SECT_SIZE30, (H5FS_section_info_t **)&node) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (node->sect_info.type != TEST_FSPACE_SECT_TYPE_NONE)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (TEST_sect_free((H5FS_section_info_t *)node) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5FS_sect_remove(f, frsp, (H5FS_section_info_t *)sect_node2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Free the section node(s) */
     if (TEST_sect_free((H5FS_section_info_t *)sect_node2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     sect_node2 = NULL;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2263,11 +2263,11 @@ test_fs_sect_change_class(hid_t fapl)
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_cparam(&cparam);
     nclasses = NELMTS(test_classes);
@@ -2275,102 +2275,102 @@ test_fs_sect_change_class(hid_t fapl)
     init_flags = H5FS_CLS_SEPAR_OBJ;
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section A
      */
     if (NULL == (sect_node1 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE30, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Add section B
      */
     if (NULL == (sect_node2 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50,
                    TEST_FSPACE_SECT_TYPE_NONE, H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Add section C
      */
     if (NULL == (sect_node3 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node3, (haddr_t)TEST_SECT_ADDR200, (hsize_t)TEST_SECT_SIZE80,
                    TEST_FSPACE_SECT_TYPE_NONE, H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node3, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* change the class of B to A's class */
     if (H5FS_sect_change_class(f, frsp, (H5FS_section_info_t *)sect_node2, TEST_FSPACE_SECT_TYPE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* change the class of C to A's class */
     if (H5FS_sect_change_class(f, frsp, (H5FS_section_info_t *)sect_node3, TEST_FSPACE_SECT_TYPE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* the merge_list should be empty */
     if (frsp->sinfo->merge_list)
         if (H5SL_count(frsp->sinfo->merge_list))
-            TEST_ERROR
+            TEST_ERROR;
 
     /* verify that section B has changed class */
     if (H5FS_sect_find(f, frsp, (hsize_t)TEST_SECT_SIZE50, (H5FS_section_info_t **)&node) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (node->sect_info.type != TEST_FSPACE_SECT_TYPE)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (TEST_sect_free((H5FS_section_info_t *)node) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* verify that section C has changed class */
     if (H5FS_sect_find(f, frsp, (hsize_t)TEST_SECT_SIZE80, (H5FS_section_info_t **)&node) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (node->sect_info.type != TEST_FSPACE_SECT_TYPE)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (TEST_sect_free((H5FS_section_info_t *)node) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* remove section A from free-space */
     if (H5FS_sect_remove(f, frsp, (H5FS_section_info_t *)sect_node1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Free the section node(s) */
     if (TEST_sect_free((H5FS_section_info_t *)sect_node1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     sect_node1 = NULL;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2442,11 +2442,11 @@ test_fs_sect_extend(hid_t fapl)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Tag with the global free space tag */
     H5AC_tag(H5AC__FREESPACE_TAG, NULL);
@@ -2459,22 +2459,22 @@ test_fs_sect_extend(hid_t fapl)
 
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section A
      */
     if (NULL == (sect_node1 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE5, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += sect_node1->sect_info.size;
@@ -2482,49 +2482,49 @@ test_fs_sect_extend(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section B
      */
     if (NULL == (sect_node2 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE40, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     state.tot_space += sect_node2->sect_info.size;
     state.tot_sect_count += 1;
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Extend a block by requested-size */
     if ((status = H5FS_sect_try_extend(f, frsp, (haddr_t)TEST_SECT_SIZE80, (hsize_t)TEST_SECT_SIZE20,
                                        (hsize_t)TEST_SECT_SIZE40, 0, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (FALSE == status)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Succeed in extending the block: free space info is decremented accordingly */
     state.tot_space -= (hsize_t)TEST_SECT_SIZE40;
     state.tot_sect_count -= 1;
     state.serial_sect_count -= 1;
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     PASSED();
@@ -2536,22 +2536,22 @@ test_fs_sect_extend(hid_t fapl)
 
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section A
      */
     if (NULL == (sect_node1 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE5, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += sect_node1->sect_info.size;
@@ -2559,46 +2559,46 @@ test_fs_sect_extend(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section B
      */
     if (NULL == (sect_node2 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE40, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     state.tot_space += sect_node2->sect_info.size;
     state.tot_sect_count += 1;
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Extend the block by requested-size */
     if ((status = H5FS_sect_try_extend(f, frsp, (haddr_t)TEST_SECT_ADDR80, (hsize_t)TEST_SECT_SIZE20,
                                        (hsize_t)TEST_SECT_SIZE50, 0, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (TRUE == status)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Not able to extend the block: free space info remains the same */
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     PASSED();
@@ -2610,22 +2610,22 @@ test_fs_sect_extend(hid_t fapl)
 
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section A
      */
     if (NULL == (sect_node1 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE5, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += sect_node1->sect_info.size;
@@ -2633,47 +2633,47 @@ test_fs_sect_extend(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section B
      */
     if (NULL == (sect_node2 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE40, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     state.tot_space += sect_node2->sect_info.size;
     state.tot_sect_count += 1;
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Extend the block by requested-size */
     if ((status = H5FS_sect_try_extend(f, frsp, (haddr_t)TEST_SECT_ADDR80, (hsize_t)TEST_SECT_SIZE20,
                                        (hsize_t)TEST_SECT_SIZE30, 0, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (FALSE == status)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Succeed in extending the block: total free space is decreased but other info remains the same */
     state.tot_space -= 30;
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     PASSED();
@@ -2685,22 +2685,22 @@ test_fs_sect_extend(hid_t fapl)
 
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section A
      */
     if (NULL == (sect_node1 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE5, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
     state.tot_space += sect_node1->sect_info.size;
@@ -2708,53 +2708,53 @@ test_fs_sect_extend(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Add section B
      */
     if (NULL == (sect_node2 = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE40, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
     if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     state.tot_space += sect_node2->sect_info.size;
     state.tot_sect_count += 1;
     state.serial_sect_count += 1;
 
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Extend the block by requested-size */
     if ((status = H5FS_sect_try_extend(f, frsp, (haddr_t)TEST_SECT_ADDR80, (hsize_t)TEST_SECT_SIZE15,
                                        (hsize_t)TEST_SECT_SIZE40, 0, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (TRUE == status)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Not able to extend the block: free space manager info remains the same */
     if (check_stats(f, frsp, &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     PASSED();
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     return 0;
 
@@ -2801,11 +2801,11 @@ test_fs_sect_iterate(hid_t fapl)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     init_cparam(&cparam);
     nclasses             = NELMTS(test_classes);
@@ -2818,45 +2818,45 @@ test_fs_sect_iterate(hid_t fapl)
     init_flags = H5FS_CLS_SEPAR_OBJ;
     if (NULL == (frsp = H5FS_create(f, &fs_addr, &cparam, nclasses, test_classes, &init_flags,
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!H5F_addr_defined(fs_addr))
-        TEST_ERROR
+        TEST_ERROR;
 
     for (i = 1; i <= NUM_SECTIONS; i++) {
         if (NULL == (sect_node = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         sect_size = (unsigned)((i - 1) % 9) + 1;
         init_sect_node(sect_node, (haddr_t)i * 10, (hsize_t)sect_size, TEST_FSPACE_SECT_TYPE, H5FS_SECT_LIVE);
 
         if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     if (H5FS_sect_iterate(f, frsp, TEST_sects_cb, &udata) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     H5FS_sect_stats(frsp, &tot_space, &nsects);
 
     if (udata.tot_size != tot_space)
-        TEST_ERROR
+        TEST_ERROR;
     if (udata.tot_sect_count != nsects)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the free space manager */
     if (H5FS_close(f, frsp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     frsp = NULL;
 
     /* Delete free space manager */
     if (H5FS_delete(f, fs_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     fs_addr = HADDR_UNDEF;
 
     /* Close the file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2884,18 +2884,18 @@ main(void)
 
     if ((fapl = h5_fileaccess()) < 0) {
         nerrors++;
-        PUTS_ERROR("Can't get VFD-dependent fapl")
+        PUTS_ERROR("Can't get VFD-dependent fapl");
     } /* end if */
 
     /* Push API context */
     if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = TRUE;
 
     /* make sure alignment is not set for tests to succeed */
     if (H5Pset_alignment(fapl, (hsize_t)1, (hsize_t)1) < 0) {
         nerrors++;
-        PUTS_ERROR("Can't set alignment")
+        PUTS_ERROR("Can't set alignment");
     } /* end if */
 
     nerrors += test_fs_create(fapl);
@@ -2916,7 +2916,7 @@ main(void)
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = FALSE;
 
     h5_cleanup(FILENAME, fapl);

--- a/test/gen_bad_offset.c
+++ b/test/gen_bad_offset.c
@@ -58,43 +58,43 @@ main(void)
 
     /* Create the test file */
     if ((fid = H5Fcreate(TESTFILE, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create two groups */
     if ((gid1 = H5Gcreate2(fid, GRP1, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((gid2 = H5Gcreate2(gid1, GRP2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the groups */
     if (H5Gclose(gid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create soft links to the groups */
     if (H5Lcreate_soft("/group1", fid, SOFT1, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("/group1/group2", fid, SOFT2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataset */
     if ((sid = H5Screate(H5S_SCALAR)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did = H5Dcreate2(fid, DSET, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataspace */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Write bad offset values at 3 locations in the file
@@ -102,32 +102,32 @@ main(void)
 
     /* Open the file */
     if ((fd = HDopen(TESTFILE, O_RDWR, 0663)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Position the file for /group1/group2: replace heap offset "8" by bad offset */
     if (HDlseek(fd, (HDoff_t)880, SEEK_SET) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Write the bad offset value to the file */
     if (HDwrite(fd, &val, sizeof(val)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Position the file for /dsetA: replace name offset into private heap "72" by bad offset */
     if (HDlseek(fd, (HDoff_t)1512, SEEK_SET) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Write the bad offset value to the file */
     if (HDwrite(fd, &val, sizeof(val)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Position the file for /soft_one: replace link value offset in the scratch pad "32" by bad offset */
     if (HDlseek(fd, (HDoff_t)1616, SEEK_SET) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Write the bad offset value to the file */
     if (HDwrite(fd, &val, sizeof(val)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (HDclose(fd) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     return EXIT_SUCCESS;
 

--- a/test/gen_cross.c
+++ b/test/gen_cross.c
@@ -123,53 +123,53 @@ create_normal_dset(hid_t fid, hid_t fsid, hid_t msid)
      * Create the dataset creation property list, set the fill value.
      */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_FLOAT, &fillvalue) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create a new dataset within the file using defined dataspace and
      * little-endian datatype and default dataset creation properties.
      */
     if ((dataset = H5Dcreate2(fid, DATASETNAME, H5T_IEEE_F64LE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Write the data to the dataset using default transfer properties.
      */
     if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Close dataset
      */
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create a new dataset within the file using defined dataspace and
      * big-endian datatype and default dataset creation properties.
      */
     if ((dataset = H5Dcreate2(fid, DATASETNAME1, H5T_IEEE_F64BE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Write the data to the dataset using default transfer properties.
      */
     if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Close dataset
      */
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Close/release resources.
      */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -222,44 +222,44 @@ create_scale_offset_dsets_float(hid_t fid, hid_t fsid, hid_t msid)
      * filter, set the chunk size, and set the fill value.
      */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_scaleoffset(dcpl, H5Z_SO_FLOAT_DSCALE, 3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(dcpl, RANK, chunk) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_FLOAT, &fillvalue) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create a new dataset within the file using defined dataspace, little
      * endian datatype and default dataset creation properties.
      */
     if ((dataset = H5Dcreate2(fid, DATASETNAME2, H5T_IEEE_F32LE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Write the data to the dataset using default transfer properties.
      */
     if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now create a dataset with a big-endian type */
     if ((dataset = H5Dcreate2(fid, DATASETNAME3, H5T_IEEE_F32BE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Close/release resources.
      */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -312,44 +312,44 @@ create_scale_offset_dsets_double(hid_t fid, hid_t fsid, hid_t msid)
      * filter, set the chunk size, and set the fill value.
      */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_scaleoffset(dcpl, H5Z_SO_FLOAT_DSCALE, 3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(dcpl, RANK, chunk) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_DOUBLE, &fillvalue) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create a new dataset within the file using defined dataspace, little
      * endian datatype and default dataset creation properties.
      */
     if ((dataset = H5Dcreate2(fid, DATASETNAME4, H5T_IEEE_F64LE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Write the data to the dataset using default transfer properties.
      */
     if (H5Dwrite(dataset, H5T_NATIVE_DOUBLE, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now create a dataset with a big-endian type */
     if ((dataset = H5Dcreate2(fid, DATASETNAME5, H5T_IEEE_F64BE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dataset, H5T_NATIVE_DOUBLE, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Close/release resources.
      */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -410,44 +410,44 @@ create_scale_offset_dsets_char(hid_t fid, hid_t fsid, hid_t msid)
      * filter, set the chunk size, and set the fill value.
      */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_scaleoffset(dcpl, H5Z_SO_INT, H5Z_SO_INT_MINBITS_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(dcpl, RANK, chunk) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_CHAR, &fillvalue) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create a new dataset within the file using defined dataspace, little
      * endian datatype and default dataset creation properties.
      */
     if ((dataset = H5Dcreate2(fid, DATASETNAME6, H5T_STD_I8LE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Write the data to the dataset using default transfer properties.
      */
     if (H5Dwrite(dataset, H5T_NATIVE_CHAR, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now create a dataset with a big-endian type */
     if ((dataset = H5Dcreate2(fid, DATASETNAME7, H5T_STD_I8BE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dataset, H5T_NATIVE_CHAR, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Close/release resources.
      */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -508,44 +508,44 @@ create_scale_offset_dsets_short(hid_t fid, hid_t fsid, hid_t msid)
      * filter, set the chunk size, and set the fill value.
      */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_scaleoffset(dcpl, H5Z_SO_INT, H5Z_SO_INT_MINBITS_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(dcpl, RANK, chunk) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_SHORT, &fillvalue) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create a new dataset within the file using defined dataspace, little
      * endian datatype and default dataset creation properties.
      */
     if ((dataset = H5Dcreate2(fid, DATASETNAME8, H5T_STD_I16LE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Write the data to the dataset using default transfer properties.
      */
     if (H5Dwrite(dataset, H5T_NATIVE_SHORT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now create a dataset with a big-endian type */
     if ((dataset = H5Dcreate2(fid, DATASETNAME9, H5T_STD_I16BE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dataset, H5T_NATIVE_SHORT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Close/release resources.
      */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -606,44 +606,44 @@ create_scale_offset_dsets_int(hid_t fid, hid_t fsid, hid_t msid)
      * filter, set the chunk size, and set the fill value.
      */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_scaleoffset(dcpl, H5Z_SO_INT, H5Z_SO_INT_MINBITS_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(dcpl, RANK, chunk) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fillvalue) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create a new dataset within the file using defined dataspace, little
      * endian datatype and default dataset creation properties.
      */
     if ((dataset = H5Dcreate2(fid, DATASETNAME10, H5T_STD_I32LE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Write the data to the dataset using default transfer properties.
      */
     if (H5Dwrite(dataset, H5T_NATIVE_INT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now create a dataset with a big-endian type */
     if ((dataset = H5Dcreate2(fid, DATASETNAME11, H5T_STD_I32BE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dataset, H5T_NATIVE_INT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Close/release resources.
      */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -705,44 +705,44 @@ create_scale_offset_dsets_long_long(hid_t fid, hid_t fsid, hid_t msid)
      * filter, set the chunk size, and set the fill value.
      */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_scaleoffset(dcpl, H5Z_SO_INT, H5Z_SO_INT_MINBITS_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(dcpl, RANK, chunk) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_LLONG, &fillvalue) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create a new dataset within the file using defined dataspace, little
      * endian datatype and default dataset creation properties.
      */
     if ((dataset = H5Dcreate2(fid, DATASETNAME12, H5T_STD_I64LE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Write the data to the dataset using default transfer properties.
      */
     if (H5Dwrite(dataset, H5T_NATIVE_LLONG, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now create a dataset with a big-endian type */
     if ((dataset = H5Dcreate2(fid, DATASETNAME13, H5T_STD_I64BE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dataset, H5T_NATIVE_LLONG, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Close/release resources.
      */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -795,44 +795,44 @@ create_fletcher_dsets_float(hid_t fid, hid_t fsid, hid_t msid)
      * filter, set the chunk size, and set the fill value.
      */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_filter(dcpl, H5Z_FILTER_FLETCHER32, 0, (size_t)0, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(dcpl, RANK, chunk) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_FLOAT, &fillvalue) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create a new dataset within the file using defined dataspace, little
      * endian datatype and default dataset creation properties.
      */
     if ((dataset = H5Dcreate2(fid, DATASETNAME14, H5T_IEEE_F32LE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Write the data to the dataset using default transfer properties.
      */
     if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now create a dataset with a big-endian type */
     if ((dataset = H5Dcreate2(fid, DATASETNAME15, H5T_IEEE_F32BE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Close/release resources.
      */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -886,44 +886,44 @@ create_deflate_dsets_float(hid_t fid, hid_t fsid, hid_t msid)
      * filter, set the chunk size, and set the fill value.
      */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_deflate(dcpl, 6) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(dcpl, RANK, chunk) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_FLOAT, &fillvalue) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create a new dataset within the file using defined dataspace, little
      * endian datatype and default dataset creation properties.
      */
     if ((dataset = H5Dcreate2(fid, DATASETNAME16, H5T_IEEE_F32LE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Write the data to the dataset using default transfer properties.
      */
     if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now create a dataset with a big-endian type */
     if ((dataset = H5Dcreate2(fid, DATASETNAME17, H5T_IEEE_F32BE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Close/release resources.
      */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #else  /* H5_HAVE_FILTER_DEFLATE */
     const char *not_supported = "Deflate filter is not enabled. Can't create the dataset.";
@@ -986,44 +986,44 @@ create_szip_dsets_float(hid_t fid, hid_t fsid, hid_t msid)
      * filter, set the chunk size, and set the fill value.
      */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_szip(dcpl, H5_SZIP_NN_OPTION_MASK, 4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(dcpl, RANK, chunk) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_FLOAT, &fillvalue) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create a new dataset within the file using defined dataspace, little
      * endian datatype and default dataset creation properties.
      */
     if ((dataset = H5Dcreate2(fid, DATASETNAME18, H5T_IEEE_F32LE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Write the data to the dataset using default transfer properties.
      */
     if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now create a dataset with a big-endian type */
     if ((dataset = H5Dcreate2(fid, DATASETNAME19, H5T_IEEE_F32BE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Close/release resources.
      */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -1077,44 +1077,44 @@ create_shuffle_dsets_float(hid_t fid, hid_t fsid, hid_t msid)
      * filter, set the chunk size, and set the fill value.
      */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_shuffle(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(dcpl, RANK, chunk) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_FLOAT, &fillvalue) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create a new dataset within the file using defined dataspace, little
      * endian datatype and default dataset creation properties.
      */
     if ((dataset = H5Dcreate2(fid, DATASETNAME20, H5T_IEEE_F32LE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Write the data to the dataset using default transfer properties.
      */
     if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now create a dataset with a big-endian type */
     if ((dataset = H5Dcreate2(fid, DATASETNAME21, H5T_IEEE_F32BE, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Close/release resources.
      */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -1169,63 +1169,63 @@ create_nbit_dsets_float(hid_t fid, hid_t fsid, hid_t msid)
      * filter, set the chunk size, and set the fill value.
      */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_nbit(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(dcpl, RANK, chunk) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_FLOAT, &fillvalue) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Define user-defined single-precision floating-point type for dataset.
      * A 20-bit little-endian data type. */
     if ((datatype = H5Tcopy(H5T_IEEE_F32LE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_fields(datatype, (size_t)26, (size_t)20, (size_t)6, (size_t)7, (size_t)13) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     offset = 7;
     if (H5Tset_offset(datatype, offset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     precision = 20;
     if (H5Tset_precision(datatype, precision) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_size(datatype, (size_t)4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_ebias(datatype, (size_t)31) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create a new dataset within the file using defined dataspace,
      * user-defined datatype, and default dataset creation properties.
      */
     if ((dataset = H5Dcreate2(fid, DATASETNAME22, datatype, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Write the data to the dataset using default transfer properties.
      */
     if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now create a dataset with a big-endian type */
     if (H5Tset_order(datatype, H5T_ORDER_BE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dataset = H5Dcreate2(fid, DATASETNAME23, datatype, fsid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dataset, H5T_NATIVE_FLOAT, msid, fsid, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dataset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Close/release resources.
      */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 

--- a/test/gen_deflate.c
+++ b/test/gen_deflate.c
@@ -56,7 +56,7 @@ main(void)
     /* Initialize the data */
     /* (Try for something easily compressible) */
     if (NULL == (data = (int *)HDmalloc(SPACE_DIM1 * SPACE_DIM2 * sizeof(int))))
-        TEST_ERROR
+        TEST_ERROR;
 
     for (i = 0; i < SPACE_DIM1; i++)
         for (j = 0; j < SPACE_DIM2; j++)
@@ -64,39 +64,39 @@ main(void)
 
     /* Create the file */
     if ((fid = H5Fcreate(TESTFILE, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dataspace */
     if ((sid = H5Screate_simple(SPACE_RANK, dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dataset creation property list */
     if ((dcpl_id = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set up for deflated data */
     if (H5Pset_chunk(dcpl_id, 2, chunk_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_deflate(dcpl_id, 9) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the compressed dataset */
     if ((did = H5Dcreate2(fid, "Dataset1", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl_id, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write the data to the dataset */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close everything */
     if (H5Pclose(dcpl_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDfree(data);
 

--- a/test/gen_file_image.c
+++ b/test/gen_file_image.c
@@ -47,7 +47,7 @@ main(void)
 
     /* Initialize the data */
     if (NULL == (data = (int *)HDmalloc(SPACE_DIM1 * SPACE_DIM2 * sizeof(int))))
-        TEST_ERROR
+        TEST_ERROR;
 
     for (i = 0; i < SPACE_DIM1; i++)
         for (j = 0; j < SPACE_DIM2; j++)
@@ -55,27 +55,27 @@ main(void)
 
     /* Create the file */
     if ((fid = H5Fcreate(TESTFILE, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dataspace */
     if ((sid = H5Screate_simple(SPACE_RANK, dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the compressed dataset */
     if ((did = H5Dcreate2(fid, "Dataset1", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write the data to the dataset */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close everything */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     return EXIT_SUCCESS;
 

--- a/test/getname.c
+++ b/test/getname.c
@@ -60,12 +60,12 @@ check_name(hid_t id, const char *chk_name, const char *chk_user_path)
     /* Get name */
     *name = '\0';
     if (H5Iget_name(id, name, NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get user path */
     *user_path = '\0';
     if (H5G__user_path_test(id, user_path, &user_path_len, &user_path_hidden) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on name from H5Iget_name() */
     if (HDstrcmp(name, chk_name) != 0)
@@ -77,7 +77,7 @@ check_name(hid_t id, const char *chk_name, const char *chk_user_path)
 
     /* Check that if user path is hidden, the name from H5Iget_name() and the user path should be different */
     if (user_path_hidden && !HDstrcmp(chk_name, chk_user_path))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Everything matches */
     return 0;
@@ -119,11 +119,11 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create group "g0" in the root group using absolute name */
     if ((group_id = H5Gcreate2(file_id, "/g0", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g0", "/g0") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     H5Gclose(group_id);
@@ -138,19 +138,19 @@ test_main(hid_t file_id, hid_t fapl)
     TESTING("H5Iget_name with more than one group");
     /* Create group "g1" in the root group using absolute name */
     if ((group_id = H5Gcreate2(file_id, "/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create group "g2" in group "g1" using absolute name */
     if ((group2_id = H5Gcreate2(file_id, "/g1/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g1", "/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g1/g2", "/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     H5Gclose(group_id);
@@ -167,25 +167,25 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Reopen the group */
     if ((group_id = H5Gopen2(file_id, "/g1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reopen the group */
     if ((group2_id = H5Gopen2(file_id, "/g1/g2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g1", "/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g1/g2", "/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -198,41 +198,41 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create the dataspace  */
     if ((space_id = H5Screate_simple(1, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a new dataset */
     if ((dataset_id =
              H5Dcreate2(file_id, "d1", H5T_NATIVE_INT, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(dataset_id, "/d1", "/d1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reopen the group */
     if ((group_id = H5Gopen2(file_id, "g1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a new dataset inside "g1" */
     if ((dataset_id =
              H5Dcreate2(group_id, "d1", H5T_NATIVE_INT, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(dataset_id, "/g1/d1", "/g1/d1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -245,33 +245,33 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Reopen the dataset */
     if ((dataset_id = H5Dopen2(file_id, "d1", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(dataset_id, "/d1", "/d1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reopen the group */
     if ((group_id = H5Gopen2(file_id, "g1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reopen the dataset */
     if ((dataset_id = H5Dopen2(group_id, "d1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(dataset_id, "/g1/d1", "/g1/d1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -284,42 +284,42 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create group "g2/bar/baz" */
     if ((group_id = H5Gcreate2(file_id, "g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "g2/bar", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file_id, "g2/bar/baz", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataset */
     if ((space_id = H5Screate_simple(1, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dataset_id = H5Dcreate2(group3_id, "d1", H5T_NATIVE_INT, space_id, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reopen the dataset */
     if ((dataset_id = H5Dopen2(file_id, "/g2/bar/baz/d1", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(dataset_id, "/g2/bar/baz/d1", "/g2/bar/baz/d1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -332,23 +332,23 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create a datatype */
     if ((type_id = H5Tcreate(H5T_COMPOUND, sizeof(s1_t))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Insert fields */
     if (H5Tinsert(type_id, "a", HOFFSET(s1_t, a), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(type_id, "b", HOFFSET(s1_t, b), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(type_id, "c", HOFFSET(s1_t, c), H5T_NATIVE_FLOAT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Save datatype for later */
     if (H5Tcommit2(file_id, "t1", type_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(type_id, "/t1", "/t1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close datatype */
     H5Tclose(type_id);
@@ -364,15 +364,15 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Open the named datatype */
     if ((type_id = H5Topen2(file_id, "t1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(type_id, "/t1", "/t1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close datatype */
     if (H5Tclose(type_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -385,19 +385,19 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Reopen the group */
     if ((group_id = H5Gopen2(file_id, "/g1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Rename group */
     if (H5Lmove(file_id, "/g1", H5L_SAME_LOC, "/g1a", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g1a", "/g1a") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -410,19 +410,19 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Reopen the dataset */
     if ((dataset_id = H5Dopen2(file_id, "/d1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Rename dataset */
     if (H5Lmove(file_id, "/d1", H5L_SAME_LOC, "/d1a", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(dataset_id, "/d1a", "/d1a") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -435,19 +435,19 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Open the named datatype */
     if ((type_id = H5Topen2(file_id, "/t1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Rename datatype */
     if (H5Lmove(file_id, "/t1", H5L_SAME_LOC, "/t1a", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(type_id, "/t1a", "/t1a") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close datatype */
     if (H5Tclose(type_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -460,55 +460,55 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create group "/g3" */
     if ((group_id = H5Gcreate2(file_id, "/g3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create group "/g3/foo" using absolute name */
     if ((group2_id = H5Gcreate2(file_id, "/g3/foo1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open group "/g3/foo" again */
     if ((group3_id = H5Gopen2(file_id, "/g3/foo1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Rename group */
     if (H5Lmove(group_id, "foo1", H5L_SAME_LOC, "foo2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g3", "/g3") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g3/foo2", "/g3/foo2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g3/foo2", "/g3/foo2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Rename group again */
     if (H5Lmove(file_id, "g3/foo2", H5L_SAME_LOC, "g3/foo1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g3", "/g3") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g3/foo1", "/g3/foo1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g3/foo1", "/g3/foo1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -521,61 +521,61 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create group "g4/A/B" */
     if ((group_id = H5Gcreate2(file_id, "g4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "g4/A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file_id, "g4/A/B", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create group "g5/C" */
     if ((group4_id = H5Gcreate2(file_id, "g5", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group5_id = H5Gcreate2(file_id, "g5/C", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g4/A/B", "/g4/A/B") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move group "B" to "D"*/
     if (H5Lmove(file_id, "/g4/A/B", H5L_SAME_LOC, "/g5/C/D", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g5/C/D", "/g5/C/D") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move group "/g5/C/D" back to "/g4/A/B" using relative name */
     if (H5Lmove(group5_id, "D", group2_id, "B", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g4/A/B", "/g4/A/B") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move group "/g4/A/B" to "/g4/F/B" using relative name */
     if (H5Lmove(group_id, "A", group_id, "F", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g4/F/B", "/g4/F/B") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g4/F", "/g4/F") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group4_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group5_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -588,39 +588,39 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create group "g6/A/B" and "g7" */
     if ((group_id = H5Gcreate2(file_id, "g6", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "g6/A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file_id, "g6/A/B", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group4_id = H5Gcreate2(file_id, "g7", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g6/A/B", "/g6/A/B") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move group "A" to "C"*/
     if (H5Lmove(file_id, "/g6/A", H5L_SAME_LOC, "/g7/C", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g7/C", "/g7/C") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g7/C/B", "/g7/C/B") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group4_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -633,19 +633,19 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create a new group. */
     if ((group_id = H5Gcreate2(file_id, "/g8", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete */
     if (H5Ldelete(file_id, "/g8", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -658,99 +658,99 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create group "g9/a/b" */
     if ((group_id = H5Gcreate2(file_id, "g9", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "g9/a", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file_id, "g9/a/b", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete */
     if (H5Ldelete(file_id, "/g9/a", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Recreate groups */
     if ((group2_id = H5Gcreate2(group_id, "a", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(group_id, "a/b", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete, using relative path */
     if (H5Ldelete(group_id, "a", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create group "g10/a/b" */
     if ((group_id = H5Gcreate2(file_id, "g10", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "g10/a", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file_id, "g10/a/b", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete */
     if (H5Ldelete(file_id, "/g10/a/b", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Recreate group */
     if ((group3_id = H5Gcreate2(group_id, "a/b", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete, using relative path */
     if (H5Ldelete(group_id, "a/b", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -763,43 +763,43 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create group "g11/g" */
     if ((group_id = H5Gcreate2(file_id, "g11", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "g11/g", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create two datasets "g11/d" and "g11/g/d"*/
     if ((space_id = H5Screate_simple(1, dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dataset_id =
              H5Dcreate2(group_id, "d", H5T_NATIVE_INT, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dataset2_id =
              H5Dcreate2(group2_id, "d", H5T_NATIVE_INT, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete */
     if (H5Ldelete(file_id, "/g11/d", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(dataset_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(dataset2_id, "/g11/g/d", "/g11/g/d") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -812,51 +812,51 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create a group "g12" in the first file */
     if ((group_id = H5Gcreate2(file_id, "/g12", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create second file and dataset "d" in it */
     if ((file1_id = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataspace  */
     if ((space_id = H5Screate_simple(1, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the dataset */
     if ((dataset_id =
              H5Dcreate2(file1_id, "d", H5T_NATIVE_INT, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Mount second file under "g12" in the first file */
     if (H5Fmount(file_id, "/g12", file1_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Access dataset D in the first file under "/G/D" name */
     if ((dataset_id = H5Dopen2(file_id, "/g12/d", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(dataset_id, "/g12/d", "/g12/d") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Funmount(file_id, "/g12") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -869,251 +869,251 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create a group "g13/g1/g2" in the first file */
     if ((group_id = H5Gcreate2(file_id, "/g13", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "/g13/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file_id, "/g13/g1/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create second file and group "g" in it */
     file1_id = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
 
     if ((group_id = H5Gcreate2(file1_id, "/g14", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file1_id, "/g14/g3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file1_id, "/g14/g3/g4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Mount second file under "/g13/g1" in the first file */
     if (H5Fmount(file_id, "/g13/g1", file1_id, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Access group in the first file */
     if ((group_id = H5Gopen2(file_id, "/g13/g1/g14/g3/g4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g13/g1/g14/g3/g4", "/g13/g1/g14/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Funmount(file_id, "/g13/g1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g14/g3/g4", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Access group in the file to mount */
     if ((group3_id = H5Gopen2(file1_id, "/g14/g3/g4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Mount second file under "/g13/g1" in the first file(again) */
     if (H5Fmount(file_id, "/g13/g1", file1_id, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a group ID for the parent of the newly mounted group */
     if ((group2_id = H5Gopen2(file_id, "/g13", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Access group in the first file */
     if ((group_id = H5Gopen2(file_id, "/g13/g1/g14/g3/g4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g13/g1/g14/g3/g4", "/g13/g1/g14/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group3_id, "/g14/g3/g4", "/g14/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Funmount(group2_id, "g1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g14/g3/g4", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group3_id, "/g14/g3/g4", "/g14/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Mount second file under "/g13/g1" in the first file(again) */
     if (H5Fmount(file_id, "/g13/g1", file1_id, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a group ID for the newly mounted group */
     if ((group2_id = H5Gopen2(file_id, "/g13/g1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Access group in the first file */
     if ((group_id = H5Gopen2(file_id, "/g13/g1/g14/g3/g4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g13/g1/g14/g3/g4", "/g13/g1/g14/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group2_id, "/g13/g1", "/g13/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Funmount(group2_id, ".") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g14/g3/g4", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group2_id, "/", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Mount second file under "/g13/g1" in the first file, using relative path */
 
     if ((group3_id = H5Gopen2(file_id, "/g13", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g13", "/g13") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fmount(group3_id, "g1", file1_id, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a group ID for the newly mounted group */
     if ((group2_id = H5Gopen2(file_id, "/g13/g1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g13/g1", "/g13/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Access group in the first file */
     if ((group_id = H5Gopen2(file_id, "/g13/g1/g14/g3/g4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g13/g1/g14/g3/g4", "/g13/g1/g14/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Access group in the first file, with relative path */
     if ((group_id = H5Gopen2(group2_id, "g14/g3/g4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g13/g1/g14/g3/g4", "/g13/g1/g14/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Funmount(group2_id, ".") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Mount second file under "/g13/g1" in the first file, using relative path */
 
     if ((group3_id = H5Gopen2(file_id, "/g13/g1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g13/g1", "/g13/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fmount(group3_id, ".", file1_id, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a group ID for the newly mounted group */
     if ((group2_id = H5Gopen2(file_id, "/g13/g1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g13/g1", "/g13/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Access group in the first file */
     if ((group_id = H5Gopen2(file_id, "/g13/g1/g14/g3/g4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g13/g1/g14/g3/g4", "/g13/g1/g14/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Access group in the first file, with relative path */
     if ((group_id = H5Gopen2(group2_id, "g14/g3/g4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g13/g1/g14/g3/g4", "/g13/g1/g14/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Funmount(group2_id, ".") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group3_id, "/g13/g1", "/g13/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Fclose(file1_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1126,13 +1126,13 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create a group "g15/g1/g2" in the first file */
     if ((group_id = H5Gcreate2(file_id, "/g15", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "/g15/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file_id, "/g15/g1/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group4_id = H5Gcreate2(file_id, "/g15/g1/g2/g3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     H5Gclose(group_id);
@@ -1144,58 +1144,58 @@ test_main(hid_t file_id, hid_t fapl)
     file1_id = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
 
     if ((group_id = H5Gcreate2(file1_id, "/g16", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file1_id, "/g16/g4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file1_id, "/g16/g4/g5", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Access group in the first file */
     if ((group_id = H5Gopen2(file_id, "/g15/g1/g2/g3", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Mount second file under "/g13/g1" in the first file */
     if (H5Fmount(file_id, "/g15/g1", file1_id, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Access group in the second file */
     if ((group2_id = H5Gopen2(file_id, "/g15/g1/g16/g4/g5", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "", "/g15/g1/g2/g3") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g15/g1/g16/g4/g5", "/g15/g1/g16/g4/g5") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Funmount(file_id, "/g15/g1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g15/g1/g2/g3", "/g15/g1/g2/g3") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g16/g4/g5", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1208,72 +1208,72 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create a datatype */
     if ((type_id = H5Tcreate(H5T_COMPOUND, sizeof(s1_t))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Insert fields */
     if (H5Tinsert(type_id, "a", HOFFSET(s1_t, a), H5T_NATIVE_INT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(type_id, "b", HOFFSET(s1_t, b), H5T_NATIVE_INT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(type_id, "c", HOFFSET(s1_t, c), H5T_NATIVE_FLOAT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create group "g17" */
     if ((group_id = H5Gcreate2(file_id, "g17", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Save datatype for later */
     if (H5Tcommit2(group_id, "t", type_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataspace  */
     if ((space_id = H5Screate_simple(1, dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a new dataset */
     if ((dataset_id = H5Dcreate2(group_id, "d", type_id, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(type_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the named datatype */
     if ((type_id = H5Topen2(file_id, "/g17/t", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(type_id, "/g17/t", "/g17/t") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close datatype */
     if (H5Tclose(type_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reopen the dataset */
     if ((dataset_id = H5Dopen2(file_id, "/g17/d", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get datatype*/
     if ((type_id = H5Dget_type(dataset_id)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(type_id, "/g17/t", "/g17/t") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(type_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1286,24 +1286,24 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Open dataset named "d"*/
     if ((dataset_id = H5Dopen2(file_id, "/g17/d", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create link to dataset named "link" */
     if (H5Lcreate_hard(dataset_id, ".", file_id, "/g17/link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dataset2_id = H5Dopen2(file_id, "/g17/link", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Make sure that the two IDs use two different names */
     if (check_name(dataset_id, "/g17/d", "/g17/d") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(dataset2_id, "/g17/link", "/g17/link") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1316,49 +1316,49 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create a new file using default properties. */
     if ((file2_id = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a new file using default properties. */
     if ((file3_id = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dataspace  */
     if ((space_id = H5Screate_simple(1, dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a new dataset */
     if ((dataset_id =
              H5Dcreate2(file2_id, "d", H5T_NATIVE_INT, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a new dataset */
     if ((dataset2_id =
              H5Dcreate2(file3_id, "d", H5T_NATIVE_INT, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete */
     if (H5Ldelete(file2_id, "/d", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(dataset_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(dataset2_id, "/d", "/d") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1371,49 +1371,49 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create a new file using default properties. */
     if ((file2_id = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a new file using default properties. */
     if ((file3_id = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dataspace  */
     if ((space_id = H5Screate_simple(1, dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a new dataset */
     if ((dataset_id =
              H5Dcreate2(file2_id, "d", H5T_NATIVE_INT, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a new dataset */
     if ((dataset2_id =
              H5Dcreate2(file3_id, "d", H5T_NATIVE_INT, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete */
     if (H5Ldelete(file3_id, "/d", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(dataset_id, "/d", "/d") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(dataset2_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1426,26 +1426,26 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Reopen the group */
     if ((group_id = H5Gopen2(file_id, "/g17", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
-        {
-            /*small buffer to hold name and its size */
-            char name2[SMALL_NAME_BUF_SIZE];
+    {
+        /*small buffer to hold name and its size */
+        char name2[SMALL_NAME_BUF_SIZE];
 
-            /* Get name */
-            *name2   = '\0';
-            name_len = (size_t)H5Iget_name(group_id, name2, SMALL_NAME_BUF_SIZE);
+        /* Get name */
+        *name2   = '\0';
+        name_len = (size_t)H5Iget_name(group_id, name2, SMALL_NAME_BUF_SIZE);
 
-            /* Check that name is longer */
-            if (name_len <= SMALL_NAME_BUF_SIZE)
-                TEST_ERROR
-            if (HDstrcmp(name2, "/") != 0)
-                TEST_ERROR
-        }
+        /* Check that name is longer */
+        if (name_len <= SMALL_NAME_BUF_SIZE)
+            TEST_ERROR;
+        if (HDstrcmp(name2, "/") != 0)
+            TEST_ERROR;
+    }
 
     /* Verify */
     if (check_name(group_id, "/g17", "/g17") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     H5Gclose(group_id);
@@ -1461,7 +1461,7 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Reopen the group */
     if ((group_id = H5Gopen2(file_id, "/g17", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get name */
     name_len = (size_t)H5Iget_name(group_id, NULL, NAME_BUF_SIZE);
@@ -1473,33 +1473,33 @@ test_main(hid_t file_id, hid_t fapl)
         /* Include the extra null character */
         name3 = (char *)HDmalloc(name_len + 1);
         if (!name3)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get name with dynamic buffer */
         *name3 = '\0';
         if (H5Iget_name(group_id, name3, name_len + 1) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify */
         if (HDstrcmp(name3, "/g17") != 0)
-            TEST_ERROR
+            TEST_ERROR;
         *name3 = '\0';
 
         /* Get name with smaller buffer */
         *name3 = '\0';
         if (H5Iget_name(group_id, name3, 3) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify */
         if (HDstrcmp(name3, "/g") != 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         HDfree(name3);
     }
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1512,44 +1512,44 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create a dataspace  */
     if ((space_id = H5Screate_simple(1, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Define a datatype */
     if ((type_id = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a new dataset */
     if ((dataset_id = H5Dcreate2(file_id, "d2", type_id, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
+    {
+        char name[NAME_BUF_SIZE]; /* Buffer to hold name and its size */
+
+        /* Get name for non committed datatype, it should fail */
+        H5E_BEGIN_TRY
         {
-            char name[NAME_BUF_SIZE]; /* Buffer to hold name and its size */
-
-            /* Get name for non committed datatype, it should fail */
-            H5E_BEGIN_TRY
-            {
-                if (H5Iget_name(type_id, name, NAME_BUF_SIZE) > 0)
-                    TEST_ERROR
-            }
-            H5E_END_TRY;
-
-            /* Get name for dataspace, it should fail */
-            H5E_BEGIN_TRY
-            {
-                if (H5Iget_name(space_id, name, NAME_BUF_SIZE) > 0)
-                    TEST_ERROR
-            }
-            H5E_END_TRY;
+            if (H5Iget_name(type_id, name, NAME_BUF_SIZE) > 0)
+                TEST_ERROR;
         }
+        H5E_END_TRY;
+
+        /* Get name for dataspace, it should fail */
+        H5E_BEGIN_TRY
+        {
+            if (H5Iget_name(space_id, name, NAME_BUF_SIZE) > 0)
+                TEST_ERROR;
+        }
+        H5E_END_TRY;
+    }
 
     /* Close */
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(space_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(type_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1562,114 +1562,114 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create a group "g18/g2" in the first file */
     if ((group_id = H5Gcreate2(file_id, "/g18", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "/g18/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Also create a dataset and a datatype */
     if ((space_id = H5Screate_simple(1, dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((type_id = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dataset_id =
              H5Dcreate2(file_id, "g18/d2", type_id, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Tcommit2(file_id, "g18/t2", type_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create second file and group "/g3/g4/g5" in it */
     if ((file1_id = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file1_id, "/g3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group4_id = H5Gcreate2(file1_id, "/g3/g4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group5_id = H5Gcreate2(file1_id, "/g3/g4/g5", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Mount first file at "g3/g4" in the second file */
     if (H5Fmount(file1_id, "/g3/g4", file_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get name for the group ID in the first file, should be "/g18/g2" still */
     if (check_name(group2_id, "/g18/g2", "/g18/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get name for the dataset ID in the first file, should be "/g18/g2/d2" still */
     if (check_name(dataset_id, "/g18/d2", "/g18/d2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get name for the datatype ID in the first file, should be "/g18/g2/t2" still */
     if (check_name(type_id, "/g18/t2", "/g18/t2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the mounted group, dataset, and datatype through their new names */
     if ((group6_id = H5Gopen2(file1_id, "/g3/g4/g18/g2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dataset2_id = H5Dopen2(file1_id, "/g3/g4/g18/d2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((type2_id = H5Topen2(file1_id, "/g3/g4/g18/t2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify names */
     if (check_name(group6_id, "/g3/g4/g18/g2", "/g3/g4/g18/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(dataset2_id, "/g3/g4/g18/d2", "/g3/g4/g18/d2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(type2_id, "/g3/g4/g18/t2", "/g3/g4/g18/t2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that old IDs still refer to objects by their old names */
     if (check_name(group2_id, "/g18/g2", "/g18/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(dataset_id, "/g18/d2", "/g18/d2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(type_id, "/g18/t2", "/g18/t2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount */
     if (H5Funmount(file1_id, "/g3/g4") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get name for the IDs of the first file, should be unchanged */
     if (check_name(group2_id, "/g18/g2", "/g18/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(dataset_id, "/g18/d2", "/g18/d2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(type_id, "/g18/t2", "/g18/t2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get name for the IDs of the second file, should be local names now */
     if (check_name(group6_id, "/g18/g2", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(dataset2_id, "/g18/d2", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(type2_id, "/g18/t2", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Tclose(type_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(type2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group4_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group5_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group6_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1682,29 +1682,29 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create a file and group "/g1/g2" in it */
     if ((file1_id = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group_id = H5Gcreate2(file1_id, "/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file1_id, "/g1/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g1/g2", "/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(file1_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g1/g2", "/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1717,59 +1717,59 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create a file and group "/g1/g2" in it */
     if ((file1_id = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group_id = H5Gcreate2(file1_id, "/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file1_id, "/g1/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a new file and group "/g3/g4" in it */
     if ((file2_id = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file2_id, "/g3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group4_id = H5Gcreate2(file2_id, "/g3/g4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Mount first file at "/g3/g4" in the second file */
     if (H5Fmount(file2_id, "/g3/g4", file1_id, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the mounted group */
     if ((group5_id = H5Gopen2(file2_id, "/g3/g4/g1/g2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group5_id, "/g3/g4/g1/g2", "/g3/g4/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete */
     if (H5Ldelete(file1_id, "/g3/g4/g1/g2", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group5_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group4_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group5_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1782,139 +1782,139 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create a file and group "/g1/g2" in it */
     if ((file1_id = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group_id = H5Gcreate2(file1_id, "/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file1_id, "/g1/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a new file and group "/g3/g4" in it */
     if ((file2_id = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file2_id, "/g3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group4_id = H5Gcreate2(file2_id, "/g3/g4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Mount first file at "g3/g4" in the second file */
     if (H5Fmount(file2_id, "/g3/g4", file1_id, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group4_id, "/g3/g4", "/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the mounted group */
     if ((group5_id = H5Gopen2(file2_id, "/g3/g4/g1/g2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group5_id, "/g3/g4/g1/g2", "/g3/g4/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open another mounted group, in the middle of the path */
     if ((group6_id = H5Gopen2(file2_id, "/g3/g4/g1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group6_id, "/g3/g4/g1", "/g3/g4/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Rename group */
     if (H5Lmove(file2_id, "/g3/g4/g1/g2", H5L_SAME_LOC, "/g3/g4/g1/g5", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group5_id, "/g3/g4/g1/g5", "/g3/g4/g1/g5") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group2_id, "/g1/g5", "/g1/g5") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Rename group */
     if (H5Lmove(file2_id, "/g3/g4/g1", H5L_SAME_LOC, "/g3/g4/g1a", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group5_id, "/g3/g4/g1a/g5", "/g3/g4/g1a/g5") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group2_id, "/g1a/g5", "/g1a/g5") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group6_id, "/g3/g4/g1a", "/g3/g4/g1a") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group_id, "/g1a", "/g1a") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Rename middle group back, using relative path */
     if (H5Lmove(group3_id, "g4/g1a", H5L_SAME_LOC, "g4/g1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group5_id, "/g3/g4/g1/g5", "/g3/g4/g1/g5") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group2_id, "/g1/g5", "/g1/g5") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group6_id, "/g3/g4/g1", "/g3/g4/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group_id, "/g1", "/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Rename end group back, using relative path */
     if (H5Lmove(group3_id, "g4/g1/g5", H5L_SAME_LOC, "g4/g1/g2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group5_id, "/g3/g4/g1/g2", "/g3/g4/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group2_id, "/g1/g2", "/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group6_id, "/g3/g4/g1", "/g3/g4/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group_id, "/g1", "/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Rename mount point */
     if (H5Lmove(file2_id, "/g3/g4", H5L_SAME_LOC, "/g3/g4a", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group4_id, "/g3/g4a", "/g3/g4a") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group5_id, "/g3/g4a/g1/g2", "/g3/g4a/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group6_id, "/g3/g4a/g1", "/g3/g4a/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Rename mount point back, using relative path*/
     if (H5Lmove(group3_id, "g4a", H5L_SAME_LOC, "g4", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group4_id, "/g3/g4", "/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group5_id, "/g3/g4/g1/g2", "/g3/g4/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group6_id, "/g3/g4/g1", "/g3/g4/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group4_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group5_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group6_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1927,109 +1927,109 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create group "g19/g1" */
     if ((group_id = H5Gcreate2(file_id, "/g19", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "/g19/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create hard link to "g19/g1/ group */
     if (H5Lcreate_hard(file_id, "/g19/g1", H5L_SAME_LOC, "/g19/g2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g19/g1", "/g19/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group */
     if ((group3_id = H5Gopen2(file_id, "/g19/g2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g19/g2", "/g19/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Rename original group */
     if (H5Lmove(file_id, "/g19/g1", H5L_SAME_LOC, "/g19/g3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g19/g3", "/g19/g3") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group3_id, "/g19/g2", "/g19/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Rename original group back, using relative path */
     if (H5Lmove(group_id, "g3", H5L_SAME_LOC, "g1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g19/g1", "/g19/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group3_id, "/g19/g2", "/g19/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create another hard link to "/g19/g1" group */
     if (H5Lcreate_hard(file_id, "/g19/g1", H5L_SAME_LOC, "/g19/g3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the group */
     if ((group4_id = H5Gopen2(file_id, "/g19/g3", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group4_id, "/g19/g3", "/g19/g3") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete group */
     if (H5Ldelete(file_id, "/g19/g3", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group4_id, "/g19/g1", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group2_id, "/g19/g1", "/g19/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group3_id, "/g19/g2", "/g19/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the unlinked group */
     if (H5Gclose(group4_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create another hard link to "/g19/g1" group */
     if (H5Lcreate_hard(file_id, "/g19/g1", H5L_SAME_LOC, "/g19/g3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the group */
     if ((group4_id = H5Gopen2(file_id, "/g19/g3", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group4_id, "/g19/g3", "/g19/g3") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete group, using relative path */
     if (H5Ldelete(group_id, "g3", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group4_id, "/g19/g1", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group2_id, "/g19/g1", "/g19/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group3_id, "/g19/g2", "/g19/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the unlinked group */
     if (H5Gclose(group4_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2042,33 +2042,33 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create group "g20/g1" */
     if ((group_id = H5Gcreate2(file_id, "/g20", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "/g20/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create symbolic link to "g20/g1/ group */
     if (H5Lcreate_soft("/g20/g1", file_id, "/g20/g2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g20/g1", "/g20/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group */
     if ((group3_id = H5Gopen2(file_id, "/g20/g2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g20/g2", "/g20/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2081,39 +2081,39 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create group "g21/g1" */
     if ((group_id = H5Gcreate2(file_id, "/g21", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "/g21/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create symbolic link to "g21/g1/ group */
     if (H5Lcreate_soft("/g21/g1", file_id, "/g21/g2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g21/g1", "/g21/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group */
     if ((group3_id = H5Gopen2(file_id, "/g21/g2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Rename group */
     if (H5Lmove(file_id, "/g21/g1", H5L_SAME_LOC, "/g21/g3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g21/g3", "/g21/g3") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group3_id, "/g21/g2", "/g21/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2126,49 +2126,49 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create group "g22/g1" */
     if ((group_id = H5Gcreate2(file_id, "/g22", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "/g22/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create symbolic link to "g22/g1/ group */
     if (H5Lcreate_soft("/g22/g1", file_id, "/g22/g2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g22/g1", "/g22/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group */
     if ((group3_id = H5Gopen2(file_id, "/g22/g2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Rename soft link */
     if (H5Lmove(file_id, "/g22/g2", H5L_SAME_LOC, "/g22/g3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g22/g1", "/g22/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group3_id, "/g22/g3", "/g22/g3") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Rename soft link, using relative paths */
     if (H5Lmove(group_id, "g3", H5L_SAME_LOC, "g2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g22/g1", "/g22/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group3_id, "/g22/g2", "/g22/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2181,37 +2181,37 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create group "g23/g1" */
     if ((group_id = H5Gcreate2(file_id, "/g23", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "/g23/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create symbolic link to "g23/g1/ group */
     if (H5Lcreate_soft("/g23/g1", file_id, "/g23/g2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g23/g1", "/g23/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group */
     if ((group3_id = H5Gopen2(file_id, "/g23/g2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete group */
     if (H5Ldelete(file_id, "/g23/g1", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g23/g2", "/g23/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2224,37 +2224,37 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create group "g24/g1" */
     if ((group_id = H5Gcreate2(file_id, "/g24", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "/g24/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create symbolic link to "g24/g1/ group */
     if (H5Lcreate_soft("/g24/g1", file_id, "/g24/g2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g24/g1", "/g24/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group */
     if ((group3_id = H5Gopen2(file_id, "/g24/g2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete symbolic link */
     if (H5Ldelete(file_id, "/g24/g2", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g24/g1", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2267,185 +2267,185 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create a group "g25/g1/g2" in the first file */
     if ((group_id = H5Gcreate2(file_id, "/g25", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "/g25/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file_id, "/g25/g1/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create second file and group "/g26/g3/g4" in it */
     if ((file1_id = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((group_id = H5Gcreate2(file1_id, "/g26", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file1_id, "/g26/g3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file1_id, "/g26/g3/g4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create third file and group "/g27/g5/g6" in it */
     if ((file2_id = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((group_id = H5Gcreate2(file2_id, "/g27", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file2_id, "/g27/g5", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file2_id, "/g27/g5/g6", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create fourth file and group "/g28/g5/g6" in it */
     if ((file3_id = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((group_id = H5Gcreate2(file3_id, "/g28", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file3_id, "/g28/g7", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file3_id, "/g28/g7/g8", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Access group which will be hidden in the first file */
     if ((group_id = H5Gopen2(file_id, "/g25/g1/g2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g25/g1/g2", "/g25/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount second file under "/g25/g1" in the first file */
     if (H5Fmount(file_id, "/g25/g1", file1_id, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "", "/g25/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Access group which will be hidden in the second file */
     if ((group2_id = H5Gopen2(file_id, "/g25/g1/g26/g3/g4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g25/g1/g26/g3/g4", "/g25/g1/g26/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount third file under "/g25/g1/g26/g3" in the first file */
     if (H5Fmount(file_id, "/g25/g1/g26/g3", file2_id, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "", "/g25/g1/g26/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Access group in the third file */
     if ((group3_id = H5Gopen2(file_id, "/g25/g1/g26/g3/g27/g5/g6", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g25/g1/g26/g3/g27/g5/g6", "/g25/g1/g26/g3/g27/g5/g6") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount fourth file under "/g25/g1/g26/g3/g27/g5" in the first file */
     if (H5Fmount(file_id, "/g25/g1/g26/g3/g27/g5", file3_id, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "", "/g25/g1/g26/g3/g27/g5/g6") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Access group in the fourth file */
     if ((group4_id = H5Gopen2(file_id, "/g25/g1/g26/g3/g27/g5/g28/g7/g8", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group4_id, "/g25/g1/g26/g3/g27/g5/g28/g7/g8", "/g25/g1/g26/g3/g27/g5/g28/g7/g8") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Funmount(file_id, "/g25/g1/g26/g3/g27/g5") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group4_id, "/g28/g7/g8", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group3_id, "/g25/g1/g26/g3/g27/g5/g6", "/g25/g1/g26/g3/g27/g5/g6") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group2_id, "", "/g25/g1/g26/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group_id, "", "/g25/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group4_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Funmount(file_id, "/g25/g1/g26/g3") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g27/g5/g6", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group2_id, "/g25/g1/g26/g3/g4", "/g25/g1/g26/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group_id, "", "/g25/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Funmount(file_id, "/g25/g1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g26/g3/g4", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group_id, "/g25/g1/g2", "/g25/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2458,55 +2458,55 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create a group "g29/g1/g2/g1/g2" in a file */
     if ((group_id = H5Gcreate2(file_id, "/g29", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "/g29/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file_id, "/g29/g1/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group4_id = H5Gcreate2(file_id, "/g29/g1/g2/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group5_id = H5Gcreate2(file_id, "/g29/g1/g2/g1/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Rename group */
     if (H5Lmove(file_id, "/g29/g1/g2/g1/g2", H5L_SAME_LOC, "/g29/g1/g2/g1/g3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group5_id, "/g29/g1/g2/g1/g3", "/g29/g1/g2/g1/g3") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Rename group in middle of path, keeping within the same group */
     if (H5Lmove(file_id, "/g29/g1/g2/g1", H5L_SAME_LOC, "/g29/g1/g2/g3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group4_id, "/g29/g1/g2/g3", "/g29/g1/g2/g3") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group5_id, "/g29/g1/g2/g3/g3", "/g29/g1/g2/g3/g3") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Rename group in middle of path, moving to another group in file */
     if (H5Lmove(file_id, "/g29/g1/g2/g3", H5L_SAME_LOC, "/g29/g3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group4_id, "/g29/g3", "/g29/g3") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group5_id, "/g29/g3/g3", "/g29/g3/g3") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group4_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group5_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2519,11 +2519,11 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create a group "/g30/g1/g2" in the first file */
     if ((group_id = H5Gcreate2(file_id, "/g30", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "/g30/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file_id, "/g30/g1/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     H5Gclose(group_id);
@@ -2534,11 +2534,11 @@ test_main(hid_t file_id, hid_t fapl)
     file1_id = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
 
     if ((group_id = H5Gcreate2(file1_id, "/g31", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file1_id, "/g31/g3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file1_id, "/g31/g3/g4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     H5Gclose(group_id);
@@ -2549,11 +2549,11 @@ test_main(hid_t file_id, hid_t fapl)
     file2_id = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
 
     if ((group_id = H5Gcreate2(file2_id, "/g32", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file2_id, "/g32/g5", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file2_id, "/g32/g5/g6", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     H5Gclose(group_id);
@@ -2564,11 +2564,11 @@ test_main(hid_t file_id, hid_t fapl)
     file3_id = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
 
     if ((group_id = H5Gcreate2(file3_id, "/g33", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file3_id, "/g33/g7", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file3_id, "/g33/g7/g8", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     H5Gclose(group_id);
@@ -2577,101 +2577,101 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Access group which will be hidden in the first file */
     if ((group_id = H5Gopen2(file_id, "/g30/g1/g2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g30/g1/g2", "/g30/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount second file under "/g30/g1" in the first file */
     if (H5Fmount(file_id, "/g30/g1", file1_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group_id, "", "/g30/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Access group which will be hidden in the second file */
     if ((group2_id = H5Gopen2(file_id, "/g30/g1/g31/g3/g4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g30/g1/g31/g3/g4", "/g30/g1/g31/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount third file under "/g30/g1/g31/g3" in the first file */
     if (H5Fmount(file_id, "/g30/g1/g31/g3", file2_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "", "/g30/g1/g31/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Access group which will be hidden in the third file */
     if ((group3_id = H5Gopen2(file_id, "/g30/g1/g31/g3/g32/g5/g6", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g30/g1/g31/g3/g32/g5/g6", "/g30/g1/g31/g3/g32/g5/g6") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount fourth file under "/g30" in the first file, hiding the files below it */
     if (H5Fmount(file_id, "/g30", file3_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "", "/g30/g1/g31/g3/g32/g5/g6") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Access group which will be in the fourth file */
     if ((group4_id = H5Gopen2(file_id, "/g30/g33/g7/g8", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group4_id, "/g30/g33/g7/g8", "/g30/g33/g7/g8") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount fourth file */
     if (H5Funmount(file_id, "/g30") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group4_id, "/g33/g7/g8", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group3_id, "/g30/g1/g31/g3/g32/g5/g6", "/g30/g1/g31/g3/g32/g5/g6") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group2_id, "", "/g30/g1/g31/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group_id, "", "/g30/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount third file */
     if (H5Funmount(file_id, "/g30/g1/g31/g3") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group4_id, "/g33/g7/g8", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group3_id, "/g32/g5/g6", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group2_id, "/g30/g1/g31/g3/g4", "/g30/g1/g31/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group_id, "", "/g30/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount second file */
     if (H5Funmount(file_id, "/g30/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group4_id, "/g33/g7/g8", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group3_id, "/g32/g5/g6", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group2_id, "/g31/g3/g4", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group_id, "/g30/g1/g2", "/g30/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close groups */
     H5Gclose(group_id);
@@ -2695,78 +2695,78 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create second file and group "/g35/g3/g4" in it */
     if ((file1_id = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((group_id = H5Gcreate2(file1_id, "/g35", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file1_id, "/g35/g3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file1_id, "/g35/g3/g4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create group "/g34/g1/g2" in first file */
     if ((group_id = H5Gcreate2(file_id, "/g34", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "/g34/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file_id, "/g34/g1/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create hard link to "/g34/g1/g2 group */
     if (H5Lcreate_hard(file_id, "/g34/g1/g2", H5L_SAME_LOC, "/g34/g2a", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g34/g1/g2", "/g34/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the link to the group */
     if ((group4_id = H5Gopen2(file_id, "/g34/g2a", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group4_id, "/g34/g2a", "/g34/g2a") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount second file under "/g34/g1" in the first file */
     if (H5Fmount(file_id, "/g34/g1", file1_id, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "", "/g34/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group4_id, "/g34/g2a", "/g34/g2a") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount second file */
     if (H5Funmount(file_id, "/g34/g1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group3_id, "/g34/g1/g2", "/g34/g1/g2") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group4_id, "/g34/g2a", "/g34/g2a") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group4_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2779,117 +2779,117 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create group "/g36/g1/g2" in first file */
     if ((group_id = H5Gcreate2(file_id, "/g36", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "/g36/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file_id, "/g36/g1/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create second file and group "/g37/g4" in it */
     if ((file1_id = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((group_id = H5Gcreate2(file1_id, "/g37", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file1_id, "/g37/g4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file1_id, "/g37/g4/g5a", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group4_id = H5Gcreate2(file1_id, "/g37/g4/g5b", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Mount second file under "/g36/g1" in the first file */
     if (H5Fmount(file_id, "/g36/g1", file1_id, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open group in mounted file */
     if ((group5_id = H5Gopen2(file_id, "/g36/g1/g37/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group5_id, "/g36/g1/g37", "/g36/g1/g37") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group to delete in mounted file */
     if ((group6_id = H5Gopen2(file_id, "/g36/g1/g37/g4/g5a", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group6_id, "/g36/g1/g37/g4/g5a", "/g36/g1/g37/g4/g5a") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete end group in mounted file, using relative paths */
     if (H5Ldelete(group5_id, "g4/g5a", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group6_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group3_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close deleted group */
     if (H5Gclose(group6_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open groups to delete in mounted file */
     if ((group6_id = H5Gopen2(file_id, "/g36/g1/g37/g4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group7_id = H5Gopen2(file_id, "/g36/g1/g37/g4/g5b", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group6_id, "/g36/g1/g37/g4", "/g36/g1/g37/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group7_id, "/g36/g1/g37/g4/g5b", "/g36/g1/g37/g4/g5b") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete middle group in mounted file, using relative paths */
     if (H5Ldelete(group5_id, "g4", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group6_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group2_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group7_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group4_id, "", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close deleted groups */
     if (H5Gclose(group6_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group7_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close group in mounted file */
     if (H5Gclose(group5_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Funmount(file_id, "/g36/g1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group4_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2902,14 +2902,14 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create file and group "/g38/g1/g2" in it */
     if ((file1_id = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((group_id = H5Gcreate2(file1_id, "/g38", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file1_id, "/g38/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file1_id, "/g38/g1/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     H5Gclose(group_id);
@@ -2918,14 +2918,14 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create second file and group "/g39/g1/g2" in it */
     if ((file2_id = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((group_id = H5Gcreate2(file2_id, "/g39", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file2_id, "/g39/g3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file2_id, "/g39/g3/g4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     H5Gclose(group_id);
@@ -2934,14 +2934,14 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Create third file and group "/g40/g5/g6" in it */
     if ((file3_id = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((group_id = H5Gcreate2(file3_id, "/g40", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file3_id, "/g40/g5", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file3_id, "/g40/g5/g6", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     H5Gclose(group_id);
@@ -2950,45 +2950,45 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Mount second file under "/g38/g1" in the first file */
     if (H5Fmount(file1_id, "/g38/g1", file2_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((group_id = H5Gopen2(file1_id, "/g38/g1/g39/g3/g4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g38/g1/g39/g3/g4", "/g38/g1/g39/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount first file under "/g40/g5" in the third file */
     if (H5Fmount(file3_id, "/g40/g5", file1_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((group2_id = H5Gopen2(file3_id, "/g40/g5/g38/g1/g39/g3/g4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g40/g5/g38/g1/g39/g3/g4", "/g40/g5/g38/g1/g39/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group_id, "/g38/g1/g39/g3/g4", "/g38/g1/g39/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount first file */
     if (H5Funmount(file3_id, "/g40/g5") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g38/g1/g39/g3/g4", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (check_name(group_id, "/g38/g1/g39/g3/g4", "/g38/g1/g39/g3/g4") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount second file */
     if (H5Funmount(file1_id, "/g38/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g39/g3/g4", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     H5Gclose(group_id);
@@ -3010,11 +3010,11 @@ test_main(hid_t file_id, hid_t fapl)
     file1_id = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
 
     if ((group_id = H5Gcreate2(file1_id, "/g41", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file1_id, "/g41/g1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file1_id, "/g41/g1/g2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     H5Gclose(group_id);
@@ -3025,11 +3025,11 @@ test_main(hid_t file_id, hid_t fapl)
     file2_id = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
 
     if ((group_id = H5Gcreate2(file2_id, "/g42", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file2_id, "/g42/g3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group3_id = H5Gcreate2(file2_id, "/g42/g3/g4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close */
     H5Gclose(group_id);
@@ -3038,25 +3038,25 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Mount second file under "/g41/g1" in the first file */
     if (H5Fmount(file1_id, "/g41/g1", file2_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((group_id = H5Gopen2(file1_id, "/g41/g1/g42/g3", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group_id, "/g41/g1/g42/g3", "/g41/g1/g42/g3") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount file */
     if (H5Funmount(file1_id, "/g41/g1") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((group2_id = H5Gopen2(group_id, "g4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify */
     if (check_name(group2_id, "/g42/g3/g4", "") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     H5Gclose(group_id);
@@ -3074,66 +3074,66 @@ test_main(hid_t file_id, hid_t fapl)
 
     /* Commit the type anonymously and link it in */
     if ((dtype = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Test H5Iget_name with created datatype, should fail because not committed */
     H5E_BEGIN_TRY
     {
         if ((size = H5Iget_name(dtype, NULL, 0)) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
     if (H5Tcommit_anon(file2_id, dtype, H5P_DEFAULT, H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5Iget_name with anonymously created datatype, should pass because committed */
     if ((size = H5Iget_name(dtype, NULL, 0)) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a link to the object */
     if (H5Olink(dtype, file2_id, "datatype", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Commit a second datatype with no links to it and commit it */
     if ((dtype_anon = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit_anon(file2_id, dtype_anon, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5Iget_name with anonymously created datatype, should pass because committed */
     if ((size = H5Iget_name(dtype_anon, NULL, 0)) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Store the address of the datatype for later use */
     if (H5Oget_info3(dtype_anon, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Update the reference count to dtype_anon to preserve the datatype */
     if (H5Oincr_refcount(dtype_anon) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Tclose(dtype) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(dtype_anon) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file2_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file and check that the anonymous datatypes persist */
     if ((file2_id = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the H5Iget_name does not return an error for anon committed datatypes */
     if ((dtype_anon = H5Oopen_by_token(file2_id, oinfo.token)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((size = H5Iget_name(dtype_anon, NULL, 0)) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Tclose(dtype_anon) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file2_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -3166,30 +3166,30 @@ test_obj_ref(hid_t fapl)
 
     /* Create files */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataspace for datasets */
     if ((sid1 = H5Screate_simple(SPACE1_RANK, dims1, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a group */
     if ((group = H5Gcreate2(fid1, "Group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a single dataset inside the second file, which will be mounted
      * and used to mask objects in the first file */
     if ((dataset = H5Dcreate2(fid2, "Dataset1", H5T_STD_U32LE, sid1, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataset(inside Group1) */
     if ((dataset =
              H5Dcreate2(group, "Dataset1", H5T_STD_U32LE, sid1, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize data buffer */
     for (i = 0; i < SPACE1_DIM1; i++)
@@ -3197,300 +3197,300 @@ test_obj_ref(hid_t fapl)
 
     /* Write selection to disk */
     if (H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, tu32) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close Dataset */
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create another dataset(inside Group1) */
     if ((dataset = H5Dcreate2(group, "Dataset2", H5T_NATIVE_UCHAR, sid1, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close Dataset */
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a datatype to refer to */
     if ((tid1 = H5Tcreate(H5T_COMPOUND, sizeof(s1_t))) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Insert fields */
     if (H5Tinsert(tid1, "a", HOFFSET(s1_t, a), H5T_NATIVE_INT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(tid1, "b", HOFFSET(s1_t, b), H5T_NATIVE_INT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tinsert(tid1, "c", HOFFSET(s1_t, c), H5T_NATIVE_FLOAT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Save datatype for later */
     if (H5Tcommit2(group, "Datatype1", tid1, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close datatype */
     if (H5Tclose(tid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a new group in group1 */
     if ((group2 = H5Gcreate2(group, "Group2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a hard link to group1 in group2 */
     if (H5Lcreate_hard(fid1, "/Group1", H5L_SAME_LOC, "/Group1/Group2/Link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataset in that group */
     if ((dataset = H5Dcreate2(group2, "Dataset4", H5T_NATIVE_UCHAR, sid1, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close Dataset */
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close group */
     if (H5Gclose(group) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open up that hard link and make a new dataset there */
     if ((group = H5Gopen2(fid1, "/Group1/Group2/Link", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dataset = H5Dcreate2(group, "Dataset5", H5T_NATIVE_UCHAR, sid1, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataset to store references */
     if ((dataset =
              H5Dcreate2(fid1, "Dataset3", H5T_STD_REF_OBJ, sid1, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create reference to dataset */
     if (H5Rcreate(&wbuf[0], fid1, "/Dataset3", H5R_OBJECT, (hid_t)-1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create reference to dataset */
     if (H5Rcreate(&wbuf[1], fid1, "/Group1/Dataset2", H5R_OBJECT, (hid_t)-1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create reference to group */
     if (H5Rcreate(&wbuf[2], fid1, "/Group1", H5R_OBJECT, (hid_t)-1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create reference to named datatype */
     if (H5Rcreate(&wbuf[3], fid1, "/Group1/Datatype1", H5R_OBJECT, (hid_t)-1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Rcreate(&wbuf[4], fid1, "/Group1/Group2/Dataset4", H5R_OBJECT, (hid_t)-1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Rcreate(&wbuf[5], fid1, "/Group1/Group2", H5R_OBJECT, (hid_t)-1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Rcreate(&wbuf[6], fid1, "/Group1/Group2/Link/Dataset5", H5R_OBJECT, (hid_t)-1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create reference to root group */
     if (H5Rcreate(&wbuf[7], fid1, "/", H5R_OBJECT, (hid_t)-1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write selection to disk */
     if (H5Dwrite(dataset, H5T_STD_REF_OBJ, H5S_ALL, H5S_ALL, H5P_DEFAULT, wbuf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     TESTING("getting path to normal dataset in root group");
     if ((dataset2 = H5Rdereference2(dataset, H5P_DEFAULT, H5R_OBJECT, &wbuf[0])) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     *buf    = '\0';
     namelen = H5Iget_name(dataset2, (char *)buf, sizeof(buf));
     if (H5Dclose(dataset2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!((HDstrcmp(buf, "/Dataset3") == 0) && (namelen == 9)))
-        TEST_ERROR
+        TEST_ERROR;
     *buf = '\0';
 
     /* Check H5Rget_name returns the correct length of the name when name is NULL */
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[0], NULL, 0);
     if (namelen != 9)
-        TEST_ERROR
+        TEST_ERROR;
     /* Make sure size parameter is ignored */
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[0], NULL, 200);
     if (namelen != 9)
-        TEST_ERROR
+        TEST_ERROR;
 
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[0], (char *)buf, sizeof(buf));
     if (!((HDstrcmp(buf, "/Dataset3") == 0) && (namelen == 9)))
-        TEST_ERROR
+        TEST_ERROR;
     PASSED();
 
     HDmemset(buf, 0, sizeof(buf));
     TESTING("getting path to dataset in /Group1");
     if ((dataset2 = H5Rdereference2(dataset, H5P_DEFAULT, H5R_OBJECT, &wbuf[1])) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     *buf    = '\0';
     namelen = H5Iget_name(dataset2, (char *)buf, sizeof(buf));
     if (H5Dclose(dataset2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!((HDstrcmp(buf, "/Group1/Dataset2") == 0) && (namelen == 16)))
-        TEST_ERROR
+        TEST_ERROR;
     *buf    = '\0';
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[1], (char *)buf, sizeof(buf));
     if (!((HDstrcmp(buf, "/Group1/Dataset2") == 0) && (namelen == 16)))
-        TEST_ERROR
+        TEST_ERROR;
     PASSED();
 
     HDmemset(buf, 0, sizeof(buf));
     TESTING("getting path to /Group1");
     if ((group = H5Rdereference2(dataset, H5P_DEFAULT, H5R_OBJECT, &wbuf[2])) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     *buf    = '\0';
     namelen = H5Iget_name(group, (char *)buf, sizeof(buf));
     if (H5Gclose(group) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!((HDstrcmp(buf, "/Group1") == 0) && (namelen == 7)))
-        TEST_ERROR
+        TEST_ERROR;
     *buf    = '\0';
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[2], (char *)buf, sizeof(buf));
     if (!((HDstrcmp(buf, "/Group1") == 0) && (namelen == 7)))
-        TEST_ERROR
+        TEST_ERROR;
     PASSED();
 
     HDmemset(buf, 0, sizeof(buf));
     TESTING("getting path to datatype in /Group1");
     if ((tid1 = H5Rdereference2(dataset, H5P_DEFAULT, H5R_OBJECT, &wbuf[3])) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     *buf    = '\0';
     namelen = H5Iget_name(tid1, (char *)buf, sizeof(buf));
     if (H5Tclose(tid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!((HDstrcmp(buf, "/Group1/Datatype1") == 0) && (namelen == 17)))
-        TEST_ERROR
+        TEST_ERROR;
     *buf    = '\0';
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[3], (char *)buf, sizeof(buf));
     if (!((HDstrcmp(buf, "/Group1/Datatype1") == 0) && (namelen == 17)))
-        TEST_ERROR
+        TEST_ERROR;
     PASSED();
 
     HDmemset(buf, 0, sizeof(buf));
     TESTING("getting path to dataset in nested group");
     if ((dataset2 = H5Rdereference2(dataset, H5P_DEFAULT, H5R_OBJECT, &wbuf[4])) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     *buf    = '\0';
     namelen = H5Iget_name(dataset2, (char *)buf, sizeof(buf));
     if (H5Dclose(dataset2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!((HDstrcmp(buf, "/Group1/Group2/Dataset4") == 0) && (namelen == 23)))
-        TEST_ERROR
+        TEST_ERROR;
     *buf    = '\0';
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[4], (char *)buf, sizeof(buf));
     if (!((HDstrcmp(buf, "/Group1/Group2/Dataset4") == 0) && (namelen == 23)))
-        TEST_ERROR
+        TEST_ERROR;
     PASSED();
 
     HDmemset(buf, 0, sizeof(buf));
     TESTING("getting path to nested group");
     if ((group = H5Rdereference2(dataset, H5P_DEFAULT, H5R_OBJECT, &wbuf[5])) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     *buf    = '\0';
     namelen = H5Iget_name(group, (char *)buf, sizeof(buf));
     if (H5Gclose(group) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!((HDstrcmp(buf, "/Group1/Group2") == 0) && (namelen == 14)))
-        TEST_ERROR
+        TEST_ERROR;
     *buf    = '\0';
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[5], (char *)buf, sizeof(buf));
     if (!((HDstrcmp(buf, "/Group1/Group2") == 0) && (namelen == 14)))
-        TEST_ERROR
+        TEST_ERROR;
     PASSED();
 
     HDmemset(buf, 0, sizeof(buf));
     TESTING("getting path to dataset created via hard link");
     if ((dataset2 = H5Rdereference2(dataset, H5P_DEFAULT, H5R_OBJECT, &wbuf[6])) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     *buf    = '\0';
     namelen = H5Iget_name(dataset2, (char *)buf, sizeof(buf));
     if (H5Dclose(dataset2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!((HDstrcmp(buf, "/Group1/Dataset5") == 0) && (namelen == 16)))
-        TEST_ERROR
+        TEST_ERROR;
     *buf    = '\0';
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[6], (char *)buf, sizeof(buf));
     if (!((HDstrcmp(buf, "/Group1/Dataset5") == 0) && (namelen == 16)))
-        TEST_ERROR
+        TEST_ERROR;
     PASSED();
 
     HDmemset(buf, 0, sizeof(buf));
     TESTING("getting path to root group");
     if ((group = H5Rdereference2(dataset, H5P_DEFAULT, H5R_OBJECT, &wbuf[7])) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     *buf    = '\0';
     namelen = H5Iget_name(group, (char *)buf, sizeof(buf));
     if (H5Gclose(group) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!((HDstrcmp(buf, "/") == 0) && (namelen == 1)))
-        TEST_ERROR
+        TEST_ERROR;
     *buf    = '\0';
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[7], (char *)buf, sizeof(buf));
     if (!((HDstrcmp(buf, "/") == 0) && (namelen == 1)))
-        TEST_ERROR
+        TEST_ERROR;
     PASSED();
 
     /* Now we mount fid2 at /Group2 and look for dataset4.  It shouldn't be found */
     if (H5Fmount(fid1, "/Group1/Group2", fid2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     TESTING("getting path to dataset hidden by a mounted file");
     if ((dataset2 = H5Rdereference2(dataset, H5P_DEFAULT, H5R_OBJECT, &wbuf[4])) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     *buf    = '\0';
     namelen = H5Iget_name(dataset2, (char *)buf, sizeof(buf));
     if (H5Dclose(dataset2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (namelen != 0)
-        TEST_ERROR
+        TEST_ERROR;
     *buf    = '\0';
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[4], (char *)buf, sizeof(buf));
     if (namelen != 0)
-        TEST_ERROR
+        TEST_ERROR;
     PASSED();
 
     /* Now we try unlinking dataset2 from the file and searching for it.  It shouldn't be found */
     if ((dataset2 = H5Rdereference2(dataset, H5P_DEFAULT, H5R_OBJECT, &wbuf[1])) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid1, "/Group1/Dataset2", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     TESTING("getting path to dataset that has been unlinked");
     *buf    = '\0';
     namelen = H5Iget_name(dataset2, (char *)buf, sizeof(buf));
     if (H5Dclose(dataset2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (namelen != 0)
-        TEST_ERROR
+        TEST_ERROR;
     *buf    = '\0';
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[1], (char *)buf, sizeof(buf));
     if (namelen != 0)
-        TEST_ERROR
+        TEST_ERROR;
     PASSED();
 
     /* Close disk dataspace */
     if (H5Sclose(sid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close Dataset */
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     return 0;
 
@@ -3525,29 +3525,29 @@ test_reg_ref(hid_t fapl)
 
     /* Create file with default file create property but vfd access property. */
     if ((file_id = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace for datasets */
     if ((space_id = H5Screate_simple(rank, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((spacer_id = H5Screate_simple(rankr, dimsr, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create integer dataset */
     if ((dsetv_id = H5Dcreate2(file_id, REFREG_DSETNAMEV, H5T_NATIVE_INT, space_id, H5P_DEFAULT, H5P_DEFAULT,
                                H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Write data to the dataset */
     if (H5Dwrite(dsetv_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dsetv_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Dataset with references */
     if ((dsetr_id = H5Dcreate2(file_id, REFREG_DSETNAMER, H5T_STD_REF_DSETREG, spacer_id, H5P_DEFAULT,
                                H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create a reference to the hyperslab.
@@ -3557,42 +3557,42 @@ test_reg_ref(hid_t fapl)
     count[0] = 2;
     count[1] = 3;
     if (H5Sselect_hyperslab(space_id, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate(&ref[0], file_id, REFREG_DSETNAMEV, H5R_DATASET_REGION, space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a reference to elements selection */
     if (H5Sselect_none(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sselect_elements(space_id, H5S_SELECT_SET, num_points, (const hsize_t *)coord) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate(&ref[1], file_id, REFREG_DSETNAMEV, H5R_DATASET_REGION, space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Write dataset with the references */
     if (H5Dwrite(dsetr_id, H5T_STD_REF_DSETREG, H5S_ALL, H5S_ALL, H5P_DEFAULT, ref) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close all objects */
     if (H5Sclose(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(spacer_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dsetr_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reopen the file to read selections back */
     if ((file_id = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reopen the dataset with object references and read references to the buffer */
     if ((dsetr_id = H5Dopen2(file_id, REFREG_DSETNAMER, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dread(dsetr_id, H5T_STD_REF_DSETREG, H5S_ALL, H5S_ALL, H5P_DEFAULT, ref_out) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get name of the dataset the first region reference points to using H5Rget_name */
     TESTING("H5Rget_name to get name from region reference(hyperslab)");
@@ -3601,11 +3601,11 @@ test_reg_ref(hid_t fapl)
     /* Check H5Rget_name returns the correct length of the name when name is NULL */
     name_size1 = H5Rget_name(dsetr_id, H5R_DATASET_REGION, &ref_out[0], NULL, 0);
     if (name_size1 != 7)
-        TEST_ERROR
+        TEST_ERROR;
 
     name_size1 = H5Rget_name(dsetr_id, H5R_DATASET_REGION, &ref_out[0], (char *)buf1, NAME_BUF_SIZE);
     if (!((HDstrcmp(buf1, "/MATRIX") == 0) && (name_size1 == 7)))
-        TEST_ERROR
+        TEST_ERROR;
     PASSED();
 
     TESTING("H5Iget_name to get name from region reference(hyperslab)");
@@ -3617,10 +3617,10 @@ test_reg_ref(hid_t fapl)
     *buf2      = '\0';
     name_size2 = H5Iget_name(dsetv_id, (char *)buf2, NAME_BUF_SIZE);
     if (!((HDstrcmp(buf2, "/MATRIX") == 0) && (name_size2 == 7)))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dclose(dsetv_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -3629,30 +3629,30 @@ test_reg_ref(hid_t fapl)
     *buf1      = '\0';
     name_size1 = H5Rget_name(dsetr_id, H5R_DATASET_REGION, &ref_out[1], (char *)buf1, NAME_BUF_SIZE);
     if (!((HDstrcmp(buf1, "/MATRIX") == 0) && (name_size1 == 7)))
-        TEST_ERROR
+        TEST_ERROR;
     PASSED();
 
     TESTING("H5Iget_name to get name from region reference(pnt selec)");
 
     /* Dereference the second reference */
     if ((dsetv_id = H5Rdereference2(dsetr_id, H5P_DEFAULT, H5R_DATASET_REGION, &ref_out[1])) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get name of the dataset the first region reference points using H5Iget_name */
     *buf2      = '\0';
     name_size2 = H5Iget_name(dsetv_id, (char *)buf2, NAME_BUF_SIZE);
     if (!((HDstrcmp(buf2, "/MATRIX") == 0) && (name_size2 == 7)))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dclose(dsetv_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
     if (H5Dclose(dsetr_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -3691,62 +3691,62 @@ test_elinks(hid_t fapl)
 
     /* Create files */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a group in the second file */
     if ((group2 = H5Gcreate2(fid2, "Group2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close Group */
     if (H5Gclose(group2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create an external link in first file to the group in the second file */
     if (H5Lcreate_external(filename2, "Group2", fid1, "Link_to_Group2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create an external link in second file to the external link in the first file */
     if (H5Lcreate_external(filename1, "Link_to_Group2", fid2, "Link_to_Link_to_Group2", H5P_DEFAULT,
                            H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the group in thesecond file through the external link */
     if ((group = H5Gopen2(fid1, "Link_to_Group2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Query the external link object's name */
     *name       = '\0';
     name_cached = FALSE;
     namelen     = H5I__get_name_test(group, (char *)name, sizeof(name), &name_cached);
     if (!((HDstrcmp(name, "/Group2") == 0) && (namelen == 7) && name_cached))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close Group */
     if (H5Gclose(group) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the group in the second file through the external link to the external link */
     if ((group = H5Gopen2(fid2, "Link_to_Link_to_Group2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Query the external link to external link object's name */
     *name       = '\0';
     name_cached = FALSE;
     namelen     = H5I__get_name_test(group, (char *)name, sizeof(name), &name_cached);
     if (!((HDstrcmp(name, "/Group2") == 0) && (namelen == 7) && name_cached))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close Group */
     if (H5Gclose(group) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close files */
     if (H5Fclose(fid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     return 0;
 
@@ -3771,7 +3771,7 @@ main(void)
      * property.
      */
     if ((file_id = H5Fcreate(filename0, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Call "main" test routine */
     nerrors += test_main(file_id, fapl);

--- a/test/gheap.c
+++ b/test/gheap.c
@@ -586,7 +586,7 @@ main(void)
 
     /* Push API context */
     if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = TRUE;
 
     nerrors += test_1(fapl_id);
@@ -605,7 +605,7 @@ main(void)
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = FALSE;
 
     h5_cleanup(FILENAME, fapl_id);

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -89,7 +89,10 @@ H5TEST_DLLVAR MPI_Info h5_io_info_g; /* MPI INFO object for IO */
 /*
  * Print the current location on the standard output stream.
  */
-#define AT() HDprintf("   at %s:%d in %s()...\n", __FILE__, __LINE__, __func__);
+#define AT()                                                                                                 \
+    do {                                                                                                     \
+        HDprintf("   at %s:%d in %s()...\n", __FILE__, __LINE__, __func__);                                  \
+    } while (0)
 
 /*
  * The name of the test is printed by saying TESTING("something") which will
@@ -101,66 +104,66 @@ H5TEST_DLLVAR MPI_Info h5_io_info_g; /* MPI INFO object for IO */
  * the H5_FAILED() macro is invoked automatically when an API function fails.
  */
 #define TESTING(WHAT)                                                                                        \
-    {                                                                                                        \
+    do {                                                                                                     \
         HDprintf("Testing %-62s", WHAT);                                                                     \
         HDfflush(stdout);                                                                                    \
-    }
+    } while (0)
 #define TESTING_2(WHAT)                                                                                      \
-    {                                                                                                        \
+    do {                                                                                                     \
         HDprintf("  Testing %-60s", WHAT);                                                                   \
         HDfflush(stdout);                                                                                    \
-    }
+    } while (0)
 #define PASSED()                                                                                             \
     do {                                                                                                     \
         HDputs(" PASSED");                                                                                   \
         HDfflush(stdout);                                                                                    \
     } while (0)
 #define H5_FAILED()                                                                                          \
-    {                                                                                                        \
+    do {                                                                                                     \
         HDputs("*FAILED*");                                                                                  \
         HDfflush(stdout);                                                                                    \
-    }
+    } while (0)
 #define H5_WARNING()                                                                                         \
-    {                                                                                                        \
+    do {                                                                                                     \
         HDputs("*WARNING*");                                                                                 \
         HDfflush(stdout);                                                                                    \
-    }
+    } while (0)
 #define SKIPPED()                                                                                            \
-    {                                                                                                        \
+    do {                                                                                                     \
         HDputs(" -SKIP-");                                                                                   \
         HDfflush(stdout);                                                                                    \
-    }
+    } while (0)
 #define PUTS_ERROR(s)                                                                                        \
-    {                                                                                                        \
+    do {                                                                                                     \
         HDputs(s);                                                                                           \
         AT();                                                                                                \
         goto error;                                                                                          \
-    }
+    } while (0)
 #define TEST_ERROR                                                                                           \
-    {                                                                                                        \
+    do {                                                                                                     \
         H5_FAILED();                                                                                         \
         AT();                                                                                                \
         goto error;                                                                                          \
-    }
+    } while (0)
 #define STACK_ERROR                                                                                          \
-    {                                                                                                        \
+    do {                                                                                                     \
         H5Eprint2(H5E_DEFAULT, stdout);                                                                      \
         goto error;                                                                                          \
-    }
+    } while (0)
 #define FAIL_STACK_ERROR                                                                                     \
-    {                                                                                                        \
+    do {                                                                                                     \
         H5_FAILED();                                                                                         \
         AT();                                                                                                \
         H5Eprint2(H5E_DEFAULT, stdout);                                                                      \
         goto error;                                                                                          \
-    }
+    } while (0)
 #define FAIL_PUTS_ERROR(s)                                                                                   \
-    {                                                                                                        \
+    do {                                                                                                     \
         H5_FAILED();                                                                                         \
         AT();                                                                                                \
         HDputs(s);                                                                                           \
         goto error;                                                                                          \
-    }
+    } while (0)
 
 /* Number of seconds to wait before killing a test (requires alarm(2)) */
 #define H5_ALARM_SEC 1200 /* default is 20 minutes */

--- a/test/hyperslab.c
+++ b/test/hyperslab.c
@@ -181,7 +181,7 @@ test_fill(size_t nx, size_t ny, size_t nz, size_t di, size_t dj, size_t dk, size
 
     /* Allocate array */
     if (NULL == (dst = (uint8_t *)HDcalloc((size_t)1, nx * ny * nz)))
-        TEST_ERROR
+        TEST_ERROR;
 
     init_full(dst, nx, ny, nz);
 
@@ -229,7 +229,7 @@ test_fill(size_t nx, size_t ny, size_t nz, size_t di, size_t dj, size_t dk, size
                                             acc += dst[u * ny * nz + v * nz + w];
 
                                 if (acc != ref_value) {
-                                    H5_FAILED()
+                                    H5_FAILED();
                                     if (!HDisatty(1)) {
                                         /*
                                          * Print debugging info unless output
@@ -372,9 +372,9 @@ test_copy(int mode, size_t nx, size_t ny, size_t nz, size_t di, size_t dj, size_
      * Allocate arrays
      */
     if (NULL == (src = (uint8_t *)HDcalloc((size_t)1, nx * ny * nz)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (dst = (uint8_t *)HDcalloc((size_t)1, nx * ny * nz)))
-        TEST_ERROR
+        TEST_ERROR;
 
     init_full(src, nx, ny, nz);
 
@@ -463,7 +463,7 @@ test_copy(int mode, size_t nx, size_t ny, size_t nz, size_t di, size_t dj, size_
                                     for (w = dst_offset[2]; w < dst_offset[2] + dz; w++)
                                         acc += dst[u * ny * nz + v * nz + w];
                             if (acc != ref_value) {
-                                H5_FAILED()
+                                H5_FAILED();
                                 if (!HDisatty(1)) {
                                     /*
                                      * Print debugging info unless output is
@@ -500,7 +500,7 @@ test_copy(int mode, size_t nx, size_t ny, size_t nz, size_t di, size_t dj, size_
                              */
                             if (acc + (unsigned)dx * (unsigned)dy * (unsigned)dz !=
                                 ref_value + nx * ny * nz) {
-                                H5_FAILED()
+                                H5_FAILED();
                                 if (!HDisatty(1)) {
                                     /*
                                      * Print debugging info unless output is
@@ -579,9 +579,9 @@ test_multifill(size_t nx)
 
     /* Initialize the source and destination */
     if (NULL == (src = (struct a_struct *)HDmalloc(nx * sizeof(*src))))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (dst = (struct a_struct *)HDmalloc(nx * sizeof(*dst))))
-        TEST_ERROR
+        TEST_ERROR;
 
     for (i = 0; i < nx; i++) {
         src[i].left  = 1111111;
@@ -628,7 +628,7 @@ test_multifill(size_t nx)
         else if (dst[i].right != 4444444)
             HDsprintf(s, "bad dst[%lu].right", (unsigned long)i);
         if (s[0]) {
-            H5_FAILED()
+            H5_FAILED();
             if (!HDisatty(1)) {
                 AT();
                 HDprintf("   fill={%d,%g,%d}\n   ", fill.left, fill.mid, fill.right);
@@ -691,9 +691,9 @@ test_endian(size_t nx)
 
     /* Initialize arrays */
     if (NULL == (src = (uint8_t *)HDmalloc(nx * 4)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (dst = (uint8_t *)HDcalloc(nx, (size_t)4)))
-        TEST_ERROR
+        TEST_ERROR;
 
     init_full(src, nx, (size_t)4, (size_t)1);
 
@@ -712,7 +712,7 @@ test_endian(size_t nx)
     for (i = 0; i < nx; i++) {
         for (j = 0; j < 4; j++) {
             if (src[i * 4 + j] != dst[i * 4 + 3 - j]) {
-                H5_FAILED()
+                H5_FAILED();
                 if (!HDisatty(1)) {
                     /*
                      * Print debugging info unless output is going directly
@@ -777,9 +777,9 @@ test_transpose(size_t nx, size_t ny)
 
     /* Initialize */
     if (NULL == (src = (int *)HDmalloc(nx * ny * sizeof(*src))))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (dst = (int *)HDcalloc(nx * ny, sizeof(*dst))))
-        TEST_ERROR
+        TEST_ERROR;
 
     for (i = 0; i < nx; i++)
         for (j = 0; j < ny; j++)
@@ -800,7 +800,7 @@ test_transpose(size_t nx, size_t ny)
     for (i = 0; i < nx; i++) {
         for (j = 0; j < ny; j++) {
             if (src[i * ny + j] != dst[j * nx + i]) {
-                H5_FAILED()
+                H5_FAILED();
                 if (!HDisatty(1)) {
                     AT();
                     HDprintf("   diff at i=%lu, j=%lu\n", (unsigned long)i, (unsigned long)j);
@@ -876,11 +876,11 @@ test_sub_super(size_t nx, size_t ny)
 
     /* Initialize */
     if (NULL == (full = (uint8_t *)HDmalloc(4 * nx * ny)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (half = (uint8_t *)HDcalloc((size_t)1, nx * ny)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (twice = (uint8_t *)HDcalloc((size_t)4, nx * ny)))
-        TEST_ERROR
+        TEST_ERROR;
 
     init_full(full, 2 * nx, 2 * ny, (size_t)1);
 
@@ -899,7 +899,7 @@ test_sub_super(size_t nx, size_t ny)
     for (i = 0; i < nx; i++) {
         for (j = 0; j < ny; j++) {
             if (full[4 * i * ny + 2 * j] != half[i * ny + j]) {
-                H5_FAILED()
+                H5_FAILED();
                 if (!HDisatty(1)) {
                     AT();
                     HDprintf("   full[%lu][%lu] != half[%lu][%lu]\n", (unsigned long)i * 2,
@@ -958,7 +958,7 @@ test_sub_super(size_t nx, size_t ny)
                 HDsprintf(s, "half[%lu][%lu] != twice[%lu][%lu]", (unsigned long)i, (unsigned long)j,
                           (unsigned long)i * 2 + 1, (unsigned long)j * 2 + 1);
             if (s[0]) {
-                H5_FAILED()
+                H5_FAILED();
                 if (!HDisatty(1)) {
                     AT();
                     HDprintf("   %s\n   Half is:\n", s);
@@ -1019,7 +1019,7 @@ test_array_fill(size_t lo, size_t hi)
 
     /* Initialize */
     if (NULL == (dst = (int *)HDcalloc(sizeof(int), ARRAY_FILL_SIZE * hi)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Setup */
     for (u = 0; u < ARRAY_FILL_SIZE; u++)
@@ -1033,7 +1033,7 @@ test_array_fill(size_t lo, size_t hi)
         for (u = 0; u < w; u++)
             for (v = 0; v < ARRAY_FILL_SIZE; v++)
                 if (dst[(u * ARRAY_FILL_SIZE) + v] != src[v])
-                    TEST_ERROR
+                    TEST_ERROR;
 
         HDmemset(dst, 0, sizeof(int) * ARRAY_FILL_SIZE * w);
     } /* end for */
@@ -1084,7 +1084,7 @@ test_array_offset_n_calc(size_t n, size_t x, size_t y, size_t z)
 
     /* Initialize */
     if (NULL == (a = (hsize_t *)HDmalloc(sizeof(hsize_t) * x * y * z)))
-        TEST_ERROR
+        TEST_ERROR;
 
     dims[0] = z;
     dims[1] = y;
@@ -1108,11 +1108,11 @@ test_array_offset_n_calc(size_t n, size_t x, size_t y, size_t z)
 
         /* Check offset of coordinate */
         if (a[off] != off)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get coordinates of offset */
         if (H5VM_array_calc(off, ARRAY_OFFSET_NDIMS, dims, new_coords) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check computed coordinates */
         for (v = 0; v < ARRAY_OFFSET_NDIMS; v++)

--- a/test/istore.c
+++ b/test/istore.c
@@ -484,7 +484,7 @@ test_sparse(hid_t f, const char *prefix, size_t nblocks, size_t nx, size_t ny, s
     HDsprintf(s, "istore sparse: %s", dims);
     TESTING(s);
     if (skip_test) {
-        SKIPPED()
+        SKIPPED();
         return SUCCEED;
     }
     buf = (uint8_t *)HDmalloc(nx * ny * nz);

--- a/test/lheap.c
+++ b/test/lheap.c
@@ -66,7 +66,7 @@ main(void)
 
     /* Push API context */
     if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = TRUE;
 
     /*
@@ -183,11 +183,11 @@ main(void)
             file                 = H5Fopen(testfile, H5F_ACC_RDONLY, H5P_DEFAULT);
             if (file >= 0) {
                 if ((dset = H5Dopen2(file, "/Dataset1", H5P_DEFAULT)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Dclose(dset) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Fclose(file) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             }
             else {
                 H5_FAILED();
@@ -200,11 +200,11 @@ main(void)
 
     /* Verify symbol table messages are cached */
     if (h5_verify_cached_stabs(FILENAME, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = FALSE;
 
     HDputs("All local heap tests passed.");

--- a/test/links.c
+++ b/test/links.c
@@ -423,50 +423,50 @@ mklinks(hid_t fapl, hbool_t new_format)
     char    filename[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("link creation (w/new group format)")
+        TESTING("link creation (w/new group format)");
     else
-        TESTING("link creation")
+        TESTING("link creation");
 
     /* Create a file */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((scalar = H5Screate_simple(1, size, size)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group */
     if ((grp = H5Gcreate2(file, "grp1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(grp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a dataset */
     if ((d1 = H5Dcreate2(file, "d1", H5T_NATIVE_INT, scalar, H5P_DEFAULT, dcpl_g, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(d1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a hard link */
     if (H5Lcreate_hard(file, "d1", H5L_SAME_LOC, "grp1/hard", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a symbolic link */
     if (H5Lcreate_soft("/d1", file, "grp1/soft", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a symbolic link to something that doesn't exist */
     if (H5Lcreate_soft("foobar", file, "grp1/dangle", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a recursive symbolic link */
     if (H5Lcreate_soft("/grp1/recursive", file, "/grp1/recursive", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Sclose(scalar) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -495,52 +495,52 @@ new_links(hid_t fapl, hbool_t new_format)
     hsize_t size[1] = {1};
 
     if (new_format)
-        TESTING("H5Lcreate functions (w/new group format)")
+        TESTING("H5Lcreate functions (w/new group format)");
     else
-        TESTING("H5Lcreate functions")
+        TESTING("H5Lcreate functions");
 
     /* Create two files */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((file_a = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     h5_fixname(FILENAME[2], fapl, filename, sizeof filename);
     if ((file_b = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((scalar = H5Screate_simple(1, size, size)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create two groups in each file */
     if ((grp1_a = H5Gcreate2(file_a, "grp1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((grp2_a = H5Gcreate2(file_a, "grp2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((grp1_b = H5Gcreate2(file_b, "grp1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((grp2_b = H5Gcreate2(file_b, "grp2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create datasets */
     if ((dset1 = H5Dcreate2(file_a, "dataset1", H5T_NATIVE_INT, scalar, H5P_DEFAULT, dcpl_g, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dset2 = H5Dcreate2(grp1_a, "dataset2", H5T_NATIVE_INT, scalar, H5P_DEFAULT, dcpl_g, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create links within a file.  Both of source and destination use
      * H5L_SAME_LOC.  Both hard and soft links should fail. */
     H5E_BEGIN_TRY
     {
         if (H5Lcreate_hard(H5L_SAME_LOC, "dataset1", H5L_SAME_LOC, "hard", H5P_DEFAULT, H5P_DEFAULT) != FAIL)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
     H5E_BEGIN_TRY
     {
         if (H5Lcreate_soft("dataset1", H5L_SAME_LOC, "soft", H5P_DEFAULT, H5P_DEFAULT) != FAIL)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
@@ -548,37 +548,37 @@ new_links(hid_t fapl, hbool_t new_format)
     H5E_BEGIN_TRY
     {
         if (H5Lcreate_hard(file_a, "dataset1", file_b, "hard", H5P_DEFAULT, H5P_DEFAULT) != FAIL)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
     /* Create hard link to test H5L_SAME_LOC */
     if (H5Lcreate_hard(grp1_a, "dataset2", H5L_SAME_LOC, "hard1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create links to test hard links across different locations */
     if (H5Lcreate_hard(grp1_a, "dataset2", grp2_a, "hard2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataspace and files */
     if (H5Sclose(scalar) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(grp1_a) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(grp2_a) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(grp1_b) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(grp2_b) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file_a) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file_b) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -622,48 +622,48 @@ cklinks(hid_t fapl, hbool_t new_format)
     herr_t      status;
 
     if (new_format)
-        TESTING("link queries (w/new group format)")
+        TESTING("link queries (w/new group format)");
     else
-        TESTING("link queries")
+        TESTING("link queries");
 
     /* Open the file */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     //! [H5Otoken_cmp_snip]
 
     /* Hard link */
     if (H5Oget_info_by_name3(file, "d1", &oinfo1, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_info_by_name3(file, "grp1/hard", &oinfo2, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5O_TYPE_DATASET != oinfo2.type) {
         H5_FAILED();
         HDprintf("    %d: Unexpected object type should have been a dataset\n", __LINE__);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     //! [H5Otoken_cmp_snip]
 
     if (H5Otoken_cmp(file, &oinfo1.token, &oinfo2.token, &token_cmp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (token_cmp) {
         H5_FAILED();
         HDputs("    Hard link test failed. Link seems not to point to the ");
         HDputs("    expected file location.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Lexists(file, "/", H5P_DEFAULT) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lexists(file, "d1", H5P_DEFAULT) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lexists(file, "grp1/hard", H5P_DEFAULT) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lexists(file, "/grp1", H5P_DEFAULT) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lexists(file, "/grp1/hard", H5P_DEFAULT) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     H5E_BEGIN_TRY
     {
         status = H5Lexists(file, "no_grp1/hard", H5P_DEFAULT);
@@ -672,7 +672,7 @@ cklinks(hid_t fapl, hbool_t new_format)
     if (status >= 0) {
         H5_FAILED();
         HDputs("    H5Lexists() should have failed for a path with missing components.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     H5E_BEGIN_TRY
     {
@@ -682,34 +682,34 @@ cklinks(hid_t fapl, hbool_t new_format)
     if (status >= 0) {
         H5_FAILED();
         HDputs("    H5Lexists() should have failed for a path with missing components.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Symbolic link */
     if (H5Oget_info_by_name3(file, "grp1/soft", &oinfo2, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5O_TYPE_DATASET != oinfo2.type) {
         H5_FAILED();
         HDprintf("    %d: Unexpected object type should have been a dataset\n", __LINE__);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Otoken_cmp(file, &oinfo1.token, &oinfo2.token, &token_cmp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (token_cmp) {
         H5_FAILED();
         HDputs("    Soft link test failed. Link seems not to point to the ");
         HDputs("    expected file location.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Lget_val(file, "grp1/soft", linkval, sizeof linkval, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(linkval, "/d1") != 0) {
         H5_FAILED();
         HDputs("    Soft link test failed. Wrong link value");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Lexists(file, "grp1/soft", H5P_DEFAULT) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Dangling link */
     H5E_BEGIN_TRY
@@ -720,27 +720,27 @@ cklinks(hid_t fapl, hbool_t new_format)
     if (status >= 0) {
         H5_FAILED();
         HDputs("    H5Oget_info_by_name() should have failed for a dangling link.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Lget_info2(file, "grp1/dangle", &linfo, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5L_TYPE_SOFT != linfo.type) {
         H5_FAILED();
         HDprintf("    %d: Unexpected object type should have been a symbolic link\n", __LINE__);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Lget_val(file, "grp1/dangle", linkval, sizeof linkval, H5P_DEFAULT) < 0) {
         H5_FAILED();
         HDprintf("    %d: Can't retrieve link value\n", __LINE__);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (HDstrcmp(linkval, "foobar") != 0) {
         H5_FAILED();
         HDputs("    Dangling link test failed. Wrong link value");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Lexists(file, "grp1/dangle", H5P_DEFAULT) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Recursive link */
     H5E_BEGIN_TRY
@@ -751,33 +751,33 @@ cklinks(hid_t fapl, hbool_t new_format)
     if (status >= 0) {
         H5_FAILED();
         HDputs("    H5Oget_info_by_name() should have failed for a recursive link.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Lget_info2(file, "grp1/recursive", &linfo, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5L_TYPE_SOFT != linfo.type) {
         H5_FAILED();
         HDprintf("    %d: Unexpected object type should have been a symbolic link\n", __LINE__);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Lget_val(file, "grp1/recursive", linkval, sizeof linkval, H5P_DEFAULT) < 0) {
         H5_FAILED();
         HDprintf("    %d: Can't retrieve link value\n", __LINE__);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (HDstrcmp(linkval, "/grp1/recursive") != 0) {
         H5_FAILED();
         HDputs("   Recursive link test failed. Wrong link value");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Non-existent link */
     if (H5Lexists(file, "foobar", H5P_DEFAULT) == TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Cleanup */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -805,44 +805,44 @@ ck_new_links(hid_t fapl, hbool_t new_format)
     int         token_cmp1, token_cmp2;
 
     if (new_format)
-        TESTING("new link queries (w/new group format)")
+        TESTING("new link queries (w/new group format)");
     else
-        TESTING("new link queries")
+        TESTING("new link queries");
 
     /* Open the file */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get hard link info */
     if (H5Oget_info_by_name3(file, "/grp1/dataset2", &oi_dset, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name3(file, "/grp1/hard1", &oi_hard1, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name3(file, "/grp2/hard2", &oi_hard2, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check hard links */
     if (H5O_TYPE_DATASET != oi_hard1.type || H5O_TYPE_DATASET != oi_hard2.type) {
         H5_FAILED();
         HDprintf("    %d: Unexpected object type should have been a dataset\n", __LINE__);
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Otoken_cmp(file, &oi_dset.token, &oi_hard1.token, &token_cmp1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(file, &oi_dset.token, &oi_hard2.token, &token_cmp2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp1 || token_cmp2) {
         H5_FAILED();
         HDputs("    Hard link test failed.  Link seems not to point to the ");
         HDputs("    expected file location.");
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* Cleanup */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -871,46 +871,46 @@ long_links(hid_t fapl, hbool_t new_format)
     char   filename[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("long names for objects & links (w/new group format)")
+        TESTING("long names for objects & links (w/new group format)");
     else
-        TESTING("long names for objects & links")
+        TESTING("long names for objects & links");
 
     /* Create files */
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group with short name in file (used as target for hard links) */
     if ((gid = H5Gcreate2(fid, "grp1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Construct very long file name */
     if ((objname = (char *)HDmalloc((size_t)(MAX_NAME_LEN + 1))) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
     for (u = 0; u < MAX_NAME_LEN; u++)
         objname[u] = 'a';
     objname[MAX_NAME_LEN] = '\0';
 
     /* Create hard link to existing object */
     if (H5Lcreate_hard(fid, "grp1", fid, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create soft link to existing object */
     objname[0] = 'b';
     if (H5Lcreate_soft("grp1", fid, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group with long name in existing group */
     if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close objects */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Release memory */
     HDfree(objname);
@@ -948,9 +948,9 @@ toomany(hid_t fapl, hbool_t new_format)
     char  filename[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("too many links (w/new group format)")
+        TESTING("too many links (w/new group format)");
     else
-        TESTING("too many links")
+        TESTING("too many links");
 
     /* Make certain test is valid */
     /* XXX: should probably make a "generic" test that creates the proper
@@ -961,123 +961,123 @@ toomany(hid_t fapl, hbool_t new_format)
     /* Create file */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group with short name in file (used as target for hard links) */
     if ((gid = H5Gcreate2(fid, "final", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create chain of hard links to existing object (no limit on #) */
     if (H5Lcreate_hard(fid, "final", fid, "hard1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard1", fid, "hard2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard2", fid, "hard3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard3", fid, "hard4", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard4", fid, "hard5", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard5", fid, "hard6", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard6", fid, "hard7", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard7", fid, "hard8", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard8", fid, "hard9", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard9", fid, "hard10", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard10", fid, "hard11", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard11", fid, "hard12", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard12", fid, "hard13", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard13", fid, "hard14", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard14", fid, "hard15", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard15", fid, "hard16", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard16", fid, "hard17", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard17", fid, "hard18", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard18", fid, "hard19", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard19", fid, "hard20", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "hard20", fid, "hard21", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create chain of soft links to existing object (limited) */
     if (H5Lcreate_soft("final", fid, "soft1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("soft1", fid, "soft2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("soft2", fid, "soft3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("soft3", fid, "soft4", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("soft4", fid, "soft5", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("soft5", fid, "soft6", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("soft6", fid, "soft7", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("soft7", fid, "soft8", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("soft8", fid, "soft9", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("soft9", fid, "soft10", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("soft10", fid, "soft11", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("soft11", fid, "soft12", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("soft12", fid, "soft13", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("soft13", fid, "soft14", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("soft14", fid, "soft15", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("soft15", fid, "soft16", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("soft16", fid, "soft17", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close objects */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through last hard link */
     if ((gid = H5Gopen2(fid, "hard21", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/hard21") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in hard-linked group */
     if ((gid2 = H5Gcreate2(gid, "new_hard", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in hard-linked group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close hard-linked object */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through too deep soft link */
     H5E_BEGIN_TRY
@@ -1088,32 +1088,32 @@ toomany(hid_t fapl, hbool_t new_format)
     if (gid >= 0) {
         H5_FAILED();
         HDputs("    Should have failed for sequence of too many nested links.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Open object through lesser soft link */
     if ((gid = H5Gopen2(fid, "soft16", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/soft16") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object using soft links */
     if ((gid2 = H5Gcreate2(gid, "new_soft", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close groups */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -1152,9 +1152,9 @@ test_lcpl(hid_t fapl, hbool_t new_format)
     hsize_t     dims[2];
 
     if (new_format)
-        TESTING("link creation property lists (w/new group format)")
+        TESTING("link creation property lists (w/new group format)");
     else
-        TESTING("link creation property lists")
+        TESTING("link creation property lists");
 
     /* Actually, intermediate group creation is tested elsewhere (tmisc).
      * Here we only need to test the character encoding property */
@@ -1163,167 +1163,167 @@ test_lcpl(hid_t fapl, hbool_t new_format)
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create and link a group with the default LCPL */
     if ((group_id = H5Gcreate2(file_id, "/group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is the default */
     if (H5Lget_info2(file_id, "group", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5F_DEFAULT_CSET)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create and commit a datatype with the default LCPL */
     if ((type_id = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(file_id, "/type", type_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(type_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is the default */
     if (H5Lget_info2(file_id, "type", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5F_DEFAULT_CSET)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a dataspace */
     dims[0] = H5L_DIM1;
     dims[1] = H5L_DIM2;
     if ((space_id = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a dataset using the default LCPL */
     if ((dset_id =
              H5Dcreate2(file_id, "/dataset", H5T_NATIVE_INT, space_id, H5P_DEFAULT, dcpl_g, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is the default */
     if (H5Lget_info2(file_id, "dataset", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5F_DEFAULT_CSET)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a link creation property list with the UTF-8 character encoding */
     if ((lcpl_id = H5Pcreate(H5P_LINK_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_char_encoding(lcpl_id, H5T_CSET_UTF8) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create and link a group with the new LCPL */
     if ((group_id = H5Gcreate2(file_id, "/group2", lcpl_id, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is UTF-8 */
     if (H5Lget_info2(file_id, "group2", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create and commit a datatype with the new LCPL */
     if ((type_id = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(file_id, "/type2", type_id, lcpl_id, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(type_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is UTF-8 */
     if (H5Lget_info2(file_id, "type2", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a dataset using the new LCPL */
     if ((dset_id = H5Dcreate2(file_id, "/dataset2", H5T_NATIVE_INT, space_id, lcpl_id, dcpl_g, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is UTF-8 */
     if (H5Lget_info2(file_id, "dataset2", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a new link to the dataset with a different character encoding. */
     if (H5Pclose(lcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((lcpl_id = H5Pcreate(H5P_LINK_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_char_encoding(lcpl_id, H5T_CSET_ASCII) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Lcreate_hard(file_id, "/dataset2", file_id, "/dataset2_link", lcpl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is ASCII */
     if (H5Lget_info2(file_id, "/dataset2_link", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_ASCII)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the first link's encoding hasn't changed */
     if (H5Lget_info2(file_id, "/dataset2", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make sure that LCPLs work properly for other API calls: */
     /* H5Lcreate_soft */
     if (H5Pset_char_encoding(lcpl_id, H5T_CSET_UTF8) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("dataset2", file_id, "slink_to_dset2", lcpl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(file_id, "slink_to_dset2", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Lmove */
     if (H5Pset_char_encoding(lcpl_id, H5T_CSET_ASCII) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lmove(file_id, "slink_to_dset2", file_id, "moved_slink", lcpl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(file_id, "moved_slink", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_ASCII)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Lcopy */
     if (H5Pset_char_encoding(lcpl_id, H5T_CSET_UTF8) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcopy(file_id, "moved_slink", file_id, "copied_slink", lcpl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(file_id, "copied_slink", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Lcreate_external */
     if (H5Lcreate_external("filename", "path", file_id, "extlink", lcpl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(file_id, "extlink", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close open IDs */
     if (H5Pclose(lcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -1359,33 +1359,33 @@ test_move(hid_t fapl, hbool_t new_format)
     char  filename[1024];
 
     if (new_format)
-        TESTING("H5Lmove (w/new group format)")
+        TESTING("H5Lmove (w/new group format)");
     else
-        TESTING("H5Lmove")
+        TESTING("H5Lmove");
 
     /* Create two new files */
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
     if ((file_a = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((file_b = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create groups in first file */
     if ((grp_1 = H5Gcreate2(file_a, "group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((grp_2 = H5Gcreate2(file_a, "group2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((grp_move = H5Gcreate2(grp_1, "group_move", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create hard, soft and external links. */
     if (H5Lcreate_hard(grp_1, "group_move", H5L_SAME_LOC, "hard", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("/group1/group_move", grp_2, "soft", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external("filename", "pathname", grp_2, "ext", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move a group within the file.  Both of source and destination use
      * H5L_SAME_LOC.  Should fail. */
@@ -1393,7 +1393,7 @@ test_move(hid_t fapl, hbool_t new_format)
     {
         if (H5Lmove(H5L_SAME_LOC, "group_move", H5L_SAME_LOC, "group_new_name", H5P_DEFAULT, H5P_DEFAULT) !=
             FAIL)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
@@ -1401,31 +1401,31 @@ test_move(hid_t fapl, hbool_t new_format)
     H5E_BEGIN_TRY
     {
         if (H5Lmove(grp_1, "group_move", file_b, "group_new_name", H5P_DEFAULT, H5P_DEFAULT) != FAIL)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
     /* Move a soft link across files.  Should succeed. */
     if (H5Lmove(grp_2, "soft", file_b, "soft_new_name", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lexists(file_b, "soft_new_name", H5P_DEFAULT) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move an external link across files.  Should succeed. */
     if (H5Lmove(grp_2, "ext", file_b, "ext_new_name", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lexists(file_b, "ext_new_name", H5P_DEFAULT) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move a group across groups in the same file while renaming it. */
     if (H5Lmove(grp_1, "group_move", grp_2, "group_new_name", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group just moved to the new location. */
     if ((moved_grp = H5Gopen2(grp_2, "group_new_name", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(moved_grp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the group is no longer in the original location */
     H5E_BEGIN_TRY
@@ -1436,52 +1436,52 @@ test_move(hid_t fapl, hbool_t new_format)
     if (moved_grp >= 0) {
         H5_FAILED();
         HDputs("    Group still in original location?");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Use H5Lmove to rename a group without moving it. */
     if (H5Lmove(grp_2, "group_new_name", H5L_SAME_LOC, "group_newer_name", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group. */
     if ((moved_grp = H5Gopen2(grp_2, "group_newer_name", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(moved_grp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Use H5Lmove to move a group without renaming it. */
     if (H5Lmove(grp_2, "group_newer_name", grp_1, "group_newer_name", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group . */
     if ((moved_grp = H5Gopen2(grp_1, "group_newer_name", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(moved_grp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move the group while giving long paths. */
     if (H5Lmove(file_a, "/group1/group_newer_name", grp_2, "/group2/group_newest_name", H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group just moved to the new location. */
     if ((moved_grp = H5Gopen2(grp_2, "group_newest_name", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Gclose(moved_grp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the group is in no previous locations */
     H5E_BEGIN_TRY
     {
         if ((moved_grp = H5Gopen2(grp_1, "group_newer_name", H5P_DEFAULT)) >= 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if ((moved_grp = H5Gopen2(grp_2, "group_newer_name", H5P_DEFAULT)) >= 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if ((moved_grp = H5Gopen2(grp_2, "group_new_name", H5P_DEFAULT)) >= 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if ((moved_grp = H5Gopen2(grp_1, "group_copy", H5P_DEFAULT)) >= 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     H5E_END_TRY;
 
@@ -1526,33 +1526,33 @@ test_copy(hid_t fapl, hbool_t new_format)
     char  filename[1024];
 
     if (new_format)
-        TESTING("H5Lcopy (w/new group format)")
+        TESTING("H5Lcopy (w/new group format)");
     else
-        TESTING("H5Lcopy")
+        TESTING("H5Lcopy");
 
     /* Create two new files */
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
     if ((file_a = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((file_b = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create groups in first file */
     if ((grp_1 = H5Gcreate2(file_a, "group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((grp_2 = H5Gcreate2(file_a, "group2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((grp_move = H5Gcreate2(grp_1, "group_copy", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create hard, soft and external links. */
     if (H5Lcreate_hard(grp_1, "group_copy", H5L_SAME_LOC, "hard", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("/group1/group_copy", grp_2, "soft", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external("filename", "pathname", grp_2, "ext", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Copy a group within the file.  Both of source and destination use
      * H5L_SAME_LOC.  Should fail. */
@@ -1560,7 +1560,7 @@ test_copy(hid_t fapl, hbool_t new_format)
     {
         if (H5Lcopy(H5L_SAME_LOC, "group_copy", H5L_SAME_LOC, "group_new_name", H5P_DEFAULT, H5P_DEFAULT) !=
             FAIL)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
@@ -1568,96 +1568,96 @@ test_copy(hid_t fapl, hbool_t new_format)
     H5E_BEGIN_TRY
     {
         if (H5Lcopy(grp_1, "group_copy", file_b, "group_new_name", H5P_DEFAULT, H5P_DEFAULT) != FAIL)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
     /* Copy a soft link across files.  Should succeed. */
     if (H5Lcopy(grp_2, "soft", file_b, "soft_new_name", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lexists(file_b, "soft_new_name", H5P_DEFAULT) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Copy an external link across files.  Should succeed. */
     if (H5Lcopy(grp_2, "ext", file_b, "ext_new_name", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lexists(file_b, "ext_new_name", H5P_DEFAULT) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move a group across groups in the same file while renaming it. */
     if (H5Lcopy(grp_1, "group_copy", grp_2, "group_new_name", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group just moved to the new location. */
     if ((moved_grp = H5Gopen2(grp_2, "group_new_name", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(moved_grp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the group is also in the original location */
     if ((moved_grp = H5Gopen2(grp_1, "group_copy", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(moved_grp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Use H5Lcopy to create a group in the same location with a different name. */
     if (H5Lcopy(grp_2, "group_new_name", H5L_SAME_LOC, "group_newer_name", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group. */
     if ((moved_grp = H5Gopen2(grp_2, "group_newer_name", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(moved_grp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Verify that the group is also in the original location */
     if ((moved_grp = H5Gopen2(grp_2, "group_new_name", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(moved_grp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Use H5Lcopy to copy to a different location with the same name. */
     if (H5Lcopy(grp_2, "group_newer_name", grp_1, "group_newer_name", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group . */
     if ((moved_grp = H5Gopen2(grp_1, "group_newer_name", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(moved_grp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Verify that the group is still in the previous location */
     if ((moved_grp = H5Gopen2(grp_2, "group_new_name", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(moved_grp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Copy the group while giving long paths. */
     if (H5Lcopy(file_a, "/group1/group_newer_name", grp_2, "/group2/group_newest_name", H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group just moved to the new location. */
     if ((moved_grp = H5Gopen2(grp_2, "group_newest_name", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(moved_grp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the group is still in all previous original locations */
     if ((moved_grp = H5Gopen2(grp_1, "group_newer_name", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(moved_grp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((moved_grp = H5Gopen2(grp_2, "group_newer_name", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(moved_grp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((moved_grp = H5Gopen2(grp_2, "group_new_name", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(moved_grp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((moved_grp = H5Gopen2(grp_1, "group_copy", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(moved_grp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     H5Gclose(grp_1);
     H5Gclose(grp_2);
@@ -1711,57 +1711,57 @@ test_move_preserves(hid_t fapl_id, hbool_t new_format)
     char        filename[1024];
 
     if (new_format)
-        TESTING("moving and copying links preserves their properties (w/new group format)")
+        TESTING("moving and copying links preserves their properties (w/new group format)");
     else
-        TESTING("moving and copying links preserves their properties")
+        TESTING("moving and copying links preserves their properties");
 
     /* Create a file creation property list with creation order stored for links
      * in the root group
      */
     if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_link_creation_order(fcpl_id, &crt_order_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (crt_order_flags != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_link_creation_order(fcpl_id, &crt_order_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (crt_order_flags != H5P_CRT_ORDER_TRACKED)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file */
     /* (with creation order tracking for the root group) */
     h5_fixname(FILENAME[0], fapl_id, filename, sizeof filename);
     if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a link creation property list with the UTF-8 character encoding */
     if ((lcpl_id = H5Pcreate(H5P_LINK_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_char_encoding(lcpl_id, H5T_CSET_UTF8) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group with that lcpl */
     if ((group_id = H5Gcreate2(file_id, "group", lcpl_id, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the group's link's information */
     if (H5Lget_info2(file_id, "group", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name3(file_id, "group", &oinfo, H5O_INFO_TIME, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     old_cset = linfo.cset;
     if (old_cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder_valid != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     old_corder = linfo.corder;
     if (old_corder != 0)
-        TEST_ERROR
+        TEST_ERROR;
     old_modification_time = oinfo.mtime;
 
     /* If this test happens too quickly, the times will all be the same.  Make sure the time changes. */
@@ -1771,141 +1771,141 @@ test_move_preserves(hid_t fapl_id, hbool_t new_format)
 
     /* Close the file and reopen it */
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((file_id = H5Fopen(filename, H5F_ACC_RDWR, fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the link's character set & modification time .  They should be unchanged */
     if (H5Lget_info2(file_id, "group", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name3(file_id, "group", &oinfo, H5O_INFO_TIME, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_modification_time != oinfo.mtime)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_cset != linfo.cset)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder_valid != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_corder != linfo.corder)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a new link to the group.  It should have a different creation order value but the same
      * modification time */
     if (H5Lcreate_hard(file_id, "group", file_id, "group2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name3(file_id, "group2", &oinfo, H5O_INFO_TIME, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_modification_time != oinfo.mtime)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(file_id, "group2", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_corder == linfo.corder)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder_valid != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_ASCII)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Copy the first link to a UTF-8 name.
      *  Its creation order value should be different, but modification time
      * should not change.
      */
     if (H5Lcopy(file_id, "group", file_id, "group_copied", lcpl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name3(file_id, "group_copied", &oinfo, H5O_INFO_TIME, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_modification_time != oinfo.mtime)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(file_id, "group_copied", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder_valid != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is UTF-8 */
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move the link with the default property list. */
     if (H5Lmove(file_id, "group_copied", file_id, "group_copied2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name3(file_id, "group_copied2", &oinfo, H5O_INFO_TIME, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_modification_time != oinfo.mtime)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(file_id, "group_copied2", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder_valid != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 3)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is not UTF-8 */
     if (linfo.cset == H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the original link is unchanged */
     if (H5Oget_info_by_name3(file_id, "group", &oinfo, H5O_INFO_TIME, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_modification_time != oinfo.mtime)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(file_id, "group", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder_valid != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_corder != linfo.corder)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move the first link to a UTF-8 name.
      *  Its creation order value will change, but modification time should not
      *  change. */
     if (H5Lmove(file_id, "group", file_id, "group_moved", lcpl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name3(file_id, "group_moved", &oinfo, H5O_INFO_TIME, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_modification_time != oinfo.mtime)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(file_id, "group_moved", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder_valid != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 4)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is UTF-8 */
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move the link again using the default property list. */
     if (H5Lmove(file_id, "group_moved", file_id, "group_moved_again", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name3(file_id, "group_moved_again", &oinfo, H5O_INFO_TIME, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_modification_time != oinfo.mtime)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(file_id, "group_moved_again", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder_valid != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 5)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is not UTF-8 */
     if (linfo.cset == H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close open IDs */
     if (H5Pclose(fcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(lcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -1946,170 +1946,170 @@ test_deprec(hid_t fapl, hbool_t new_format)
     char       tmpstr[1024];
 
     if (new_format)
-        TESTING("backwards compatibility (w/new group format)")
+        TESTING("backwards compatibility (w/new group format)");
     else
-        TESTING("backwards compatibility")
+        TESTING("backwards compatibility");
 
     /* Create file */
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create two groups in the file */
     if ((group1_id = H5Gcreate2(file_id, "group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gcreate2(file_id, "group2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test H5Gset and get comment */
     if (H5Gset_comment(file_id, "group1", "comment") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gget_comment(file_id, "group1", sizeof(tmpstr), tmpstr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(tmpstr, "comment") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create links using H5Glink and H5Glink2 */
     if (H5Glink(file_id, H5G_LINK_HARD, "group2", "group1/link_to_group2") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Glink2(file_id, "group1", H5G_LINK_HARD, group2_id, "link_to_group1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Glink2(file_id, "link_to_group1", H5G_LINK_SOFT, H5G_SAME_LOC, "group2/soft_link_to_group1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Glink2(file_id, "dangle", H5G_LINK_SOFT, H5G_SAME_LOC, "group2/dangle_soft_link") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test getting the names for objects */
     if (H5Gget_objname_by_idx(group1_id, (hsize_t)0, tmpstr, sizeof(tmpstr)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(tmpstr, "link_to_group2") != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         if (H5Gget_objname_by_idx(group1_id, (hsize_t)1, tmpstr, sizeof(tmpstr)) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
     /* Test getting the type for objects */
     if ((obj_type = H5Gget_objtype_by_idx(group1_id, (hsize_t)0)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (obj_type != H5G_GROUP)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         if (H5Gget_objtype_by_idx(group1_id, (hsize_t)1) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
     /* Test getting the number of objects in a group */
     if (H5Gget_num_objs(file_id, &num_objs) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (num_objs != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gget_num_objs(group1_id, &num_objs) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (num_objs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test that H5Glink created hard links properly */
     if (H5Gget_objinfo(file_id, "/group2", TRUE, &sb_hard1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gget_objinfo(file_id, "/group1/link_to_group2", TRUE, &sb_hard2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (HDmemcmp(&sb_hard1.objno, sb_hard2.objno, sizeof(sb_hard1.objno)) != 0) {
         H5_FAILED();
         HDputs("    Hard link test failed.  Link seems not to point to the ");
         HDputs("    expected file location.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Test for the other hard link created */
     if (H5Gget_objinfo(file_id, "/group1", TRUE, &sb_hard1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gget_objinfo(file_id, "/group2/link_to_group1", TRUE, &sb_hard2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (HDmemcmp(&sb_hard1.objno, sb_hard2.objno, sizeof(sb_hard1.objno)) != 0) {
         H5_FAILED();
         HDputs("    Hard link test failed.  Link seems not to point to the ");
         HDputs("    expected file location.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Test the soft link */
     if (H5Gget_objinfo(file_id, "/group2/soft_link_to_group1", FALSE, &sb_soft1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (sb_soft1.type != H5G_LINK)
-        TEST_ERROR
+        TEST_ERROR;
     if (sb_soft1.linklen != HDstrlen("link_to_group1") + 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gget_linkval(group2_id, "soft_link_to_group1", sb_soft1.linklen, tmpstr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp("link_to_group1", tmpstr) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test non-existing links with H5Gget_objinfo */
     H5E_BEGIN_TRY
     {
         if (H5Gget_objinfo(file_id, "/group2/soft_link_no_exist", TRUE, NULL) >= 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     H5E_END_TRY;
 
     /* Test the dangling soft link */
     if (H5Gget_objinfo(file_id, "/group2/dangle_soft_link", FALSE, &sb_soft2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (sb_soft2.type != H5G_LINK)
-        TEST_ERROR
+        TEST_ERROR;
     if (sb_soft2.linklen != HDstrlen("dangle") + 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gget_linkval(group2_id, "dangle_soft_link", sb_soft2.linklen, tmpstr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp("dangle", tmpstr) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5Gmove and H5Gmove2 */
     if (H5Gmove(file_id, "group1", "moved_group1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gmove2(file_id, "group2", group1_id, "moved_group2") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ensure that both groups can be opened */
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group1_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((group1_id = H5Gopen2(file_id, "moved_group1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2_id = H5Gopen2(file_id, "moved_group1/moved_group2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close open IDs */
     if (H5Gclose(group2_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group1_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test H5Gunlink */
     if (H5Gunlink(file_id, "moved_group1/moved_group2") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     H5E_BEGIN_TRY
     {
         if (H5Gopen2(file_id, "moved_group1/moved_group2", H5P_DEFAULT) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
     if (H5Fclose(file_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -2147,41 +2147,41 @@ cklinks_deprec(hid_t fapl, hbool_t new_format)
     htri_t      exists;
 
     if (new_format)
-        TESTING("link queries using deprecated routines (w/new group format)")
+        TESTING("link queries using deprecated routines (w/new group format)");
     else
-        TESTING("link queries using deprecated routines")
+        TESTING("link queries using deprecated routines");
 
     /* Open the file */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Hard link */
     if (H5Oget_info_by_name2(file, "d1", &oinfo1, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_info_by_name2(file, "grp1/hard", &oinfo2, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5O_TYPE_DATASET != oinfo2.type) {
         H5_FAILED();
         HDprintf("    %d: Unexpected object type should have been a dataset\n", __LINE__);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5F_addr_ne(oinfo1.addr, oinfo2.addr)) {
         H5_FAILED();
         HDputs("    Hard link test failed. Link seems not to point to the ");
         HDputs("    expected file location.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Lexists(file, "/", H5P_DEFAULT) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lexists(file, "d1", H5P_DEFAULT) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lexists(file, "grp1/hard", H5P_DEFAULT) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lexists(file, "/grp1", H5P_DEFAULT) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lexists(file, "/grp1/hard", H5P_DEFAULT) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     H5E_BEGIN_TRY
     {
         exists = H5Lexists(file, "no_grp1/hard", H5P_DEFAULT);
@@ -2190,7 +2190,7 @@ cklinks_deprec(hid_t fapl, hbool_t new_format)
     if (exists >= 0) {
         H5_FAILED();
         HDputs("    H5Lexists() should have failed for a path with missing components.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     H5E_BEGIN_TRY
     {
@@ -2200,32 +2200,32 @@ cklinks_deprec(hid_t fapl, hbool_t new_format)
     if (exists >= 0) {
         H5_FAILED();
         HDputs("    H5Lexists() should have failed for a path with missing components.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Symbolic link */
     if (H5Oget_info_by_name2(file, "grp1/soft", &oinfo2, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5O_TYPE_DATASET != oinfo2.type) {
         H5_FAILED();
         HDprintf("    %d: Unexpected object type should have been a dataset\n", __LINE__);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5F_addr_ne(oinfo1.addr, oinfo2.addr)) {
         H5_FAILED();
         HDputs("    Soft link test failed. Link seems not to point to the ");
         HDputs("    expected file location.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Lget_val(file, "grp1/soft", linkval, sizeof linkval, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(linkval, "/d1") != 0) {
         H5_FAILED();
         HDputs("    Soft link test failed. Wrong link value");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Lexists(file, "grp1/soft", H5P_DEFAULT) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Dangling link */
     H5E_BEGIN_TRY
@@ -2236,27 +2236,27 @@ cklinks_deprec(hid_t fapl, hbool_t new_format)
     if (status >= 0) {
         H5_FAILED();
         HDputs("    H5Oget_info_by_name() should have failed for a dangling link.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Lget_info1(file, "grp1/dangle", &linfo, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5L_TYPE_SOFT != linfo.type) {
         H5_FAILED();
         HDprintf("    %d: Unexpected object type should have been a symbolic link\n", __LINE__);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Lget_val(file, "grp1/dangle", linkval, sizeof linkval, H5P_DEFAULT) < 0) {
         H5_FAILED();
         HDprintf("    %d: Can't retrieve link value\n", __LINE__);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (HDstrcmp(linkval, "foobar") != 0) {
         H5_FAILED();
         HDputs("    Dangling link test failed. Wrong link value");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Lexists(file, "grp1/dangle", H5P_DEFAULT) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Recursive link */
     H5E_BEGIN_TRY
@@ -2267,33 +2267,33 @@ cklinks_deprec(hid_t fapl, hbool_t new_format)
     if (status >= 0) {
         H5_FAILED();
         HDputs("    H5Oget_info_by_name() should have failed for a recursive link.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Lget_info1(file, "grp1/recursive", &linfo, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5L_TYPE_SOFT != linfo.type) {
         H5_FAILED();
         HDprintf("    %d: Unexpected object type should have been a symbolic link\n", __LINE__);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Lget_val(file, "grp1/recursive", linkval, sizeof linkval, H5P_DEFAULT) < 0) {
         H5_FAILED();
         HDprintf("    %d: Can't retrieve link value\n", __LINE__);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (HDstrcmp(linkval, "/grp1/recursive") != 0) {
         H5_FAILED();
         HDputs("   Recursive link test failed. Wrong link value");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Non-existent link */
     if (H5Lexists(file, "foobar", H5P_DEFAULT) == TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Cleanup */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -2325,9 +2325,9 @@ test_lcpl_deprec(hid_t fapl, hbool_t new_format)
     hsize_t     dims[2];
 
     if (new_format)
-        TESTING("link creation property lists using deprecated routines (w/new group format)")
+        TESTING("link creation property lists using deprecated routines (w/new group format)");
     else
-        TESTING("link creation property lists using deprecated routines")
+        TESTING("link creation property lists using deprecated routines");
 
     /* Actually, intermediate group creation is tested elsewhere (tmisc).
      * Here we only need to test the character encoding property */
@@ -2336,167 +2336,167 @@ test_lcpl_deprec(hid_t fapl, hbool_t new_format)
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create and link a group with the default LCPL */
     if ((group_id = H5Gcreate2(file_id, "/group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is the default */
     if (H5Lget_info1(file_id, "group", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5F_DEFAULT_CSET)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create and commit a datatype with the default LCPL */
     if ((type_id = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(file_id, "/type", type_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(type_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is the default */
     if (H5Lget_info1(file_id, "type", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5F_DEFAULT_CSET)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a dataspace */
     dims[0] = H5L_DIM1;
     dims[1] = H5L_DIM2;
     if ((space_id = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a dataset using the default LCPL */
     if ((dset_id =
              H5Dcreate2(file_id, "/dataset", H5T_NATIVE_INT, space_id, H5P_DEFAULT, dcpl_g, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is the default */
     if (H5Lget_info1(file_id, "dataset", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5F_DEFAULT_CSET)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a link creation property list with the UTF-8 character encoding */
     if ((lcpl_id = H5Pcreate(H5P_LINK_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_char_encoding(lcpl_id, H5T_CSET_UTF8) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create and link a group with the new LCPL */
     if ((group_id = H5Gcreate2(file_id, "/group2", lcpl_id, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is UTF-8 */
     if (H5Lget_info1(file_id, "group2", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create and commit a datatype with the new LCPL */
     if ((type_id = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(file_id, "/type2", type_id, lcpl_id, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(type_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is UTF-8 */
     if (H5Lget_info1(file_id, "type2", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a dataset using the new LCPL */
     if ((dset_id = H5Dcreate2(file_id, "/dataset2", H5T_NATIVE_INT, space_id, lcpl_id, dcpl_g, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is UTF-8 */
     if (H5Lget_info1(file_id, "dataset2", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a new link to the dataset with a different character encoding. */
     if (H5Pclose(lcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((lcpl_id = H5Pcreate(H5P_LINK_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_char_encoding(lcpl_id, H5T_CSET_ASCII) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Lcreate_hard(file_id, "/dataset2", file_id, "/dataset2_link", lcpl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is ASCII */
     if (H5Lget_info1(file_id, "/dataset2_link", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_ASCII)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the first link's encoding hasn't changed */
     if (H5Lget_info1(file_id, "/dataset2", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make sure that LCPLs work properly for other API calls: */
     /* H5Lcreate_soft */
     if (H5Pset_char_encoding(lcpl_id, H5T_CSET_UTF8) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("dataset2", file_id, "slink_to_dset2", lcpl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(file_id, "slink_to_dset2", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Lmove */
     if (H5Pset_char_encoding(lcpl_id, H5T_CSET_ASCII) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lmove(file_id, "slink_to_dset2", file_id, "moved_slink", lcpl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(file_id, "moved_slink", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_ASCII)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Lcopy */
     if (H5Pset_char_encoding(lcpl_id, H5T_CSET_UTF8) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcopy(file_id, "moved_slink", file_id, "copied_slink", lcpl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(file_id, "copied_slink", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Lcreate_external */
     if (H5Lcreate_external("filename", "path", file_id, "extlink", lcpl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(file_id, "extlink", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close open IDs */
     if (H5Pclose(lcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -2544,57 +2544,57 @@ test_move_preserves_deprec(hid_t fapl_id, hbool_t new_format)
 
     if (new_format)
         TESTING("moving and copying links using deprecated routines preserves their properties (w/new group "
-                "format)")
+                "format)");
     else
-        TESTING("moving and copying links using deprecated routines preserves their properties")
+        TESTING("moving and copying links using deprecated routines preserves their properties");
 
     /* Create a file creation property list with creation order stored for links
      * in the root group
      */
     if ((fcpl_id = H5Pcreate(H5P_FILE_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_link_creation_order(fcpl_id, &crt_order_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (crt_order_flags != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_link_creation_order(fcpl_id, H5P_CRT_ORDER_TRACKED) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_link_creation_order(fcpl_id, &crt_order_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (crt_order_flags != H5P_CRT_ORDER_TRACKED)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file */
     /* (with creation order tracking for the root group) */
     h5_fixname(FILENAME[0], fapl_id, filename, sizeof filename);
     if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl_id, fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a link creation property list with the UTF-8 character encoding */
     if ((lcpl_id = H5Pcreate(H5P_LINK_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_char_encoding(lcpl_id, H5T_CSET_UTF8) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group with that lcpl */
     if ((group_id = H5Gcreate2(file_id, "group", lcpl_id, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the group's link's information */
     if (H5Lget_info1(file_id, "group", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name2(file_id, "group", &oinfo, H5O_INFO_TIME, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     old_cset = linfo.cset;
     if (old_cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder_valid != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     old_corder = linfo.corder;
     if (old_corder != 0)
-        TEST_ERROR
+        TEST_ERROR;
     old_modification_time = oinfo.mtime;
 
     /* If this test happens too quickly, the times will all be the same.  Make sure the time changes. */
@@ -2604,141 +2604,141 @@ test_move_preserves_deprec(hid_t fapl_id, hbool_t new_format)
 
     /* Close the file and reopen it */
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((file_id = H5Fopen(filename, H5F_ACC_RDWR, fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the link's character set & modification time .  They should be unchanged */
     if (H5Lget_info1(file_id, "group", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name2(file_id, "group", &oinfo, H5O_INFO_TIME, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_modification_time != oinfo.mtime)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_cset != linfo.cset)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder_valid != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_corder != linfo.corder)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a new link to the group.  It should have a different creation order value but the same
      * modification time */
     if (H5Lcreate_hard(file_id, "group", file_id, "group2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name2(file_id, "group2", &oinfo, H5O_INFO_TIME, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_modification_time != oinfo.mtime)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(file_id, "group2", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_corder == linfo.corder)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder_valid != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_ASCII)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Copy the first link to a UTF-8 name.
      *  Its creation order value should be different, but modification time
      * should not change.
      */
     if (H5Lcopy(file_id, "group", file_id, "group_copied", lcpl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name2(file_id, "group_copied", &oinfo, H5O_INFO_TIME, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_modification_time != oinfo.mtime)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(file_id, "group_copied", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder_valid != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is UTF-8 */
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move the link with the default property list. */
     if (H5Lmove(file_id, "group_copied", file_id, "group_copied2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name2(file_id, "group_copied2", &oinfo, H5O_INFO_TIME, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_modification_time != oinfo.mtime)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(file_id, "group_copied2", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder_valid != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 3)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is not UTF-8 */
     if (linfo.cset == H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the original link is unchanged */
     if (H5Oget_info_by_name2(file_id, "group", &oinfo, H5O_INFO_TIME, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_modification_time != oinfo.mtime)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(file_id, "group", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder_valid != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_corder != linfo.corder)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move the first link to a UTF-8 name.
      *  Its creation order value will change, but modification time should not
      *  change. */
     if (H5Lmove(file_id, "group", file_id, "group_moved", lcpl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name2(file_id, "group_moved", &oinfo, H5O_INFO_TIME, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_modification_time != oinfo.mtime)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(file_id, "group_moved", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder_valid != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 4)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is UTF-8 */
     if (linfo.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move the link again using the default property list. */
     if (H5Lmove(file_id, "group_moved", file_id, "group_moved_again", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name2(file_id, "group_moved_again", &oinfo, H5O_INFO_TIME, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (old_modification_time != oinfo.mtime)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(file_id, "group_moved_again", &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder_valid != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 5)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that its character encoding is not UTF-8 */
     if (linfo.cset == H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close open IDs */
     if (H5Pclose(fcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(lcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -2778,9 +2778,9 @@ external_link_root_deprec(hid_t fapl, hbool_t new_format)
     const char *path; /* Path from external link */
 
     if (new_format)
-        TESTING("external link to root using deprecated routines (w/new group format)")
+        TESTING("external link to root using deprecated routines (w/new group format)");
     else
-        TESTING("external link to root using deprecated routines")
+        TESTING("external link to root using deprecated routines");
 
     /* Set up filenames */
     h5_fixname(FILENAME[3], fapl, filename1, sizeof filename1);
@@ -2788,23 +2788,23 @@ external_link_root_deprec(hid_t fapl, hbool_t new_format)
 
     /* Create file to point to */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that external links are registered with the library */
     if (H5Lis_registered(H5L_TYPE_EXTERNAL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file with link to first file */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to object in first file */
     if (H5Lcreate_external(filename1, "/", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information for external link */
     if (H5Lget_info1(fid, "ext_link", &linfo, H5P_DEFAULT) < 0)
@@ -2815,9 +2815,9 @@ external_link_root_deprec(hid_t fapl, hbool_t new_format)
         goto error;
     }
     if (H5Lget_val(fid, "ext_link", objname, sizeof(objname), H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lunpack_elink_val(objname, linfo.u.val_size, NULL, &file, &path) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(file, filename1) != 0) {
         H5_FAILED();
         HDputs("    External link file name incorrect");
@@ -2832,7 +2832,7 @@ external_link_root_deprec(hid_t fapl, hbool_t new_format)
     /* Create external link to object in first file */
     /* (add a few extra '/'s to make certain library normalizes external link object names) */
     if (H5Lcreate_external(filename1, "///", fid, "ext_link2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information for external link */
     if (H5Lget_info1(fid, "ext_link", &linfo, H5P_DEFAULT) < 0)
@@ -2843,9 +2843,9 @@ external_link_root_deprec(hid_t fapl, hbool_t new_format)
         goto error;
     }
     if (H5Lget_val(fid, "ext_link", objname, sizeof(objname), H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lunpack_elink_val(objname, linfo.u.val_size, NULL, &file, &path) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(file, filename1) != 0) {
         H5_FAILED();
         HDputs("    External link file name incorrect");
@@ -2859,89 +2859,89 @@ external_link_root_deprec(hid_t fapl, hbool_t new_format)
 
     /* Close and re-open file to ensure that data is written to disk */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid = H5Fopen(filename2, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     if ((gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in external file */
     if ((gid2 = H5Gcreate2(gid, "new_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in external file */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close external object (lets first file close) */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a new object using H5Gcreate2 through the external link
      * directly
      */
     if ((gid = H5Gcreate2(fid, "ext_link/newer_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file and group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     /* Open first file again with read-only access and check on objects created */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open objects created through external link */
     if ((gid = H5Gopen2(fid, "new_group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((gid2 = H5Gopen2(fid, "newer_group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check names */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/new_group") != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Iget_name(gid2, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/newer_group") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close opened objects */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     /* Verify that new objects can't be created through a read-only external
      * link.
      */
     if ((fid = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -2949,15 +2949,15 @@ external_link_root_deprec(hid_t fapl, hbool_t new_format)
     }
     H5E_END_TRY
     if (gid >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close second file again */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     PASSED();
@@ -2997,9 +2997,9 @@ external_link_query_deprec(hid_t fapl, hbool_t new_format)
         query_buf[NAME_BUF_SIZE];                            /* Buffer to hold query result */
 
     if (new_format)
-        TESTING("query aspects of external link using deprecated routines (w/new group format)")
+        TESTING("query aspects of external link using deprecated routines (w/new group format)");
     else
-        TESTING("query aspects of external link using deprecated routines")
+        TESTING("query aspects of external link using deprecated routines");
 
     /* Set up filenames */
     h5_fixname(FILENAME[3], fapl, filename1, sizeof filename1);
@@ -3007,18 +3007,18 @@ external_link_query_deprec(hid_t fapl, hbool_t new_format)
 
     /* Create first file, with external link to object in second file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link */
     /* (add a few extra '/'s to make certain library normalizes external link object names) */
     if (H5Lcreate_external(filename2, "///dst//", fid, "src", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get size of buffer for external link */
     if (H5Lget_info1(fid, "src", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.u.val_size != (1 + (HDstrlen(filename2) + 1) + (HDstrlen("/dst") + 1)))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5L_TYPE_EXTERNAL != li.type) {
         H5_FAILED();
         HDputs("    Unexpected link class - should have been an external link");
@@ -3027,31 +3027,31 @@ external_link_query_deprec(hid_t fapl, hbool_t new_format)
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create second file to point to */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object to link to */
     if ((gid = H5Gcreate2(fid, "dst", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open first file */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get size of buffer for external link */
     if (H5Lget_info1(fid, "src", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.u.val_size != (1 + (HDstrlen(filename2) + 1) + (HDstrlen("/dst") + 1)))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5L_TYPE_EXTERNAL != li.type) {
         H5_FAILED();
         HDputs("    Unexpected link class - should have been an external link");
@@ -3060,21 +3060,21 @@ external_link_query_deprec(hid_t fapl, hbool_t new_format)
 
     /* Get information for external link.  It should be two strings right after each other */
     if (H5Lget_val(fid, "src", query_buf, (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Extract the file and object names from the buffer */
     if (H5Lunpack_elink_val(query_buf, li.u.val_size, NULL, &file_name, &object_name) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compare the file and object names */
     if (HDstrcmp(file_name, filename2) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(object_name, "/dst") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query information about object that external link points to */
     if (H5Oget_info_by_name2(fid, "src", &oi, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5O_TYPE_GROUP != oi.type) {
         H5_FAILED();
         HDputs("    Unexpected object type - should have been a group");
@@ -3083,35 +3083,35 @@ external_link_query_deprec(hid_t fapl, hbool_t new_format)
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make sure that passing in NULLs to H5Lunpack_elink_val works */
     if (H5Lunpack_elink_val(query_buf, li.u.val_size, NULL, NULL, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make sure that bogus cases trigger errors in H5Lunpack_elink_val */
     H5E_BEGIN_TRY
     {
         if (H5Lunpack_elink_val(query_buf, li.u.val_size - 1, NULL, NULL, NULL) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
     H5E_BEGIN_TRY
     {
         if (H5Lunpack_elink_val(query_buf, (size_t)0, NULL, NULL, NULL) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
     H5E_BEGIN_TRY
     {
         if (H5Lunpack_elink_val(NULL, (size_t)0, NULL, NULL, NULL) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
     H5E_BEGIN_TRY
     {
         if (H5Lunpack_elink_val(NULL, (size_t)1000, NULL, NULL, NULL) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
 
@@ -3153,9 +3153,9 @@ external_link_closing_deprec(hid_t fapl, hbool_t new_format)
     hobj_ref_t  obj_ref;
 
     if (new_format)
-        TESTING("that external files are closed during traversal (w/new group format)")
+        TESTING("that external files are closed during traversal (w/new group format)");
     else
-        TESTING("that external files are closed during traversal")
+        TESTING("that external files are closed during traversal");
 
     /* In this test, external links will go from file1 to file2 and from
      * file2 to file3.
@@ -3173,204 +3173,204 @@ external_link_closing_deprec(hid_t fapl, hbool_t new_format)
 
     /* Create four files */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid3 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid4 = H5Fcreate(filename4, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a dataspace and a datatype so we can create/commit a dataset/datatype in the files */
     dims[0] = 2;
     dims[1] = 2;
     if ((sid = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid2 = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external links from each file to the next */
     if (H5Lcreate_external(filename2, "/", fid1, "elink", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename3, "/", fid2, "elink", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename4, "/", fid3, "elink", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close all files but the first */
     if (H5Fclose(fid4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test creating each kind of object */
     if ((gid = H5Gcreate2(fid1, "elink/elink/elink/group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(fid1, "elink/elink/elink/type1", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did = H5Dcreate2(fid1, "elink/elink/elink/dataset1", tid2, sid, H5P_DEFAULT, dcpl_g, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close objects */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test that getting info works */
     if (H5Lget_info1(fid1, "elink/elink/elink/type1", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(fid1, "elink/elink/elink", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name2(fid1, "elink/elink/elink/type1", &oi, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name2(fid1, "elink/elink/elink", &oi, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test move */
     if (H5Lmove(fid1, "elink/elink/elink/group1", fid1, "elink/elink/elink/group1_moved", H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open file 4 so we can do some fancy things */
     if ((fid4 = H5Fopen(filename4, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lmove(fid1, "elink/elink/elink/type1", fid4, "type1_moved", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lmove(fid4, "dataset1", fid1, "elink/elink/elink/dataset1_moved", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file 4 again */
     if (H5Fclose(fid4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test copy (as of this test, it uses the same code as move) */
     if (H5Lcopy(fid1, "elink/elink/elink", fid1, "elink/elink/elink_copied", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcopy(fid1, "elink/elink/elink", fid1, "elink/elink/elink/elink_copied2", H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test H5Gset and get comment */
     if (H5Oset_comment_by_name(fid1, "elink/elink/elink/group1_moved", "comment", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_comment_by_name(fid1, "elink/elink/elink/group1_moved", buf, sizeof(buf), H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(buf, "comment") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5*open */
     if ((gid = H5Gopen2(fid1, "elink/elink/elink/group1_moved", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((tid = H5Topen2(fid1, "elink/elink/elink/type1_moved", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did = H5Dopen2(fid1, "elink/elink/elink/dataset1_moved", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Close objects */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test H5*open2 */
     if ((gid = H5Gopen2(fid1, "elink/elink/elink/group1_moved", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((tid = H5Topen2(fid1, "elink/elink/elink/type1_moved", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did = H5Dopen2(fid1, "elink/elink/elink/dataset1_moved", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Close objects */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test H5Oopen */
     if ((did = H5Oopen(fid1, "elink/elink/elink/dataset1_moved", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5Fmount */
     if ((gid = H5Gcreate2(fid1, "elink/elink/elink/mnt", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         if (H5Fmount(fid1, "elink/elink/elink/mnt", fid1, H5P_DEFAULT) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Funmount(fid1, "elink/elink/elink/mnt") >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
 
     /* Test H5Rcreate */
     if (H5Rcreate(&obj_ref, fid1, "elink/elink/elink/type1_moved", H5R_OBJECT, (hid_t)(-1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test unlink */
     if (H5Ldelete(fid1, "elink/elink/elink/group1_moved", H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ldelete(fid1, "elink/elink/elink/type1_moved", H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ldelete(fid1, "elink/elink/elink/dataset1_moved", H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ldelete(fid1, "elink/elink/elink_copied", H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ldelete(fid1, "elink/elink/elink/elink_copied2", H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* We've tested that the various functions above don't leave files open.
      * Now test that we can't confuse HDF5 by giving unusual paths with external links
      */
     /* Create an external link that points to another external link */
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename3, "/elink", fid2, "elink2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Do an external link traversal that recursively calls another external link. */
     if ((gid = H5Gcreate2(fid1, "elink/elink2/group2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create two more groups so that the last three elements in the path are
      * all within the same external file
      */
     if ((gid = H5Gcreate2(fid1, "elink/elink2/group2/group3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid1, "elink/elink2/group2/group3/group4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name2(fid1, "elink/elink2/group2/group3/group4", &oi, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add a few regular groups and a soft link in file2 using intermediate group creation */
     if ((lcpl_id = H5Pcreate(H5P_LINK_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_create_intermediate_group(lcpl_id, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("/elink2", fid1, "elink/file2group1/file2group2/slink", lcpl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try to traverse this path.  There are three soft traversals in a row;
      * slink points to (file2)/elink2, which points to (file3)/elink, which
@@ -3378,49 +3378,49 @@ external_link_closing_deprec(hid_t fapl, hbool_t new_format)
      */
     if ((gid = H5Gcreate2(fid1, "elink/file2group1/file2group2/slink/group3", H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(fid1, "elink/file2group1/file2group2/slink/group3", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Some simpler tests */
     if ((gid = H5Gcreate2(fid1, "elink/file2group3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(fid1, "elink/file2group3", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(fid1, "elink/elink", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file1, the only file that should still be open */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-create each file. If they are hanging open, these creates will fail */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid3 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid4 = H5Fcreate(filename4, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cleanup */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -3619,102 +3619,102 @@ ud_hard_links_deprec(hid_t fapl)
     h5_stat_size_t empty_size;             /* Size of an empty file */
     char           filename[NAME_BUF_SIZE];
 
-    TESTING("user-defined hard link using deprecated routines (w/new group format)")
+    TESTING("user-defined hard link using deprecated routines (w/new group format)");
 
     /* Set up filename and create file*/
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the size of the empty file for reference */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that external links are registered and UD hard links are not */
     if (H5Lis_registered(H5L_TYPE_EXTERNAL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Register "user-defined hard links" with the library */
     if (H5Lregister(UD_hard_class_deprec) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that UD hard links are now registered */
     if (H5Lis_registered(H5L_TYPE_EXTERNAL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group for the UD hard link to point to */
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get address for the group to give to the hard link */
     if (H5Lget_info1(fid, "group", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a user-defined "hard link" to the group using the address we got
      * from H5Lget_info1 */
     if (H5Lcreate_ud(fid, "ud_link", (H5L_type_t)UD_HARD_TYPE, &(li.u.address), (size_t)sizeof(haddr_t),
                      H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close and re-open file to ensure that data is written to disk */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group through UD link */
     if ((gid = H5Gopen2(fid, "ud_link", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/group") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in group */
     if ((gid2 = H5Gcreate2(gid, "new_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close groups*/
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open group without using ud link to check that it was created properly */
     if ((gid = H5Gopen2(fid, "group/new_group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/group/new_group") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close opened object */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that H5Lget_objinfo works on the hard link */
     if (H5Lget_info1(fid, "ud_link", &li, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* UD hard links have no query function, thus return a "link length" of 0 */
     if (li.u.val_size != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (UD_HARD_TYPE != li.type) {
         H5_FAILED();
         HDputs("    Unexpected link class - should have been a UD hard link");
@@ -3724,33 +3724,33 @@ ud_hard_links_deprec(hid_t fapl)
     /* Unlink the group pointed to by the UD link.  It shouldn't be
      * deleted because of the UD link. */
     if (H5Ldelete(fid, "/group", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ensure we can open the group through the UD link */
     if ((gid = H5Gopen2(fid, "ud_link", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Unlink the group contained within it. */
     if (H5Ldelete(gid, "new_group", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Now delete the UD link.  This should cause the group to be
      * deleted, too. */
     if (H5Ldelete(fid, "ud_link", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* The file should be empty again. */
     if (empty_size != h5_get_file_size(filename, fapl))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Lunregister((H5L_type_t)UD_HARD_TYPE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -3776,66 +3776,66 @@ ud_link_reregister_deprec(hid_t fapl)
     char           filename[NAME_BUF_SIZE];
     h5_stat_size_t empty_size; /* Size of an empty file */
 
-    TESTING("registering a new class for existing UD links using deprecated routines (w/new group format)")
+    TESTING("registering a new class for existing UD links using deprecated routines (w/new group format)");
 
     /* Set up filename and create file*/
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the size of the empty file for reference */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that UD hard links are not registered */
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Register "user-defined hard links" with the library */
     if (H5Lregister(UD_hard_class_deprec) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that UD hard links are registered */
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Point a UD defined hard link to a group in the same way as the previous test */
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(fid, "group", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Lcreate_ud(fid, "ud_link", (H5L_type_t)UD_HARD_TYPE, &(li.u.address), sizeof(li.u.address),
                      H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group named REREG_TARGET_NAME in the same group as the ud link */
     if ((gid = H5Gcreate2(fid, REREG_TARGET_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now unregister UD hard links */
     if (H5Lunregister((H5L_type_t)UD_HARD_TYPE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that UD hard links are no longer registered */
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we can't traverse the ud link anymore */
     H5E_BEGIN_TRY
     {
         if ((gid = H5Gopen2(fid, "ud_link", H5P_DEFAULT)) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
 
@@ -3844,97 +3844,97 @@ ud_link_reregister_deprec(hid_t fapl)
     {
         if (H5Lcreate_ud(fid, "ud_link2", (H5L_type_t)UD_HARD_TYPE, &(li.u.address), sizeof(li.u.address),
                          H5P_DEFAULT, H5P_DEFAULT) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
 
     /* Register a new kind of link with the same ID number */
     if (H5Lregister(UD_rereg_class) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that UD hard links are registered again */
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open a group through the ud link (now a different class of link).
      * It should be a different group
      * than the UD hard link pointed to */
     if ((gid = H5Gopen2(fid, "ud_link", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/" REREG_TARGET_NAME) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in group */
     if ((gid2 = H5Gcreate2(gid, "new_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close groups*/
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open group without using ud link to check that it was created properly */
     if ((gid = H5Gopen2(fid, "rereg_target/new_group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/rereg_target/new_group") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close opened object */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Unlink the group pointed to by the UD hard link.  It shouldn't be
      * deleted because the UD link incremented its reference count. */
     if (H5Ldelete(fid, "/group", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* What a mess! Re-register user-defined links to clean up the
      * reference counts.  We shouldn't actually need to unregister the
      * other link type */
     if (H5Lregister(UD_hard_class_deprec) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ensure we can open the group through the UD link (now that UD hard
      * links have been registered) */
     if ((gid = H5Gopen2(fid, "ud_link", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete the UD hard link.  This should cause the group to be
      * deleted, too. */
     if (H5Ldelete(fid, "ud_link", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Unlink the other two groups so that we can make sure the file is empty */
     if (H5Ldelete(fid, "/rereg_target/new_group", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, REREG_TARGET_NAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* The file should be empty again. */
     if (empty_size != h5_get_file_size(filename, fapl))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Lunregister((H5L_type_t)UD_HARD_TYPE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != FALSE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -3962,64 +3962,64 @@ ud_callbacks_deprec(hid_t fapl, hbool_t new_format)
     char        query_buf[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("user-defined link callbacks using deprecated routines (w/new group format)")
+        TESTING("user-defined link callbacks using deprecated routines (w/new group format)");
     else
-        TESTING("user-defined link callbacks using deprecated routines")
+        TESTING("user-defined link callbacks using deprecated routines");
 
     /* Set up filename and create file*/
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that registered link classes are, and unregistered ones aren't */
     if (H5Lis_registered(H5L_TYPE_EXTERNAL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lis_registered((H5L_type_t)UD_CB_TYPE) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Hit two birds with one stone: register UD hard links from previous
      * test to check that having two UD links registered at once presents
      * no problems. */
     if (H5Lregister(UD_hard_class_deprec) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Register user-defined link class.  This is the one we'll actually be using. */
     if (H5Lregister(UD_cb_class) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that registered link classes are, and unregistered ones aren't */
     if (H5Lis_registered(H5L_TYPE_EXTERNAL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lis_registered((H5L_type_t)UD_CB_TYPE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group for the UD link to point to */
     if ((gid = H5Gcreate2(fid, UD_CB_TARGET, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a user-defined link to the group.  These UD links behave like soft links. */
     if (H5Lcreate_ud(fid, UD_CB_LINK_NAME, (H5L_type_t)UD_CB_TYPE, ud_target_name, (size_t)UD_CB_TARGET_LEN,
                      H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try opening group through UD link */
     if ((gid = H5Gopen2(fid, UD_CB_LINK_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the link to test its query callback */
     if (H5Lget_info1(fid, UD_CB_LINK_NAME, &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.u.val_size != 16)
-        TEST_ERROR
+        TEST_ERROR;
     if (UD_CB_TYPE != li.type) {
         H5_FAILED();
         HDputs("    Unexpected link class - should have been a UD hard link");
@@ -4028,80 +4028,80 @@ ud_callbacks_deprec(hid_t fapl, hbool_t new_format)
 
     /* Fill the query buffer */
     if (H5Lget_val(fid, UD_CB_LINK_NAME, query_buf, (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(query_buf, "query succeeded") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move the link */
     if (H5Lmove(fid, UD_CB_LINK_NAME, H5L_SAME_LOC, NEW_UD_CB_LINK_NAME, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open group to ensure that move worked */
     if ((gid = H5Gopen2(fid, NEW_UD_CB_LINK_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove UD link */
     if (H5Ldelete(fid, NEW_UD_CB_LINK_NAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test that the callbacks don't work if the link class is not registered */
 
     /* Create a new link. Just for fun, give it a non-default character
      * encoding (to test that LAPLs work) */
     if ((lcpl = H5Pcreate(H5P_LINK_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_char_encoding(lcpl, H5T_CSET_UTF8) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_ud(fid, UD_CB_LINK_NAME, (H5L_type_t)UD_CB_TYPE, ud_target_name, (size_t)UD_CB_TARGET_LEN,
                      lcpl, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(lcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check its character encoding */
     if (H5Lget_info1(fid, UD_CB_LINK_NAME, &li, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (li.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unregister the link class so the library forgets what its callbacks do */
     if (H5Lunregister((H5L_type_t)UD_CB_TYPE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Now test that each of the callbacks fails */
     H5E_BEGIN_TRY
     {
         if (H5Lcreate_ud(fid, NEW_UD_CB_LINK_NAME, (H5L_type_t)UD_CB_TYPE, ud_target_name,
                          (size_t)UD_CB_TARGET_LEN, H5P_DEFAULT, H5P_DEFAULT) >= 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Lmove(fid, UD_CB_LINK_NAME, H5L_SAME_LOC, NEW_UD_CB_LINK_NAME, H5P_DEFAULT, H5P_DEFAULT) >= 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Ldelete(fid, UD_CB_LINK_NAME, H5P_DEFAULT) >= 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if ((gid = H5Gopen2(gid, UD_CB_LINK_NAME, H5P_DEFAULT)) >= 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Ldelete(fid, UD_CB_LINK_NAME, H5P_DEFAULT) >= 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     H5E_END_TRY
 
     /* The query callback should NOT fail, but should be unable to give a linklen */
     if (H5Lget_info1(fid, UD_CB_LINK_NAME, &li, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (li.u.val_size != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.type != UD_CB_TYPE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unregister the UD hard links */
     if (H5Lunregister((H5L_type_t)UD_HARD_TYPE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -4141,9 +4141,9 @@ lapl_nlinks_deprec(hid_t fapl, hbool_t new_format)
     hsize_t dims[2];
 
     if (new_format)
-        TESTING("adjusting nlinks with LAPL using deprecated routines (w/new group format)")
+        TESTING("adjusting nlinks with LAPL using deprecated routines (w/new group format)");
     else
-        TESTING("adjusting nlinks with LAPL using deprecated routines")
+        TESTING("adjusting nlinks with LAPL using deprecated routines");
 
     /* Make certain test is valid */
     /* XXX: should probably make a "generic" test that creates the proper
@@ -4154,105 +4154,105 @@ lapl_nlinks_deprec(hid_t fapl, hbool_t new_format)
     /* Create file */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group with short name in file (used as target for links) */
     if ((gid = H5Gcreate2(fid, "final", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create chain of soft links to existing object (limited) */
     if (H5Lcreate_soft("final", fid, "soft1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft1", fid, "soft2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft2", fid, "soft3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft3", fid, "soft4", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft4", fid, "soft5", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft5", fid, "soft6", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft6", fid, "soft7", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft7", fid, "soft8", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft8", fid, "soft9", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft9", fid, "soft10", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft10", fid, "soft11", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft11", fid, "soft12", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft12", fid, "soft13", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft13", fid, "soft14", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft14", fid, "soft15", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft15", fid, "soft16", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft16", fid, "soft17", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close objects */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create LAPL with higher-than-usual nlinks value */
     /* Create a non-default lapl with udata set to point to the first group */
     if ((plist = H5Pcreate(H5P_LINK_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     nlinks = 20;
     if (H5Pset_nlinks(plist, nlinks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Ensure that nlinks was set successfully */
     nlinks = 0;
     if (H5Pget_nlinks(plist, &nlinks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (nlinks != 20)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through what is normally too many soft links using
      * new property list */
     if ((gid = H5Oopen(fid, "soft17", plist)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/soft17") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group using soft link */
     if ((gid2 = H5Gcreate2(gid, "new_soft", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close groups */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set nlinks to a smaller number */
     nlinks = 4;
     if (H5Pset_nlinks(plist, nlinks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Ensure that nlinks was set successfully */
     nlinks = 0;
     if (H5Pget_nlinks(plist, &nlinks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (nlinks != 4)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try opening through what is now too many soft links */
     H5E_BEGIN_TRY
@@ -4268,141 +4268,141 @@ lapl_nlinks_deprec(hid_t fapl, hbool_t new_format)
 
     /* Open object through lesser soft link */
     if ((gid = H5Oopen(fid, "soft4", plist)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/soft4") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test other functions that should use a LAPL */
     nlinks = 20;
     if (H5Pset_nlinks(plist, nlinks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try copying and moving when both src and dst contain many soft links
      * using a non-default LAPL
      */
     if (H5Lcopy(fid, "soft17", fid, "soft17/newer_soft", H5P_DEFAULT, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lmove(fid, "soft17/newer_soft", fid, "soft17/newest_soft", H5P_DEFAULT, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Olink */
     if (H5Olink(gid, fid, "soft17/link_to_group", H5P_DEFAULT, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Lcreate_hard  and H5Lcreate_soft */
     if (H5Lcreate_hard(fid, "soft17", fid, "soft17/link2_to_group", H5P_DEFAULT, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("/soft4", fid, "soft17/soft_link", H5P_DEFAULT, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Ldelete */
     if (H5Ldelete(fid, "soft17/soft_link", plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Lget_val and H5Lget_info1 */
     if (H5Lget_val(fid, "soft17", NULL, (size_t)0, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(fid, "soft17", NULL, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Lcreate_external and H5Lcreate_ud */
     if (H5Lcreate_external("filename", "path", fid, "soft17/extlink", H5P_DEFAULT, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lregister(UD_rereg_class) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_ud(fid, "soft17/udlink", (H5L_type_t)UD_HARD_TYPE, NULL, (size_t)0, H5P_DEFAULT, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close plist */
     if (H5Pclose(plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a datatype and dataset as targets inside the group */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(gid, "datatype", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dims[0] = 2;
     dims[1] = 2;
     if ((sid = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did = H5Dcreate2(gid, "dataset", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl_g, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try to open the objects using too many symlinks with default *APLs */
     H5E_BEGIN_TRY
     {
         if ((gid = H5Gopen2(fid, "soft17", H5P_DEFAULT)) >= 0)
-            FAIL_PUTS_ERROR("    Should have failed for too many nested links.")
+            FAIL_PUTS_ERROR("    Should have failed for too many nested links.");
         if ((tid = H5Topen2(fid, "soft17/datatype", H5P_DEFAULT)) >= 0)
-            FAIL_PUTS_ERROR("    Should have failed for too many nested links.")
+            FAIL_PUTS_ERROR("    Should have failed for too many nested links.");
         if ((did = H5Dopen2(fid, "soft17/dataset", H5P_DEFAULT)) >= 0)
-            FAIL_PUTS_ERROR("    Should have failed for too many nested links.")
+            FAIL_PUTS_ERROR("    Should have failed for too many nested links.");
     }
     H5E_END_TRY
 
     /* Create property lists with nlinks set */
     if ((gapl = H5Pcreate(H5P_GROUP_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tapl = H5Pcreate(H5P_DATATYPE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     nlinks = 20;
     if (H5Pset_nlinks(gapl, nlinks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_nlinks(tapl, nlinks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_nlinks(dapl, nlinks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* We should now be able to use these property lists to open each kind
      * of object.
      */
     if ((gid = H5Gopen2(fid, "soft17", gapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((tid = H5Topen2(fid, "soft17/datatype", tapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did = H5Dopen2(fid, "soft17/dataset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close objects */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close plists */
     if (H5Pclose(gapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(tapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unregister UD hard link class */
     if (H5Lunregister((H5L_type_t)UD_HARD_TYPE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -4445,82 +4445,82 @@ linkinfo_deprec(hid_t fapl, hbool_t new_format)
     char        filename[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("link type field in H5Lget_info using deprecated routines (w/new group format)")
+        TESTING("link type field in H5Lget_info using deprecated routines (w/new group format)");
     else
-        TESTING("link type field in H5Lget_info using deprecated routines")
+        TESTING("link type field in H5Lget_info using deprecated routines");
 
     /* Set up filename and create file*/
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Register a couple of user-defined link classes with the library */
     if (H5Lregister(UD_plist_class) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an object of each type */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(fid, "datatype", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("group", fid, "softlink", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((sid = H5Screate(H5S_SCALAR)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did = H5Dcreate2(fid, "dataset", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl_g, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Lcreate_ud(fid, "ud_link", (H5L_type_t)UD_PLIST_TYPE, NULL, (size_t)0, H5P_DEFAULT, H5P_DEFAULT) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external("file_name", "obj_path", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close all objects */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make sure that link type is correct when objects are queried */
     if (H5Lget_info1(fid, "datatype", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.type != H5L_TYPE_HARD)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(fid, "group", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.type != H5L_TYPE_HARD)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(fid, "dataset", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.type != H5L_TYPE_HARD)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Lget_info1(fid, "ext_link", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.type != H5L_TYPE_EXTERNAL)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(fid, "softlink", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.type != H5L_TYPE_SOFT)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info1(fid, "ud_link", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.type != UD_PLIST_TYPE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Ensure that passing a NULL pointer doesn't cause an error */
     if (H5Lget_info1(fid, "group", NULL, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -4560,85 +4560,85 @@ corder_create_compact_deprec(hid_t fapl)
     char     filename[NAME_BUF_SIZE];       /* File name */
     unsigned u;                             /* Local index variable */
 
-    TESTING("creating compact group with creation order indexing using deprecated routines")
+    TESTING("creating compact group with creation order indexing using deprecated routines");
 
     /* Create file */
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
     if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group creation property list */
     if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set creation order tracking & indexing on group */
     if (H5Pset_link_creation_order(gcpl_id, (H5P_CRT_ORDER_TRACKED | H5P_CRT_ORDER_INDEXED)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group with creation order indexing & tracking on */
     if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on group's initial status */
     if (H5G__is_empty_test(group_id) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties */
     if (H5Pget_link_phase_change(gcpl_id, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create several links, but keep group in compact form */
     for (u = 0; u < max_compact; u++) {
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(group_id2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify state of group */
         if (H5G__has_links_test(group_id, &nlinks) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (nlinks != (u + 1))
-            TEST_ERROR
+            TEST_ERROR;
         if (H5G__has_stab_test(group_id) == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5G__is_new_dense_test(group_id) == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Close the group */
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group creation property list */
     if (H5Pclose(gcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file_id = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group created */
     if ((group_id = H5Gopen2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify state of group */
     if (H5G__has_links_test(group_id, &nlinks) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (nlinks != max_compact)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop through links, checking their creation order values */
     /* (the name index is used, but the creation order value is in the same order) */
@@ -4648,22 +4648,22 @@ corder_create_compact_deprec(hid_t fapl)
         /* Retrieve information for link */
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Lget_info1(group_id, objname, &linfo, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify creation order of link */
         if (linfo.corder_valid != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (linfo.corder != u)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Close the group */
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -4704,104 +4704,104 @@ corder_create_dense_deprec(hid_t fapl)
     char     filename[NAME_BUF_SIZE];       /* File name */
     unsigned u;                             /* Local index variable */
 
-    TESTING("creating dense group with creation order indexing using deprecated routines")
+    TESTING("creating dense group with creation order indexing using deprecated routines");
 
     /* Create file */
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
     if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group creation property list */
     if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set creation order tracking & indexing on group */
     if (H5Pset_link_creation_order(gcpl_id, (H5P_CRT_ORDER_TRACKED | H5P_CRT_ORDER_INDEXED)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group with creation order indexing & tracking on */
     if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on group's initial status */
     if (H5G__is_empty_test(group_id) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties */
     if (H5Pget_link_phase_change(gcpl_id, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create several links, up to limit of compact form */
     for (u = 0; u < max_compact; u++) {
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(group_id2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify state of group */
         if (H5G__has_links_test(group_id, &nlinks) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (nlinks != (u + 1))
-            TEST_ERROR
+            TEST_ERROR;
         if (H5G__has_stab_test(group_id) == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5G__is_new_dense_test(group_id) == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Create another link, to push group into dense form */
     HDsnprintf(objname, sizeof(objname), "filler %u", max_compact);
     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(group_id2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify state of group */
     if (H5G__has_links_test(group_id, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(group_id) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve & verify # of records in the name & creation order indices */
     if (H5G__new_dense_info_test(group_id, &name_count, &corder_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_count != corder_count)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group */
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group creation property list */
     if (H5Pclose(gcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file_id = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group created */
     if ((group_id = H5Gopen2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify state of group */
     if (H5G__has_links_test(group_id, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(group_id) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop through links, checking their creation order values */
     /* (the name index is used, but the creation order value is in the same order) */
@@ -4811,22 +4811,22 @@ corder_create_dense_deprec(hid_t fapl)
         /* Retrieve information for link */
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Lget_info1(group_id, objname, &linfo, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify creation order of link */
         if (linfo.corder_valid != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (linfo.corder != u)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Close the group */
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -4871,34 +4871,34 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, h
     HDmemset(&linfo, 0, sizeof(linfo));
     if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, (hsize_t)0, &linfo, H5P_DEFAULT) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the link information for new link, in increasing creation order */
     HDmemset(&linfo, 0, sizeof(linfo));
     if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != (int64_t)n)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify value for new soft link, in increasing creation order */
     if (!hard_link) {
         HDmemset(tmpval, 0, (size_t)NAME_BUF_SIZE);
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (HDstrcmp(valname, tmpval) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Verify the name for new link, in increasing creation order */
     HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, tmpname, (size_t)NAME_BUF_SIZE,
                            H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(linkname, tmpname) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Don't test "native" order if there is no creation order index, since
      *  there's not a good way to easily predict the link's order in the name
@@ -4909,101 +4909,101 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, h
         HDmemset(&linfo, 0, sizeof(linfo));
         if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, (hsize_t)0, &linfo,
                                 H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (linfo.corder != 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the link information for new link, in native creation order (which is increasing) */
         HDmemset(&linfo, 0, sizeof(linfo));
         if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, n, &linfo, H5P_DEFAULT) <
             0)
-            TEST_ERROR
+            TEST_ERROR;
         if (linfo.corder != (int64_t)n)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify value for new soft link, in native creation order (which is increasing) */
         if (!hard_link) {
             HDmemset(tmpval, 0, (size_t)NAME_BUF_SIZE);
             if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, n, tmpval,
                                   (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (HDstrcmp(valname, tmpval) != 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
 
         /* Verify the name for new link, in native creation order (which is increasing) */
         HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
         if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, n, tmpname,
                                (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (HDstrcmp(linkname, tmpname) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Verify the link information for first link, in decreasing creation order */
     HDmemset(&linfo, 0, sizeof(linfo));
     if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, n, &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the link information for new link, in decreasing creation order */
     HDmemset(&linfo, 0, sizeof(linfo));
     if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, &linfo, H5P_DEFAULT) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != (int64_t)n)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify value for new soft link, in decreasing creation order */
     if (!hard_link) {
         HDmemset(tmpval, 0, (size_t)NAME_BUF_SIZE);
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (HDstrcmp(valname, tmpval) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Verify the name for new link, in decreasing creation order */
     HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, tmpname,
                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(linkname, tmpname) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the link information for first link, in increasing link name order */
     HDmemset(&linfo, 0, sizeof(linfo));
     if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)0, &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the link information for new link, in increasing link name order */
     HDmemset(&linfo, 0, sizeof(linfo));
     if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != (int64_t)n)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify value for new soft link, in increasing link name order */
     if (!hard_link) {
         HDmemset(tmpval, 0, (size_t)NAME_BUF_SIZE);
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, tmpval, (size_t)NAME_BUF_SIZE,
                               H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (HDstrcmp(valname, tmpval) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Verify the name for new link, in increasing link name order */
     HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, tmpname, (size_t)NAME_BUF_SIZE,
                            H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(linkname, tmpname) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Don't test "native" order queries on link name order, since there's not
      *  a good way to easily predict the order of the links in the name index.
@@ -5012,34 +5012,34 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, h
     /* Verify the link information for first link, in decreasing link name order */
     HDmemset(&linfo, 0, sizeof(linfo));
     if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, n, &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the link information for new link, in decreasing link name order */
     HDmemset(&linfo, 0, sizeof(linfo));
     if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != (int64_t)n)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify value for new soft link, in decreasing link name order */
     if (!hard_link) {
         HDmemset(tmpval, 0, (size_t)NAME_BUF_SIZE);
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (HDstrcmp(valname, tmpval) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Verify the name for new link, in decreasing link name order */
     HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, tmpname,
                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(linkname, tmpname) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return (0);
@@ -5085,41 +5085,41 @@ link_info_by_idx_deprec(hid_t fapl)
             if (hard_link) {
                 if (use_index)
                     TESTING("querying info by index w/creation order index, using hard links and deprecated "
-                            "routines")
+                            "routines");
                 else
                     TESTING("querying info by index w/o creation order index, using hard links and "
-                            "deprecated routines")
+                            "deprecated routines");
             } /* end if */
             else {
                 if (use_index)
                     TESTING("querying info by index w/creation order index, using soft links and deprecated "
-                            "routines")
+                            "routines");
                 else
                     TESTING("querying info by index w/o creation order index, using soft links and "
-                            "deprecated routines")
+                            "deprecated routines");
             } /* end else */
 
             /* Create file */
             h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
             if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create group creation property list */
             if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Set creation order tracking & indexing on group */
             if (H5Pset_link_creation_order(
                     gcpl_id, (H5P_CRT_ORDER_TRACKED | (use_index ? H5P_CRT_ORDER_INDEXED : (unsigned)0))) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create group with creation order indexing & tracking on */
             if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Query the group creation properties */
             if (H5Pget_link_phase_change(gcpl_id, &max_compact, &min_dense) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check for query on empty group */
             H5E_BEGIN_TRY
@@ -5129,7 +5129,7 @@ link_info_by_idx_deprec(hid_t fapl)
             }
             H5E_END_TRY;
             if (ret >= 0)
-                TEST_ERROR
+                TEST_ERROR;
             H5E_BEGIN_TRY
             {
                 name_len = H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, (hsize_t)0,
@@ -5137,7 +5137,7 @@ link_info_by_idx_deprec(hid_t fapl)
             }
             H5E_END_TRY;
             if (name_len >= 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create several links, up to limit of compact form */
             for (u = 0; u < max_compact; u++) {
@@ -5151,9 +5151,9 @@ link_info_by_idx_deprec(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end if */
                 else {
                     /* Make value for link */
@@ -5161,17 +5161,17 @@ link_info_by_idx_deprec(hid_t fapl)
 
                     /* Create soft link */
                     if (H5Lcreate_soft(valname, group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end else */
 
                 /* Verify link information for new link */
                 if (link_info_by_idx_check_deprec(group_id, objname, (hsize_t)u, hard_link, use_index) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end for */
 
             /* Verify state of group */
             if (H5G__has_links_test(group_id, NULL) != TRUE)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check for out of bound offset queries */
             H5E_BEGIN_TRY
@@ -5181,7 +5181,7 @@ link_info_by_idx_deprec(hid_t fapl)
             }
             H5E_END_TRY;
             if (ret >= 0)
-                TEST_ERROR
+                TEST_ERROR;
             H5E_BEGIN_TRY
             {
                 ret = H5Lget_info_by_idx1(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)u, &linfo,
@@ -5189,7 +5189,7 @@ link_info_by_idx_deprec(hid_t fapl)
             }
             H5E_END_TRY;
             if (ret >= 0)
-                TEST_ERROR
+                TEST_ERROR;
             H5E_BEGIN_TRY
             {
                 name_len = H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, (hsize_t)u,
@@ -5197,7 +5197,7 @@ link_info_by_idx_deprec(hid_t fapl)
             }
             H5E_END_TRY;
             if (name_len >= 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create more links, to push group into dense form */
             for (; u < (max_compact * 2); u++) {
@@ -5211,9 +5211,9 @@ link_info_by_idx_deprec(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end if */
                 else {
                     /* Make value for link */
@@ -5221,16 +5221,16 @@ link_info_by_idx_deprec(hid_t fapl)
 
                     /* Create soft link */
                     if (H5Lcreate_soft(valname, group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end else */
 
                 /* Verify state of group */
                 if (H5G__is_new_dense_test(group_id) != TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Verify link information for new link */
                 if (link_info_by_idx_check_deprec(group_id, objname, (hsize_t)u, hard_link, use_index) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end for */
 
             /* Check for out of bound offset queries */
@@ -5241,7 +5241,7 @@ link_info_by_idx_deprec(hid_t fapl)
             }
             H5E_END_TRY;
             if (ret >= 0)
-                TEST_ERROR
+                TEST_ERROR;
             H5E_BEGIN_TRY
             {
                 ret = H5Lget_info_by_idx1(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)u, &linfo,
@@ -5249,7 +5249,7 @@ link_info_by_idx_deprec(hid_t fapl)
             }
             H5E_END_TRY;
             if (ret >= 0)
-                TEST_ERROR
+                TEST_ERROR;
             H5E_BEGIN_TRY
             {
                 name_len = H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, (hsize_t)u,
@@ -5257,19 +5257,19 @@ link_info_by_idx_deprec(hid_t fapl)
             }
             H5E_END_TRY;
             if (name_len >= 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close the group */
             if (H5Gclose(group_id) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close the group creation property list */
             if (H5Pclose(gcpl_id) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close the file */
             if (H5Fclose(file_id) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             PASSED();
         } /* end for */
@@ -5318,18 +5318,18 @@ link_info_by_idx_old_deprec(hid_t fapl)
     /* Loop over creating hard or soft links */
     for (hard_link = FALSE; hard_link <= TRUE; hard_link++) {
         if (hard_link)
-            TESTING("querying info by index in old-style group, using hard links and deprecated routines")
+            TESTING("querying info by index in old-style group, using hard links and deprecated routines");
         else
-            TESTING("querying info by index in old-style group, using soft links and deprecated routines")
+            TESTING("querying info by index in old-style group, using soft links and deprecated routines");
 
         /* Create file */
         h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
         if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create group to operate on */
         if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create several links */
         for (u = 0; u < CORDER_NLINKS; u++) {
@@ -5342,16 +5342,16 @@ link_info_by_idx_old_deprec(hid_t fapl)
 
                 /* Create group */
                 if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Retrieve group's address on disk */
                 if (H5Oget_info2(group_id2, &oi, H5O_INFO_BASIC) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 objno[u] = oi.addr;
 
                 /* Close group */
                 if (H5Gclose(group_id2) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 /* Make value for link */
@@ -5359,7 +5359,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
 
                 /* Create soft link */
                 if (H5Lcreate_soft(valname, group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end else */
         }     /* end for */
 
@@ -5377,47 +5377,47 @@ link_info_by_idx_old_deprec(hid_t fapl)
             if (hard_link) {
                 if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)u, &linfo,
                                         H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5F_addr_ne(linfo.u.address, objno[u]))
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (HDstrcmp(valname, tmpval) != 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end else */
 
             /* Verify link name (in increasing order) */
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (HDstrcmp(objname, tmpname) != 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Verify link information (in native order - native is increasing) */
             if (hard_link) {
                 if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)u, &linfo,
                                         H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5F_addr_ne(linfo.u.address, objno[u]))
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (HDstrcmp(valname, tmpval) != 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end else */
 
             /* Verify link name (in native order - native is increasing) */
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (HDstrcmp(objname, tmpname) != 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Make link name for decreasing order queries */
             HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
@@ -5429,24 +5429,24 @@ link_info_by_idx_old_deprec(hid_t fapl)
             if (hard_link) {
                 if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)u, &linfo,
                                         H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5F_addr_ne(linfo.u.address, objno[dec_u]))
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (HDstrcmp(valname, tmpval) != 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end else */
 
             /* Verify link name (in decreasing order) */
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (HDstrcmp(objname, tmpname) != 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Check for creation order index queries */
@@ -5457,7 +5457,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
         H5E_BEGIN_TRY
         {
             name_len = H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, (hsize_t)u, tmpname,
@@ -5465,19 +5465,19 @@ link_info_by_idx_old_deprec(hid_t fapl)
         }
         H5E_END_TRY;
         if (name_len >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify state of group */
         if (H5G__has_stab_test(group_id) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the group */
         if (H5Gclose(group_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file */
         if (H5Fclose(file_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end for */
@@ -5533,62 +5533,62 @@ delete_by_idx_deprec(hid_t fapl)
                     if (order == H5_ITER_INC) {
                         if (use_index)
                             TESTING("deleting links by creation order index in increasing order w/creation "
-                                    "order index using deprecated routines")
+                                    "order index using deprecated routines");
                         else
                             TESTING("deleting links by creation order index in increasing order w/o creation "
-                                    "order index using deprecated routines")
+                                    "order index using deprecated routines");
                     } /* end if */
                     else {
                         if (use_index)
                             TESTING("deleting links by creation order index in decreasing order w/creation "
-                                    "order index using deprecated routines")
+                                    "order index using deprecated routines");
                         else
                             TESTING("deleting links by creation order index in decreasing order w/o creation "
-                                    "order index using deprecated routines")
+                                    "order index using deprecated routines");
                     } /* end else */
                 }     /* end if */
                 else {
                     if (order == H5_ITER_INC) {
                         if (use_index)
                             TESTING("deleting links by name index in increasing order w/creation order index "
-                                    "using deprecated routines")
+                                    "using deprecated routines");
                         else
                             TESTING("deleting links by name index in increasing order w/o creation order "
-                                    "index using deprecated routines")
+                                    "index using deprecated routines");
                     } /* end if */
                     else {
                         if (use_index)
                             TESTING("deleting links by name index in decreasing order w/creation order index "
-                                    "using deprecated routines")
+                                    "using deprecated routines");
                         else
                             TESTING("deleting links by name index in decreasing order w/o creation order "
-                                    "index using deprecated routines")
+                                    "index using deprecated routines");
                     } /* end else */
                 }     /* end else */
 
                 /* Create file */
                 h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
                 if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create group creation property list */
                 if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Set creation order tracking & indexing on group */
                 if (H5Pset_link_creation_order(gcpl_id, (H5P_CRT_ORDER_TRACKED |
                                                          (use_index ? H5P_CRT_ORDER_INDEXED : (unsigned)0))) <
                     0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create group with creation order tracking on */
                 if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) <
                     0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Query the group creation properties */
                 if (H5Pget_link_phase_change(gcpl_id, &max_compact, &min_dense) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Delete links from one end */
 
@@ -5599,7 +5599,7 @@ delete_by_idx_deprec(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for deletion on non-existing group */
                 H5E_BEGIN_TRY
@@ -5608,7 +5608,7 @@ delete_by_idx_deprec(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create several links, up to limit of compact form */
                 for (u = 0; u < max_compact; u++) {
@@ -5620,18 +5620,18 @@ delete_by_idx_deprec(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Verify link information for new link */
                     if (link_info_by_idx_check_deprec(group_id, objname, (hsize_t)u, TRUE, use_index) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Verify state of group (compact) */
                 if (H5G__has_links_test(group_id, NULL) != TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for out of bound deletion */
                 H5E_BEGIN_TRY
@@ -5640,48 +5640,48 @@ delete_by_idx_deprec(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Delete links from compact group */
                 for (u = 0; u < (max_compact - 1); u++) {
                     /* Delete first link in appropriate order */
                     if (H5Ldelete_by_idx(group_id, ".", idx_type, order, (hsize_t)0, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Verify the link information for first link in appropriate order */
                     HDmemset(&linfo, 0, sizeof(linfo));
                     if (H5Lget_info_by_idx1(group_id, ".", idx_type, order, (hsize_t)0, &linfo, H5P_DEFAULT) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (order == H5_ITER_INC) {
                         if (linfo.corder != (u + 1))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end if */
                     else {
                         if (linfo.corder != (max_compact - (u + 2)))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end else */
 
                     /* Verify the name for first link in appropriate order */
                     HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
                     if (H5Lget_name_by_idx(group_id, ".", idx_type, order, (hsize_t)0, tmpname,
                                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (order == H5_ITER_INC)
                         HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
                     else
                         HDsnprintf(objname, sizeof(objname), "filler %02u", (max_compact - (u + 2)));
                     if (HDstrcmp(objname, tmpname) != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Delete last link */
                 if (H5Ldelete_by_idx(group_id, ".", idx_type, order, (hsize_t)0, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Verify state of group (empty) */
                 if (H5G__has_links_test(group_id, NULL) == TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create more links, to push group into dense form */
                 for (u = 0; u < (max_compact * 2); u++) {
@@ -5693,18 +5693,18 @@ delete_by_idx_deprec(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Verify state of group (dense) */
                     if (u >= max_compact)
                         if (H5G__is_new_dense_test(group_id) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
 
                     /* Verify link information for new link */
                     if (link_info_by_idx_check_deprec(group_id, objname, (hsize_t)u, TRUE, use_index) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Check for out of bound deletion again */
@@ -5714,50 +5714,50 @@ delete_by_idx_deprec(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Delete links from dense group, in appropriate order */
                 for (u = 0; u < ((max_compact * 2) - 1); u++) {
                     /* Delete first link in appropriate order */
                     if (H5Ldelete_by_idx(group_id, ".", idx_type, order, (hsize_t)0, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Verify the link information for first link in appropriate order */
                     HDmemset(&linfo, 0, sizeof(linfo));
                     if (H5Lget_info_by_idx1(group_id, ".", idx_type, order, (hsize_t)0, &linfo, H5P_DEFAULT) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (order == H5_ITER_INC) {
                         if (linfo.corder != (u + 1))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end if */
                     else {
                         if (linfo.corder != ((max_compact * 2) - (u + 2)))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end else */
 
                     /* Verify the name for first link in appropriate order */
                     HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
                     if (H5Lget_name_by_idx(group_id, ".", idx_type, order, (hsize_t)0, tmpname,
                                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (order == H5_ITER_INC)
                         HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
                     else
                         HDsnprintf(objname, sizeof(objname), "filler %02u", ((max_compact * 2) - (u + 2)));
                     if (HDstrcmp(objname, tmpname) != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Delete last link */
                 if (H5Ldelete_by_idx(group_id, ".", idx_type, order, (hsize_t)0, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Verify state of group (empty) */
                 if (H5G__has_links_test(group_id, NULL) == TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5G__is_new_dense_test(group_id) == TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for deletion on empty group again */
                 H5E_BEGIN_TRY
@@ -5766,7 +5766,7 @@ delete_by_idx_deprec(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Delete links in middle */
 
@@ -5780,109 +5780,109 @@ delete_by_idx_deprec(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Verify state of group (dense) */
                     if (u >= max_compact)
                         if (H5G__is_new_dense_test(group_id) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
 
                     /* Verify link information for new link */
                     if (link_info_by_idx_check_deprec(group_id, objname, (hsize_t)u, TRUE, use_index) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Delete every other link from dense group, in appropriate order */
                 for (u = 0; u < max_compact; u++) {
                     /* Delete link */
                     if (H5Ldelete_by_idx(group_id, ".", idx_type, order, (hsize_t)u, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Verify the link information for current link in appropriate order */
                     HDmemset(&linfo, 0, sizeof(linfo));
                     if (H5Lget_info_by_idx1(group_id, ".", idx_type, order, (hsize_t)u, &linfo, H5P_DEFAULT) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (order == H5_ITER_INC) {
                         if (linfo.corder != ((u * 2) + 1))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end if */
                     else {
                         if (linfo.corder != ((max_compact * 2) - ((u * 2) + 2)))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end else */
 
                     /* Verify the name for current link in appropriate order */
                     HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
                     if (H5Lget_name_by_idx(group_id, ".", idx_type, order, (hsize_t)u, tmpname,
                                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (order == H5_ITER_INC)
                         HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 1));
                     else
                         HDsnprintf(objname, sizeof(objname), "filler %02u",
                                    ((max_compact * 2) - ((u * 2) + 2)));
                     if (HDstrcmp(objname, tmpname) != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Delete remaining links from dense group, in appropriate order */
                 for (u = 0; u < (max_compact - 1); u++) {
                     /* Delete link */
                     if (H5Ldelete_by_idx(group_id, ".", idx_type, order, (hsize_t)0, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Verify the link information for first link in appropriate order */
                     HDmemset(&linfo, 0, sizeof(linfo));
                     if (H5Lget_info_by_idx1(group_id, ".", idx_type, order, (hsize_t)0, &linfo, H5P_DEFAULT) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (order == H5_ITER_INC) {
                         if (linfo.corder != ((u * 2) + 3))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end if */
                     else {
                         if (linfo.corder != ((max_compact * 2) - ((u * 2) + 4)))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end else */
 
                     /* Verify the name for first link in appropriate order */
                     HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
                     if (H5Lget_name_by_idx(group_id, ".", idx_type, order, (hsize_t)0, tmpname,
                                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (order == H5_ITER_INC)
                         HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 3));
                     else
                         HDsnprintf(objname, sizeof(objname), "filler %02u",
                                    ((max_compact * 2) - ((u * 2) + 4)));
                     if (HDstrcmp(objname, tmpname) != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Delete last link */
                 if (H5Ldelete_by_idx(group_id, ".", idx_type, order, (hsize_t)0, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Verify state of group (empty) */
                 if (H5G__has_links_test(group_id, NULL) == TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5G__is_new_dense_test(group_id) == TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the group */
                 if (H5Gclose(group_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the group creation property list */
                 if (H5Pclose(gcpl_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the file */
                 if (H5Fclose(file_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 PASSED();
             } /* end for */
@@ -5931,19 +5931,19 @@ delete_by_idx_old_deprec(hid_t fapl)
         /* Print test banner */
         if (order == H5_ITER_INC)
             TESTING(
-                "deleting links by index in increasing order in old-style group using deprecated routines")
+                "deleting links by index in increasing order in old-style group using deprecated routines");
         else
             TESTING(
-                "deleting links by index in decreasing order in old-style group using deprecated routines")
+                "deleting links by index in decreasing order in old-style group using deprecated routines");
 
         /* Create file */
         h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
         if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create group to operate on */
         if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Delete links from one end */
 
@@ -5954,7 +5954,7 @@ delete_by_idx_old_deprec(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create several links */
         for (u = 0; u < CORDER_NLINKS; u++) {
@@ -5965,16 +5965,16 @@ delete_by_idx_old_deprec(hid_t fapl)
 
             /* Create group */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Retrieve group's address on disk */
             if (H5Oget_info2(group_id2, &oi, H5O_INFO_BASIC) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             objno[u] = oi.addr;
 
             /* Close group */
             if (H5Gclose(group_id2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Check for bad index type deletion */
@@ -5984,7 +5984,7 @@ delete_by_idx_old_deprec(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for out of bounds deletion */
         H5E_BEGIN_TRY
@@ -5993,7 +5993,7 @@ delete_by_idx_old_deprec(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Delete links, in appropriate order */
         for (u = 0; u < (CORDER_NLINKS - 1); u++) {
@@ -6001,37 +6001,37 @@ delete_by_idx_old_deprec(hid_t fapl)
 
             /* Delete first link in appropriate order */
             if (H5Ldelete_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Verify the link information for first link in appropriate order */
             HDmemset(&linfo, 0, sizeof(linfo));
             if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, &linfo, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (order == H5_ITER_INC) {
                 if (H5F_addr_ne(linfo.u.address, objno[u + 1]))
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 if (H5F_addr_ne(linfo.u.address, objno[dec_u]))
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end else */
 
             /* Verify the name for first link in appropriate order */
             HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (order == H5_ITER_INC)
                 HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
             else
                 HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
             if (HDstrcmp(objname, tmpname) != 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Delete last link */
         if (H5Ldelete_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for deletion in empty group (again) */
         H5E_BEGIN_TRY
@@ -6040,11 +6040,11 @@ delete_by_idx_old_deprec(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify state of group */
         if (H5G__has_stab_test(group_id) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Delete links in middle */
 
@@ -6057,16 +6057,16 @@ delete_by_idx_old_deprec(hid_t fapl)
 
             /* Create group */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Retrieve group's address on disk */
             if (H5Oget_info2(group_id2, &oi, H5O_INFO_BASIC) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             objno[u] = oi.addr;
 
             /* Close group */
             if (H5Gclose(group_id2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Delete every other link from group, in appropriate order */
@@ -6075,32 +6075,32 @@ delete_by_idx_old_deprec(hid_t fapl)
 
             /* Delete link */
             if (H5Ldelete_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)u, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Verify the link information for current link in appropriate order */
             HDmemset(&linfo, 0, sizeof(linfo));
             if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_NAME, order, (hsize_t)u, &linfo, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (order == H5_ITER_INC) {
                 if (H5F_addr_ne(linfo.u.address, objno[(u * 2) + 1]))
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 if (H5F_addr_ne(linfo.u.address, objno[dec_u]))
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end else */
 
             /* Verify the name for current link in appropriate order */
             HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (order == H5_ITER_INC)
                 HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 1));
             else
                 HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
             if (HDstrcmp(objname, tmpname) != 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Delete remaining links from group, in appropriate order */
@@ -6109,49 +6109,49 @@ delete_by_idx_old_deprec(hid_t fapl)
 
             /* Delete link */
             if (H5Ldelete_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Verify the link information for first link in appropriate order */
             HDmemset(&linfo, 0, sizeof(linfo));
             if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, &linfo, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (order == H5_ITER_INC) {
                 if (H5F_addr_ne(linfo.u.address, objno[(u * 2) + 3]))
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 if (H5F_addr_ne(linfo.u.address, objno[dec_u]))
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end else */
 
             /* Verify the name for first link in appropriate order */
             HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (order == H5_ITER_INC)
                 HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 3));
             else
                 HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
             if (HDstrcmp(objname, tmpname) != 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Delete last link */
         if (H5Ldelete_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify state of group */
         if (H5G__has_stab_test(group_id) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the group */
         if (H5Gclose(group_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file */
         if (H5Fclose(file_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end for */
@@ -6298,14 +6298,14 @@ link_iterate_check_deprec(hid_t group_id, H5_index_t idx_type, H5_iter_order_t o
     iter_info->curr     = order != H5_ITER_DEC ? 0 : (max_links - 1);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if (H5Literate1(group_id, idx_type, order, &skip, link_iterate_deprec_cb, iter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we visited all the links */
     if (skip != max_links)
-        TEST_ERROR
+        TEST_ERROR;
     for (v = 0; v < max_links; v++)
         if (iter_info->visited[v] == FALSE)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Iterate over links in group, with H5Giterate */
     iter_info->nskipped = (unsigned)(gskip = 0);
@@ -6315,14 +6315,14 @@ link_iterate_check_deprec(hid_t group_id, H5_index_t idx_type, H5_iter_order_t o
     iter_info->curr     = order != H5_ITER_DEC ? 0 : (max_links - 1);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if (H5Giterate(group_id, ".", &gskip, group_iterate_deprec_cb, iter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we visited all the links */
     if (gskip != (int)max_links)
-        TEST_ERROR
+        TEST_ERROR;
     for (v = 0; v < max_links; v++)
         if (iter_info->visited[v] == FALSE)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Skip over some links in group */
     iter_info->nskipped = (unsigned)(skip = max_links / 2);
@@ -6332,20 +6332,20 @@ link_iterate_check_deprec(hid_t group_id, H5_index_t idx_type, H5_iter_order_t o
     iter_info->curr     = (int64_t)(order != H5_ITER_DEC ? skip : ((max_links - 1) - skip));
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if (H5Literate1(group_id, idx_type, order, &skip, link_iterate_deprec_cb, iter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we visited all the links */
     if (skip != max_links)
-        TEST_ERROR
+        TEST_ERROR;
     if (order == H5_ITER_INC) {
         for (v = 0; v < (max_links / 2); v++)
             if (iter_info->visited[v + (max_links / 2)] == FALSE)
-                TEST_ERROR
+                TEST_ERROR;
     } /* end if */
     else if (order == H5_ITER_DEC) {
         for (v = 0; v < (max_links / 2); v++)
             if (iter_info->visited[v] == FALSE)
-                TEST_ERROR
+                TEST_ERROR;
     } /* end if */
     else {
         unsigned nvisit = 0; /* # of links visited */
@@ -6356,7 +6356,7 @@ link_iterate_check_deprec(hid_t group_id, H5_index_t idx_type, H5_iter_order_t o
                 nvisit++;
 
         if (nvisit != (max_links / 2))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end else */
 
     /* Skip over some links in group, with H5Giterate */
@@ -6367,20 +6367,20 @@ link_iterate_check_deprec(hid_t group_id, H5_index_t idx_type, H5_iter_order_t o
     iter_info->curr     = order != H5_ITER_DEC ? (unsigned)gskip : ((max_links - 1) - (unsigned)gskip);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if (H5Giterate(group_id, ".", &gskip, group_iterate_deprec_cb, iter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we visited all the links */
     if (gskip != (int)max_links)
-        TEST_ERROR
+        TEST_ERROR;
     if (order == H5_ITER_INC) {
         for (v = 0; v < (max_links / 2); v++)
             if (iter_info->visited[v + (max_links / 2)] == FALSE)
-                TEST_ERROR
+                TEST_ERROR;
     } /* end if */
     else if (order == H5_ITER_DEC) {
         for (v = 0; v < (max_links / 2); v++)
             if (iter_info->visited[v] == FALSE)
-                TEST_ERROR
+                TEST_ERROR;
     } /* end if */
     else {
         unsigned nvisit = 0; /* # of links visited */
@@ -6391,7 +6391,7 @@ link_iterate_check_deprec(hid_t group_id, H5_index_t idx_type, H5_iter_order_t o
                 nvisit++;
 
         if (nvisit != (max_links / 2))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end else */
 
     /* Iterate over links in group, stopping in the middle */
@@ -6402,11 +6402,11 @@ link_iterate_check_deprec(hid_t group_id, H5_index_t idx_type, H5_iter_order_t o
     iter_info->curr     = order != H5_ITER_DEC ? 0 : (max_links - 1);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if ((ret = H5Literate1(group_id, idx_type, order, &skip, link_iterate_deprec_cb, iter_info)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ret != CORDER_ITER_STOP)
-        TEST_ERROR
+        TEST_ERROR;
     if (iter_info->ncalled != 3)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over links in group, stopping in the middle, with H5Giterate() */
     iter_info->nskipped = (unsigned)(gskip = 0);
@@ -6416,11 +6416,11 @@ link_iterate_check_deprec(hid_t group_id, H5_index_t idx_type, H5_iter_order_t o
     iter_info->curr     = order != H5_ITER_DEC ? 0 : (max_links - 1);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if ((ret = H5Giterate(group_id, ".", &gskip, group_iterate_deprec_cb, iter_info)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ret != CORDER_ITER_STOP)
-        TEST_ERROR
+        TEST_ERROR;
     if (iter_info->ncalled != 3)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for iteration routine indicating failure */
     skip = 0;
@@ -6430,7 +6430,7 @@ link_iterate_check_deprec(hid_t group_id, H5_index_t idx_type, H5_iter_order_t o
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return SUCCEED;
@@ -6474,16 +6474,16 @@ link_iterate_deprec(hid_t fapl)
 
     /* Create group creation property list */
     if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties */
     if (H5Pget_link_phase_change(gcpl_id, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate the "visited link" array */
     iter_info.max_visit = max_compact * 2;
     if (NULL == (visited = (hbool_t *)HDmalloc(sizeof(hbool_t) * iter_info.max_visit)))
-        TEST_ERROR
+        TEST_ERROR;
     iter_info.visited = visited;
 
     /* Loop over operating on different indices on link fields */
@@ -6497,77 +6497,77 @@ link_iterate_deprec(hid_t fapl)
                     if (order == H5_ITER_INC) {
                         if (use_index)
                             TESTING("iterating over links by creation order index in increasing order "
-                                    "w/creation order index using deprecated routines")
+                                    "w/creation order index using deprecated routines");
                         else
                             TESTING("iterating over links by creation order index in increasing order w/o "
-                                    "creation order index using deprecated routines")
+                                    "creation order index using deprecated routines");
                     } /* end if */
                     else if (order == H5_ITER_DEC) {
                         if (use_index)
                             TESTING("iterating over links by creation order index in decreasing order "
-                                    "w/creation order index using deprecated routines")
+                                    "w/creation order index using deprecated routines");
                         else
                             TESTING("iterating over links by creation order index in decreasing order w/o "
-                                    "creation order index using deprecated routines")
+                                    "creation order index using deprecated routines");
                     } /* end else */
                     else {
                         HDassert(order == H5_ITER_NATIVE);
                         if (use_index)
                             TESTING("iterating over links by creation order index in native order w/creation "
-                                    "order index using deprecated routines")
+                                    "order index using deprecated routines");
                         else
                             TESTING("iterating over links by creation order index in native order w/o "
-                                    "creation order index using deprecated routines")
+                                    "creation order index using deprecated routines");
                     } /* end else */
                 }     /* end if */
                 else {
                     if (order == H5_ITER_INC) {
                         if (use_index)
                             TESTING("iterating over links by name index in increasing order w/creation order "
-                                    "index using deprecated routines")
+                                    "index using deprecated routines");
                         else
                             TESTING("iterating over links by name index in increasing order w/o creation "
-                                    "order index using deprecated routines")
+                                    "order index using deprecated routines");
                     } /* end if */
                     else if (order == H5_ITER_DEC) {
                         if (use_index)
                             TESTING("iterating over links by name index in decreasing order w/creation order "
-                                    "index using deprecated routines")
+                                    "index using deprecated routines");
                         else
                             TESTING("iterating over links by name index in decreasing order w/o creation "
-                                    "order index using deprecated routines")
+                                    "order index using deprecated routines");
                     } /* end else */
                     else {
                         HDassert(order == H5_ITER_NATIVE);
                         if (use_index)
                             TESTING("iterating over links by name index in native order w/creation order "
-                                    "index using deprecated routines")
+                                    "index using deprecated routines");
                         else
                             TESTING("iterating over links by name index in native order w/o creation order "
-                                    "index using deprecated routines")
+                                    "index using deprecated routines");
                     } /* end else */
                 }     /* end else */
 
                 /* Create file */
                 h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
                 if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Set creation order tracking & indexing on group */
                 if (H5Pset_link_creation_order(gcpl_id, (H5P_CRT_ORDER_TRACKED |
                                                          (use_index ? H5P_CRT_ORDER_INDEXED : (unsigned)0))) <
                     0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create group with creation order tracking on */
                 if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) <
                     0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for iteration on empty group */
                 /* (should be OK) */
                 if (H5Literate1(group_id, idx_type, order, NULL, link_iterate_deprec_cb, NULL) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create several links, up to limit of compact form */
                 for (u = 0; u < max_compact; u++) {
@@ -6579,14 +6579,14 @@ link_iterate_deprec(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Verify state of group (compact) */
                 if (H5G__has_links_test(group_id, NULL) != TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for out of bound iteration on compact group */
                 skip = (hsize_t)u;
@@ -6596,11 +6596,11 @@ link_iterate_deprec(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Test iteration over links in compact group */
                 if (link_iterate_check_deprec(group_id, idx_type, order, u, &iter_info) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create more links, to push group into dense form */
                 for (; u < (max_compact * 2); u++) {
@@ -6612,14 +6612,14 @@ link_iterate_deprec(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Verify state of group (dense) */
                 if (H5G__is_new_dense_test(group_id) != TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for out of bound iteration on dense group */
                 skip = (hsize_t)u;
@@ -6629,19 +6629,19 @@ link_iterate_deprec(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Test iteration over links in dense group */
                 if (link_iterate_check_deprec(group_id, idx_type, order, u, &iter_info) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the group */
                 if (H5Gclose(group_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the file */
                 if (H5Fclose(file_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 PASSED();
             } /* end for */
@@ -6650,7 +6650,7 @@ link_iterate_deprec(hid_t fapl)
 
     /* Close the group creation property list */
     if (H5Pclose(gcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     if (visited)
@@ -6781,14 +6781,14 @@ link_iterate_old_check_deprec(hid_t group_id, H5_iter_order_t order, unsigned ma
     iter_info->curr     = order != H5_ITER_DEC ? 0 : (max_links - 1);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if (H5Literate1(group_id, H5_INDEX_NAME, order, &skip, link_iterate_old_deprec_cb, iter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we visited all the links */
     if (skip != max_links)
-        TEST_ERROR
+        TEST_ERROR;
     for (v = 0; v < max_links; v++)
         if (iter_info->visited[v] == FALSE)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Iterate over links in group, with H5Giterate */
     iter_info->nskipped = (unsigned)(gskip = 0);
@@ -6798,14 +6798,14 @@ link_iterate_old_check_deprec(hid_t group_id, H5_iter_order_t order, unsigned ma
     iter_info->curr     = order != H5_ITER_DEC ? 0 : (max_links - 1);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if (H5Giterate(group_id, ".", &gskip, group_iterate_old_deprec_cb, iter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we visited all the links */
     if (gskip != (int)max_links)
-        TEST_ERROR
+        TEST_ERROR;
     for (v = 0; v < max_links; v++)
         if (iter_info->visited[v] == FALSE)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Skip over some links in group */
     iter_info->nskipped = (unsigned)(skip = max_links / 2);
@@ -6815,20 +6815,20 @@ link_iterate_old_check_deprec(hid_t group_id, H5_iter_order_t order, unsigned ma
     iter_info->curr     = (int64_t)(order != H5_ITER_DEC ? skip : ((max_links - 1) - skip));
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if (H5Literate1(group_id, H5_INDEX_NAME, order, &skip, link_iterate_old_deprec_cb, iter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we visited all the links */
     if (skip != max_links)
-        TEST_ERROR
+        TEST_ERROR;
     if (order == H5_ITER_INC) {
         for (v = 0; v < (max_links / 2); v++)
             if (iter_info->visited[v + (max_links / 2)] == FALSE)
-                TEST_ERROR
+                TEST_ERROR;
     } /* end if */
     else if (order == H5_ITER_DEC) {
         for (v = 0; v < (max_links / 2); v++)
             if (iter_info->visited[v] == FALSE)
-                TEST_ERROR
+                TEST_ERROR;
     } /* end if */
     else {
         unsigned nvisit = 0; /* # of links visited */
@@ -6839,7 +6839,7 @@ link_iterate_old_check_deprec(hid_t group_id, H5_iter_order_t order, unsigned ma
                 nvisit++;
 
         if (nvisit != (max_links / 2))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end else */
 
     /* Skip over some links in group, with H5Giterate */
@@ -6850,20 +6850,20 @@ link_iterate_old_check_deprec(hid_t group_id, H5_iter_order_t order, unsigned ma
     iter_info->curr     = order != H5_ITER_DEC ? (unsigned)gskip : ((max_links - 1) - (unsigned)gskip);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if (H5Giterate(group_id, ".", &gskip, group_iterate_old_deprec_cb, iter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we visited all the links */
     if (gskip != (int)max_links)
-        TEST_ERROR
+        TEST_ERROR;
     if (order == H5_ITER_INC) {
         for (v = 0; v < (max_links / 2); v++)
             if (iter_info->visited[v + (max_links / 2)] == FALSE)
-                TEST_ERROR
+                TEST_ERROR;
     } /* end if */
     else if (order == H5_ITER_DEC) {
         for (v = 0; v < (max_links / 2); v++)
             if (iter_info->visited[v] == FALSE)
-                TEST_ERROR
+                TEST_ERROR;
     } /* end if */
     else {
         unsigned nvisit = 0; /* # of links visited */
@@ -6874,7 +6874,7 @@ link_iterate_old_check_deprec(hid_t group_id, H5_iter_order_t order, unsigned ma
                 nvisit++;
 
         if (nvisit != (max_links / 2))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end else */
 
     /* Iterate over links in group, stopping in the middle */
@@ -6885,11 +6885,11 @@ link_iterate_old_check_deprec(hid_t group_id, H5_iter_order_t order, unsigned ma
     iter_info->curr     = order != H5_ITER_DEC ? 0 : (max_links - 1);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if ((ret = H5Literate1(group_id, H5_INDEX_NAME, order, &skip, link_iterate_old_deprec_cb, iter_info)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ret != CORDER_ITER_STOP)
-        TEST_ERROR
+        TEST_ERROR;
     if (iter_info->ncalled != 3)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over links in group, stopping in the middle, with H5Giterate() */
     iter_info->nskipped = (unsigned)(gskip = 0);
@@ -6899,11 +6899,11 @@ link_iterate_old_check_deprec(hid_t group_id, H5_iter_order_t order, unsigned ma
     iter_info->curr     = order != H5_ITER_DEC ? 0 : (max_links - 1);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if ((ret = H5Giterate(group_id, ".", &gskip, group_iterate_old_deprec_cb, iter_info)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ret != CORDER_ITER_STOP)
-        TEST_ERROR
+        TEST_ERROR;
     if (iter_info->ncalled != 3)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for iteration routine indicating failure */
     skip = 0;
@@ -6913,7 +6913,7 @@ link_iterate_old_check_deprec(hid_t group_id, H5_iter_order_t order, unsigned ma
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for iteration w/bad location ID */
     skip = 0;
@@ -6923,7 +6923,7 @@ link_iterate_old_check_deprec(hid_t group_id, H5_iter_order_t order, unsigned ma
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -6931,7 +6931,7 @@ link_iterate_old_check_deprec(hid_t group_id, H5_iter_order_t order, unsigned ma
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return SUCCEED;
@@ -6966,7 +6966,7 @@ link_iterate_old_deprec(hid_t fapl)
     /* Allocate the "visited link" array */
     iter_info.max_visit = CORDER_NLINKS;
     if (NULL == (visited = (hbool_t *)HDmalloc(sizeof(hbool_t) * iter_info.max_visit)))
-        TEST_ERROR
+        TEST_ERROR;
     iter_info.visited = visited;
 
     /* Loop over operating in different orders */
@@ -6974,31 +6974,31 @@ link_iterate_old_deprec(hid_t fapl)
         /* Print appropriate test message */
         if (order == H5_ITER_INC) {
             TESTING("iterating over links by name index in increasing order in old-style group using "
-                    "deprecated routines")
+                    "deprecated routines");
         } /* end if */
         else if (order == H5_ITER_DEC) {
             TESTING("iterating over links by name index in decreasing order in old-style group using "
-                    "deprecated routines")
+                    "deprecated routines");
         } /* end else */
         else {
             HDassert(order == H5_ITER_NATIVE);
             TESTING("iterating over links by name index in native order in old-style group using deprecated "
-                    "routines")
+                    "routines");
         } /* end else */
 
         /* Create file */
         h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
         if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create group with creation order tracking on */
         if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for iteration on empty group */
         /* (should be OK) */
         if (H5Literate1(group_id, H5_INDEX_NAME, order, NULL, link_iterate_old_deprec_cb, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create several links */
         for (u = 0; u < CORDER_NLINKS; u++) {
@@ -7009,14 +7009,14 @@ link_iterate_old_deprec(hid_t fapl)
 
             /* Create hard link, with group object */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Gclose(group_id2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Verify state of group (symbol table) */
         if (H5G__has_stab_test(group_id) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for out of bound iteration on old-style group */
         skip = (hsize_t)u;
@@ -7026,7 +7026,7 @@ link_iterate_old_deprec(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for iteration on creation order */
         /* (should fail) */
@@ -7037,19 +7037,19 @@ link_iterate_old_deprec(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Test iteration over links in group */
         if (link_iterate_old_check_deprec(group_id, order, u, &iter_info) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the group */
         if (H5Gclose(group_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file */
         if (H5Fclose(file_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end for */
@@ -7098,9 +7098,9 @@ external_link_root(hid_t fapl, hbool_t new_format)
     const char *path; /* Path from external link */
 
     if (new_format)
-        TESTING("external link to root (w/new group format)")
+        TESTING("external link to root (w/new group format)");
     else
-        TESTING("external link to root")
+        TESTING("external link to root");
 
     /* Set up filenames */
     h5_fixname(FILENAME[3], fapl, filename1, sizeof filename1);
@@ -7108,23 +7108,23 @@ external_link_root(hid_t fapl, hbool_t new_format)
 
     /* Create file to point to */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that external links are registered with the library */
     if (H5Lis_registered(H5L_TYPE_EXTERNAL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file with link to first file */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to object in first file */
     if (H5Lcreate_external(filename1, "/", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information for external link */
     if (H5Lget_info2(fid, "ext_link", &linfo, H5P_DEFAULT) < 0)
@@ -7135,9 +7135,9 @@ external_link_root(hid_t fapl, hbool_t new_format)
         goto error;
     }
     if (H5Lget_val(fid, "ext_link", objname, sizeof(objname), H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lunpack_elink_val(objname, linfo.u.val_size, NULL, &file, &path) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(file, filename1) != 0) {
         H5_FAILED();
         HDputs("    External link file name incorrect");
@@ -7152,7 +7152,7 @@ external_link_root(hid_t fapl, hbool_t new_format)
     /* Create external link to object in first file */
     /* (add a few extra '/'s to make certain library normalizes external link object names) */
     if (H5Lcreate_external(filename1, "///", fid, "ext_link2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information for external link */
     if (H5Lget_info2(fid, "ext_link", &linfo, H5P_DEFAULT) < 0)
@@ -7163,9 +7163,9 @@ external_link_root(hid_t fapl, hbool_t new_format)
         goto error;
     }
     if (H5Lget_val(fid, "ext_link", objname, sizeof(objname), H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lunpack_elink_val(objname, linfo.u.val_size, NULL, &file, &path) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(file, filename1) != 0) {
         H5_FAILED();
         HDputs("    External link file name incorrect");
@@ -7179,89 +7179,89 @@ external_link_root(hid_t fapl, hbool_t new_format)
 
     /* Close and re-open file to ensure that data is written to disk */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid = H5Fopen(filename2, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     if ((gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in external file */
     if ((gid2 = H5Gcreate2(gid, "new_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in external file */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close external object (lets first file close) */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a new object using H5Gcreate2 through the external link
      * directly
      */
     if ((gid = H5Gcreate2(fid, "ext_link/newer_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file and group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     /* Open first file again with read-only access and check on objects created */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open objects created through external link */
     if ((gid = H5Gopen2(fid, "new_group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((gid2 = H5Gopen2(fid, "newer_group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check names */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/new_group") != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Iget_name(gid2, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/newer_group") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close opened objects */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     /* Verify that new objects can't be created through a read-only external
      * link.
      */
     if ((fid = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -7269,15 +7269,15 @@ external_link_root(hid_t fapl, hbool_t new_format)
     }
     H5E_END_TRY
     if (gid >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close second file again */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     PASSED();
@@ -7314,9 +7314,9 @@ external_link_path(hid_t fapl, hbool_t new_format)
     char  filename2[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external link to object on path (w/new group format)")
+        TESTING("external link to object on path (w/new group format)");
     else
-        TESTING("external link to object on path")
+        TESTING("external link to object on path");
 
     /* Set up filenames */
     h5_fixname(FILENAME[3], fapl, filename1, sizeof filename1);
@@ -7324,83 +7324,83 @@ external_link_path(hid_t fapl, hbool_t new_format)
 
     /* Create file to point to */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object down a path */
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gid = H5Gcreate2(fid, "A/B", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gid = H5Gcreate2(fid, "A/B/C", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file with link to first file */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to object in first file */
     if (H5Lcreate_external(filename1, "/A/B/C", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     if ((gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/A/B/C") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in external file */
     if ((gid2 = H5Gcreate2(gid, "new_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in external file */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close external object (lets first file close) */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close second file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open first file again and check on object created */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object created through external link */
     if ((gid = H5Gopen2(fid, "/A/B/C/new_group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/A/B/C/new_group") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close opened object */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -7436,9 +7436,9 @@ external_link_mult(hid_t fapl, hbool_t new_format)
         filename4[NAME_BUF_SIZE]; /* Names of files to externally link across */
 
     if (new_format)
-        TESTING("external links across multiple files (w/new group format)")
+        TESTING("external links across multiple files (w/new group format)");
     else
-        TESTING("external links across multiple files")
+        TESTING("external links across multiple files");
 
     /* Set up filenames */
     h5_fixname(FILENAME[3], fapl, filename1, sizeof filename1);
@@ -7448,158 +7448,158 @@ external_link_mult(hid_t fapl, hbool_t new_format)
 
     /* Create first file to point to */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object down a path */
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gid = H5Gcreate2(fid, "A/B", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gid = H5Gcreate2(fid, "A/B/C", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create second file to point to */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link down a path */
     if ((gid = H5Gcreate2(fid, "D", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gid = H5Gcreate2(fid, "D/E", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to object in first file */
     if (H5Lcreate_external(filename1, "/A/B/C", gid, "F", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create third file to point to */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link down a path */
     if ((gid = H5Gcreate2(fid, "G", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gid = H5Gcreate2(fid, "G/H", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to object in second file */
     if (H5Lcreate_external(filename2, "/D/E/F", gid, "I", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file with link to third file */
     if ((fid = H5Fcreate(filename4, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to object in first file */
     if (H5Lcreate_external(filename3, "/G/H/I", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     if ((gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/A/B/C") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in external file */
     if ((gid2 = H5Gcreate2(gid, "new_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in external file */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close external object (lets first file close) */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close second file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open first file again and check on object created */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object created through external link */
     if ((gid = H5Gopen2(fid, "/A/B/C/new_group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/A/B/C/new_group") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close opened object */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open an object through external links */
     if ((fid = H5Fopen(filename4, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* The intermediate files should not stay open. Replace one of them with a new file. */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the other with write access and delete the external link in it */
     if ((fid2 = H5Fopen(filename3, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ldelete(fid2, "G/H/I", H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cleanup */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -7636,9 +7636,9 @@ external_link_self(hid_t fapl, hbool_t new_format)
     char  filename3[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external link to self (w/new group format)")
+        TESTING("external link to self (w/new group format)");
     else
-        TESTING("external link to self")
+        TESTING("external link to self");
 
     /* Set up filename */
     h5_fixname(FILENAME[1], fapl, filename1, sizeof filename1);
@@ -7647,70 +7647,70 @@ external_link_self(hid_t fapl, hbool_t new_format)
 
     /* Create file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an lcpl with intermediate group creation set */
     if ((lcpl_id = H5Pcreate(H5P_LINK_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_create_intermediate_group(lcpl_id, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a series of groups within the file: /A/B and /X/Y/Z */
     if ((gid = H5Gcreate2(fid, "A/B", lcpl_id, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "X/Y", lcpl_id, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pclose(lcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to own root group*/
     if (H5Lcreate_external(filename1, "/X", fid, "A/B/C", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     if ((gid = H5Gopen2(fid, "A/B/C/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/X") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object through external link */
     if ((gid2 = H5Gcreate2(gid, "new_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close created group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close object opened through external link */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on object created */
     if ((gid = H5Gopen2(fid, "X/new_group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/X/new_group") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close opened object */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Complicate things. Use this file as an intermediate file in a chain
      * of external links that will go: file2 -> file1 -> file1 -> file3
@@ -7718,67 +7718,67 @@ external_link_self(hid_t fapl, hbool_t new_format)
 
     /* Create file2 with an external link to file1  */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Lcreate_external(filename1, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file2 */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file3 as a target */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "end", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open file1 and create an extlink pointing to file3 */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Lcreate_external(filename3, "/", fid, "/X/Y/Z", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file1 */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open file2 and traverse through file1 (with its recursive extlink) to file3 */
     if ((fid = H5Fopen(filename2, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gid = H5Gopen2(fid, "ext_link/B/C/Y/Z/end", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create object through external link */
     if ((gid2 = H5Gcreate2(gid, "newer_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cleanup */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open up file3 and make sure the object was created successfully */
     if ((fid = H5Fopen(filename3, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((gid = H5Gopen2(fid, "end/newer_group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Cleanup */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -7829,9 +7829,9 @@ external_link_pingpong(hid_t fapl, hbool_t new_format)
     char  filename1[NAME_BUF_SIZE], filename2[NAME_BUF_SIZE]; /* Names of files to externally link across */
 
     if (new_format)
-        TESTING("external links back and forth (w/new group format)")
+        TESTING("external links back and forth (w/new group format)");
     else
-        TESTING("external links back and forth")
+        TESTING("external links back and forth");
 
     /* Set up filenames */
     h5_fixname(FILENAME[3], fapl, filename1, sizeof filename1);
@@ -7839,93 +7839,93 @@ external_link_pingpong(hid_t fapl, hbool_t new_format)
 
     /* Create first file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external links for chain */
     if (H5Lcreate_external(filename2, "/link2", fid, "link1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename2, "/link4", fid, "link3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename2, "/link6", fid, "link5", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create final object */
     if ((gid = H5Gcreate2(fid, "final", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create second file */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external links for chain */
     if (H5Lcreate_external(filename1, "/link3", fid, "link2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename1, "/link5", fid, "link4", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename1, "/final", fid, "link6", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open first file */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     if ((gid = H5Gopen2(fid, "link1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/final") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in external file */
     if ((gid2 = H5Gcreate2(gid, "new_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in external file */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close external object (lets first file close) */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open first file again and check on object created */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object created through external link */
     if ((gid = H5Gopen2(fid, "/final/new_group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/final/new_group") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close opened object */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -7981,9 +7981,9 @@ external_link_toomany(hid_t fapl, hbool_t new_format)
     char  filename1[NAME_BUF_SIZE], filename2[NAME_BUF_SIZE]; /* Names of files to externally link across */
 
     if (new_format)
-        TESTING("too many external links (w/new group format)")
+        TESTING("too many external links (w/new group format)");
     else
-        TESTING("too many external links")
+        TESTING("too many external links");
 
     /* Make certain test is valid */
     /* XXX: should probably make a "generic" test that creates the proper
@@ -7997,67 +7997,67 @@ external_link_toomany(hid_t fapl, hbool_t new_format)
 
     /* Create first file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external links for chain */
     if (H5Lcreate_external(filename2, "/link2", fid, "link1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename2, "/link4", fid, "link3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename2, "/link6", fid, "link5", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename2, "/link8", fid, "link7", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename2, "/link10", fid, "link9", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename2, "/link12", fid, "link11", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename2, "/link14", fid, "link13", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename2, "/link16", fid, "link15", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename2, "/final", fid, "link17", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create second file */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external links for chain */
     if (H5Lcreate_external(filename1, "/link3", fid, "link2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename1, "/link5", fid, "link4", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename1, "/link7", fid, "link6", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename1, "/link9", fid, "link8", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename1, "/link11", fid, "link10", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename1, "/link13", fid, "link12", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename1, "/link15", fid, "link14", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename1, "/link17", fid, "link16", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create final object */
     if ((gid = H5Gcreate2(fid, "final", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open first file */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -8073,29 +8073,29 @@ external_link_toomany(hid_t fapl, hbool_t new_format)
 
     /* Open object through external link */
     if ((gid = H5Gopen2(fid, "link3", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/final") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in external file */
     if ((gid2 = H5Gcreate2(gid, "new_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in external file */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close external object */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -8131,9 +8131,9 @@ external_link_dangling(hid_t fapl, hbool_t new_format)
     char  filename1[NAME_BUF_SIZE], filename2[NAME_BUF_SIZE]; /* Names of files to externally link across */
 
     if (new_format)
-        TESTING("dangling external links (w/new group format)")
+        TESTING("dangling external links (w/new group format)");
     else
-        TESTING("dangling external links")
+        TESTING("dangling external links");
 
     /* Set up filenames */
     h5_fixname(FILENAME[3], fapl, filename1, sizeof filename1);
@@ -8141,29 +8141,29 @@ external_link_dangling(hid_t fapl, hbool_t new_format)
 
     /* Create first file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dangling external links */
     if (H5Lcreate_external("missing", "/missing", fid, "no_file", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename2, "/missing", fid, "no_object", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create second file (for dangling object test) */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open first file */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get root group ID */
     if ((rid = H5Gopen2(fid, "/", H5P_DEFAULT)) < 0)
@@ -8207,11 +8207,11 @@ external_link_dangling(hid_t fapl, hbool_t new_format)
 
     /* Close root group */
     if (H5Gclose(rid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -8250,9 +8250,9 @@ external_link_prefix(hid_t fapl, hbool_t new_format)
     char  filename1[NAME_BUF_SIZE], filename2[NAME_BUF_SIZE], filename3[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external links via H5Pset_elink_prefix()(w/new group format)")
+        TESTING("external links via H5Pset_elink_prefix()(w/new group format)");
     else
-        TESTING("external links via H5Pset_elink_prefix()")
+        TESTING("external links via H5Pset_elink_prefix()");
 
     /* set up name for main file: "extlinks0" */
     h5_fixname(FILENAME[12], fapl, filename1, sizeof filename1);
@@ -8261,36 +8261,36 @@ external_link_prefix(hid_t fapl, hbool_t new_format)
 
     /* create tmp_links directory and get current working directory path */
     if (HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set up name for target file: "tmp_links/extlinks2" */
     h5_fixname(FILENAME[17], fapl, filename3, sizeof filename3);
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file (without the absolute path) */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set up prefix for external link */
     if ((gapl_id = H5Pcreate(H5P_GROUP_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_elink_prefix(gapl_id, TMPDIR) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -8308,9 +8308,9 @@ external_link_prefix(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -8347,9 +8347,9 @@ external_link_abs_mainpath(hid_t fapl, hbool_t new_format)
         cwdpath[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external links via main file's absolute path (w/new group format)")
+        TESTING("external links via main file's absolute path (w/new group format)");
     else
-        TESTING("external links via main file's absolute path")
+        TESTING("external links via main file's absolute path");
 
     /* set up name for external linked target file: "extlinks3" */
     h5_fixname(FILENAME[18], fapl, filename2, sizeof filename2);
@@ -8359,7 +8359,7 @@ external_link_abs_mainpath(hid_t fapl, hbool_t new_format)
     /* create tmp_links directory and get current working directory path */
     if ((HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST) ||
         (NULL == HDgetcwd(cwdpath, (size_t)NAME_BUF_SIZE)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * set up name for main file:
@@ -8371,23 +8371,23 @@ external_link_abs_mainpath(hid_t fapl, hbool_t new_format)
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -8405,9 +8405,9 @@ external_link_abs_mainpath(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -8442,15 +8442,15 @@ external_link_rel_mainpath(hid_t fapl, hbool_t new_format)
     char  filename1[NAME_BUF_SIZE], filename2[NAME_BUF_SIZE], filename3[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external links via main file's CWD + relative path(w/new group format)")
+        TESTING("external links via main file's CWD + relative path(w/new group format)");
     else
-        TESTING("external links via main file's CWD + relative path")
+        TESTING("external links via main file's CWD + relative path");
 
     /* set up name for external linked target file: "extlinks4" */
     h5_fixname(FILENAME[20], fapl, filename2, sizeof filename2);
 
     if (HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set up name for main file: "tmp_links/extlinks0" */
     h5_fixname(FILENAME[13], fapl, filename1, sizeof filename1);
@@ -8459,23 +8459,23 @@ external_link_rel_mainpath(hid_t fapl, hbool_t new_format)
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -8493,9 +8493,9 @@ external_link_rel_mainpath(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -8530,9 +8530,9 @@ external_link_cwd(hid_t fapl, hbool_t new_format)
     char  filename1[NAME_BUF_SIZE], filename2[NAME_BUF_SIZE], tmpname[NAME_BUF_SIZE], cwdpath[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external links via current working directory(w/new group format)")
+        TESTING("external links via current working directory(w/new group format)");
     else
-        TESTING("external links via current working directory")
+        TESTING("external links via current working directory");
 
     /* set up name for external linked target file: "extlinks5"  */
     /* set up name for target file: "extlinks5" */
@@ -8540,7 +8540,7 @@ external_link_cwd(hid_t fapl, hbool_t new_format)
 
     if ((HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST) ||
         (NULL == HDgetcwd(cwdpath, (size_t)NAME_BUF_SIZE)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * set up name for main file:
@@ -8552,23 +8552,23 @@ external_link_cwd(hid_t fapl, hbool_t new_format)
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -8586,9 +8586,9 @@ external_link_cwd(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -8625,9 +8625,9 @@ external_link_abstar(hid_t fapl, hbool_t new_format)
         cwdpath[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external links via target's absolute path (w/new group format)")
+        TESTING("external links via target's absolute path (w/new group format)");
     else
-        TESTING("external links via target's absolute path")
+        TESTING("external links via target's absolute path");
 
     /* set up name for main file: "extlinks0" */
     h5_fixname(FILENAME[12], fapl, filename1, sizeof filename1);
@@ -8635,7 +8635,7 @@ external_link_abstar(hid_t fapl, hbool_t new_format)
     /* create tmp_links directory and get current working directory path */
     if ((HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST) ||
         (NULL == HDgetcwd(cwdpath, (size_t)NAME_BUF_SIZE)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * set up name for external linked target file:
@@ -8650,23 +8650,23 @@ external_link_abstar(hid_t fapl, hbool_t new_format)
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -8684,9 +8684,9 @@ external_link_abstar(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -8723,9 +8723,9 @@ external_link_abstar_cur(hid_t fapl, hbool_t new_format)
         cwdpath[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external links via main file's CWD (w/new group format)")
+        TESTING("external links via main file's CWD (w/new group format)");
     else
-        TESTING("external links via main file's CWD")
+        TESTING("external links via main file's CWD");
 
     /* set up name for main file: "extlinks0" */
     h5_fixname(FILENAME[12], fapl, filename1, sizeof filename1);
@@ -8736,7 +8736,7 @@ external_link_abstar_cur(hid_t fapl, hbool_t new_format)
     /* create tmp_links directory and get current working directory path */
     if ((HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST) ||
         (NULL == HDgetcwd(cwdpath, (size_t)NAME_BUF_SIZE)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * set up name for external linked target file:
@@ -8748,23 +8748,23 @@ external_link_abstar_cur(hid_t fapl, hbool_t new_format)
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -8782,9 +8782,9 @@ external_link_abstar_cur(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -8819,16 +8819,16 @@ external_link_reltar(hid_t fapl, hbool_t new_format)
     char  filename1[NAME_BUF_SIZE], filename2[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external links via main file's CWD + target's relative path(w/new group format)")
+        TESTING("external links via main file's CWD + target's relative path(w/new group format)");
     else
-        TESTING("external links via main file's CWD + target's relative path")
+        TESTING("external links via main file's CWD + target's relative path");
 
     /* set up name for main file: "extlinks0" */
     h5_fixname(FILENAME[12], fapl, filename1, sizeof filename1);
 
     /* create tmp_links directory */
     if (HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set up name for target file name: "tmp_links/extlinks8" */
     /* set up name for external linked target file: "tmp_links/extlinks8" */
@@ -8836,23 +8836,23 @@ external_link_reltar(hid_t fapl, hbool_t new_format)
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "///A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     if ((gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT)) < 0) {
@@ -8863,9 +8863,9 @@ external_link_reltar(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -8902,9 +8902,9 @@ external_link_chdir(hid_t fapl, hbool_t new_format)
     char  filename1[NAME_BUF_SIZE], filename2[NAME_BUF_SIZE], filename3[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external links via chdir and found in current working directory (w/new group format)")
+        TESTING("external links via chdir and found in current working directory (w/new group format)");
     else
-        TESTING("external links via chdir and found in current working directory")
+        TESTING("external links via chdir and found in current working directory");
 
     /* set up name for main file: "extlinks0" */
     h5_fixname(FILENAME[12], fapl, filename1, sizeof filename1);
@@ -8913,33 +8913,33 @@ external_link_chdir(hid_t fapl, hbool_t new_format)
 
     /* create tmp_links directory */
     if (HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set up name for target file name ("tmp_links/extlinks9") */
     h5_fixname(FILENAME[28], fapl, filename3, sizeof filename3);
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (HDchdir(TMPDIR) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -8949,7 +8949,7 @@ external_link_chdir(hid_t fapl, hbool_t new_format)
     H5E_END_TRY;
 
     if (HDchdir("..") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Should be able to find the target file from:
@@ -8963,9 +8963,9 @@ external_link_chdir(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -9018,13 +9018,13 @@ external_set_elink_fapl1(hid_t fapl, hbool_t new_format)
     haddr_t     memb_addr[H5FD_MEM_NTYPES];
 
     if (new_format)
-        TESTING("H5Pset/get_elink_fapl() with different physical layouts (w/new group format)")
+        TESTING("H5Pset/get_elink_fapl() with different physical layouts (w/new group format)");
     else
-        TESTING("H5Pset/get_elink_fapl() with different physical layouts")
+        TESTING("H5Pset/get_elink_fapl() with different physical layouts");
 
     if ((HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST) ||
         (NULL == HDgetcwd(cwdpath, (size_t)NAME_BUF_SIZE)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * set up name for main file:
@@ -9095,42 +9095,42 @@ external_set_elink_fapl1(hid_t fapl, hbool_t new_format)
 
     /* Create target file A to be a "family" file */
     if ((fidA = H5Fcreate(filename2A, H5F_ACC_TRUNC, H5P_DEFAULT, fam_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gidA = H5Gcreate2(fidA, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create target file B to be a "multi" file */
     if ((fidB = H5Fcreate(filename2B, H5F_ACC_TRUNC, H5P_DEFAULT, multi_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gidB = H5Gcreate2(fidB, "B", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target files */
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidB) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fidB) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file A:/A */
     if (H5Lcreate_external(filename2A, "/A", fid, "ext_linkA", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Create external link to target file B:/B */
     if (H5Lcreate_external(filename2B, "/B", fid, "ext_linkB", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set file access property list for link access to use the family driver */
     if ((lapl_idA = H5Pcreate(H5P_LINK_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_elink_fapl(lapl_idA, fam_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open target object A */
     oidA = H5Oopen(fid, "ext_linkA", lapl_idA);
@@ -9144,9 +9144,9 @@ external_set_elink_fapl1(hid_t fapl, hbool_t new_format)
 
     /* Set file access property list for link access to use the multi driver */
     if ((lapl_idB = H5Pcreate(H5P_LINK_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_elink_fapl(lapl_idB, multi_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open target object B */
     oidB = H5Oopen(fid, "ext_linkB", lapl_idB);
@@ -9160,19 +9160,19 @@ external_set_elink_fapl1(hid_t fapl, hbool_t new_format)
 
     /* closing */
     if (H5Pclose(lapl_idA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(lapl_idB) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(fam_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(multi_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oclose(oidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oclose(oidB) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -9240,9 +9240,9 @@ external_set_elink_fapl2(hid_t fapl, hbool_t new_format)
     h5_stat_size_t new_filesize;
 
     if (new_format)
-        TESTING("H5Pset/get_elink_fapl() with same physical layout (w/new group format)")
+        TESTING("H5Pset/get_elink_fapl() with same physical layout (w/new group format)");
     else
-        TESTING("H5Pset/get_elink_fapl() with same physical layout")
+        TESTING("H5Pset/get_elink_fapl() with same physical layout");
 
     /* Set up file names and paths */
     if (NULL == (filename1 = (char *)HDcalloc(NAME_BUF_SIZE, sizeof(char))))
@@ -9256,7 +9256,7 @@ external_set_elink_fapl2(hid_t fapl, hbool_t new_format)
 
     if ((HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST) ||
         (NULL == HDgetcwd(cwdpath, (size_t)NAME_BUF_SIZE)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set up data array */
     if (NULL == (points_data = (int *)HDcalloc(NUM40 * NUM40, sizeof(int))))
@@ -9277,7 +9277,7 @@ external_set_elink_fapl2(hid_t fapl, hbool_t new_format)
     /* create fapl for the target file to be a "core" file */
     core_fapl = h5_fileaccess();
     if (H5Pset_fapl_core(core_fapl, (size_t)CORE_INCREMENT, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set up name for external linked target file: "extlinks17"  */
     /* set up name for target file: "extlinks17" */
@@ -9285,14 +9285,14 @@ external_set_elink_fapl2(hid_t fapl, hbool_t new_format)
 
     /* Create the target file to be a "core" file */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, core_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dims[0] = NUM40;
     dims[1] = NUM40;
     if ((space = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataset creation property list */
     if (dcpl_g == H5P_DEFAULT)
@@ -9306,40 +9306,40 @@ external_set_elink_fapl2(hid_t fapl, hbool_t new_format)
 
     /* create "Dataset" in group "A" of target file */
     if ((dset = H5Dcreate2(gid, "Dataset", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(space) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get size of target file */
     filesize = h5_get_file_size(filename2, core_fapl);
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file: ext_link->extlinks17:/A/Dataset */
     if (H5Lcreate_external(filename2, "/A/Dataset", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create fapl to be a "core" file without backing store */
     if (H5Pset_fapl_core(core_fapl, (size_t)CORE_INCREMENT, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set file access property list for link access to use the "core" driver */
     if ((dapl_id = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_elink_fapl(dapl_id, core_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* try to open the external linked target dataset */
     did = H5Dopen2(fid, "ext_link", dapl_id);
@@ -9356,23 +9356,23 @@ external_set_elink_fapl2(hid_t fapl, hbool_t new_format)
 
     /* Write the data to the dataset */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, points_data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pclose(dapl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     new_filesize = h5_get_file_size(filename2, core_fapl);
 
     /* the file size should remain the same since there is no backing store */
     if (new_filesize != filesize)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pclose(core_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDfree(points);
     HDfree(points_data);
@@ -9442,75 +9442,75 @@ external_set_elink_fapl3(hbool_t new_format)
     hid_t lapl_id = -1, new_lapl_id = -1, l_fapl = -1, out_fapl;
 
     if (new_format)
-        TESTING("H5Pset/get_fapl() (w/new group format)")
+        TESTING("H5Pset/get_fapl() (w/new group format)");
     else
-        TESTING("H5Pset/get_fapl()")
+        TESTING("H5Pset/get_fapl()");
 
     /* create fapl for the target file to be a "core" file */
     core_fapl = h5_fileaccess();
     if (H5Pset_fapl_core(core_fapl, (size_t)CORE_INCREMENT, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     stdio_fapl = h5_fileaccess();
     if (H5Pset_fapl_stdio(stdio_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set file access property list for link access to use the "stdio" driver */
     if ((lapl_id = H5Pcreate(H5P_LINK_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_elink_fapl(lapl_id, stdio_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the driver for the link's fapl is the "stdio" driver */
     if ((l_fapl = H5Pget_elink_fapl(lapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_driver(l_fapl) != H5FD_STDIO)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(l_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set file access property list for link access to use the "core" driver */
     if (H5Pset_elink_fapl(lapl_id, core_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make a copy of the link access property */
     if ((new_lapl_id = H5Pcopy(lapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get the fapl set in lapl_id */
     if (H5Pget(lapl_id, "external link fapl", &out_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(lapl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try closing out_fapl, should succeed since H5Pget() should clone its fapl */
     if (H5Pclose(out_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the driver for the copied link's fapl is the "core" driver */
     if ((l_fapl = H5Pget_elink_fapl(new_lapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_driver(l_fapl) != H5FD_CORE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get the fapl set in new_lapl_id */
     if (H5Pget(new_lapl_id, "external link fapl", &out_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Premove(new_lapl_id, "external link fapl") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try closing out_fapl, should succeed since H5Pget() should clone its fapl */
     if (H5Pclose(out_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pclose(l_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(new_lapl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(core_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(stdio_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -9546,35 +9546,35 @@ external_set_elink_acc_flags(const char *env_h5_drvr, hid_t fapl, hbool_t new_fo
     unsigned flags;
 
     if (new_format)
-        TESTING("H5Pset/get_elink_acc_flags() (w/new group format)")
+        TESTING("H5Pset/get_elink_acc_flags() (w/new group format)");
     else
-        TESTING("H5Pset/get_elink_acc_flags()")
+        TESTING("H5Pset/get_elink_acc_flags()");
 
     /* Create parent and target files, and external link */
     h5_fixname(FILENAME[40], fapl, filename1, sizeof filename1);
     h5_fixname(FILENAME[41], fapl, filename2, sizeof filename2);
     if ((file1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((file2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename2, "/", file1, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file2, leave file1 open (should be read-write) */
     if (H5Fclose(file2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create new gapl, and set elink access flags to be H5F_ACC_RDONLY */
     if ((gapl = H5Pcreate(H5P_GROUP_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_elink_acc_flags(gapl, H5F_ACC_RDONLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify "get" routine functionality */
     if (H5Pget_elink_acc_flags(gapl, &flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (flags != H5F_ACC_RDONLY)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to create a group through the external link using gapl (should fail) */
     H5E_BEGIN_TRY
@@ -9583,29 +9583,29 @@ external_set_elink_acc_flags(const char *env_h5_drvr, hid_t fapl, hbool_t new_fo
     }
     H5E_END_TRY;
     if (group != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file1 and reopen with read only access */
     if (H5Fclose(file1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set elink access flags on gapl to be H5F_ACC_RDWR */
     if (H5Pset_elink_acc_flags(gapl, H5F_ACC_RDWR) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group through the external link using gapl (should succeed) */
     if ((group = H5Gcreate2(file1, "/ext_link/group", H5P_DEFAULT, H5P_DEFAULT, gapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group */
     if (H5Gclose(group) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unset elink access flags on gapl */
     if (H5Pset_elink_acc_flags(gapl, H5F_ACC_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to create a group through the external link using gapl (should fail) */
     H5E_BEGIN_TRY
@@ -9614,7 +9614,7 @@ external_set_elink_acc_flags(const char *env_h5_drvr, hid_t fapl, hbool_t new_fo
     }
     H5E_END_TRY;
     if (subgroup != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to set SWMR flags on gapl.
      * This is just a smoke check of the flags. The actual external link
@@ -9622,10 +9622,10 @@ external_set_elink_acc_flags(const char *env_h5_drvr, hid_t fapl, hbool_t new_fo
      */
     /* Set SWMR reader flags on gapl */
     if (H5Pset_elink_acc_flags(gapl, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Set SWMR writer flags on gapl */
     if (H5Pset_elink_acc_flags(gapl, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to set invalid flags on gapl */
     H5E_BEGIN_TRY
@@ -9634,21 +9634,21 @@ external_set_elink_acc_flags(const char *env_h5_drvr, hid_t fapl, hbool_t new_fo
     }
     H5E_END_TRY;
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         ret = H5Pset_elink_acc_flags(gapl, H5F_ACC_EXCL);
     }
     H5E_END_TRY;
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         ret = H5Pset_elink_acc_flags(gapl, H5F_ACC_CREAT);
     }
     H5E_END_TRY;
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
     /* SWMR reader with write access */
     H5E_BEGIN_TRY
     {
@@ -9656,7 +9656,7 @@ external_set_elink_acc_flags(const char *env_h5_drvr, hid_t fapl, hbool_t new_fo
     }
     H5E_END_TRY;
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
     /* SWMR writer with read-only access */
     H5E_BEGIN_TRY
     {
@@ -9664,11 +9664,11 @@ external_set_elink_acc_flags(const char *env_h5_drvr, hid_t fapl, hbool_t new_fo
     }
     H5E_END_TRY;
     if (ret != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file1 */
     if (H5Fclose(file1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Only run this part with VFDs that support SWMR */
     if (H5FD__supports_swmr_test(env_h5_drvr)) {
@@ -9677,100 +9677,100 @@ external_set_elink_acc_flags(const char *env_h5_drvr, hid_t fapl, hbool_t new_fo
         /* Only supported under the latest file format */
         if (new_format) {
             if ((file1 = H5Fopen(filename1, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Open a group through the external link using default gapl */
             if ((group = H5Gopen2(file1, "/ext_link/group", H5P_DEFAULT)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Verify that the correct parameters have been set on file2 */
             if ((file2 = H5Iget_file_id(group)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Fget_intent(file2, &flags) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (flags != (H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close file2 and group */
             if (H5Gclose(group) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Fclose(file2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Set elink access flags on gapl to be H5F_ACC_RDWR (dropping SWMR_WRITE) */
             if (H5Pset_elink_acc_flags(gapl, H5F_ACC_RDWR) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Open a group through the external link using gapl */
             if ((group = H5Gopen2(file1, "/ext_link/group", gapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Verify that the correct parameters have been set on file2 */
             if ((file2 = H5Iget_file_id(group)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Fget_intent(file2, &flags) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (flags != H5F_ACC_RDWR)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close file2 and group */
             if (H5Gclose(group) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Fclose(file2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Close file1 */
             if (H5Fclose(file1) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         /* Reopen file1, with read-only and SWMR-read access */
         if ((file1 = H5Fopen(filename1, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Open a group through the external link using default gapl */
         if ((group = H5Gopen2(file1, "/ext_link/group", H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify that the correct parameters have been set on file2 */
         if ((file2 = H5Iget_file_id(group)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Fget_intent(file2, &flags) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (flags != (H5F_ACC_RDONLY | H5F_ACC_SWMR_READ))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close file2 and group */
         if (H5Gclose(group) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Fclose(file2) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set elink access flags on gapl to be H5F_ACC_RDWR (dropping SWMR_WRITE) */
         if (H5Pset_elink_acc_flags(gapl, H5F_ACC_RDONLY) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Open a group through the external link using gapl */
         if ((group = H5Gopen2(file1, "/ext_link/group", gapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify that the correct parameters have been set on file2 */
         if ((file2 = H5Iget_file_id(group)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Fget_intent(file2, &flags) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (flags != H5F_ACC_RDONLY)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close file2 and group */
         if (H5Gclose(group) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Fclose(file2) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file1 */
         if (H5Fclose(file1) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Verify that H5Fcreate and H5Fopen reject H5F_ACC_DEFAULT */
@@ -9780,32 +9780,32 @@ external_set_elink_acc_flags(const char *env_h5_drvr, hid_t fapl, hbool_t new_fo
     }
     H5E_END_TRY;
     if (file1 != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         file1 = H5Fcreate(filename1, H5F_ACC_TRUNC | H5F_ACC_DEFAULT, H5P_DEFAULT, fapl);
     }
     H5E_END_TRY;
     if (file1 != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         file1 = H5Fopen(filename1, H5F_ACC_DEFAULT, fapl);
     }
     H5E_END_TRY;
     if (file1 != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         file1 = H5Fopen(filename1, H5F_ACC_RDWR | H5F_ACC_DEFAULT, fapl);
     }
     H5E_END_TRY;
     if (file1 != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close gapl */
     if (H5Pclose(gapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -9885,9 +9885,9 @@ external_set_elink_cb(hid_t fapl, hbool_t new_format)
     unsigned             flags;
 
     if (new_format)
-        TESTING("H5Pset/get_elink_cb() (w/new group format)")
+        TESTING("H5Pset/get_elink_cb() (w/new group format)");
     else
-        TESTING("H5Pset/get_elink_cb()")
+        TESTING("H5Pset/get_elink_cb()");
 
     /* Build user data for callback */
     op_data.parent_file = filename1;
@@ -9906,74 +9906,74 @@ external_set_elink_cb(hid_t fapl, hbool_t new_format)
 
     /* Create family fapl */
     if ((fam_fapl = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_fapl_family(fam_fapl, op_data.fam_size, op_data.base_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create parent and target files, group, and external link */
     h5_fixname(FILENAME[42], fapl, filename1, sizeof filename1);
     h5_fixname(FILENAME[43], fam_fapl, filename2, sizeof filename2);
     if ((file1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((file2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fam_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((group = H5Gcreate2(file1, "group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename2, "/", group, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close files and group */
     if (H5Fclose(file1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(group) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create new gapl, and set elink callback */
     if ((gapl = H5Pcreate(H5P_GROUP_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_elink_cb(gapl, external_set_elink_cb_cb, &op_data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify "get" routine functionality */
     if (H5Pget_elink_cb(gapl, &cb, (void **)&op_data_p) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (cb != external_set_elink_cb_cb)
-        TEST_ERROR
+        TEST_ERROR;
     if (op_data_p != &op_data)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open file1 with read only access */
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group through the external link using gapl */
     if ((group = H5Gcreate2(file1, "/group1/ext_link/group2", H5P_DEFAULT, H5P_DEFAULT, gapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the correct parameters have been set on file2 (somewhat
      * redundant as the library would be unable to create the group otherwise)
      */
     if ((file2 = H5Iget_file_id(group)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fget_intent(file2, &flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!(flags & H5F_ACC_RDWR))
-        TEST_ERROR
+        TEST_ERROR;
     if ((ret_fapl = H5Fget_access_plist(file2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5FD_FAMILY != H5Pget_driver(ret_fapl))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(group) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(ret_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(fam_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Modify the user data structure to cause the callback to fail next time */
     op_data.code = 1;
@@ -9985,7 +9985,7 @@ external_set_elink_cb(hid_t fapl, hbool_t new_format)
     }
     H5E_END_TRY;
     if (group != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Modify the user data structure to cause the callback to return invalid flags */
     op_data.code = 2;
@@ -9997,13 +9997,13 @@ external_set_elink_cb(hid_t fapl, hbool_t new_format)
     }
     H5E_END_TRY;
     if (group != FAIL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Fclose(file1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(gapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -10038,39 +10038,39 @@ external_reset_register(void)
     hid_t file;
     char  filename[NAME_BUF_SIZE];
 
-    TESTING("external links are registered after reset")
+    TESTING("external links are registered after reset");
 
     /* Create and close file */
     h5_fixname(FILENAME[44], H5P_DEFAULT, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reset the library */
     H5close();
 
     /* Re open file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an external link */
     if (H5Lcreate_external("some_file", "some_obj", file, "ext_link1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try again to make sure the previous H5Lcreate_external call does not
      * affect the ability to reset */
     H5close();
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external("another_file", "another_obj", file, "ext_link2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -10114,15 +10114,15 @@ external_link_win1(hid_t fapl, hbool_t new_format)
         cwdpath[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external links via main file's current drive/rel path(windows)(w/new group format)")
+        TESTING("external links via main file's current drive/rel path(windows)(w/new group format)");
     else
-        TESTING("external links via main file's current drive/rel path(windows)")
+        TESTING("external links via main file's current drive/rel path(windows)");
 
     /* set up name for main file: "extlinks0" */
     h5_fixname(FILENAME[12], fapl, filename1, sizeof filename1);
 
     if (NULL == HDgetcwd(cwdpath, (size_t)NAME_BUF_SIZE))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set up name for target link: "/CWD/tmp_links/extlinks10" */
     HDstrcpy(tmpname, &cwdpath[2]); /* stripped the drive letter to make it rel drive but absolute path */
@@ -10135,23 +10135,23 @@ external_link_win1(hid_t fapl, hbool_t new_format)
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -10169,9 +10169,9 @@ external_link_win1(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -10208,9 +10208,9 @@ external_link_win2(hid_t fapl, hbool_t new_format)
         cwdpath[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external links via target's rel drive/abs path directly(windows)(w/new group format)")
+        TESTING("external links via target's rel drive/abs path directly(windows)(w/new group format)");
     else
-        TESTING("external links via target's rel drive/abs path directly(windows)")
+        TESTING("external links via target's rel drive/abs path directly(windows)");
 
     /* set up name for main file: "extlinks0" */
     h5_fixname(FILENAME[12], fapl, filename1, sizeof filename1);
@@ -10218,7 +10218,7 @@ external_link_win2(hid_t fapl, hbool_t new_format)
     /* create tmp_links directory and get current working directory path */
     if ((HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST) ||
         (NULL == HDgetcwd(cwdpath, (size_t)NAME_BUF_SIZE)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set up name for target link: "/CWD/tmp_links/extlinks11" */
     HDstrcpy(tmpname,
@@ -10232,23 +10232,23 @@ external_link_win2(hid_t fapl, hbool_t new_format)
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -10266,9 +10266,9 @@ external_link_win2(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -10305,16 +10305,16 @@ external_link_win3(hid_t fapl, hbool_t new_format)
     char filename1[NAME_BUF_SIZE], filename2[NAME_BUF_SIZE], filename3[NAME_BUF_SIZE], tmpname[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external links via target's abs drive/rel path directly (windows)(w/new group format)")
+        TESTING("external links via target's abs drive/rel path directly (windows)(w/new group format)");
     else
-        TESTING("external links via target's abs drive/rel path directly (windows)")
+        TESTING("external links via target's abs drive/rel path directly (windows)");
 
     /* set up name for main file: "extlinks0" */
     h5_fixname(FILENAME[12], fapl, filename1, sizeof filename1);
 
     /* create tmp_links directory */
     if (HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set up name for target link: "<drive-letter>:tmp_links/extlinks12" */
     drive = HDgetdrive();
@@ -10326,23 +10326,23 @@ external_link_win3(hid_t fapl, hbool_t new_format)
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -10360,9 +10360,9 @@ external_link_win3(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -10399,9 +10399,9 @@ external_link_win4(hid_t fapl, hbool_t new_format)
     char filename1[NAME_BUF_SIZE], filename2[NAME_BUF_SIZE], filename3[NAME_BUF_SIZE], tmpname[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external links via main file's abs drive/rel path (windows)(w/new group format)")
+        TESTING("external links via main file's abs drive/rel path (windows)(w/new group format)");
     else
-        TESTING("external links via main file's abs drive/rel path (windows)")
+        TESTING("external links via main file's abs drive/rel path (windows)");
 
     /* set up name for main file: "<drive-letter>:tmp_links/extlinks0" */
     drive = HDgetdrive();
@@ -10417,23 +10417,23 @@ external_link_win4(hid_t fapl, hbool_t new_format)
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -10451,9 +10451,9 @@ external_link_win4(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -10491,12 +10491,12 @@ external_link_win5(hid_t fapl, hbool_t new_format)
         cwdpath[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external links via main file's rel drive/abs path (windows)(w/new group format)")
+        TESTING("external links via main file's rel drive/abs path (windows)(w/new group format)");
     else
-        TESTING("external links via main file's rel drive/abs path (windows)")
+        TESTING("external links via main file's rel drive/abs path (windows)");
 
     if (NULL == HDgetcwd(cwdpath, (size_t)NAME_BUF_SIZE))
-        TEST_ERROR
+        TEST_ERROR;
     drive = HDgetdrive();
     if (drive >= 26)
         drive -= 1; /* account for drive Z */
@@ -10518,23 +10518,23 @@ external_link_win5(hid_t fapl, hbool_t new_format)
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -10552,9 +10552,9 @@ external_link_win5(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -10591,13 +10591,13 @@ external_link_win6(hid_t fapl, hbool_t new_format)
     char filename1[NAME_BUF_SIZE], filename2[NAME_BUF_SIZE], filename3[NAME_BUF_SIZE], tmpname[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external links via target's current drive/rel path (windows)(w/new group format)")
+        TESTING("external links via target's current drive/rel path (windows)(w/new group format)");
     else
-        TESTING("external links via target's current drive/rel path (windows)")
+        TESTING("external links via target's current drive/rel path (windows)");
 
     /* create tmp_links directory */
     if (HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST)
-        TEST_ERROR
+        TEST_ERROR;
     drive = HDgetdrive();
     if (drive >= 26)
         drive -= 1; /* account for drive Z */
@@ -10616,23 +10616,23 @@ external_link_win6(hid_t fapl, hbool_t new_format)
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -10650,9 +10650,9 @@ external_link_win6(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -10692,13 +10692,13 @@ external_link_win7(hid_t fapl, hbool_t new_format)
         TESTING(
             "external links via main file's UNC local host/main drive/rel path(windows)(w/new group format)")
     else
-        TESTING("external links via main file's UNC local host/main drive/rel path(windows)")
+        TESTING("external links via main file's UNC local host/main drive/rel path(windows)");
 
     /* set up name for main file: "extlinks0" */
     h5_fixname(FILENAME[12], fapl, filename1, sizeof filename1);
 
     if (NULL == HDgetcwd(cwdpath, (size_t)NAME_BUF_SIZE))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set up name for target link: "\\127.0.0.1\c$/tmp_links/extlinks10" */
     HDstrcpy(tmpname, "\\\\127.0.0.1\\c$"); /* absolute path */
@@ -10711,23 +10711,23 @@ external_link_win7(hid_t fapl, hbool_t new_format)
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -10745,9 +10745,9 @@ external_link_win7(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -10789,17 +10789,17 @@ external_link_win8(hid_t fapl, hbool_t new_format)
         TESTING(
             "external links via target's Long UNC abs drive/abs path directly (windows)(w/new group format)")
     else
-        TESTING("external links via target's Long UNC abs drive/abs path directly (windows)")
+        TESTING("external links via target's Long UNC abs drive/abs path directly (windows)");
 
     /* set up name for main file: "extlinks0" */
     h5_fixname(FILENAME[12], fapl, filename1, sizeof filename1);
 
     if (NULL == HDgetcwd(cwdpath, (size_t)NAME_BUF_SIZE))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create tmp_links directory */
     if (HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set up name for target link: "<drive-letter>:\CWD\extlinks10" */
     drive = HDgetdrive();
@@ -10811,23 +10811,23 @@ external_link_win8(hid_t fapl, hbool_t new_format)
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -10845,9 +10845,9 @@ external_link_win8(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -10885,15 +10885,15 @@ external_link_win9(hid_t fapl, hbool_t new_format)
 
     if (new_format)
         TESTING("external links via main file's Long UNC local host/main drive/rel path(windows)(w/new group "
-                "format)")
+                "format)");
     else
-        TESTING("external links via main file's Long UNC local host/main drive/rel path(windows)")
+        TESTING("external links via main file's Long UNC local host/main drive/rel path(windows)");
 
     /* set up name for main file: "extlinks0" */
     h5_fixname(FILENAME[12], fapl, filename1, sizeof filename1);
 
     if (NULL == HDgetcwd(cwdpath, (size_t)NAME_BUF_SIZE))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set up name for target link: "\\?\UNC\127.0.0.1\c$/tmp_links/extlinks10" */
     HDstrcpy(tmpname, "\\\\?\\UNC\127.0.0.1\\c$"); /* absolute path */
@@ -10906,23 +10906,23 @@ external_link_win9(hid_t fapl, hbool_t new_format)
 
     /* Create the target file */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -10940,9 +10940,9 @@ external_link_win9(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -10976,28 +10976,28 @@ external_link_recursive(hid_t fapl, hbool_t new_format)
     char  filename1[NAME_BUF_SIZE]; /* Names of files to externally link across */
 
     if (new_format)
-        TESTING("recursive external links (w/new group format)")
+        TESTING("recursive external links (w/new group format)");
     else
-        TESTING("recursive external links")
+        TESTING("recursive external links");
 
     /* Set up filenames */
     h5_fixname(FILENAME[3], fapl, filename1, sizeof filename1);
 
     /* Create first file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create recursive external links */
     if (H5Lcreate_external(filename1, "/recursive", fid, "recursive", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open file */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through dangling file external link */
     H5E_BEGIN_TRY
@@ -11013,7 +11013,7 @@ external_link_recursive(hid_t fapl, hbool_t new_format)
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -11051,9 +11051,9 @@ external_link_query(hid_t fapl, hbool_t new_format)
         query_buf[NAME_BUF_SIZE];                            /* Buffer to hold query result */
 
     if (new_format)
-        TESTING("query aspects of external link (w/new group format)")
+        TESTING("query aspects of external link (w/new group format)");
     else
-        TESTING("query aspects of external link")
+        TESTING("query aspects of external link");
 
     /* Set up filenames */
     h5_fixname(FILENAME[3], fapl, filename1, sizeof filename1);
@@ -11061,18 +11061,18 @@ external_link_query(hid_t fapl, hbool_t new_format)
 
     /* Create first file, with external link to object in second file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link */
     /* (add a few extra '/'s to make certain library normalizes external link object names) */
     if (H5Lcreate_external(filename2, "///dst//", fid, "src", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get size of buffer for external link */
     if (H5Lget_info2(fid, "src", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.u.val_size != (1 + (HDstrlen(filename2) + 1) + (HDstrlen("/dst") + 1)))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5L_TYPE_EXTERNAL != li.type) {
         H5_FAILED();
         HDputs("    Unexpected link class - should have been an external link");
@@ -11081,31 +11081,31 @@ external_link_query(hid_t fapl, hbool_t new_format)
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create second file to point to */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object to link to */
     if ((gid = H5Gcreate2(fid, "dst", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open first file */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get size of buffer for external link */
     if (H5Lget_info2(fid, "src", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.u.val_size != (1 + (HDstrlen(filename2) + 1) + (HDstrlen("/dst") + 1)))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5L_TYPE_EXTERNAL != li.type) {
         H5_FAILED();
         HDputs("    Unexpected link class - should have been an external link");
@@ -11114,21 +11114,21 @@ external_link_query(hid_t fapl, hbool_t new_format)
 
     /* Get information for external link.  It should be two strings right after each other */
     if (H5Lget_val(fid, "src", query_buf, (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Extract the file and object names from the buffer */
     if (H5Lunpack_elink_val(query_buf, li.u.val_size, NULL, &file_name, &object_name) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compare the file and object names */
     if (HDstrcmp(file_name, filename2) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(object_name, "/dst") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query information about object that external link points to */
     if (H5Oget_info_by_name3(fid, "src", &oi, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5O_TYPE_GROUP != oi.type) {
         H5_FAILED();
         HDputs("    Unexpected object type - should have been a group");
@@ -11137,35 +11137,35 @@ external_link_query(hid_t fapl, hbool_t new_format)
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make sure that passing in NULLs to H5Lunpack_elink_val works */
     if (H5Lunpack_elink_val(query_buf, li.u.val_size, NULL, NULL, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make sure that bogus cases trigger errors in H5Lunpack_elink_val */
     H5E_BEGIN_TRY
     {
         if (H5Lunpack_elink_val(query_buf, li.u.val_size - 1, NULL, NULL, NULL) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
     H5E_BEGIN_TRY
     {
         if (H5Lunpack_elink_val(query_buf, (size_t)0, NULL, NULL, NULL) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
     H5E_BEGIN_TRY
     {
         if (H5Lunpack_elink_val(NULL, (size_t)0, NULL, NULL, NULL) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
     H5E_BEGIN_TRY
     {
         if (H5Lunpack_elink_val(NULL, (size_t)1000, NULL, NULL, NULL) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
 
@@ -11199,9 +11199,9 @@ external_link_unlink_compact(hid_t fapl, hbool_t new_format)
     char  filename1[NAME_BUF_SIZE], filename2[NAME_BUF_SIZE]; /* Names of files to externally link across */
 
     if (new_format)
-        TESTING("unlinking external link in compact group (w/new group format)")
+        TESTING("unlinking external link in compact group (w/new group format)");
     else
-        TESTING("unlinking external link in compact group")
+        TESTING("unlinking external link in compact group");
 
     /* Set up filenames */
     h5_fixname(FILENAME[3], fapl, filename1, sizeof filename1);
@@ -11209,57 +11209,57 @@ external_link_unlink_compact(hid_t fapl, hbool_t new_format)
 
     /* Create first file, with external link to object in second file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link */
     if (H5Lcreate_external(filename2, "/dst", fid, "src", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create second file to point to */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object to link to */
     if ((gid = H5Gcreate2(fid, "dst", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open first file */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Unlink external link */
     if (H5Ldelete(fid, "src", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open second file */
     if ((fid = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open group for external link */
     if ((gid = H5Gopen2(fid, "dst", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -11298,9 +11298,9 @@ external_link_unlink_dense(hid_t fapl, hbool_t new_format)
     unsigned u;           /* Local index variable */
 
     if (new_format)
-        TESTING("unlinking external link in dense group (w/new group format)")
+        TESTING("unlinking external link in dense group (w/new group format)");
     else
-        TESTING("unlinking external link in dense group")
+        TESTING("unlinking external link in dense group");
 
     /* Set up filenames */
     h5_fixname(FILENAME[3], fapl, filename1, sizeof filename1);
@@ -11308,135 +11308,135 @@ external_link_unlink_dense(hid_t fapl, hbool_t new_format)
 
     /* Create first file, with external link to object in second file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open root group */
     if ((gid = H5Gopen2(fid, "/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check on root group's status */
     if (H5G__is_empty_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties */
     if ((gcpl = H5Gget_create_plist(gid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_link_phase_change(gcpl, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link */
     /* (This also covers the case of having an external link in a compact group that's converted to a dense
      * group) */
     if (H5Lcreate_external(filename2, "/dst", gid, "src", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on root group's status */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, &nmsgs) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (nmsgs != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create enough objects in the root group to change it into a "dense" group */
     for (u = 0; u < max_compact; u++) {
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(gid2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check on root group's status */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group creation property list */
     if (H5Pclose(gcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close root group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create second file to point to */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object to link to */
     if ((gid = H5Gcreate2(fid, "dst", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open first file */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open root group */
     if ((gid = H5Gopen2(fid, "/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Unlink external link */
     if (H5Ldelete(fid, "src", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove enough objects in the root group to change it into a "compact" group */
     for (u = 0; u < ((max_compact - min_dense) + 1); u++) {
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check on root group's status */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, &nmsgs) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (nmsgs != (min_dense - 1))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close root group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open second file */
     if ((fid = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open group for external link (should be unaffected) */
     if ((gid = H5Gopen2(fid, "dst", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -11470,9 +11470,9 @@ external_link_move(hid_t fapl, hbool_t new_format)
     char  filename1[NAME_BUF_SIZE], filename2[NAME_BUF_SIZE]; /* Names of files to externally link across */
 
     if (new_format)
-        TESTING("move external link (w/new group format)")
+        TESTING("move external link (w/new group format)");
     else
-        TESTING("move external link")
+        TESTING("move external link");
 
     /* Set up filenames */
     h5_fixname(FILENAME[3], fapl, filename1, sizeof filename1);
@@ -11480,197 +11480,197 @@ external_link_move(hid_t fapl, hbool_t new_format)
 
     /* Create first file, with external link to object in second file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link */
     if (H5Lcreate_external(filename2, "/dst", fid, "src", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create second file to point to */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object to link to */
     if ((gid = H5Gcreate2(fid, "dst", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move external link to different name within same group */
     /* Open first file */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Move external link within same group */
     if (H5Lmove(fid, "src", H5L_SAME_LOC, "src2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open object through external link */
     if ((gid = H5Gopen2(fid, "src2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(objname, "/dst") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in external file */
     if ((gid2 = H5Gcreate2(gid, "new_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close group in external file */
     if (H5Gclose(gid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close external object */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open second file */
     if ((fid = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open group created through external link */
     if ((gid = H5Gopen2(fid, "dst/new_group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Move external link to different group */
 
     /* Open first file */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create another group, to move the external link into */
     if ((gid = H5Gcreate2(fid, "group2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Move external link to different group */
     if (H5Lmove(fid, "src2", gid, "src3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close new group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open object through external link */
     if ((gid = H5Gopen2(fid, "/group2/src3", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(objname, "/dst") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in external file */
     if ((gid2 = H5Gcreate2(gid, "new_group2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close group in external file */
     if (H5Gclose(gid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close external object */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open second file */
     if ((fid = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open group created through external link */
     if ((gid = H5Gopen2(fid, "dst/new_group2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Move external link back to original group */
     /* Open first file */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open object through external link */
     if ((gid = H5Gopen2(fid, "/group2/src3", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(objname, "/dst") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move external link back to original location */
     if (H5Lmove(fid, "/group2/src3", H5L_SAME_LOC, "/src", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(objname, "/dst") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in external file */
     if ((gid2 = H5Gcreate2(gid, "new_group3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close group in external file */
     if (H5Gclose(gid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close external object */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open second file */
     if ((fid = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open group created through external link */
     if ((gid = H5Gopen2(fid, "dst/new_group3", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -11710,9 +11710,9 @@ external_link_ride(hid_t fapl, hbool_t new_format)
     unsigned u;           /* Local index variable */
 
     if (new_format)
-        TESTING("external link along for the ride (w/new group format)")
+        TESTING("external link along for the ride (w/new group format)");
     else
-        TESTING("external link along for the ride")
+        TESTING("external link along for the ride");
 
     /* Set up filenames */
     h5_fixname(FILENAME[3], fapl, filename1, sizeof filename1);
@@ -11720,188 +11720,188 @@ external_link_ride(hid_t fapl, hbool_t new_format)
 
     /* Create first file, with external link to object in second file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open root group */
     if ((gid = H5Gopen2(fid, "/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check on root group's status */
     if (H5G__is_empty_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties */
     if ((gcpl = H5Gget_create_plist(gid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_link_phase_change(gcpl, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create enough objects in the root group to change it into a "dense" group */
     for (u = 0; u < (max_compact + 1); u++) {
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(gid2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check on root group's status */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (new_format) {
         if (H5G__is_new_dense_test(gid) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else {
         if (H5G__has_stab_test(gid) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end else */
 
     /* Create external link */
     /* (This also covers the case of adding an external link to a dense group) */
     if (H5Lcreate_external(filename2, "/dst", gid, "src", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on root group's status */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group creation property list */
     if (H5Pclose(gcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close root group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create second file to point to */
     if ((fid = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object to link to */
     if ((gid = H5Gcreate2(fid, "dst", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Remove enough objects to convert group containing external link back into compact form */
 
     /* Open first file */
     if ((fid = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     if ((gid = H5Gopen2(fid, "src", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/dst") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in external file */
     if ((gid2 = H5Gcreate2(gid, "new_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in external file */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close external object */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open root group */
     if ((gid = H5Gopen2(fid, "/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove enough objects in the root group to change it into a "compact" group */
     for (u = 0; u < ((max_compact - min_dense) + 3); u++) {
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check on root group's status */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, &nmsgs) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (nmsgs != (min_dense - 1))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close root group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open object through external link */
     if ((gid = H5Gopen2(fid, "src", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/dst") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in external file */
     if ((gid2 = H5Gcreate2(gid, "new_group2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close group in external file */
     if (H5Gclose(gid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close external object */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open second file */
     if ((fid = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open group created through external link */
     if ((gid = H5Gopen2(fid, "dst/new_group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open group created through external link */
     if ((gid = H5Gopen2(fid, "dst/new_group2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -11943,9 +11943,9 @@ external_link_closing(hid_t fapl, hbool_t new_format)
     hobj_ref_t  obj_ref;
 
     if (new_format)
-        TESTING("that external files are closed during traversal (w/new group format)")
+        TESTING("that external files are closed during traversal (w/new group format)");
     else
-        TESTING("that external files are closed during traversal")
+        TESTING("that external files are closed during traversal");
 
     /* In this test, external links will go from file1 to file2 and from
      * file2 to file3.
@@ -11963,204 +11963,204 @@ external_link_closing(hid_t fapl, hbool_t new_format)
 
     /* Create four files */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid3 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid4 = H5Fcreate(filename4, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a dataspace and a datatype so we can create/commit a dataset/datatype in the files */
     dims[0] = 2;
     dims[1] = 2;
     if ((sid = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid2 = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external links from each file to the next */
     if (H5Lcreate_external(filename2, "/", fid1, "elink", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename3, "/", fid2, "elink", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename4, "/", fid3, "elink", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close all files but the first */
     if (H5Fclose(fid4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test creating each kind of object */
     if ((gid = H5Gcreate2(fid1, "elink/elink/elink/group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(fid1, "elink/elink/elink/type1", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did = H5Dcreate2(fid1, "elink/elink/elink/dataset1", tid2, sid, H5P_DEFAULT, dcpl_g, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close objects */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test that getting info works */
     if (H5Lget_info2(fid1, "elink/elink/elink/type1", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(fid1, "elink/elink/elink", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name3(fid1, "elink/elink/elink/type1", &oi, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name3(fid1, "elink/elink/elink", &oi, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test move */
     if (H5Lmove(fid1, "elink/elink/elink/group1", fid1, "elink/elink/elink/group1_moved", H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open file 4 so we can do some fancy things */
     if ((fid4 = H5Fopen(filename4, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lmove(fid1, "elink/elink/elink/type1", fid4, "type1_moved", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lmove(fid4, "dataset1", fid1, "elink/elink/elink/dataset1_moved", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file 4 again */
     if (H5Fclose(fid4) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test copy (as of this test, it uses the same code as move) */
     if (H5Lcopy(fid1, "elink/elink/elink", fid1, "elink/elink/elink_copied", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcopy(fid1, "elink/elink/elink", fid1, "elink/elink/elink/elink_copied2", H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test H5Gset and get comment */
     if (H5Oset_comment_by_name(fid1, "elink/elink/elink/group1_moved", "comment", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_comment_by_name(fid1, "elink/elink/elink/group1_moved", buf, sizeof(buf), H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(buf, "comment") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5*open */
     if ((gid = H5Gopen2(fid1, "elink/elink/elink/group1_moved", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((tid = H5Topen2(fid1, "elink/elink/elink/type1_moved", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did = H5Dopen2(fid1, "elink/elink/elink/dataset1_moved", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Close objects */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test H5*open2 */
     if ((gid = H5Gopen2(fid1, "elink/elink/elink/group1_moved", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((tid = H5Topen2(fid1, "elink/elink/elink/type1_moved", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did = H5Dopen2(fid1, "elink/elink/elink/dataset1_moved", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Close objects */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test H5Oopen */
     if ((did = H5Oopen(fid1, "elink/elink/elink/dataset1_moved", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5Fmount */
     if ((gid = H5Gcreate2(fid1, "elink/elink/elink/mnt", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         if (H5Fmount(fid1, "elink/elink/elink/mnt", fid1, H5P_DEFAULT) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Funmount(fid1, "elink/elink/elink/mnt") >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
 
     /* Test H5Rcreate */
     if (H5Rcreate(&obj_ref, fid1, "elink/elink/elink/type1_moved", H5R_OBJECT, (hid_t)(-1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test unlink */
     if (H5Ldelete(fid1, "elink/elink/elink/group1_moved", H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ldelete(fid1, "elink/elink/elink/type1_moved", H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ldelete(fid1, "elink/elink/elink/dataset1_moved", H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ldelete(fid1, "elink/elink/elink_copied", H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ldelete(fid1, "elink/elink/elink/elink_copied2", H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* We've tested that the various functions above don't leave files open.
      * Now test that we can't confuse HDF5 by giving unusual paths with external links
      */
     /* Create an external link that points to another external link */
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename3, "/elink", fid2, "elink2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Do an external link traversal that recursively calls another external link. */
     if ((gid = H5Gcreate2(fid1, "elink/elink2/group2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create two more groups so that the last three elements in the path are
      * all within the same external file
      */
     if ((gid = H5Gcreate2(fid1, "elink/elink2/group2/group3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid1, "elink/elink2/group2/group3/group4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info_by_name3(fid1, "elink/elink2/group2/group3/group4", &oi, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add a few regular groups and a soft link in file2 using intermediate group creation */
     if ((lcpl_id = H5Pcreate(H5P_LINK_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_create_intermediate_group(lcpl_id, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("/elink2", fid1, "elink/file2group1/file2group2/slink", lcpl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try to traverse this path.  There are three soft traversals in a row;
      * slink points to (file2)/elink2, which points to (file3)/elink, which
@@ -12168,49 +12168,49 @@ external_link_closing(hid_t fapl, hbool_t new_format)
      */
     if ((gid = H5Gcreate2(fid1, "elink/file2group1/file2group2/slink/group3", H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(fid1, "elink/file2group1/file2group2/slink/group3", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Some simpler tests */
     if ((gid = H5Gcreate2(fid1, "elink/file2group3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(fid1, "elink/file2group3", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(fid1, "elink/elink", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file1, the only file that should still be open */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-create each file. If they are hanging open, these creates will fail */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid3 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid4 = H5Fcreate(filename4, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Cleanup */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -12254,55 +12254,55 @@ external_link_endian(hbool_t new_format)
     const char *namebuf;
 
     if (new_format)
-        TESTING("endianness of external links (w/new group format)")
+        TESTING("endianness of external links (w/new group format)");
     else
-        TESTING("endianness of external links")
+        TESTING("endianness of external links");
 
     /* Create a link access property list with the path to the srcdir */
     if ((lapl_id = H5Pcreate(H5P_LINK_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_elink_prefix(lapl_id, pathbuf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     namebuf = H5_get_srcdir_filename(LE_FILENAME); /* Corrected test file name */
 
     /* Test LE file; try to open a group through the external link */
     if ((fid = H5Fopen(namebuf, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Oopen(fid, "ext_link", lapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open a group in the external file using that group ID */
     if ((gid2 = H5Gopen2(gid, "subgroup", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the IDs */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     namebuf = H5_get_srcdir_filename(BE_FILENAME); /* Corrected test file name */
 
     /* Test BE file; try to open a group through the external link */
     if ((fid = H5Fopen(namebuf, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Oopen(fid, "ext_link", lapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open a group in the external file using that group ID */
     if ((gid2 = H5Gopen2(gid, "subgroup", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the IDs */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -12339,9 +12339,9 @@ external_link_strong(hid_t fapl, hbool_t new_format)
     char  filename1[NAME_BUF_SIZE], filename2[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("that external files work with strong file close degree (w/new group format)")
+        TESTING("that external files work with strong file close degree (w/new group format)");
     else
-        TESTING("that external files work with strong file close degree")
+        TESTING("that external files work with strong file close degree");
 
     /* Set up filenames */
     h5_fixname(FILENAME[0], fapl, filename1, sizeof filename1);
@@ -12349,63 +12349,63 @@ external_link_strong(hid_t fapl, hbool_t new_format)
 
     /* Copy file access property list */
     if ((my_fapl = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set strong file close degree */
     if (H5Pset_fclose_degree(my_fapl, H5F_CLOSE_STRONG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group at /A/B/C in first file */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid1 = H5Gcreate2(fid1, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid1 = H5Gcreate2(fid1, "A/B", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid1 = H5Gcreate2(fid1, "A/B/C", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an external link /W/X/DLINK in second file to <filename1>:/A/B/C */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid2 = H5Gcreate2(fid2, "/W", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid2 = H5Gcreate2(fid2, "/W/X", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename1, "/A/B/C", gid2, "DLINK", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Access external link from file #1 */
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid2 = H5Gopen2(fid2, "/W/X/DLINK", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Iget_name(gid2, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/A/B/C") != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close fapl */
     if (H5Pclose(my_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -12462,9 +12462,9 @@ external_symlink(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
 #endif                             /* H5_HAVE_SYMLINK */
 
     if (new_format)
-        TESTING("external links w/symlink files (w/new group format)")
+        TESTING("external links w/symlink files (w/new group format)");
     else
-        TESTING("external links w/symlink files")
+        TESTING("external links w/symlink files");
 
 #ifdef H5_HAVE_SYMLINK
     /* Skip test when using VFDs that can't provide a POSIX compatible file
@@ -12506,11 +12506,11 @@ external_symlink(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
 
     /* create tmp_links directory and get current working directory path */
     if (HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDmkdir(TMPDIR2, (mode_t)0755) < 0 && errno != EEXIST)
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == HDgetcwd(cwdpath, (size_t)NAME_BUF_SIZE))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set up names for files in the subdirectories */
 
@@ -12522,7 +12522,7 @@ external_symlink(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
     /* Create symbolic link #1 in temporary directory #1 to file #2 in temporary directory #2 */
     /* (i.e. tmp_links/sym1.h5 -> <full path to>/tmp2_links/extlinks21B.h5) */
     if (HDsymlink(filename2b, SYMLINK1) < 0 && errno != EEXIST)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set up name for file #3 in temporary directory #2: "tmp2_links/extlinks21C" */
     h5_fixname(FILENAME[47], fapl, filename3a, NAME_BUF_SIZE);
@@ -12536,7 +12536,7 @@ external_symlink(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
     /* Create symbolic link #2 in temporary directory #2 to file #4 in temporary directory #1 */
     /* (i.e. tmp2_links/sym2.h5 -> <full path to>/tmp_links/extlinks21D.h5) */
     if (HDsymlink(filename4b, SYMLINK2) < 0 && errno != EEXIST)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set up name for file #5 in temporary directory #1: "tmp_links/extlinks21E" */
     h5_fixname(FILENAME[50], fapl, filename5a, NAME_BUF_SIZE);
@@ -12544,129 +12544,129 @@ external_symlink(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
 
     /* Create file #1 in current directory */
     if ((file1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to file & object in temporary directory #2, using symlink #1 name */
     if (H5Lcreate_external(SYMLINK1, "group2", file1, "extlink2-sym", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #1 */
     if (H5Fclose(file1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #2 in tmp_links directory #2 */
     if ((file2 = H5Fcreate(filename2a, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open file #2 in tmp_links directory through symlink */
     if ((file2 = H5Fopen(SYMLINK1, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group in file #2 in temporary directory */
     if ((group2 = H5Gcreate2(file2, "group2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to file #3 & object in temporary directory #2 */
     if (H5Lcreate_external(filename3b, "group3", group2, "extlink3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in file #2 */
     if (H5Gclose(group2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #2 */
     if (H5Fclose(file2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #3 in temp. directory #2 */
     if ((file3 = H5Fcreate(filename3a, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group in file #3 */
     if ((group3 = H5Gcreate2(file3, "group3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to file & object in temporary directory #1, using symlink #2 name */
     if (H5Lcreate_external(SYMLINK2, "group4", group3, "extlink4-sym", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in file #3 */
     if (H5Gclose(group3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #3 */
     if (H5Fclose(file3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #4 in temporary directory #1 */
     if ((file4 = H5Fcreate(filename4b, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group in file #4 in 'temporary' directory */
     if ((group4 = H5Gcreate2(file4, "group4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to file #5 & object in temporary directory #1 */
     if (H5Lcreate_external(filename5b, "group5", group4, "extlink5", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in file #4 */
     if (H5Gclose(group4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #4 */
     if (H5Fclose(file4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #5 in temporary directory #1 */
     if ((file5 = H5Fcreate(filename5a, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group in file #5 in 'temporary' directory #1 */
     if ((group5 = H5Gcreate2(file5, "group5", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(group5) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #5 */
     if (H5Fclose(file5) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Actual tests... */
 
     /* Reopen file #1 */
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group in file #2, through external link w/symlink */
     if ((group2 = H5Gopen2(file1, "extlink2-sym", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group in file #3, through external link w/symlink to external link */
     if ((group3 = H5Gopen2(file1, "extlink2-sym/extlink3", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group in file #4, through external link w/symlink to external link w/symlink */
     if ((group4 = H5Gopen2(file1, "extlink2-sym/extlink3/extlink4-sym", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group in file #5, through external link w/symlink to external link w/symlink to external link */
     if ((group5 = H5Gopen2(file1, "extlink2-sym/extlink3/extlink4-sym/extlink5", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group5) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #1 */
     if (H5Fclose(file1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDfree(filename1);
     HDfree(filename2a);
@@ -12742,50 +12742,50 @@ external_copy_invalid_object(hid_t fapl, hbool_t new_format)
     char  filename[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("copying invalid external links to the source file (w/new group format)")
+        TESTING("copying invalid external links to the source file (w/new group format)");
     else
-        TESTING("copying invalid external links to the source file")
+        TESTING("copying invalid external links to the source file");
 
     /* Set up filename */
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     /* Create object copy plist, set expand external flag */
     if ((ocpyplid = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_copy_object(ocpyplid, H5O_COPY_EXPAND_EXT_LINK_FLAG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file and group */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an external link in the group to the source file with an invalid
      * object name */
     if (H5Lcreate_external(filename, "no_object", fid, "/group1/link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Copy the group containing the external link */
     if (H5Ocopy(fid, "group1", fid, "group2", ocpyplid, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to truncate the file again.  If there is a lingering id for this
      * file this will fail */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(ocpyplid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -12822,26 +12822,26 @@ external_dont_fail_to_source(hid_t fapl, hbool_t new_format)
     char  filename[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("that invalid external links don't open the source file (w/new group format)")
+        TESTING("that invalid external links don't open the source file (w/new group format)");
     else
-        TESTING("that invalid external links don't open the source file")
+        TESTING("that invalid external links don't open the source file");
 
     /* Set up filename */
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     /* Create file and group */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an external link with an invalid file name, but the same object
      * name as the group.  This way, if the external link is interpreted to
      * refer to the source file, it will link to the group */
     if (H5Lcreate_external("no_file", "/group", fid, "link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to open the object the link points to.  This should fail */
     H5E_BEGIN_TRY
@@ -12850,11 +12850,11 @@ external_dont_fail_to_source(hid_t fapl, hbool_t new_format)
     }
     H5E_END_TRY
     if (oid >= 0)
-        FAIL_PUTS_ERROR("Succeeded in opening target of invalid external link")
+        FAIL_PUTS_ERROR("Succeeded in opening target of invalid external link");
 
     /* Close */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -12898,9 +12898,9 @@ external_file_cache(hid_t fapl, hbool_t new_format)
     char     filename4[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("external file cache with external links (w/new group format)")
+        TESTING("external file cache with external links (w/new group format)");
     else
-        TESTING("external file cache with external links")
+        TESTING("external file cache with external links");
 
     /* Set up filenames */
     h5_fixname(FILENAME[0], fapl, filename1, sizeof filename1);
@@ -12910,52 +12910,52 @@ external_file_cache(hid_t fapl, hbool_t new_format)
 
     /* Verify that the default EFC size is 0 */
     if (H5Pget_elink_file_cache_size(fapl, &efc_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (efc_size != 0)
-        FAIL_PUTS_ERROR("default external file cache size is not 0")
+        FAIL_PUTS_ERROR("default external file cache size is not 0");
 
     /* Copy FAPL and enable external file caching */
     if ((my_fapl = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_elink_file_cache_size(my_fapl, 8) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the external file cache size has been set */
     if (H5Pget_elink_file_cache_size(my_fapl, &efc_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (efc_size != 8)
-        FAIL_PUTS_ERROR("external file cache size different from expected")
+        FAIL_PUTS_ERROR("external file cache size different from expected");
 
     /* Test 1: One file caches another */
     /* Create files */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create link */
     if (H5Lcreate_external(filename2, "/", fid1, "link_to_2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file 2 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that only 1 file is open */
     H5F_sfile_assert_num(1);
 
     /* Open and close the target of the external link */
     if ((oid = H5Oopen(fid1, "link_to_2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oclose(oid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that both files are now open */
     H5F_sfile_assert_num(2);
 
     /* Close file 1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that both files are now closed */
     H5F_sfile_assert_num(0);
@@ -12963,40 +12963,40 @@ external_file_cache(hid_t fapl, hbool_t new_format)
     /* Test 2: One file caches another, release parent's EFC */
     /* Create files */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create link */
     if (H5Lcreate_external(filename2, "/", fid1, "link_to_2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file 2 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that only 1 file is open */
     H5F_sfile_assert_num(1);
 
     /* Open and close the target of the external link */
     if ((oid = H5Oopen(fid1, "link_to_2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oclose(oid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that both files are now open */
     H5F_sfile_assert_num(2);
 
     /* Release file 1's EFC */
     if (H5Fclear_elink_file_cache(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that only the parent file is now open */
     H5F_sfile_assert_num(1);
 
     /* Close file 1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that both files are now closed */
     H5F_sfile_assert_num(0);
@@ -13004,54 +13004,54 @@ external_file_cache(hid_t fapl, hbool_t new_format)
     /* Test 3: "Y" shaped tree */
     /* Create files */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid3 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid4 = H5Fcreate(filename4, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create links */
     if (H5Lcreate_external(filename2, "/", fid1, "link_to_2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename3, "/", fid2, "link_to_3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename4, "/", fid2, "link_to_4", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close files 2-4 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that only 1 file is open */
     H5F_sfile_assert_num(1);
 
     /* Open and close one branch of the tree */
     if ((oid = H5Oopen(fid1, "link_to_2/link_to_3", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oclose(oid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that files 2 and 3 are now open */
     H5F_sfile_assert_num(3);
 
     /* Open and close the other branch of the tree */
     if ((oid = H5Oopen(fid1, "link_to_2/link_to_4", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oclose(oid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that all files are now open */
     H5F_sfile_assert_num(4);
 
     /* Close file 1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that all files are now closed */
     H5F_sfile_assert_num(0);
@@ -13059,61 +13059,61 @@ external_file_cache(hid_t fapl, hbool_t new_format)
     /* Test 4: "Y" shaped tree, release parent's EFC */
     /* Create files */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid3 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid4 = H5Fcreate(filename4, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create links */
     if (H5Lcreate_external(filename2, "/", fid1, "link_to_2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename3, "/", fid2, "link_to_3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename4, "/", fid2, "link_to_4", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close files 2-4 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that only 1 file is open */
     H5F_sfile_assert_num(1);
 
     /* Open and close one branch of the tree */
     if ((oid = H5Oopen(fid1, "link_to_2/link_to_3", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oclose(oid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that files 2 and 3 are now open */
     H5F_sfile_assert_num(3);
 
     /* Open and close the other branch of the tree */
     if ((oid = H5Oopen(fid1, "link_to_2/link_to_4", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oclose(oid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that all files are now open */
     H5F_sfile_assert_num(4);
 
     /* Release file 1's EFC */
     if (H5Fclear_elink_file_cache(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that only file 1 is now open */
     H5F_sfile_assert_num(1);
 
     /* Close file 1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that all files are now closed */
     H5F_sfile_assert_num(0);
@@ -13121,41 +13121,41 @@ external_file_cache(hid_t fapl, hbool_t new_format)
     /* Test 5: 3 file cycle */
     /* Create files */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid3 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create links */
     if (H5Lcreate_external(filename2, "/", fid1, "link_to_2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename3, "/", fid2, "link_to_3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename1, "/", fid3, "link_to_1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close files 2-3 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that only 1 file is open */
     H5F_sfile_assert_num(1);
 
     /* Open and close one complete cycle */
     if ((oid = H5Oopen(fid1, "link_to_2/link_to_3/link_to_1", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oclose(oid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that all files are now open */
     H5F_sfile_assert_num(3);
 
     /* Close file 1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that all files are now closed */
     H5F_sfile_assert_num(0);
@@ -13163,48 +13163,48 @@ external_file_cache(hid_t fapl, hbool_t new_format)
     /* Test 6: 3 file cycle, release parent's EFC */
     /* Create files */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid3 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create links */
     if (H5Lcreate_external(filename2, "/", fid1, "link_to_2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename3, "/", fid2, "link_to_3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external(filename1, "/", fid3, "link_to_1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close files 2-3 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that only 1 file is open */
     H5F_sfile_assert_num(1);
 
     /* Open and close one complete cycle */
     if ((oid = H5Oopen(fid1, "link_to_2/link_to_3/link_to_1", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oclose(oid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that all files are now open */
     H5F_sfile_assert_num(3);
 
     /* Release file 1's EFC */
     if (H5Fclear_elink_file_cache(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that only file 1 is now open */
     H5F_sfile_assert_num(1);
 
     /* Close file 1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that all files are now closed */
     H5F_sfile_assert_num(0);
@@ -13253,9 +13253,9 @@ external_open_twice(hid_t fapl, hbool_t new_format)
     char  filename2[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("opening object twice through elink (w/new group format)")
+        TESTING("opening object twice through elink (w/new group format)");
     else
-        TESTING("opening object twice through elink")
+        TESTING("opening object twice through elink");
 
     /* Set up filenames */
     h5_fixname(FILENAME[0], fapl, filename1, sizeof filename1);
@@ -13264,33 +13264,33 @@ external_open_twice(hid_t fapl, hbool_t new_format)
     /* Test 1: Open root group twice */
     /* Create files */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create link */
     if (H5Lcreate_external(filename2, "/", fid1, "link_to_2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file 2 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the target of the external link twice */
     if ((oid1 = H5Oopen(fid1, "link_to_2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((oid2 = H5Oopen(fid1, "link_to_2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close both objects, in the reverse opening order (necessary to duplicate bug */
     if (H5Oclose(oid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oclose(oid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file 1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that both files are now closed */
     H5F_sfile_assert_num(0);
@@ -13298,39 +13298,39 @@ external_open_twice(hid_t fapl, hbool_t new_format)
     /* Test 2: Open group twice */
     /* Create files */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create target group */
     if ((oid1 = H5Gcreate2(fid2, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(oid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create link */
     if (H5Lcreate_external(filename2, "/group", fid1, "link_to_2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file 2 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the target of the external link twice */
     if ((oid1 = H5Oopen(fid1, "link_to_2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((oid2 = H5Oopen(fid1, "link_to_2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close both objects, in the reverse opening order (necessary to duplicate bug */
     if (H5Oclose(oid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oclose(oid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file 1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that both files are now closed */
     H5F_sfile_assert_num(0);
@@ -13338,43 +13338,43 @@ external_open_twice(hid_t fapl, hbool_t new_format)
     /* Test 3: Open dataset twice */
     /* Create files */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create target dataset */
     if ((space = H5Screate(H5S_SCALAR)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((oid1 = H5Dcreate2(fid2, "dset", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl_g, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(oid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(space) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create link */
     if (H5Lcreate_external(filename2, "/dset", fid1, "link_to_2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file 2 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the target of the external link twice */
     if ((oid1 = H5Oopen(fid1, "link_to_2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((oid2 = H5Oopen(fid1, "link_to_2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close both objects, in the reverse opening order (necessary to duplicate bug */
     if (H5Oclose(oid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oclose(oid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file 1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that both files are now closed */
     H5F_sfile_assert_num(0);
@@ -13382,41 +13382,41 @@ external_open_twice(hid_t fapl, hbool_t new_format)
     /* Test 4: Open datatype twice */
     /* Create files */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create target datatype */
     if ((type = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(fid2, "dtype", type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(type) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create link */
     if (H5Lcreate_external(filename2, "/dtype", fid1, "link_to_2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file 2 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the target of the external link twice */
     if ((oid1 = H5Oopen(fid1, "link_to_2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((oid2 = H5Oopen(fid1, "link_to_2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close both objects, in the reverse opening order (necessary to duplicate bug */
     if (H5Oclose(oid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oclose(oid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file 1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that both files are now closed */
     H5F_sfile_assert_num(0);
@@ -13481,9 +13481,9 @@ external_link_with_committed_datatype(hid_t fapl, hbool_t new_format)
     hsize_t chunks[2] = {3, 7};       /* Chunk sizes */
 
     if (new_format)
-        TESTING("attach committed datatype to external group's attribute/dataset(w/new group format)")
+        TESTING("attach committed datatype to external group's attribute/dataset(w/new group format)");
     else
-        TESTING("attach committed datatype to external group's attribute/dataset")
+        TESTING("attach committed datatype to external group's attribute/dataset");
 
     /* Set up filenames */
     h5_fixname(FILENAME[0], fapl, filename1, sizeof filename1);
@@ -13491,74 +13491,74 @@ external_link_with_committed_datatype(hid_t fapl, hbool_t new_format)
 
     /* Main file */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create external link from main file to target file */
     if (H5Lcreate_external(filename2, "target_group", fid1, "link_to_2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create target file */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Create group in target file */
     if ((gid2 = H5Gcreate2(fid2, "target_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the group */
     if (H5Gclose(gid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Close the file */
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the group which is externally linked to target file */
     if ((gid1 = H5Gopen2(fid1, "link_to_2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a copy of integer datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Commit the datatype to the main file root group */
     if (H5Tcommit2(fid1, "myDatatype", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create dataspace */
     if ((sid = H5Screate(H5S_SCALAR)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Attach an attribute with the committed datatype to the group */
     if ((aid = H5Acreate2(gid1, "myAttribute", tid, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write data to the attribute */
     if (H5Awrite(aid, tid, &wdata) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the attribute's datatype */
     if ((atid = H5Aget_type(aid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the datatype is not committed */
     if (H5Tcommitted(atid) == TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the attribute */
     if (H5Aclose(aid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a chunked dataset */
     if ((sid2 = H5Screate_simple(2, dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (dcpl_g == H5P_DEFAULT)
         dcpl = H5Pcreate(H5P_DATASET_CREATE);
     else
         dcpl = H5Pcopy(dcpl_g);
     if (0 > dcpl)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl, 2, chunks) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize data buffers */
     for (i = 0; i < 60; i++) {
@@ -13568,125 +13568,125 @@ external_link_with_committed_datatype(hid_t fapl, hbool_t new_format)
 
     /* Create a dataset with the committed datatype in the group */
     if ((did = H5Dcreate2(gid1, "myDataset", tid, sid2, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write to the dataset */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, wbuf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the dataset's datatype */
     if ((dtid = H5Dget_type(did)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the datatype is not committed */
     if (H5Tcommitted(dtid) == TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataset creation property list */
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataspaces */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(sid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the datatypes */
     if (H5Tclose(tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(atid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(dtid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the group */
     if (H5Gclose(gid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the mainfile */
     if ((fid1 = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the committed datatype in the mainfile */
     if ((tid = H5Topen2(fid1, "myDatatype", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the datatype is committed */
     if (H5Tcommitted(tid) == FALSE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the group which is externally linked to target file */
     if ((gid1 = H5Gopen2(fid1, "link_to_2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the attribute attached to the group */
     if ((aid = H5Aopen(gid1, "myAttribute", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the attribute's datatype */
     if ((atid = H5Aget_type(aid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the attribute's datatype is not committed */
     if (H5Tcommitted(atid) == TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the attribute */
     if (H5Aclose(aid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete the attribute */
     if (H5Adelete(gid1, "myAttribute") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset in the group */
     if ((did = H5Dopen2(gid1, "myDataset", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the dataset's datatype */
     if ((dtid = H5Dget_type(did)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify the dataset's datatype is not committed */
     if (H5Tcommitted(dtid) == TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read the dataset */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Compare the data read should be the same as wbuf */
     if (HDmemcmp(wbuf, rbuf, sizeof(wbuf)) != 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the group */
     if (H5Gclose(gid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the datatypes */
     if (H5Tclose(tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(atid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(dtid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -13903,102 +13903,102 @@ ud_hard_links(hid_t fapl)
     h5_stat_size_t empty_size;             /* Size of an empty file */
     char           filename[NAME_BUF_SIZE];
 
-    TESTING("user-defined hard link (w/new group format)")
+    TESTING("user-defined hard link (w/new group format)");
 
     /* Set up filename and create file*/
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the size of the empty file for reference */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that external links are registered and UD hard links are not */
     if (H5Lis_registered(H5L_TYPE_EXTERNAL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Register "user-defined hard links" with the library */
     if (H5Lregister(UD_hard_class) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that UD hard links are now registered */
     if (H5Lis_registered(H5L_TYPE_EXTERNAL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group for the UD hard link to point to */
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get address for the group to give to the hard link */
     if (H5Lget_info2(fid, "group", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a user-defined "hard link" to the group using the address we got
      * from H5Lget_info2 */
     if (H5Lcreate_ud(fid, "ud_link", (H5L_type_t)UD_HARD_TYPE, &(li.u.token), sizeof(H5O_token_t),
                      H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close and re-open file to ensure that data is written to disk */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group through UD link */
     if ((gid = H5Gopen2(fid, "ud_link", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/group") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in group */
     if ((gid2 = H5Gcreate2(gid, "new_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close groups*/
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open group without using ud link to check that it was created properly */
     if ((gid = H5Gopen2(fid, "group/new_group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/group/new_group") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close opened object */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that H5Lget_objinfo works on the hard link */
     if (H5Lget_info2(fid, "ud_link", &li, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* UD hard links have no query function, thus return a "link length" of 0 */
     if (li.u.val_size != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (UD_HARD_TYPE != li.type) {
         H5_FAILED();
         HDputs("    Unexpected link class - should have been a UD hard link");
@@ -14008,33 +14008,33 @@ ud_hard_links(hid_t fapl)
     /* Unlink the group pointed to by the UD link.  It shouldn't be
      * deleted because of the UD link. */
     if (H5Ldelete(fid, "/group", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ensure we can open the group through the UD link */
     if ((gid = H5Gopen2(fid, "ud_link", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Unlink the group contained within it. */
     if (H5Ldelete(gid, "new_group", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Now delete the UD link.  This should cause the group to be
      * deleted, too. */
     if (H5Ldelete(fid, "ud_link", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* The file should be empty again. */
     if (empty_size != h5_get_file_size(filename, fapl))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Lunregister((H5L_type_t)UD_HARD_TYPE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -14070,7 +14070,7 @@ UD_rereg_traverse(const char H5_ATTR_UNUSED *link_name, hid_t cur_group, const v
     hid_t ret_value;
 
     if ((ret_value = H5Oopen(cur_group, REREG_TARGET_NAME, lapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return ret_value;
 
@@ -14088,66 +14088,66 @@ ud_link_reregister(hid_t fapl)
     char           filename[NAME_BUF_SIZE];
     h5_stat_size_t empty_size; /* Size of an empty file */
 
-    TESTING("registering a new class for existing UD links (w/new group format)")
+    TESTING("registering a new class for existing UD links (w/new group format)");
 
     /* Set up filename and create file*/
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the size of the empty file for reference */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that UD hard links are not registered */
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Register "user-defined hard links" with the library */
     if (H5Lregister(UD_hard_class) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that UD hard links are registered */
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Point a UD defined hard link to a group in the same way as the previous test */
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(fid, "group", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Lcreate_ud(fid, "ud_link", (H5L_type_t)UD_HARD_TYPE, &(li.u.token), sizeof(H5O_token_t),
                      H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group named REREG_TARGET_NAME in the same group as the ud link */
     if ((gid = H5Gcreate2(fid, REREG_TARGET_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now unregister UD hard links */
     if (H5Lunregister((H5L_type_t)UD_HARD_TYPE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that UD hard links are no longer registered */
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we can't traverse the ud link anymore */
     H5E_BEGIN_TRY
     {
         if ((gid = H5Gopen2(fid, "ud_link", H5P_DEFAULT)) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
 
@@ -14156,97 +14156,97 @@ ud_link_reregister(hid_t fapl)
     {
         if (H5Lcreate_ud(fid, "ud_link2", (H5L_type_t)UD_HARD_TYPE, &(li.u.token), sizeof(H5O_token_t),
                          H5P_DEFAULT, H5P_DEFAULT) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
 
     /* Register a new kind of link with the same ID number */
     if (H5Lregister(UD_rereg_class) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that UD hard links are registered again */
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open a group through the ud link (now a different class of link).
      * It should be a different group
      * than the UD hard link pointed to */
     if ((gid = H5Gopen2(fid, "ud_link", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/" REREG_TARGET_NAME) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in group */
     if ((gid2 = H5Gcreate2(gid, "new_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close groups*/
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open group without using ud link to check that it was created properly */
     if ((gid = H5Gopen2(fid, "rereg_target/new_group", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/rereg_target/new_group") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close opened object */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Unlink the group pointed to by the UD hard link.  It shouldn't be
      * deleted because the UD link incremented its reference count. */
     if (H5Ldelete(fid, "/group", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* What a mess! Re-register user-defined links to clean up the
      * reference counts.  We shouldn't actually need to unregister the
      * other link type */
     if (H5Lregister(UD_hard_class) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != TRUE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Ensure we can open the group through the UD link (now that UD hard
      * links have been registered) */
     if ((gid = H5Gopen2(fid, "ud_link", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete the UD hard link.  This should cause the group to be
      * deleted, too. */
     if (H5Ldelete(fid, "ud_link", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Unlink the other two groups so that we can make sure the file is empty */
     if (H5Ldelete(fid, "/rereg_target/new_group", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, REREG_TARGET_NAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* The file should be empty again. */
     if (empty_size != h5_get_file_size(filename, fapl))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Lunregister((H5L_type_t)UD_HARD_TYPE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != FALSE)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -14278,20 +14278,20 @@ static herr_t
 UD_cb_create(const char *link_name, hid_t loc_group, const void *udata, size_t udata_size, hid_t lcpl_id)
 {
     if (!link_name)
-        TEST_ERROR
+        TEST_ERROR;
     if (loc_group < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (udata_size > 0 && !udata)
-        TEST_ERROR
+        TEST_ERROR;
     if (lcpl_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (HDstrcmp(link_name, UD_CB_LINK_NAME) != 0 && HDstrcmp(link_name, NEW_UD_CB_LINK_NAME) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp((const char *)udata, UD_CB_TARGET) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (udata_size != UD_CB_TARGET_LEN)
-        TEST_ERROR
+        TEST_ERROR;
 
     return SUCCEED;
 
@@ -14307,21 +14307,21 @@ UD_cb_traverse(const char *link_name, hid_t cur_group, const void *udata, size_t
     hid_t       ret_value;
 
     if (!link_name)
-        TEST_ERROR
+        TEST_ERROR;
     if (cur_group < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (udata_size > 0 && !udata)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (HDstrcmp(link_name, UD_CB_LINK_NAME) != 0 && HDstrcmp(link_name, NEW_UD_CB_LINK_NAME) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp((const char *)udata, UD_CB_TARGET) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (udata_size != UD_CB_TARGET_LEN)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((ret_value = H5Oopen(cur_group, target, lapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return ret_value;
 
@@ -14334,18 +14334,18 @@ static herr_t
 UD_cb_move(const char *new_name, hid_t new_loc, const void *udata, size_t udata_size)
 {
     if (!new_name)
-        TEST_ERROR
+        TEST_ERROR;
     if (new_loc < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (udata_size > 0 && !udata)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (HDstrcmp(new_name, NEW_UD_CB_LINK_NAME) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp((const char *)udata, UD_CB_TARGET) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (udata_size != UD_CB_TARGET_LEN)
-        TEST_ERROR
+        TEST_ERROR;
 
     return SUCCEED;
 
@@ -14358,18 +14358,18 @@ static herr_t
 UD_cb_delete(const char *link_name, hid_t file, const void *udata, size_t udata_size)
 {
     if (!link_name)
-        TEST_ERROR
+        TEST_ERROR;
     if (file < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (udata_size > 0 && !udata)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (HDstrcmp(link_name, UD_CB_LINK_NAME) != 0 && HDstrcmp(link_name, NEW_UD_CB_LINK_NAME) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp((const char *)udata, UD_CB_TARGET) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (udata_size != UD_CB_TARGET_LEN)
-        TEST_ERROR
+        TEST_ERROR;
 
     return SUCCEED;
 
@@ -14382,20 +14382,20 @@ static ssize_t
 UD_cb_query(const char *link_name, const void *udata, size_t udata_size, void *buf, size_t buf_size)
 {
     if (!link_name)
-        TEST_ERROR
+        TEST_ERROR;
     if (udata_size > 0 && !udata)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (HDstrcmp(link_name, UD_CB_LINK_NAME) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp((const char *)udata, UD_CB_TARGET) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (udata_size != UD_CB_TARGET_LEN)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (buf) {
         if (buf_size < 16)
-            TEST_ERROR
+            TEST_ERROR;
         HDstrcpy((char *)buf, "query succeeded");
     } /* end if */
 
@@ -14418,64 +14418,64 @@ ud_callbacks(hid_t fapl, hbool_t new_format)
     char        query_buf[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("user-defined link callbacks (w/new group format)")
+        TESTING("user-defined link callbacks (w/new group format)");
     else
-        TESTING("user-defined link callbacks")
+        TESTING("user-defined link callbacks");
 
     /* Set up filename and create file*/
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that registered link classes are, and unregistered ones aren't */
     if (H5Lis_registered(H5L_TYPE_EXTERNAL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lis_registered((H5L_type_t)UD_CB_TYPE) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Hit two birds with one stone: register UD hard links from previous
      * test to check that having two UD links registered at once presents
      * no problems. */
     if (H5Lregister(UD_hard_class) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Register user-defined link class.  This is the one we'll actually be using. */
     if (H5Lregister(UD_cb_class) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that registered link classes are, and unregistered ones aren't */
     if (H5Lis_registered(H5L_TYPE_EXTERNAL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lis_registered((H5L_type_t)UD_HARD_TYPE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lis_registered((H5L_type_t)UD_CB_TYPE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group for the UD link to point to */
     if ((gid = H5Gcreate2(fid, UD_CB_TARGET, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a user-defined link to the group.  These UD links behave like soft links. */
     if (H5Lcreate_ud(fid, UD_CB_LINK_NAME, (H5L_type_t)UD_CB_TYPE, ud_target_name, (size_t)UD_CB_TARGET_LEN,
                      H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try opening group through UD link */
     if ((gid = H5Gopen2(fid, UD_CB_LINK_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the link to test its query callback */
     if (H5Lget_info2(fid, UD_CB_LINK_NAME, &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.u.val_size != 16)
-        TEST_ERROR
+        TEST_ERROR;
     if (UD_CB_TYPE != li.type) {
         H5_FAILED();
         HDputs("    Unexpected link class - should have been a UD hard link");
@@ -14484,80 +14484,80 @@ ud_callbacks(hid_t fapl, hbool_t new_format)
 
     /* Fill the query buffer */
     if (H5Lget_val(fid, UD_CB_LINK_NAME, query_buf, (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(query_buf, "query succeeded") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Move the link */
     if (H5Lmove(fid, UD_CB_LINK_NAME, H5L_SAME_LOC, NEW_UD_CB_LINK_NAME, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open group to ensure that move worked */
     if ((gid = H5Gopen2(fid, NEW_UD_CB_LINK_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove UD link */
     if (H5Ldelete(fid, NEW_UD_CB_LINK_NAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test that the callbacks don't work if the link class is not registered */
 
     /* Create a new link. Just for fun, give it a non-default character
      * encoding (to test that LAPLs work) */
     if ((lcpl = H5Pcreate(H5P_LINK_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_char_encoding(lcpl, H5T_CSET_UTF8) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_ud(fid, UD_CB_LINK_NAME, (H5L_type_t)UD_CB_TYPE, ud_target_name, (size_t)UD_CB_TARGET_LEN,
                      lcpl, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(lcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check its character encoding */
     if (H5Lget_info2(fid, UD_CB_LINK_NAME, &li, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (li.cset != H5T_CSET_UTF8)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unregister the link class so the library forgets what its callbacks do */
     if (H5Lunregister((H5L_type_t)UD_CB_TYPE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Now test that each of the callbacks fails */
     H5E_BEGIN_TRY
     {
         if (H5Lcreate_ud(fid, NEW_UD_CB_LINK_NAME, (H5L_type_t)UD_CB_TYPE, ud_target_name,
                          (size_t)UD_CB_TARGET_LEN, H5P_DEFAULT, H5P_DEFAULT) >= 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Lmove(fid, UD_CB_LINK_NAME, H5L_SAME_LOC, NEW_UD_CB_LINK_NAME, H5P_DEFAULT, H5P_DEFAULT) >= 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Ldelete(fid, UD_CB_LINK_NAME, H5P_DEFAULT) >= 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if ((gid = H5Gopen2(gid, UD_CB_LINK_NAME, H5P_DEFAULT)) >= 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Ldelete(fid, UD_CB_LINK_NAME, H5P_DEFAULT) >= 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     H5E_END_TRY
 
     /* The query callback should NOT fail, but should be unable to give a linklen */
     if (H5Lget_info2(fid, UD_CB_LINK_NAME, &li, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (li.u.val_size != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.type != UD_CB_TYPE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unregister the UD hard links */
     if (H5Lunregister((H5L_type_t)UD_HARD_TYPE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -14591,14 +14591,14 @@ UD_plist_traverse(const char H5_ATTR_UNUSED *link_name, hid_t cur_group, const v
     hid_t ret_value;
 
     if (udata_size != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the name of the target from the property list. */
     if (H5Pget(lapl_id, DEST_PROP_NAME, target) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((ret_value = H5Oopen(cur_group, target, lapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return ret_value;
 
@@ -14617,101 +14617,101 @@ lapl_udata(hid_t fapl, hbool_t new_format)
     char  filename[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("user data passed through lapl (w/new group format)")
+        TESTING("user data passed through lapl (w/new group format)");
     else
-        TESTING("user data passed through lapl")
+        TESTING("user data passed through lapl");
 
     /* Set up filename and create file*/
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Register UD link types from previous tests to check that having
      * multiple types registered at once presents no problems. */
     if (H5Lregister(UD_cb_class) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Register the link class.  We'll actually be using for this test. */
     if (H5Lregister(UD_plist_class) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Another link class from a previous test */
     if (H5Lregister(UD_hard_class) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unregister the first link type registered to make sure this doesn't
      * break anything. */
     if (H5Lunregister((H5L_type_t)UD_CB_TYPE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create two groups for the UD link to point to */
     if ((gid = H5Gcreate2(fid, "group_a", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "group_b", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a user-defined link to the group.  These UD links have no udata. */
     if (H5Lcreate_ud(fid, "ud_link", (H5L_type_t)UD_PLIST_TYPE, NULL, (size_t)0, H5P_DEFAULT, H5P_DEFAULT) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a non-default lapl with a new property pointing to group a*/
     if ((plist_id = H5Pcreate(H5P_LINK_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDstrcpy(group_a_name, "group_a");
     if (H5Pinsert2(plist_id, DEST_PROP_NAME, (size_t)NAME_BUF_SIZE, group_a_name, NULL, NULL, NULL, NULL,
                    NULL, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try opening group through UD link */
     if ((gid = H5Oopen(fid, "ud_link", plist_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid2 = H5Gcreate2(gid, "subgroup_a", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we can open the new group without using the ud link */
     if ((gid2 = H5Gopen2(fid, "/group_a/subgroup_a", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now use the same ud link to access group_b */
     HDstrcpy(group_b_name, "group_b");
     if (H5Pset(plist_id, DEST_PROP_NAME, group_b_name) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a subgroup */
     if ((gid = H5Oopen(fid, "ud_link", plist_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid2 = H5Gcreate2(gid, "subgroup_b", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we can open the new group without using the ud link */
     if ((gid2 = H5Gopen2(fid, "/group_b/subgroup_b", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close property list */
     if (H5Pclose(plist_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -14942,50 +14942,50 @@ ud_link_errors(hid_t fapl, hbool_t new_format)
     H5L_info2_t li; /* Link information */
 
     if (new_format)
-        TESTING("user-defined link error conditions (w/new group format)")
+        TESTING("user-defined link error conditions (w/new group format)");
     else
-        TESTING("user-defined link error conditions")
+        TESTING("user-defined link error conditions");
 
     /* Set up filename and create file*/
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try to register some invalid link classes */
     H5E_BEGIN_TRY
     {
         if (H5Lregister(UD_error1_class) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Lregister(UD_error2_class) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Lregister(UD_error3_class) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Lregister(UD_error4_class) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
 
     /* Register the UD plist class. */
     if (H5Lregister(UD_plist_class) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Now register the first class we'll be using.
      * It has the same ID as the plist class, and should replace it. */
     if (H5Lregister(UD_cbfail_class1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a group for the UD link to point to */
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Try to create internally defined links with H5Lcreate_ud */
     H5E_BEGIN_TRY
     {
         if (H5Lcreate_ud(fid, "/ud_link", H5L_TYPE_HARD, NULL, (size_t)0, H5P_DEFAULT, H5P_DEFAULT) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Lcreate_ud(fid, "/ud_link", H5L_TYPE_SOFT, "str", (size_t)4, H5P_DEFAULT, H5P_DEFAULT) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
 
@@ -14994,7 +14994,7 @@ ud_link_errors(hid_t fapl, hbool_t new_format)
     H5E_BEGIN_TRY
     {
         if (H5Lcreate_ud(fid, "/ud_link", (H5L_type_t)UD_CBFAIL_TYPE, NULL, 1, H5P_DEFAULT, H5P_DEFAULT) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
@@ -15002,13 +15002,13 @@ ud_link_errors(hid_t fapl, hbool_t new_format)
     HDstrcpy(group_name, "/group");
     if (H5Lcreate_ud(fid, "/ud_link", (H5L_type_t)UD_CBFAIL_TYPE, &group_name, HDstrlen(group_name) + 1,
                      H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the group through the ud link */
     if ((gid = H5Gopen2(fid, "ud_link", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Now test that each of the callbacks will cause a failure if it returns -1 */
     H5E_BEGIN_TRY
@@ -15016,84 +15016,84 @@ ud_link_errors(hid_t fapl, hbool_t new_format)
         /* The create callback will fail if we pass in no udata */
         if (H5Lcreate_ud(fid, "fail", (H5L_type_t)UD_CBFAIL_TYPE, NULL, (size_t)0, H5P_DEFAULT,
                          H5P_DEFAULT) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* The move and copy callbacks will fail */
         if (H5Lmove(fid, "ud_link", H5L_SAME_LOC, "move_fail", H5P_DEFAULT, H5P_DEFAULT) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Lcopy(fid, "ud_link", fid, "copy_fail", H5P_DEFAULT, H5P_DEFAULT) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* The traversal callback will fail if we remove its target */
         if (H5Ldelete(fid, "group", H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((gid = H5Gopen2(gid, "ud_link", H5P_DEFAULT)) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* The deletion callback will always fail */
         if (H5Ldelete(fid, "ud_link", H5P_DEFAULT) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* The query callback will fail */
         if (H5Lget_info2(fid, "ud_link", &li, H5P_DEFAULT) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
 
     /* Now use a class with different callback functions */
     if (H5Lregister(UD_cbfail_class2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Moving should still fail, but copying will succeed */
     H5E_BEGIN_TRY
     {
         if (H5Lmove(fid, "ud_link", H5L_SAME_LOC, "move_fail", H5P_DEFAULT, H5P_DEFAULT) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
     if (H5Lcopy(fid, "ud_link", fid, "copy_succ", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* The query callback will succeed when we only want to get the size of the buffer... */
     if (H5Lget_info2(fid, "ud_link", &li, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (li.u.val_size != 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* ...but fail when we try to write data to the buffer itself*/
     H5E_BEGIN_TRY
     {
         if (H5Lget_val(fid, "ud_link", query_buf, (size_t)NAME_BUF_SIZE, H5P_DEFAULT) >= 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY
 
     /* Register a new class */
     if (H5Lregister(UD_cbfail_class3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Now querying should succeed */
     if (H5Lget_info2(fid, "ud_link", &li, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (li.u.val_size != 8)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_val(fid, "ud_link", query_buf, (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(query_buf, "succeed") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Moving and copying should both succeed */
     if (H5Lmove(fid, "copy_succ", H5L_SAME_LOC, "move_succ", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcopy(fid, "ud_link", fid, "copy_succ2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete link (this callback should work now) */
     if (H5Ldelete(fid, "ud_link", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -15132,9 +15132,9 @@ lapl_nlinks(hid_t fapl, hbool_t new_format)
     hsize_t dims[2];
 
     if (new_format)
-        TESTING("adjusting nlinks with LAPL (w/new group format)")
+        TESTING("adjusting nlinks with LAPL (w/new group format)");
     else
-        TESTING("adjusting nlinks with LAPL")
+        TESTING("adjusting nlinks with LAPL");
 
     /* Make certain test is valid */
     /* XXX: should probably make a "generic" test that creates the proper
@@ -15145,105 +15145,105 @@ lapl_nlinks(hid_t fapl, hbool_t new_format)
     /* Create file */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group with short name in file (used as target for links) */
     if ((gid = H5Gcreate2(fid, "final", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create chain of soft links to existing object (limited) */
     if (H5Lcreate_soft("final", fid, "soft1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft1", fid, "soft2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft2", fid, "soft3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft3", fid, "soft4", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft4", fid, "soft5", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft5", fid, "soft6", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft6", fid, "soft7", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft7", fid, "soft8", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft8", fid, "soft9", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft9", fid, "soft10", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft10", fid, "soft11", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft11", fid, "soft12", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft12", fid, "soft13", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft13", fid, "soft14", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft14", fid, "soft15", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft15", fid, "soft16", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("soft16", fid, "soft17", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close objects */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create LAPL with higher-than-usual nlinks value */
     /* Create a non-default lapl with udata set to point to the first group */
     if ((plist = H5Pcreate(H5P_LINK_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     nlinks = 20;
     if (H5Pset_nlinks(plist, nlinks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Ensure that nlinks was set successfully */
     nlinks = 0;
     if (H5Pget_nlinks(plist, &nlinks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (nlinks != 20)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through what is normally too many soft links using
      * new property list */
     if ((gid = H5Oopen(fid, "soft17", plist)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/soft17") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group using soft link */
     if ((gid2 = H5Gcreate2(gid, "new_soft", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close groups */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set nlinks to a smaller number */
     nlinks = 4;
     if (H5Pset_nlinks(plist, nlinks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Ensure that nlinks was set successfully */
     nlinks = 0;
     if (H5Pget_nlinks(plist, &nlinks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (nlinks != 4)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try opening through what is now too many soft links */
     H5E_BEGIN_TRY
@@ -15259,141 +15259,141 @@ lapl_nlinks(hid_t fapl, hbool_t new_format)
 
     /* Open object through lesser soft link */
     if ((gid = H5Oopen(fid, "soft4", plist)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/soft4") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test other functions that should use a LAPL */
     nlinks = 20;
     if (H5Pset_nlinks(plist, nlinks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try copying and moving when both src and dst contain many soft links
      * using a non-default LAPL
      */
     if (H5Lcopy(fid, "soft17", fid, "soft17/newer_soft", H5P_DEFAULT, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lmove(fid, "soft17/newer_soft", fid, "soft17/newest_soft", H5P_DEFAULT, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Olink */
     if (H5Olink(gid, fid, "soft17/link_to_group", H5P_DEFAULT, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Lcreate_hard  and H5Lcreate_soft */
     if (H5Lcreate_hard(fid, "soft17", fid, "soft17/link2_to_group", H5P_DEFAULT, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("/soft4", fid, "soft17/soft_link", H5P_DEFAULT, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Ldelete */
     if (H5Ldelete(fid, "soft17/soft_link", plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Lget_val and H5Lget_info2 */
     if (H5Lget_val(fid, "soft17", NULL, (size_t)0, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(fid, "soft17", NULL, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Lcreate_external and H5Lcreate_ud */
     if (H5Lcreate_external("filename", "path", fid, "soft17/extlink", H5P_DEFAULT, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lregister(UD_rereg_class) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_ud(fid, "soft17/udlink", (H5L_type_t)UD_HARD_TYPE, NULL, (size_t)0, H5P_DEFAULT, plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close plist */
     if (H5Pclose(plist) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a datatype and dataset as targets inside the group */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(gid, "datatype", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dims[0] = 2;
     dims[1] = 2;
     if ((sid = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did = H5Dcreate2(gid, "dataset", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl_g, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try to open the objects using too many symlinks with default *APLs */
     H5E_BEGIN_TRY
     {
         if ((gid = H5Gopen2(fid, "soft17", H5P_DEFAULT)) >= 0)
-            FAIL_PUTS_ERROR("    Should have failed for too many nested links.")
+            FAIL_PUTS_ERROR("    Should have failed for too many nested links.");
         if ((tid = H5Topen2(fid, "soft17/datatype", H5P_DEFAULT)) >= 0)
-            FAIL_PUTS_ERROR("    Should have failed for too many nested links.")
+            FAIL_PUTS_ERROR("    Should have failed for too many nested links.");
         if ((did = H5Dopen2(fid, "soft17/dataset", H5P_DEFAULT)) >= 0)
-            FAIL_PUTS_ERROR("    Should have failed for too many nested links.")
+            FAIL_PUTS_ERROR("    Should have failed for too many nested links.");
     }
     H5E_END_TRY
 
     /* Create property lists with nlinks set */
     if ((gapl = H5Pcreate(H5P_GROUP_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tapl = H5Pcreate(H5P_DATATYPE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     nlinks = 20;
     if (H5Pset_nlinks(gapl, nlinks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_nlinks(tapl, nlinks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_nlinks(dapl, nlinks) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* We should now be able to use these property lists to open each kind
      * of object.
      */
     if ((gid = H5Gopen2(fid, "soft17", gapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((tid = H5Topen2(fid, "soft17/datatype", tapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did = H5Dopen2(fid, "soft17/dataset", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close objects */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close plists */
     if (H5Pclose(gapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(tapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unregister UD hard link class */
     if (H5Lunregister((H5L_type_t)UD_HARD_TYPE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -15436,82 +15436,82 @@ linkinfo(hid_t fapl, hbool_t new_format)
     char        filename[NAME_BUF_SIZE];
 
     if (new_format)
-        TESTING("link type field in H5Lget_info (w/new group format)")
+        TESTING("link type field in H5Lget_info (w/new group format)");
     else
-        TESTING("link type field in H5Lget_info")
+        TESTING("link type field in H5Lget_info");
 
     /* Set up filename and create file*/
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Register a couple of user-defined link classes with the library */
     if (H5Lregister(UD_plist_class) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an object of each type */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(fid, "datatype", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("group", fid, "softlink", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((sid = H5Screate(H5S_SCALAR)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did = H5Dcreate2(fid, "dataset", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl_g, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Lcreate_ud(fid, "ud_link", (H5L_type_t)UD_PLIST_TYPE, NULL, (size_t)0, H5P_DEFAULT, H5P_DEFAULT) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_external("file_name", "obj_path", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close all objects */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make sure that link type is correct when objects are queried */
     if (H5Lget_info2(fid, "datatype", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.type != H5L_TYPE_HARD)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(fid, "group", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.type != H5L_TYPE_HARD)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(fid, "dataset", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.type != H5L_TYPE_HARD)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Lget_info2(fid, "ext_link", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.type != H5L_TYPE_EXTERNAL)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(fid, "softlink", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.type != H5L_TYPE_SOFT)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lget_info2(fid, "ud_link", &li, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (li.type != UD_PLIST_TYPE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Ensure that passing a NULL pointer doesn't cause an error */
     if (H5Lget_info2(fid, "group", NULL, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -15550,9 +15550,9 @@ check_all_closed(hid_t fapl, hbool_t new_format, int stopat)
     int   x;
 
     if (new_format)
-        TESTING("that all files were closed correctly (w/new group format)")
+        TESTING("that all files were closed correctly (w/new group format)");
     else
-        TESTING("that all files were closed correctly")
+        TESTING("that all files were closed correctly");
 
     /* Some of the external or UD link tests may have failed to close
      * an external file properly.
@@ -15563,9 +15563,9 @@ check_all_closed(hid_t fapl, hbool_t new_format, int stopat)
         h5_fixname(FILENAME[x], fapl, filename, sizeof filename);
 
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Fclose(fid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     PASSED();
@@ -15604,99 +15604,99 @@ build_visit_file(hid_t fapl)
 
     /* Create file for visiting */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group */
     if ((gid = H5Gcreate2(fid, "/Group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create nested group */
     if ((gid2 = H5Gcreate2(gid, "Group2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close groups */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create soft links to groups created */
     if (H5Lcreate_soft("/Group1", fid, "/soft_one", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("/Group1/Group2", fid, "/soft_two", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dangling soft link */
     if (H5Lcreate_soft("nowhere", fid, "/soft_dangle", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create hard links to all groups */
     if (H5Lcreate_hard(fid, "/", fid, "hard_zero", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "/Group1", fid, "hard_one", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "/Group1/Group2", fid, "hard_two", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create loops w/hard links */
     if (H5Lcreate_hard(fid, "/Group1", fid, "/Group1/hard_one", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_hard(fid, "/", fid, "/Group1/Group2/hard_zero", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to existing file */
     if (H5Lcreate_external(pathname, "/group", fid, "/ext_one", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dangling external link to non-existent file */
     if (H5Lcreate_external("foo.h5", "/group", fid, "/ext_dangle", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataset in each group */
     if ((sid = H5Screate(H5S_SCALAR)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((did = H5Dcreate2(fid, "/Dataset_zero", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl_g, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((did = H5Dcreate2(fid, "/Group1/Dataset_one", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl_g,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((did = H5Dcreate2(fid, "/Group1/Group2/Dataset_two", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl_g,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create named datatype in each group */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(fid, "/Type_zero", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(fid, "/Group1/Type_one", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommit2(fid, "/Group1/Group2/Type_two", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return (fid);
 
@@ -15752,52 +15752,52 @@ link_visit(hid_t fapl, hbool_t new_format)
     hid_t       gid = -1; /* Group ID */
 
     if (new_format)
-        TESTING("link visiting (w/new group format)")
+        TESTING("link visiting (w/new group format)");
     else
-        TESTING("link visiting")
+        TESTING("link visiting");
 
     /* Construct "interesting" file to visit */
     if ((fid = build_visit_file(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Visit all the links reachable from the root group (with file ID) */
     udata.idx  = 0;
     udata.info = lvisit0;
     if (H5Lvisit2(fid, H5_INDEX_NAME, H5_ITER_INC, visit_link_cb, &udata) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Visit all the links reachable from the root group (with group ID) */
     if ((gid = H5Gopen2(fid, "/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     udata.idx  = 0;
     udata.info = lvisit0;
     if (H5Lvisit2(gid, H5_INDEX_NAME, H5_ITER_INC, visit_link_cb, &udata) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Visit all the links reachable from each internal group */
     if ((gid = H5Gopen2(fid, "/Group1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     udata.idx  = 0;
     udata.info = lvisit1;
     if (H5Lvisit2(gid, H5_INDEX_NAME, H5_ITER_INC, visit_link_cb, &udata) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((gid = H5Gopen2(fid, "/Group1/Group2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     udata.idx  = 0;
     udata.info = lvisit2;
     if (H5Lvisit2(gid, H5_INDEX_NAME, H5_ITER_INC, visit_link_cb, &udata) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file created */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -15829,63 +15829,63 @@ link_visit_by_name(hid_t fapl, hbool_t new_format)
     hid_t       gid = -1; /* Group ID */
 
     if (new_format)
-        TESTING("link visiting by name (w/new group format)")
+        TESTING("link visiting by name (w/new group format)");
     else
-        TESTING("link visiting by name")
+        TESTING("link visiting by name");
 
     /* Construct "interesting" file to visit */
     if ((fid = build_visit_file(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Visit all the links reachable from the root group (with file ID) */
     udata.idx  = 0;
     udata.info = lvisit0;
     if (H5Lvisit_by_name2(fid, "/", H5_INDEX_NAME, H5_ITER_INC, visit_link_cb, &udata, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Visit all the links reachable from the root group (with group ID) */
     if ((gid = H5Gopen2(fid, "/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     udata.idx  = 0;
     udata.info = lvisit0;
     if (H5Lvisit_by_name2(gid, ".", H5_INDEX_NAME, H5_ITER_INC, visit_link_cb, &udata, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Visit all the links reachable from each internal group */
     udata.idx  = 0;
     udata.info = lvisit1;
     if (H5Lvisit_by_name2(fid, "/Group1", H5_INDEX_NAME, H5_ITER_INC, visit_link_cb, &udata, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((gid = H5Gopen2(fid, "/Group1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     udata.idx  = 0;
     udata.info = lvisit1;
     if (H5Lvisit_by_name2(gid, ".", H5_INDEX_NAME, H5_ITER_INC, visit_link_cb, &udata, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     udata.idx  = 0;
     udata.info = lvisit2;
     if (H5Lvisit_by_name2(fid, "/Group1/Group2", H5_INDEX_NAME, H5_ITER_INC, visit_link_cb, &udata,
                           H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((gid = H5Gopen2(fid, "/Group1/Group2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     udata.idx  = 0;
     udata.info = lvisit2;
     if (H5Lvisit_by_name2(gid, ".", H5_INDEX_NAME, H5_ITER_INC, visit_link_cb, &udata, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file created */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -15943,13 +15943,13 @@ obj_visit(hid_t fapl, hbool_t new_format)
     hid_t       gid = -1; /* Group ID */
 
     if (new_format)
-        TESTING("object visiting (w/new group format)")
+        TESTING("object visiting (w/new group format)");
     else
-        TESTING("object visiting")
+        TESTING("object visiting");
 
     /* Construct "interesting" file to visit */
     if ((fid = build_visit_file(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     //! [H5Ovisit3_snip]
 
@@ -15957,42 +15957,42 @@ obj_visit(hid_t fapl, hbool_t new_format)
     udata.idx  = 0;
     udata.info = new_format ? ovisit0_new : ovisit0_old;
     if (H5Ovisit3(fid, H5_INDEX_NAME, H5_ITER_INC, visit_obj_cb, &udata, H5O_INFO_BASIC) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     //! [H5Ovisit3_snip]
 
     /* Visit all the objects reachable from the root group (with group ID) */
     if ((gid = H5Gopen2(fid, "/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     udata.idx  = 0;
     udata.info = new_format ? ovisit0_new : ovisit0_old;
     if (H5Ovisit3(gid, H5_INDEX_NAME, H5_ITER_INC, visit_obj_cb, &udata, H5O_INFO_BASIC) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Visit all the objects reachable from each internal group */
     if ((gid = H5Gopen2(fid, "/Group1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     udata.idx  = 0;
     udata.info = new_format ? ovisit1_new : ovisit1_old;
     if (H5Ovisit3(gid, H5_INDEX_NAME, H5_ITER_INC, visit_obj_cb, &udata, H5O_INFO_BASIC) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((gid = H5Gopen2(fid, "/Group1/Group2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     udata.idx  = 0;
     udata.info = new_format ? ovisit2_new : ovisit2_old;
     if (H5Ovisit3(gid, H5_INDEX_NAME, H5_ITER_INC, visit_obj_cb, &udata, H5O_INFO_BASIC) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file created */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -16024,13 +16024,13 @@ obj_visit_by_name(hid_t fapl, hbool_t new_format)
     hid_t       gid = -1; /* Group ID */
 
     if (new_format)
-        TESTING("object visiting by name (w/new group format)")
+        TESTING("object visiting by name (w/new group format)");
     else
-        TESTING("object visiting by name")
+        TESTING("object visiting by name");
 
     /* Construct "interesting" file to visit */
     if ((fid = build_visit_file(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     //! [H5Ovisit_by_name3_snip]
 
@@ -16039,57 +16039,57 @@ obj_visit_by_name(hid_t fapl, hbool_t new_format)
     udata.info = new_format ? ovisit0_new : ovisit0_old;
     if (H5Ovisit_by_name3(fid, "/", H5_INDEX_NAME, H5_ITER_INC, visit_obj_cb, &udata, H5O_INFO_BASIC,
                           H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     //! [H5Ovisit_by_name3_snip]
 
     /* Visit all the objects reachable from the root group (with group ID) */
     if ((gid = H5Gopen2(fid, "/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     udata.idx  = 0;
     udata.info = new_format ? ovisit0_new : ovisit0_old;
     if (H5Ovisit_by_name3(gid, ".", H5_INDEX_NAME, H5_ITER_INC, visit_obj_cb, &udata, H5O_INFO_BASIC,
                           H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Visit all the objects reachable from each internal group */
     udata.idx  = 0;
     udata.info = new_format ? ovisit1_new : ovisit1_old;
     if (H5Ovisit_by_name3(fid, "/Group1", H5_INDEX_NAME, H5_ITER_INC, visit_obj_cb, &udata, H5O_INFO_BASIC,
                           H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((gid = H5Gopen2(fid, "/Group1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     udata.idx  = 0;
     udata.info = new_format ? ovisit1_new : ovisit1_old;
     if (H5Ovisit_by_name3(gid, ".", H5_INDEX_NAME, H5_ITER_INC, visit_obj_cb, &udata, H5O_INFO_BASIC,
                           H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     udata.idx  = 0;
     udata.info = new_format ? ovisit2_new : ovisit2_old;
     if (H5Ovisit_by_name3(fid, "/Group1/Group2", H5_INDEX_NAME, H5_ITER_INC, visit_obj_cb, &udata,
                           H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((gid = H5Gopen2(fid, "/Group1/Group2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     udata.idx  = 0;
     udata.info = new_format ? ovisit2_new : ovisit2_old;
     if (H5Ovisit_by_name3(gid, ".", H5_INDEX_NAME, H5_ITER_INC, visit_obj_cb, &udata, H5O_INFO_BASIC,
                           H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file created */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -16142,38 +16142,38 @@ obj_visit_stop(hid_t fapl, hbool_t new_format)
     herr_t   ret; /* Return value */
 
     if (new_format)
-        TESTING("stopping object iteration (w/new group format)")
+        TESTING("stopping object iteration (w/new group format)");
     else
-        TESTING("stopping object iteration")
+        TESTING("stopping object iteration");
 
     /* Construct "interesting" file to visit */
     if ((fid = build_visit_file(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Start iteration.  The callback should only be called once because it
      * returns H5_ITER_STOP
      */
     nvisited = 0;
     if ((ret = H5Ovisit3(fid, H5_INDEX_NAME, H5_ITER_INC, visit_obj_stop_cb, &nvisited, H5O_INFO_BASIC)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ret != H5_ITER_STOP)
-        TEST_ERROR
+        TEST_ERROR;
     if (nvisited != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Same test with H5Ovisit_by_name */
     nvisited = 0;
     if ((ret = H5Ovisit_by_name3(fid, "/", H5_INDEX_NAME, H5_ITER_INC, visit_obj_stop_cb, &nvisited,
                                  H5O_INFO_BASIC, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (ret != H5_ITER_STOP)
-        TEST_ERROR
+        TEST_ERROR;
     if (nvisited != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file created */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -16285,9 +16285,9 @@ link_filters(hid_t fapl, hbool_t new_format)
      * The new format flag affects the version of object header messages,
      * etc., which are important for this test. */
     if (new_format)
-        TESTING("group link filters (w/new group format)")
+        TESTING("group link filters (w/new group format)");
     else
-        TESTING("group link filters")
+        TESTING("group link filters");
 
     /* Initialize link filter state global */
     link_filter_state = LFS_INIT;
@@ -16296,27 +16296,27 @@ link_filters(hid_t fapl, hbool_t new_format)
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create gcpl, force use of dense storage */
     if ((gcpl1 = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_link_phase_change(gcpl1, 2, 2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add deflate and checksum filters, if available */
     if ((tri_ret = H5Zfilter_avail(H5Z_FILTER_DEFLATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (tri_ret) {
         if (H5Pset_deflate(gcpl1, 6) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         nfilters++;
     } /* end if */
     if ((tri_ret = H5Zfilter_avail(H5Z_FILTER_FLETCHER32)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (tri_ret) {
         if (H5Pset_fletcher32(gcpl1) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         nfilters++;
     } /* end if */
 
@@ -16330,152 +16330,152 @@ link_filters(hid_t fapl, hbool_t new_format)
     filter_class.set_local       = link_filter_set_local;
     filter_class.filter          = link_filter_filter;
     if (H5Zregister(&filter_class) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_filter(gcpl1, H5Z_FILTER_RESERVED + 42, 0, (size_t)1, &cd_value) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     nfilters++;
 
     /* Test various other filter functions for use on gcpl's */
     if (H5Pget_nfilters(gcpl1) != nfilters)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pall_filters_avail(gcpl1) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group using this filter, add some soft links to it */
     if ((gid1 = H5Gcreate2(fid, "group1", H5P_DEFAULT, gcpl1, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("/", gid1, "link1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("/", gid1, "link2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("/", gid1, "link3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file and group */
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the filter has been applied */
     if (link_filter_state != LFS_ENCODED)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reopen file and group */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid1 = H5Gopen2(fid, "group1", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve gcpl, verify number of filters */
     if ((gcpl2 = H5Gget_create_plist(gid1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_nfilters(gcpl2) != nfilters)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(gcpl2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now try copying gcpl1, and verify number of filters */
     if ((gcpl2 = H5Pcopy(gcpl1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_nfilters(gcpl2) != nfilters)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(gcpl2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add another soft link */
     if (H5Lcreate_soft("/", gid1, "link4", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Copy the group */
     if (H5Ocopy(fid, "group1", fid, "group2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid2 = H5Gopen2(fid, "group2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that all links have been copied */
     if (H5Lexists(gid2, "link1", H5P_DEFAULT) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lexists(gid2, "link2", H5P_DEFAULT) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lexists(gid2, "link3", H5P_DEFAULT) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lexists(gid2, "link4", H5P_DEFAULT) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve gcpl, verify number of filters */
     if ((gcpl2 = H5Gget_create_plist(gid2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_nfilters(gcpl2) != nfilters)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete 3 links to force the group back into compact mode */
     if (H5Ldelete(gid1, "link2", H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ldelete(gid1, "link3", H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ldelete(gid1, "link4", H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file and groups */
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reset link filter state */
     link_filter_state = LFS_INIT;
 
     /* Reopen file and group, add 2 links */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid1 = H5Gopen2(fid, "group1", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("/", gid1, "link2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Lcreate_soft("/", gid1, "link3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file and group */
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the filter was reapplied */
     if (link_filter_state != LFS_ENCODED)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5Pget_filter_by_id2 and H5Pget_filter2 */
     if (H5Pget_filter_by_id2(gcpl2, H5Z_FILTER_RESERVED + 42, &flags_out, &cd_nelmts, &cd_value_out,
                              (size_t)24, name_out, &filter_config_out) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (flags_out != 0 || cd_value_out != cd_value || HDstrcmp(filter_class.name, name_out) != 0 ||
         filter_config_out != (H5Z_FILTER_CONFIG_ENCODE_ENABLED | H5Z_FILTER_CONFIG_DECODE_ENABLED))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_filter2(gcpl2, (unsigned)(nfilters - 1), &flags_out, &cd_nelmts, &cd_value_out, (size_t)24,
                        name_out, &filter_config_out) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (flags_out != 0 || cd_value_out != cd_value || HDstrcmp(filter_class.name, name_out) != 0 ||
         filter_config_out != (H5Z_FILTER_CONFIG_ENCODE_ENABLED | H5Z_FILTER_CONFIG_DECODE_ENABLED))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5Pmodify_filter */
     cd_value++;
     if (H5Pmodify_filter(gcpl2, H5Z_FILTER_RESERVED + 42, 0, (size_t)1, &cd_value) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_filter_by_id2(gcpl2, H5Z_FILTER_RESERVED + 42, &flags_out, &cd_nelmts, &cd_value_out,
                              (size_t)24, name_out, &filter_config_out) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (flags_out != 0 || cd_value_out != cd_value || HDstrcmp(filter_class.name, name_out) != 0 ||
         filter_config_out != (H5Z_FILTER_CONFIG_ENCODE_ENABLED | H5Z_FILTER_CONFIG_DECODE_ENABLED))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5Premove_filter */
     if (H5Premove_filter(gcpl2, H5Z_FILTER_RESERVED + 42) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         status = H5Pget_filter_by_id2(gcpl2, H5Z_FILTER_RESERVED + 42, &flags_out, &cd_nelmts, &cd_value_out,
@@ -16483,91 +16483,91 @@ link_filters(hid_t fapl, hbool_t new_format)
     }
     H5E_END_TRY
     if (status >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close remaining ids */
     if (H5Pclose(gcpl1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(gcpl2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now create an object in the compressed group, creating intermediate
      * groups, to verify that the filter pipeline is inherited for the groups
      * that are created along the way */
     /* Reopen file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create lcpl, setting the "create intermediate groups" flag */
     if ((lcpl = H5Pcreate(H5P_LINK_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_create_intermediate_group(lcpl, (unsigned)TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create new group, with missing intermediate groups, in compressed group */
     if ((gid1 = H5Gcreate2(fid, "group1/group2/group3/group4", lcpl, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close LCPL ID */
     if (H5Pclose(lcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that new group doesn't have filters */
     if ((gcpl1 = H5Gget_create_plist(gid1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_nfilters(gcpl1) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group & GCPL IDs */
     if (H5Pclose(gcpl1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open intermediate groups that were created and verify that they have filters */
     if ((gid1 = H5Gopen2(fid, "group1/group2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gcpl1 = H5Gget_create_plist(gid1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_nfilters(gcpl1) != nfilters)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(gcpl1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid1 = H5Gopen2(fid, "group1/group2/group3", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gcpl1 = H5Gget_create_plist(gid1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_nfilters(gcpl1) != nfilters)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(gcpl1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now create the same file with and without deflate, and verify that the
      * file size is smaller with deflate */
     /* But only if the deflate filter is available */
     if ((tri_ret = H5Zfilter_avail(H5Z_FILTER_DEFLATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (tri_ret) {
         h5_stat_size_t filesize_filtered;
         h5_stat_size_t filesize_unfiltered;
 
         /* Create gcpl, force use of dense storage */
         if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_link_phase_change(fcpl, 2, 2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create file */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create links in file */
         if (H5Lcreate_soft("/", fid,
@@ -16576,7 +16576,7 @@ link_filters(hid_t fapl, hbool_t new_format)
                            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                            H5P_DEFAULT, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Lcreate_soft(
                 "/", fid,
                 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -16584,7 +16584,7 @@ link_filters(hid_t fapl, hbool_t new_format)
                 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
                 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
                 H5P_DEFAULT, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Lcreate_soft("/", fid,
                            "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
                            "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
@@ -16592,27 +16592,27 @@ link_filters(hid_t fapl, hbool_t new_format)
                            "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
                            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
                            H5P_DEFAULT, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close file, get file size */
         if (H5Fclose(fid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         filesize_unfiltered = h5_get_file_size(filename, fapl);
 
         /* Set deflate filter */
         if (H5Pset_deflate(fcpl, 6) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Recreate the same file with the deflate filter */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Lcreate_soft("/", fid,
                            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                            H5P_DEFAULT, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Lcreate_soft(
                 "/", fid,
                 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -16620,7 +16620,7 @@ link_filters(hid_t fapl, hbool_t new_format)
                 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
                 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
                 H5P_DEFAULT, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Lcreate_soft("/", fid,
                            "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
                            "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
@@ -16628,23 +16628,23 @@ link_filters(hid_t fapl, hbool_t new_format)
                            "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
                            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
                            H5P_DEFAULT, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close file, get file size */
         if (H5Fclose(fid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (h5_using_default_driver(NULL)) {
             filesize_filtered = h5_get_file_size(filename, fapl);
 
             /* Check that the file size is smaller with the filter */
             if ((double)filesize_filtered > ((double)filesize_unfiltered * FILTER_FILESIZE_MAX_FRACTION))
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         /* Close */
         if (H5Pclose(fcpl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     PASSED();
@@ -16683,15 +16683,15 @@ obj_exists(hid_t fapl, hbool_t new_format)
     herr_t status;                  /* Generic return value */
 
     if (new_format)
-        TESTING("object exists (w/new group format)")
+        TESTING("object exists (w/new group format)");
     else
-        TESTING("object exists")
+        TESTING("object exists");
 
     /* Set up filename and create file*/
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Hard links */
     /* Verify that H5Oexists_by_name() returns false for non-existent link in root group */
@@ -16701,17 +16701,17 @@ obj_exists(hid_t fapl, hbool_t new_format)
     }
     H5E_END_TRY
     if (status >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group, as a destination for testing */
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() succeeds for hard linked object */
     if (TRUE != H5Oexists_by_name(fid, "group", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that H5Oexists_by_name() returns false for non-existent object in non-root group */
     H5E_BEGIN_TRY
@@ -16720,266 +16720,266 @@ obj_exists(hid_t fapl, hbool_t new_format)
     }
     H5E_END_TRY
     if (status >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Soft links */
     /* Create dangling soft-link in root group */
     if (H5Lcreate_soft("dangle", fid, "soft1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE for dangling soft-link in root group */
     if (FALSE != H5Oexists_by_name(fid, "soft1", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create soft-link in root group that points to object */
     if (H5Lcreate_soft("/group", fid, "soft2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() returns TRUE for soft-link in root group that points to object */
     if (TRUE != H5Oexists_by_name(fid, "soft2", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dangling soft-link in non-root group */
     if (H5Lcreate_soft("dangle", fid, "group/soft1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE for dangling soft-link in non-root group */
     if (FALSE != H5Oexists_by_name(fid, "group/soft1", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create soft-link in non-root group that points to object */
     if (H5Lcreate_soft("/group", fid, "group/soft2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() returns TRUE for soft-link in non-root group that points to object */
     if (TRUE != H5Oexists_by_name(fid, "group/soft2", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* External links */
     /* Create dangling (file doesn't exist) external link in root group */
     if (H5Lcreate_external("nofile", "dangle", fid, "external1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE for dangling (file doesn't exist) external link in root
      * group */
     if (FALSE != H5Oexists_by_name(fid, "external1", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dangling (object doesn't exist) external link in root group */
     if (H5Lcreate_external(filename, "dangle", fid, "external2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE for dangling (object doesn't exist) external link in root
      * group */
     if (FALSE != H5Oexists_by_name(fid, "external2", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link in root group that points to object */
     if (H5Lcreate_external(filename, "group", fid, "external3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that H5Oexists_by_name() returns TRUE for external link in root group that points to object */
     if (TRUE != H5Oexists_by_name(fid, "external3", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dangling (file doesn't exist) external link in non-root group */
     if (H5Lcreate_external("nofile", "dangle", fid, "group/external1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE for dangling (file doesn't exist) external link in
      * non-root group */
     if (FALSE != H5Oexists_by_name(fid, "group/external1", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dangling (object doesn't exist) external link in non-root group */
     if (H5Lcreate_external(filename, "dangle", fid, "group/external2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE for dangling (object doesn't exist) external link in
      * non-root group */
     if (FALSE != H5Oexists_by_name(fid, "group/external2", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link in non-root group that points to object */
     if (H5Lcreate_external(filename, "group", fid, "group/external3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that H5Oexists_by_name() returns TRUE for external link in non-root group that points to object
      */
     if (TRUE != H5Oexists_by_name(fid, "group/external3", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Soft->External links */
     /* Create soft-link in root group that points to dangling (file doesn't exist) external link */
     if (H5Lcreate_soft("external1", fid, "soft-elink1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE */
     if (FALSE != H5Oexists_by_name(fid, "soft-elink1", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create soft-link in root group that points to dangling (object doesn't exist) external link */
     if (H5Lcreate_soft("external2", fid, "soft-elink2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE */
     if (FALSE != H5Oexists_by_name(fid, "soft-elink2", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create soft-link in root group that points to external link that points to object */
     if (H5Lcreate_soft("external3", fid, "soft-elink3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() returns TRUE */
     if (TRUE != H5Oexists_by_name(fid, "soft-elink3", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create soft-link in root group that points to dangling (file doesn't exist) external link in non-root
      * group */
     if (H5Lcreate_soft("group/external1", fid, "soft-elink4", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE */
     if (FALSE != H5Oexists_by_name(fid, "soft-elink4", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create soft-link in root group that points to dangling (object doesn't exist) external link in non-root
      * group */
     if (H5Lcreate_soft("group/external2", fid, "soft-elink5", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE */
     if (FALSE != H5Oexists_by_name(fid, "soft-elink5", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create soft-link in root group that points to external link in non-root group that points to object */
     if (H5Lcreate_soft("group/external3", fid, "soft-elink6", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() returns TRUE */
     if (TRUE != H5Oexists_by_name(fid, "soft-elink6", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create soft-link in non-root group that points to dangling (file doesn't exist) external link */
     if (H5Lcreate_soft("/external1", fid, "group/soft-elink1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE */
     if (FALSE != H5Oexists_by_name(fid, "group/soft-elink1", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create soft-link in non-root group that points to dangling (object doesn't exist) external link */
     if (H5Lcreate_soft("/external2", fid, "group/soft-elink2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE */
     if (FALSE != H5Oexists_by_name(fid, "group/soft-elink2", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create soft-link in non-root group that points to external link that points to object */
     if (H5Lcreate_soft("/external3", fid, "group/soft-elink3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() returns TRUE */
     if (TRUE != H5Oexists_by_name(fid, "group/soft-elink3", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create soft-link in non-root group that points to dangling (file doesn't exist) external link in
      * non-root group */
     if (H5Lcreate_soft("/group/external1", fid, "group/soft-elink4", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE */
     if (FALSE != H5Oexists_by_name(fid, "group/soft-elink4", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create soft-link in non-root group that points to dangling (object doesn't exist) external link in
      * non-root group */
     if (H5Lcreate_soft("/group/external2", fid, "group/soft-elink5", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE */
     if (FALSE != H5Oexists_by_name(fid, "group/soft-elink5", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create soft-link in non-root group that points to external link in non-root group that points to object
      */
     if (H5Lcreate_soft("/group/external3", fid, "group/soft-elink6", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that H5Oexists_by_name() returns TRUE */
     if (TRUE != H5Oexists_by_name(fid, "group/soft-elink6", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* External->Soft links */
     /* Create external link in root group that points to dangling soft link in root group */
     if (H5Lcreate_external(filename, "soft1", fid, "elink-soft1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE */
     if (FALSE != H5Oexists_by_name(fid, "elink-soft1", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link in root group that points to soft link in root group that points to object */
     if (H5Lcreate_external(filename, "soft2", fid, "elink-soft2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that H5Oexists_by_name() returns TRUE */
     if (TRUE != H5Oexists_by_name(fid, "elink-soft2", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link in root group that points to dangling soft link in non-root group */
     if (H5Lcreate_external(filename, "group/soft1", fid, "elink-soft3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE */
     if (FALSE != H5Oexists_by_name(fid, "elink-soft3", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link in root group that points to soft link in root group that points to object */
     if (H5Lcreate_external(filename, "group/soft2", fid, "elink-soft4", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that H5Oexists_by_name() returns TRUE */
     if (TRUE != H5Oexists_by_name(fid, "elink-soft4", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link in non-root group that points to dangling soft link in root group */
     if (H5Lcreate_external(filename, "soft1", fid, "group/elink-soft1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE */
     if (FALSE != H5Oexists_by_name(fid, "group/elink-soft1", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link in non-root group that points to soft link in root group that points to object */
     if (H5Lcreate_external(filename, "soft2", fid, "group/elink-soft2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that H5Oexists_by_name() returns TRUE */
     if (TRUE != H5Oexists_by_name(fid, "group/elink-soft2", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link in non-root group that points to dangling soft link in non-root group */
     if (H5Lcreate_external(filename, "group/soft1", fid, "group/elink-soft3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that H5Oexists_by_name() returns FALSE */
     if (FALSE != H5Oexists_by_name(fid, "group/elink-soft3", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link in non-root group that points to soft link in non-root group that points to object
      */
     if (H5Lcreate_external(filename, "group/soft2", fid, "group/elink-soft4", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that H5Oexists_by_name() returns TRUE */
     if (TRUE != H5Oexists_by_name(fid, "group/elink-soft4", H5P_DEFAULT))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file created */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -17013,22 +17013,22 @@ corder_create_empty(hid_t fapl)
     herr_t   ret;                     /* Generic return value */
     char     filename[NAME_BUF_SIZE]; /* File name */
 
-    TESTING("creating empty group with creation order indexing")
+    TESTING("creating empty group with creation order indexing");
 
     /* Create file */
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
     if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group creation property list */
     if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set creation order indexing on group */
     if (H5Pget_link_creation_order(gcpl_id, &crt_order_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (crt_order_flags != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Setting invalid combination of a group order creation order indexing on should fail */
     H5E_BEGIN_TRY
@@ -17040,74 +17040,74 @@ corder_create_empty(hid_t fapl)
         H5_FAILED();
         HDputs(
             "    H5Pset_link_create_order() should have failed for a creation order index with no tracking.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Set creation order tracking & indexing on group */
     if (H5Pget_link_creation_order(gcpl_id, &crt_order_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (crt_order_flags != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_link_creation_order(gcpl_id, (H5P_CRT_ORDER_TRACKED | H5P_CRT_ORDER_INDEXED)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_link_creation_order(gcpl_id, &crt_order_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (crt_order_flags != (H5P_CRT_ORDER_TRACKED | H5P_CRT_ORDER_INDEXED))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group with creation order indexing & tracking on */
     if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on group's status */
     if (H5G__is_empty_test(group_id) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group */
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group creation property list */
     if (H5Pclose(gcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file_id = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group created */
     if ((group_id = H5Gopen2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check on group's status */
     if (H5G__is_empty_test(group_id) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve group creation property list for group */
     if ((gcpl_id = H5Gget_create_plist(group_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties */
     if (H5Pget_link_creation_order(gcpl_id, &crt_order_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (crt_order_flags != (H5P_CRT_ORDER_TRACKED | H5P_CRT_ORDER_INDEXED))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group creation property list */
     if (H5Pclose(gcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group */
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -17146,85 +17146,85 @@ corder_create_compact(hid_t fapl)
     char     filename[NAME_BUF_SIZE];       /* File name */
     unsigned u;                             /* Local index variable */
 
-    TESTING("creating compact group with creation order indexing")
+    TESTING("creating compact group with creation order indexing");
 
     /* Create file */
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
     if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group creation property list */
     if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set creation order tracking & indexing on group */
     if (H5Pset_link_creation_order(gcpl_id, (H5P_CRT_ORDER_TRACKED | H5P_CRT_ORDER_INDEXED)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group with creation order indexing & tracking on */
     if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on group's initial status */
     if (H5G__is_empty_test(group_id) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties */
     if (H5Pget_link_phase_change(gcpl_id, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create several links, but keep group in compact form */
     for (u = 0; u < max_compact; u++) {
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(group_id2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify state of group */
         if (H5G__has_links_test(group_id, &nlinks) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (nlinks != (u + 1))
-            TEST_ERROR
+            TEST_ERROR;
         if (H5G__has_stab_test(group_id) == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5G__is_new_dense_test(group_id) == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Close the group */
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group creation property list */
     if (H5Pclose(gcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file_id = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group created */
     if ((group_id = H5Gopen2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify state of group */
     if (H5G__has_links_test(group_id, &nlinks) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (nlinks != max_compact)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop through links, checking their creation order values */
     /* (the name index is used, but the creation order value is in the same order) */
@@ -17234,22 +17234,22 @@ corder_create_compact(hid_t fapl)
         /* Retrieve information for link */
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Lget_info2(group_id, objname, &linfo, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify creation order of link */
         if (linfo.corder_valid != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (linfo.corder != u)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Close the group */
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -17290,104 +17290,104 @@ corder_create_dense(hid_t fapl)
     char     filename[NAME_BUF_SIZE];       /* File name */
     unsigned u;                             /* Local index variable */
 
-    TESTING("creating dense group with creation order indexing")
+    TESTING("creating dense group with creation order indexing");
 
     /* Create file */
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
     if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group creation property list */
     if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set creation order tracking & indexing on group */
     if (H5Pset_link_creation_order(gcpl_id, (H5P_CRT_ORDER_TRACKED | H5P_CRT_ORDER_INDEXED)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group with creation order indexing & tracking on */
     if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on group's initial status */
     if (H5G__is_empty_test(group_id) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties */
     if (H5Pget_link_phase_change(gcpl_id, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create several links, up to limit of compact form */
     for (u = 0; u < max_compact; u++) {
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(group_id2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify state of group */
         if (H5G__has_links_test(group_id, &nlinks) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (nlinks != (u + 1))
-            TEST_ERROR
+            TEST_ERROR;
         if (H5G__has_stab_test(group_id) == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5G__is_new_dense_test(group_id) == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Create another link, to push group into dense form */
     HDsnprintf(objname, sizeof(objname), "filler %u", max_compact);
     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(group_id2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify state of group */
     if (H5G__has_links_test(group_id, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(group_id) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve & verify # of records in the name & creation order indices */
     if (H5G__new_dense_info_test(group_id, &name_count, &corder_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_count != corder_count)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group */
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group creation property list */
     if (H5Pclose(gcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file_id = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group created */
     if ((group_id = H5Gopen2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify state of group */
     if (H5G__has_links_test(group_id, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(group_id) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop through links, checking their creation order values */
     /* (the name index is used, but the creation order value is in the same order) */
@@ -17397,22 +17397,22 @@ corder_create_dense(hid_t fapl)
         /* Retrieve information for link */
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Lget_info2(group_id, objname, &linfo, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify creation order of link */
         if (linfo.corder_valid != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (linfo.corder != u)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Close the group */
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -17455,260 +17455,260 @@ corder_transition(hid_t fapl)
     char           filename[NAME_BUF_SIZE];       /* File name */
     unsigned       u;                             /* Local index variable */
 
-    TESTING("transitioning group with creation order indexing between dense & compact forms")
+    TESTING("transitioning group with creation order indexing between dense & compact forms");
 
     /* Create file */
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
     if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group creation property list */
     if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set creation order tracking & indexing on group */
     if (H5Pset_link_creation_order(gcpl_id, (H5P_CRT_ORDER_TRACKED | H5P_CRT_ORDER_INDEXED)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties */
     if (H5Pget_link_phase_change(gcpl_id, &max_compact, &min_dense) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Increase estimated link info, so the group's object header is large
      *      enough to hold all the link messages in one chunk
      */
     if (H5Pset_est_link_info(gcpl_id, max_compact, CORDER_EST_ENTRY_LEN) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group with creation order indexing & tracking on */
     if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the group creation property list */
     if (H5Pclose(gcpl_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the group */
     if (H5Gclose(group_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file with an empty group */
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file_id = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open group created */
     if ((group_id = H5Gopen2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create several links, up to limit of compact form */
     for (u = 0; u < max_compact; u++) {
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(group_id2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Create another link, to push group into dense form */
     HDsnprintf(objname, sizeof(objname), "filler %u", max_compact);
     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(group_id2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify state of group */
     if (H5G__has_links_test(group_id, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(group_id) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve & verify # of records in the name & creation order indices */
     if (H5G__new_dense_info_test(group_id, &name_count, &corder_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_count != corder_count)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete several links from group, until it resumes compact form */
     for (u = max_compact; u >= min_dense; u--) {
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Ldelete(group_id, objname, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify state of group */
         if (H5G__has_links_test(group_id, NULL) == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5G__has_stab_test(group_id) == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5G__is_new_dense_test(group_id) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Retrieve & verify # of records in the name & creation order indices */
         if (H5G__new_dense_info_test(group_id, &name_count, &corder_count) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (name_count != corder_count)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Delete another link, to push group into compact form */
     HDsnprintf(objname, sizeof(objname), "filler %u", (min_dense - 1));
     if (H5Ldelete(group_id, objname, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify state of group */
     if (H5G__has_links_test(group_id, &nlinks) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (nlinks != (min_dense - 1))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-add links to get back into dense form */
     for (u = (min_dense - 1); u < (max_compact + 1); u++) {
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(group_id2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Verify state of group */
     if (H5G__has_links_test(group_id, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(group_id) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve & verify # of records in the name & creation order indices */
     if (H5G__new_dense_info_test(group_id, &name_count, &corder_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_count != corder_count)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group */
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file_id = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group created */
     if ((group_id = H5Gopen2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify state of group */
     if (H5G__has_links_test(group_id, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(group_id) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve & verify # of records in the name & creation order indices */
     if (H5G__new_dense_info_test(group_id, &name_count, &corder_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_count != corder_count)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete several links from group, until it resumes compact form */
     for (u = max_compact; u >= min_dense; u--) {
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Ldelete(group_id, objname, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify state of group */
         if (H5G__has_links_test(group_id, NULL) == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5G__has_stab_test(group_id) == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5G__is_new_dense_test(group_id) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Retrieve & verify # of records in the name & creation order indices */
         if (H5G__new_dense_info_test(group_id, &name_count, &corder_count) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (name_count != corder_count)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Delete another link, to push group into compact form */
     HDsnprintf(objname, sizeof(objname), "filler %u", (min_dense - 1));
     if (H5Ldelete(group_id, objname, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify state of group */
     if (H5G__has_links_test(group_id, &nlinks) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (nlinks != (min_dense - 1))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-add links to get back into dense form */
     for (u = (min_dense - 1); u < (max_compact + 1); u++) {
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(group_id2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Verify state of group */
     if (H5G__has_links_test(group_id, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(group_id) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(group_id) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve & verify # of records in the name & creation order indices */
     if (H5G__new_dense_info_test(group_id, &name_count, &corder_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_count != corder_count)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete all the links */
     for (u = max_compact; u > 0; u--) {
         HDsnprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Ldelete(group_id, objname, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
     HDsnprintf(objname, sizeof(objname), "filler %u", (unsigned)0);
     if (H5Ldelete(group_id, objname, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group */
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the size of the file now */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -17752,7 +17752,7 @@ corder_delete(hid_t fapl)
     char           filename[NAME_BUF_SIZE];       /* File name */
     unsigned       u;                             /* Local index variable */
 
-    TESTING("deleting group with creation order indexing in dense form")
+    TESTING("deleting group with creation order indexing in dense form");
 
     /* Loop to leave file open when deleting group, or to close & re-open file
      *  before deleting group */
@@ -17762,103 +17762,103 @@ corder_delete(hid_t fapl)
 
         /* Creating file with latest format will enable paged aggregation with persistent fs */
         if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file_id) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of an empty file */
         if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file_id = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create group creation property list */
         if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set creation order tracking & indexing on group */
         if (H5Pset_link_creation_order(gcpl_id, (H5P_CRT_ORDER_TRACKED | H5P_CRT_ORDER_INDEXED)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Query the group creation properties */
         if (H5Pget_link_phase_change(gcpl_id, &max_compact, &min_dense) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Increase estimated link info, so the group's object header is large
          *      enough to hold all the link messages in one chunk
          */
         if (H5Pset_est_link_info(gcpl_id, max_compact, CORDER_EST_ENTRY_LEN) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create group with creation order indexing & tracking on */
         if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close the group creation property list */
         if (H5Pclose(gcpl_id) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create links until the group is in dense form */
         for (u = 0; u < max_compact * 2; u++) {
             HDsnprintf(objname, sizeof(objname), "filler %u", u);
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Gclose(group_id2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         } /* end for */
 
         /* Verify state of group */
         if (H5G__has_links_test(group_id, NULL) == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5G__has_stab_test(group_id) == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5G__is_new_dense_test(group_id) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Retrieve & verify # of records in the name & creation order indices */
         if (H5G__new_dense_info_test(group_id, &name_count, &corder_count) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (name_count != corder_count)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the group */
         if (H5Gclose(group_id) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check for deleting group without re-opening file */
         if (!reopen_file)
             /* Delete the group with the creation order index */
             if (H5Ldelete(file_id, CORDER_GROUP_NAME, H5P_DEFAULT) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
         /* Close the file */
         if (H5Fclose(file_id) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check for deleting group after re-opening file */
         if (reopen_file) {
             /* Re-open the file */
             if ((file_id = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Delete the group with the creation order index */
             if (H5Ldelete(file_id, CORDER_GROUP_NAME, H5P_DEFAULT) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Close the file */
             if (H5Fclose(file_id) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         } /* end if */
 
         /* Get the size of the file now */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (file_size != empty_size)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     PASSED();
@@ -17903,34 +17903,34 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, hbool_t 
     HDmemset(&linfo, 0, sizeof(linfo));
     if (H5Lget_info_by_idx2(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, (hsize_t)0, &linfo, H5P_DEFAULT) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the link information for new link, in increasing creation order */
     HDmemset(&linfo, 0, sizeof(linfo));
     if (H5Lget_info_by_idx2(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != (int64_t)n)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify value for new soft link, in increasing creation order */
     if (!hard_link) {
         HDmemset(tmpval, 0, (size_t)NAME_BUF_SIZE);
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (HDstrcmp(valname, tmpval) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Verify the name for new link, in increasing creation order */
     HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, tmpname, (size_t)NAME_BUF_SIZE,
                            H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(linkname, tmpname) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Don't test "native" order if there is no creation order index, since
      *  there's not a good way to easily predict the link's order in the name
@@ -17941,101 +17941,101 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, hbool_t 
         HDmemset(&linfo, 0, sizeof(linfo));
         if (H5Lget_info_by_idx2(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, (hsize_t)0, &linfo,
                                 H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (linfo.corder != 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the link information for new link, in native creation order (which is increasing) */
         HDmemset(&linfo, 0, sizeof(linfo));
         if (H5Lget_info_by_idx2(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, n, &linfo, H5P_DEFAULT) <
             0)
-            TEST_ERROR
+            TEST_ERROR;
         if (linfo.corder != (int64_t)n)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify value for new soft link, in native creation order (which is increasing) */
         if (!hard_link) {
             HDmemset(tmpval, 0, (size_t)NAME_BUF_SIZE);
             if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, n, tmpval,
                                   (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (HDstrcmp(valname, tmpval) != 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
 
         /* Verify the name for new link, in native creation order (which is increasing) */
         HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
         if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, n, tmpname,
                                (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (HDstrcmp(linkname, tmpname) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Verify the link information for first link, in decreasing creation order */
     HDmemset(&linfo, 0, sizeof(linfo));
     if (H5Lget_info_by_idx2(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, n, &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the link information for new link, in decreasing creation order */
     HDmemset(&linfo, 0, sizeof(linfo));
     if (H5Lget_info_by_idx2(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, &linfo, H5P_DEFAULT) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != (int64_t)n)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify value for new soft link, in decreasing creation order */
     if (!hard_link) {
         HDmemset(tmpval, 0, (size_t)NAME_BUF_SIZE);
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (HDstrcmp(valname, tmpval) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Verify the name for new link, in decreasing creation order */
     HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, tmpname,
                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(linkname, tmpname) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the link information for first link, in increasing link name order */
     HDmemset(&linfo, 0, sizeof(linfo));
     if (H5Lget_info_by_idx2(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)0, &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the link information for new link, in increasing link name order */
     HDmemset(&linfo, 0, sizeof(linfo));
     if (H5Lget_info_by_idx2(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != (int64_t)n)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify value for new soft link, in increasing link name order */
     if (!hard_link) {
         HDmemset(tmpval, 0, (size_t)NAME_BUF_SIZE);
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, tmpval, (size_t)NAME_BUF_SIZE,
                               H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (HDstrcmp(valname, tmpval) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Verify the name for new link, in increasing link name order */
     HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, tmpname, (size_t)NAME_BUF_SIZE,
                            H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(linkname, tmpname) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Don't test "native" order queries on link name order, since there's not
      *  a good way to easily predict the order of the links in the name index.
@@ -18044,34 +18044,34 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, hbool_t 
     /* Verify the link information for first link, in decreasing link name order */
     HDmemset(&linfo, 0, sizeof(linfo));
     if (H5Lget_info_by_idx2(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, n, &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the link information for new link, in decreasing link name order */
     HDmemset(&linfo, 0, sizeof(linfo));
     if (H5Lget_info_by_idx2(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, &linfo, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (linfo.corder != (int64_t)n)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify value for new soft link, in decreasing link name order */
     if (!hard_link) {
         HDmemset(tmpval, 0, (size_t)NAME_BUF_SIZE);
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (HDstrcmp(valname, tmpval) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Verify the name for new link, in decreasing link name order */
     HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, tmpname,
                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(linkname, tmpname) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return (0);
@@ -18116,38 +18116,38 @@ link_info_by_idx(hid_t fapl)
         for (use_index = FALSE; use_index <= TRUE; use_index++) {
             if (hard_link) {
                 if (use_index)
-                    TESTING("querying info by index w/creation order index, using hard links")
+                    TESTING("querying info by index w/creation order index, using hard links");
                 else
-                    TESTING("querying info by index w/o creation order index, using hard links")
+                    TESTING("querying info by index w/o creation order index, using hard links");
             } /* end if */
             else {
                 if (use_index)
-                    TESTING("querying info by index w/creation order index, using soft links")
+                    TESTING("querying info by index w/creation order index, using soft links");
                 else
-                    TESTING("querying info by index w/o creation order index, using soft links")
+                    TESTING("querying info by index w/o creation order index, using soft links");
             } /* end else */
 
             /* Create file */
             h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
             if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create group creation property list */
             if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Set creation order tracking & indexing on group */
             if (H5Pset_link_creation_order(
                     gcpl_id, (H5P_CRT_ORDER_TRACKED | (use_index ? H5P_CRT_ORDER_INDEXED : (unsigned)0))) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create group with creation order indexing & tracking on */
             if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Query the group creation properties */
             if (H5Pget_link_phase_change(gcpl_id, &max_compact, &min_dense) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check for query on empty group */
             H5E_BEGIN_TRY
@@ -18157,7 +18157,7 @@ link_info_by_idx(hid_t fapl)
             }
             H5E_END_TRY;
             if (ret >= 0)
-                TEST_ERROR
+                TEST_ERROR;
             H5E_BEGIN_TRY
             {
                 name_len = H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, (hsize_t)0,
@@ -18165,7 +18165,7 @@ link_info_by_idx(hid_t fapl)
             }
             H5E_END_TRY;
             if (name_len >= 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create several links, up to limit of compact form */
             for (u = 0; u < max_compact; u++) {
@@ -18179,9 +18179,9 @@ link_info_by_idx(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end if */
                 else {
                     /* Make value for link */
@@ -18189,17 +18189,17 @@ link_info_by_idx(hid_t fapl)
 
                     /* Create soft link */
                     if (H5Lcreate_soft(valname, group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end else */
 
                 /* Verify link information for new link */
                 if (link_info_by_idx_check(group_id, objname, (hsize_t)u, hard_link, use_index) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end for */
 
             /* Verify state of group */
             if (H5G__has_links_test(group_id, NULL) != TRUE)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check for out of bound offset queries */
             H5E_BEGIN_TRY
@@ -18209,7 +18209,7 @@ link_info_by_idx(hid_t fapl)
             }
             H5E_END_TRY;
             if (ret >= 0)
-                TEST_ERROR
+                TEST_ERROR;
             H5E_BEGIN_TRY
             {
                 ret = H5Lget_info_by_idx2(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)u, &linfo,
@@ -18217,7 +18217,7 @@ link_info_by_idx(hid_t fapl)
             }
             H5E_END_TRY;
             if (ret >= 0)
-                TEST_ERROR
+                TEST_ERROR;
             H5E_BEGIN_TRY
             {
                 name_len = H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, (hsize_t)u,
@@ -18225,7 +18225,7 @@ link_info_by_idx(hid_t fapl)
             }
             H5E_END_TRY;
             if (name_len >= 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create more links, to push group into dense form */
             for (; u < (max_compact * 2); u++) {
@@ -18239,9 +18239,9 @@ link_info_by_idx(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end if */
                 else {
                     /* Make value for link */
@@ -18249,16 +18249,16 @@ link_info_by_idx(hid_t fapl)
 
                     /* Create soft link */
                     if (H5Lcreate_soft(valname, group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end else */
 
                 /* Verify state of group */
                 if (H5G__is_new_dense_test(group_id) != TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Verify link information for new link */
                 if (link_info_by_idx_check(group_id, objname, (hsize_t)u, hard_link, use_index) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end for */
 
             /* Check for out of bound offset queries */
@@ -18269,7 +18269,7 @@ link_info_by_idx(hid_t fapl)
             }
             H5E_END_TRY;
             if (ret >= 0)
-                TEST_ERROR
+                TEST_ERROR;
             H5E_BEGIN_TRY
             {
                 ret = H5Lget_info_by_idx2(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)u, &linfo,
@@ -18277,7 +18277,7 @@ link_info_by_idx(hid_t fapl)
             }
             H5E_END_TRY;
             if (ret >= 0)
-                TEST_ERROR
+                TEST_ERROR;
             H5E_BEGIN_TRY
             {
                 name_len = H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, (hsize_t)u,
@@ -18285,19 +18285,19 @@ link_info_by_idx(hid_t fapl)
             }
             H5E_END_TRY;
             if (name_len >= 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close the group */
             if (H5Gclose(group_id) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close the group creation property list */
             if (H5Pclose(gcpl_id) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close the file */
             if (H5Fclose(file_id) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             PASSED();
         } /* end for */
@@ -18349,26 +18349,26 @@ link_info_by_idx_old(hid_t fapl)
     /* Loop over creating hard or soft links */
     for (hard_link = FALSE; hard_link <= TRUE; hard_link++) {
         if (hard_link)
-            TESTING("querying info by index in old-style group, using hard links")
+            TESTING("querying info by index in old-style group, using hard links");
         else
-            TESTING("querying info by index in old-style group, using soft links")
+            TESTING("querying info by index in old-style group, using soft links");
 
         /* Create file */
         h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
         if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Need the file struct to address encoding */
         /* Retrieve VOL object */
         if (NULL == (vol_obj_file = H5VL_vol_object(file_id)))
-            TEST_ERROR
+            TEST_ERROR;
         /* Retrieve file from VOL object */
         if (NULL == (f = (H5F_t *)H5VL_object_data((const H5VL_object_t *)vol_obj_file)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create group to operate on */
         if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create several links */
         for (u = 0; u < CORDER_NLINKS; u++) {
@@ -18381,17 +18381,17 @@ link_info_by_idx_old(hid_t fapl)
 
                 /* Create group */
                 if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Retrieve group's object token */
                 if (H5Oget_info3(group_id2, &oi, H5O_INFO_BASIC) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 HDmemcpy(&objtoken[u], &oi.token, sizeof(H5O_token_t));
 
                 /* Close group */
                 if (H5Gclose(group_id2) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 /* Make value for link */
@@ -18399,7 +18399,7 @@ link_info_by_idx_old(hid_t fapl)
 
                 /* Create soft link */
                 if (H5Lcreate_soft(valname, group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end else */
         }     /* end for */
 
@@ -18417,51 +18417,51 @@ link_info_by_idx_old(hid_t fapl)
             if (hard_link) {
                 if (H5Lget_info_by_idx2(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)u, &linfo,
                                         H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Otoken_cmp(group_id, &linfo.u.token, &objtoken[u], &token_cmp) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (token_cmp)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (HDstrcmp(valname, tmpval) != 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end else */
 
             /* Verify link name (in increasing order) */
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (HDstrcmp(objname, tmpname) != 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Verify link information (in native order - native is increasing) */
             if (hard_link) {
                 if (H5Lget_info_by_idx2(group_id, ".", H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)u, &linfo,
                                         H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Otoken_cmp(group_id, &linfo.u.token, &objtoken[u], &token_cmp) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (token_cmp)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (HDstrcmp(valname, tmpval) != 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end else */
 
             /* Verify link name (in native order - native is increasing) */
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (HDstrcmp(objname, tmpname) != 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Make link name for decreasing order queries */
             HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
@@ -18473,26 +18473,26 @@ link_info_by_idx_old(hid_t fapl)
             if (hard_link) {
                 if (H5Lget_info_by_idx2(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)u, &linfo,
                                         H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Otoken_cmp(group_id, &linfo.u.token, &objtoken[dec_u], &token_cmp) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (token_cmp)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (HDstrcmp(valname, tmpval) != 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end else */
 
             /* Verify link name (in decreasing order) */
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (HDstrcmp(objname, tmpname) != 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Check for creation order index queries */
@@ -18503,7 +18503,7 @@ link_info_by_idx_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
         H5E_BEGIN_TRY
         {
             name_len = H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, (hsize_t)u, tmpname,
@@ -18511,19 +18511,19 @@ link_info_by_idx_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (name_len >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify state of group */
         if (H5G__has_stab_test(group_id) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the group */
         if (H5Gclose(group_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file */
         if (H5Fclose(file_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end for */
@@ -18579,60 +18579,62 @@ delete_by_idx(hid_t fapl)
                     if (order == H5_ITER_INC) {
                         if (use_index)
                             TESTING("deleting links by creation order index in increasing order w/creation "
-                                    "order index")
+                                    "order index");
                         else
                             TESTING("deleting links by creation order index in increasing order w/o creation "
-                                    "order index")
+                                    "order index");
                     } /* end if */
                     else {
                         if (use_index)
                             TESTING("deleting links by creation order index in decreasing order w/creation "
-                                    "order index")
+                                    "order index");
                         else
                             TESTING("deleting links by creation order index in decreasing order w/o creation "
-                                    "order index")
+                                    "order index");
                     } /* end else */
                 }     /* end if */
                 else {
                     if (order == H5_ITER_INC) {
                         if (use_index)
-                            TESTING("deleting links by name index in increasing order w/creation order index")
+                            TESTING(
+                                "deleting links by name index in increasing order w/creation order index");
                         else
                             TESTING(
-                                "deleting links by name index in increasing order w/o creation order index")
+                                "deleting links by name index in increasing order w/o creation order index");
                     } /* end if */
                     else {
                         if (use_index)
-                            TESTING("deleting links by name index in decreasing order w/creation order index")
+                            TESTING(
+                                "deleting links by name index in decreasing order w/creation order index");
                         else
                             TESTING(
-                                "deleting links by name index in decreasing order w/o creation order index")
+                                "deleting links by name index in decreasing order w/o creation order index");
                     } /* end else */
                 }     /* end else */
 
                 /* Create file */
                 h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
                 if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create group creation property list */
                 if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Set creation order tracking & indexing on group */
                 if (H5Pset_link_creation_order(gcpl_id, (H5P_CRT_ORDER_TRACKED |
                                                          (use_index ? H5P_CRT_ORDER_INDEXED : (unsigned)0))) <
                     0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create group with creation order tracking on */
                 if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) <
                     0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Query the group creation properties */
                 if (H5Pget_link_phase_change(gcpl_id, &max_compact, &min_dense) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Delete links from one end */
 
@@ -18643,7 +18645,7 @@ delete_by_idx(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for deletion on non-existing group */
                 H5E_BEGIN_TRY
@@ -18652,7 +18654,7 @@ delete_by_idx(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create several links, up to limit of compact form */
                 for (u = 0; u < max_compact; u++) {
@@ -18664,18 +18666,18 @@ delete_by_idx(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Verify link information for new link */
                     if (link_info_by_idx_check(group_id, objname, (hsize_t)u, TRUE, use_index) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Verify state of group (compact) */
                 if (H5G__has_links_test(group_id, NULL) != TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for out of bound deletion */
                 H5E_BEGIN_TRY
@@ -18684,48 +18686,48 @@ delete_by_idx(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Delete links from compact group */
                 for (u = 0; u < (max_compact - 1); u++) {
                     /* Delete first link in appropriate order */
                     if (H5Ldelete_by_idx(group_id, ".", idx_type, order, (hsize_t)0, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Verify the link information for first link in appropriate order */
                     HDmemset(&linfo, 0, sizeof(linfo));
                     if (H5Lget_info_by_idx2(group_id, ".", idx_type, order, (hsize_t)0, &linfo, H5P_DEFAULT) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (order == H5_ITER_INC) {
                         if (linfo.corder != (u + 1))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end if */
                     else {
                         if (linfo.corder != (max_compact - (u + 2)))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end else */
 
                     /* Verify the name for first link in appropriate order */
                     HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
                     if (H5Lget_name_by_idx(group_id, ".", idx_type, order, (hsize_t)0, tmpname,
                                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (order == H5_ITER_INC)
                         HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
                     else
                         HDsnprintf(objname, sizeof(objname), "filler %02u", (max_compact - (u + 2)));
                     if (HDstrcmp(objname, tmpname) != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Delete last link */
                 if (H5Ldelete_by_idx(group_id, ".", idx_type, order, (hsize_t)0, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Verify state of group (empty) */
                 if (H5G__has_links_test(group_id, NULL) == TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create more links, to push group into dense form */
                 for (u = 0; u < (max_compact * 2); u++) {
@@ -18737,18 +18739,18 @@ delete_by_idx(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Verify state of group (dense) */
                     if (u >= max_compact)
                         if (H5G__is_new_dense_test(group_id) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
 
                     /* Verify link information for new link */
                     if (link_info_by_idx_check(group_id, objname, (hsize_t)u, TRUE, use_index) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Check for out of bound deletion again */
@@ -18758,50 +18760,50 @@ delete_by_idx(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Delete links from dense group, in appropriate order */
                 for (u = 0; u < ((max_compact * 2) - 1); u++) {
                     /* Delete first link in appropriate order */
                     if (H5Ldelete_by_idx(group_id, ".", idx_type, order, (hsize_t)0, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Verify the link information for first link in appropriate order */
                     HDmemset(&linfo, 0, sizeof(linfo));
                     if (H5Lget_info_by_idx2(group_id, ".", idx_type, order, (hsize_t)0, &linfo, H5P_DEFAULT) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (order == H5_ITER_INC) {
                         if (linfo.corder != (u + 1))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end if */
                     else {
                         if (linfo.corder != ((max_compact * 2) - (u + 2)))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end else */
 
                     /* Verify the name for first link in appropriate order */
                     HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
                     if (H5Lget_name_by_idx(group_id, ".", idx_type, order, (hsize_t)0, tmpname,
                                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (order == H5_ITER_INC)
                         HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
                     else
                         HDsnprintf(objname, sizeof(objname), "filler %02u", ((max_compact * 2) - (u + 2)));
                     if (HDstrcmp(objname, tmpname) != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Delete last link */
                 if (H5Ldelete_by_idx(group_id, ".", idx_type, order, (hsize_t)0, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Verify state of group (empty) */
                 if (H5G__has_links_test(group_id, NULL) == TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5G__is_new_dense_test(group_id) == TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for deletion on empty group again */
                 H5E_BEGIN_TRY
@@ -18810,7 +18812,7 @@ delete_by_idx(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Delete links in middle */
 
@@ -18824,109 +18826,109 @@ delete_by_idx(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Verify state of group (dense) */
                     if (u >= max_compact)
                         if (H5G__is_new_dense_test(group_id) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
 
                     /* Verify link information for new link */
                     if (link_info_by_idx_check(group_id, objname, (hsize_t)u, TRUE, use_index) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Delete every other link from dense group, in appropriate order */
                 for (u = 0; u < max_compact; u++) {
                     /* Delete link */
                     if (H5Ldelete_by_idx(group_id, ".", idx_type, order, (hsize_t)u, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Verify the link information for current link in appropriate order */
                     HDmemset(&linfo, 0, sizeof(linfo));
                     if (H5Lget_info_by_idx2(group_id, ".", idx_type, order, (hsize_t)u, &linfo, H5P_DEFAULT) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (order == H5_ITER_INC) {
                         if (linfo.corder != ((u * 2) + 1))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end if */
                     else {
                         if (linfo.corder != ((max_compact * 2) - ((u * 2) + 2)))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end else */
 
                     /* Verify the name for current link in appropriate order */
                     HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
                     if (H5Lget_name_by_idx(group_id, ".", idx_type, order, (hsize_t)u, tmpname,
                                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (order == H5_ITER_INC)
                         HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 1));
                     else
                         HDsnprintf(objname, sizeof(objname), "filler %02u",
                                    ((max_compact * 2) - ((u * 2) + 2)));
                     if (HDstrcmp(objname, tmpname) != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Delete remaining links from dense group, in appropriate order */
                 for (u = 0; u < (max_compact - 1); u++) {
                     /* Delete link */
                     if (H5Ldelete_by_idx(group_id, ".", idx_type, order, (hsize_t)0, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Verify the link information for first link in appropriate order */
                     HDmemset(&linfo, 0, sizeof(linfo));
                     if (H5Lget_info_by_idx2(group_id, ".", idx_type, order, (hsize_t)0, &linfo, H5P_DEFAULT) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (order == H5_ITER_INC) {
                         if (linfo.corder != ((u * 2) + 3))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end if */
                     else {
                         if (linfo.corder != ((max_compact * 2) - ((u * 2) + 4)))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end else */
 
                     /* Verify the name for first link in appropriate order */
                     HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
                     if (H5Lget_name_by_idx(group_id, ".", idx_type, order, (hsize_t)0, tmpname,
                                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (order == H5_ITER_INC)
                         HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 3));
                     else
                         HDsnprintf(objname, sizeof(objname), "filler %02u",
                                    ((max_compact * 2) - ((u * 2) + 4)));
                     if (HDstrcmp(objname, tmpname) != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Delete last link */
                 if (H5Ldelete_by_idx(group_id, ".", idx_type, order, (hsize_t)0, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Verify state of group (empty) */
                 if (H5G__has_links_test(group_id, NULL) == TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5G__is_new_dense_test(group_id) == TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the group */
                 if (H5Gclose(group_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the group creation property list */
                 if (H5Pclose(gcpl_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the file */
                 if (H5Fclose(file_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 PASSED();
             } /* end for */
@@ -18977,26 +18979,26 @@ delete_by_idx_old(hid_t fapl)
     for (order = H5_ITER_INC; order <= H5_ITER_DEC; order++) {
         /* Print test banner */
         if (order == H5_ITER_INC)
-            TESTING("deleting links by index in increasing order in old-style group")
+            TESTING("deleting links by index in increasing order in old-style group");
         else
-            TESTING("deleting links by index in decreasing order in old-style group")
+            TESTING("deleting links by index in decreasing order in old-style group");
 
         /* Create file */
         h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
         if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Need the file struct to address encoding */
         /* Retrieve VOL object */
         if (NULL == (vol_obj_file = H5VL_vol_object(file_id)))
-            TEST_ERROR
+            TEST_ERROR;
         /* Retrieve file from VOL object */
         if (NULL == (f = (H5F_t *)H5VL_object_data((const H5VL_object_t *)vol_obj_file)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create group to operate on */
         if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Delete links from one end */
 
@@ -19007,7 +19009,7 @@ delete_by_idx_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create several links */
         for (u = 0; u < CORDER_NLINKS; u++) {
@@ -19018,17 +19020,17 @@ delete_by_idx_old(hid_t fapl)
 
             /* Create group */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Retrieve group's object token */
             if (H5Oget_info3(group_id2, &oi, H5O_INFO_BASIC) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             HDmemcpy(&objtoken[u], &oi.token, sizeof(H5O_token_t));
 
             /* Close group */
             if (H5Gclose(group_id2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Check for bad index type deletion */
@@ -19038,7 +19040,7 @@ delete_by_idx_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for out of bounds deletion */
         H5E_BEGIN_TRY
@@ -19047,7 +19049,7 @@ delete_by_idx_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Delete links, in appropriate order */
         for (u = 0; u < (CORDER_NLINKS - 1); u++) {
@@ -19055,41 +19057,41 @@ delete_by_idx_old(hid_t fapl)
 
             /* Delete first link in appropriate order */
             if (H5Ldelete_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Verify the link information for first link in appropriate order */
             HDmemset(&linfo, 0, sizeof(linfo));
             if (H5Lget_info_by_idx2(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, &linfo, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (order == H5_ITER_INC) {
                 if (H5Otoken_cmp(group_id, &linfo.u.token, &objtoken[u + 1], &token_cmp) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (token_cmp)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 if (H5Otoken_cmp(group_id, &linfo.u.token, &objtoken[dec_u], &token_cmp) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (token_cmp)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end else */
 
             /* Verify the name for first link in appropriate order */
             HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (order == H5_ITER_INC)
                 HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
             else
                 HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
             if (HDstrcmp(objname, tmpname) != 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Delete last link */
         if (H5Ldelete_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for deletion in empty group (again) */
         H5E_BEGIN_TRY
@@ -19098,11 +19100,11 @@ delete_by_idx_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify state of group */
         if (H5G__has_stab_test(group_id) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Delete links in middle */
 
@@ -19115,17 +19117,17 @@ delete_by_idx_old(hid_t fapl)
 
             /* Create group */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Retrieve group's object token */
             if (H5Oget_info3(group_id2, &oi, H5O_INFO_BASIC) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             HDmemcpy(&objtoken[u], &oi.token, sizeof(H5O_token_t));
 
             /* Close group */
             if (H5Gclose(group_id2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Delete every other link from group, in appropriate order */
@@ -19134,36 +19136,36 @@ delete_by_idx_old(hid_t fapl)
 
             /* Delete link */
             if (H5Ldelete_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)u, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Verify the link information for current link in appropriate order */
             HDmemset(&linfo, 0, sizeof(linfo));
             if (H5Lget_info_by_idx2(group_id, ".", H5_INDEX_NAME, order, (hsize_t)u, &linfo, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (order == H5_ITER_INC) {
                 if (H5Otoken_cmp(group_id, &linfo.u.token, &objtoken[(u * 2) + 1], &token_cmp) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (token_cmp)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 if (H5Otoken_cmp(group_id, &linfo.u.token, &objtoken[dec_u], &token_cmp) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (token_cmp)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end else */
 
             /* Verify the name for current link in appropriate order */
             HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (order == H5_ITER_INC)
                 HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 1));
             else
                 HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
             if (HDstrcmp(objname, tmpname) != 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Delete remaining links from group, in appropriate order */
@@ -19172,53 +19174,53 @@ delete_by_idx_old(hid_t fapl)
 
             /* Delete link */
             if (H5Ldelete_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Verify the link information for first link in appropriate order */
             HDmemset(&linfo, 0, sizeof(linfo));
             if (H5Lget_info_by_idx2(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, &linfo, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (order == H5_ITER_INC) {
                 if (H5Otoken_cmp(group_id, &linfo.u.token, &objtoken[(u * 2) + 3], &token_cmp) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (token_cmp)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 if (H5Otoken_cmp(group_id, &linfo.u.token, &objtoken[dec_u], &token_cmp) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (token_cmp)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end else */
 
             /* Verify the name for first link in appropriate order */
             HDmemset(tmpname, 0, (size_t)NAME_BUF_SIZE);
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (order == H5_ITER_INC)
                 HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 3));
             else
                 HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
             if (HDstrcmp(objname, tmpname) != 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Delete last link */
         if (H5Ldelete_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify state of group */
         if (H5G__has_stab_test(group_id) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the group */
         if (H5Gclose(group_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file */
         if (H5Fclose(file_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end for */
@@ -19374,14 +19376,14 @@ link_iterate_check(hid_t group_id, H5_index_t idx_type, H5_iter_order_t order, u
     iter_info->curr     = order != H5_ITER_DEC ? 0 : (max_links - 1);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if (H5Literate2(group_id, idx_type, order, &skip, link_iterate_cb, iter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we visited all the links */
     if (skip != max_links)
-        TEST_ERROR
+        TEST_ERROR;
     for (v = 0; v < max_links; v++)
         if (iter_info->visited[v] == FALSE)
-            TEST_ERROR
+            TEST_ERROR;
 
 #ifndef H5_NO_DEPRECATED_SYMBOLS
     /* Iterate over links in group, with H5Giterate */
@@ -19392,14 +19394,14 @@ link_iterate_check(hid_t group_id, H5_index_t idx_type, H5_iter_order_t order, u
     iter_info->curr     = order != H5_ITER_DEC ? 0 : (max_links - 1);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if (H5Giterate(group_id, ".", &gskip, group_iterate_cb, iter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we visited all the links */
     if (gskip != (int)max_links)
-        TEST_ERROR
+        TEST_ERROR;
     for (v = 0; v < max_links; v++)
         if (iter_info->visited[v] == FALSE)
-            TEST_ERROR
+            TEST_ERROR;
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
 
     /* Skip over some links in group */
@@ -19410,20 +19412,20 @@ link_iterate_check(hid_t group_id, H5_index_t idx_type, H5_iter_order_t order, u
     iter_info->curr     = (int64_t)(order != H5_ITER_DEC ? skip : ((max_links - 1) - skip));
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if (H5Literate2(group_id, idx_type, order, &skip, link_iterate_cb, iter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we visited all the links */
     if (skip != max_links)
-        TEST_ERROR
+        TEST_ERROR;
     if (order == H5_ITER_INC) {
         for (v = 0; v < (max_links / 2); v++)
             if (iter_info->visited[v + (max_links / 2)] == FALSE)
-                TEST_ERROR
+                TEST_ERROR;
     } /* end if */
     else if (order == H5_ITER_DEC) {
         for (v = 0; v < (max_links / 2); v++)
             if (iter_info->visited[v] == FALSE)
-                TEST_ERROR
+                TEST_ERROR;
     } /* end if */
     else {
         unsigned nvisit = 0; /* # of links visited */
@@ -19434,7 +19436,7 @@ link_iterate_check(hid_t group_id, H5_index_t idx_type, H5_iter_order_t order, u
                 nvisit++;
 
         if (nvisit != (max_links / 2))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end else */
 
 #ifndef H5_NO_DEPRECATED_SYMBOLS
@@ -19446,20 +19448,20 @@ link_iterate_check(hid_t group_id, H5_index_t idx_type, H5_iter_order_t order, u
     iter_info->curr     = order != H5_ITER_DEC ? (unsigned)gskip : ((max_links - 1) - (unsigned)gskip);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if (H5Giterate(group_id, ".", &gskip, group_iterate_cb, iter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we visited all the links */
     if (gskip != (int)max_links)
-        TEST_ERROR
+        TEST_ERROR;
     if (order == H5_ITER_INC) {
         for (v = 0; v < (max_links / 2); v++)
             if (iter_info->visited[v + (max_links / 2)] == FALSE)
-                TEST_ERROR
+                TEST_ERROR;
     } /* end if */
     else if (order == H5_ITER_DEC) {
         for (v = 0; v < (max_links / 2); v++)
             if (iter_info->visited[v] == FALSE)
-                TEST_ERROR
+                TEST_ERROR;
     } /* end if */
     else {
         unsigned nvisit = 0; /* # of links visited */
@@ -19470,7 +19472,7 @@ link_iterate_check(hid_t group_id, H5_index_t idx_type, H5_iter_order_t order, u
                 nvisit++;
 
         if (nvisit != (max_links / 2))
-            TEST_ERROR
+            TEST_ERROR;
     }  /* end else */
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
 
@@ -19482,11 +19484,11 @@ link_iterate_check(hid_t group_id, H5_index_t idx_type, H5_iter_order_t order, u
     iter_info->curr     = order != H5_ITER_DEC ? 0 : (max_links - 1);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if ((ret = H5Literate2(group_id, idx_type, order, &skip, link_iterate_cb, iter_info)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ret != CORDER_ITER_STOP)
-        TEST_ERROR
+        TEST_ERROR;
     if (iter_info->ncalled != 3)
-        TEST_ERROR
+        TEST_ERROR;
 
 #ifndef H5_NO_DEPRECATED_SYMBOLS
     /* Iterate over links in group, stopping in the middle, with H5Giterate() */
@@ -19497,11 +19499,11 @@ link_iterate_check(hid_t group_id, H5_index_t idx_type, H5_iter_order_t order, u
     iter_info->curr     = order != H5_ITER_DEC ? 0 : (max_links - 1);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if ((ret = H5Giterate(group_id, ".", &gskip, group_iterate_cb, iter_info)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ret != CORDER_ITER_STOP)
-        TEST_ERROR
+        TEST_ERROR;
     if (iter_info->ncalled != 3)
-        TEST_ERROR
+        TEST_ERROR;
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
 
     /* Check for iteration routine indicating failure */
@@ -19512,7 +19514,7 @@ link_iterate_check(hid_t group_id, H5_index_t idx_type, H5_iter_order_t order, u
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return SUCCEED;
@@ -19556,16 +19558,16 @@ link_iterate(hid_t fapl)
 
     /* Create group creation property list */
     if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties */
     if (H5Pget_link_phase_change(gcpl_id, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate the "visited link" array */
     iter_info.max_visit = max_compact * 2;
     if (NULL == (visited = (hbool_t *)HDmalloc(sizeof(hbool_t) * iter_info.max_visit)))
-        TEST_ERROR
+        TEST_ERROR;
     iter_info.visited = visited;
 
     /* Loop over operating on different indices on link fields */
@@ -19579,77 +19581,77 @@ link_iterate(hid_t fapl)
                     if (order == H5_ITER_INC) {
                         if (use_index)
                             TESTING("iterating over links by creation order index in increasing order "
-                                    "w/creation order index")
+                                    "w/creation order index");
                         else
                             TESTING("iterating over links by creation order index in increasing order w/o "
-                                    "creation order index")
+                                    "creation order index");
                     } /* end if */
                     else if (order == H5_ITER_DEC) {
                         if (use_index)
                             TESTING("iterating over links by creation order index in decreasing order "
-                                    "w/creation order index")
+                                    "w/creation order index");
                         else
                             TESTING("iterating over links by creation order index in decreasing order w/o "
-                                    "creation order index")
+                                    "creation order index");
                     } /* end else */
                     else {
                         HDassert(order == H5_ITER_NATIVE);
                         if (use_index)
                             TESTING("iterating over links by creation order index in native order w/creation "
-                                    "order index")
+                                    "order index");
                         else
                             TESTING("iterating over links by creation order index in native order w/o "
-                                    "creation order index")
+                                    "creation order index");
                     } /* end else */
                 }     /* end if */
                 else {
                     if (order == H5_ITER_INC) {
                         if (use_index)
                             TESTING("iterating over links by name index in increasing order w/creation order "
-                                    "index")
+                                    "index");
                         else
                             TESTING("iterating over links by name index in increasing order w/o creation "
-                                    "order index")
+                                    "order index");
                     } /* end if */
                     else if (order == H5_ITER_DEC) {
                         if (use_index)
                             TESTING("iterating over links by name index in decreasing order w/creation order "
-                                    "index")
+                                    "index");
                         else
                             TESTING("iterating over links by name index in decreasing order w/o creation "
-                                    "order index")
+                                    "order index");
                     } /* end else */
                     else {
                         HDassert(order == H5_ITER_NATIVE);
                         if (use_index)
                             TESTING(
-                                "iterating over links by name index in native order w/creation order index")
+                                "iterating over links by name index in native order w/creation order index");
                         else
-                            TESTING(
-                                "iterating over links by name index in native order w/o creation order index")
+                            TESTING("iterating over links by name index in native order w/o creation order "
+                                    "index");
                     } /* end else */
                 }     /* end else */
 
                 /* Create file */
                 h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
                 if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Set creation order tracking & indexing on group */
                 if (H5Pset_link_creation_order(gcpl_id, (H5P_CRT_ORDER_TRACKED |
                                                          (use_index ? H5P_CRT_ORDER_INDEXED : (unsigned)0))) <
                     0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create group with creation order tracking on */
                 if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) <
                     0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for iteration on empty group */
                 /* (should be OK) */
                 if (H5Literate2(group_id, idx_type, order, NULL, link_iterate_cb, NULL) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create several links, up to limit of compact form */
                 for (u = 0; u < max_compact; u++) {
@@ -19661,14 +19663,14 @@ link_iterate(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Verify state of group (compact) */
                 if (H5G__has_links_test(group_id, NULL) != TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for out of bound iteration on compact group */
                 skip = (hsize_t)u;
@@ -19678,11 +19680,11 @@ link_iterate(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Test iteration over links in compact group */
                 if (link_iterate_check(group_id, idx_type, order, u, &iter_info) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create more links, to push group into dense form */
                 for (; u < (max_compact * 2); u++) {
@@ -19694,14 +19696,14 @@ link_iterate(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Verify state of group (dense) */
                 if (H5G__is_new_dense_test(group_id) != TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for out of bound iteration on dense group */
                 skip = (hsize_t)u;
@@ -19711,19 +19713,19 @@ link_iterate(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Test iteration over links in dense group */
                 if (link_iterate_check(group_id, idx_type, order, u, &iter_info) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the group */
                 if (H5Gclose(group_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the file */
                 if (H5Fclose(file_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 PASSED();
             } /* end for */
@@ -19732,7 +19734,7 @@ link_iterate(hid_t fapl)
 
     /* Close the group creation property list */
     if (H5Pclose(gcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     if (visited)
@@ -19871,14 +19873,14 @@ link_iterate_old_check(hid_t group_id, H5_iter_order_t order, unsigned max_links
     iter_info->curr     = order != H5_ITER_DEC ? 0 : (max_links - 1);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if (H5Literate2(group_id, H5_INDEX_NAME, order, &skip, link_iterate_old_cb, iter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we visited all the links */
     if (skip != max_links)
-        TEST_ERROR
+        TEST_ERROR;
     for (v = 0; v < max_links; v++)
         if (iter_info->visited[v] == FALSE)
-            TEST_ERROR
+            TEST_ERROR;
 
 #ifndef H5_NO_DEPRECATED_SYMBOLS
     /* Iterate over links in group, with H5Giterate */
@@ -19889,14 +19891,14 @@ link_iterate_old_check(hid_t group_id, H5_iter_order_t order, unsigned max_links
     iter_info->curr     = order != H5_ITER_DEC ? 0 : (max_links - 1);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if (H5Giterate(group_id, ".", &gskip, group_iterate_old_cb, iter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we visited all the links */
     if (gskip != (int)max_links)
-        TEST_ERROR
+        TEST_ERROR;
     for (v = 0; v < max_links; v++)
         if (iter_info->visited[v] == FALSE)
-            TEST_ERROR
+            TEST_ERROR;
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
 
     /* Skip over some links in group */
@@ -19907,20 +19909,20 @@ link_iterate_old_check(hid_t group_id, H5_iter_order_t order, unsigned max_links
     iter_info->curr     = (int64_t)(order != H5_ITER_DEC ? skip : ((max_links - 1) - skip));
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if (H5Literate2(group_id, H5_INDEX_NAME, order, &skip, link_iterate_old_cb, iter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we visited all the links */
     if (skip != max_links)
-        TEST_ERROR
+        TEST_ERROR;
     if (order == H5_ITER_INC) {
         for (v = 0; v < (max_links / 2); v++)
             if (iter_info->visited[v + (max_links / 2)] == FALSE)
-                TEST_ERROR
+                TEST_ERROR;
     } /* end if */
     else if (order == H5_ITER_DEC) {
         for (v = 0; v < (max_links / 2); v++)
             if (iter_info->visited[v] == FALSE)
-                TEST_ERROR
+                TEST_ERROR;
     } /* end if */
     else {
         unsigned nvisit = 0; /* # of links visited */
@@ -19931,7 +19933,7 @@ link_iterate_old_check(hid_t group_id, H5_iter_order_t order, unsigned max_links
                 nvisit++;
 
         if (nvisit != (max_links / 2))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end else */
 
 #ifndef H5_NO_DEPRECATED_SYMBOLS
@@ -19943,20 +19945,20 @@ link_iterate_old_check(hid_t group_id, H5_iter_order_t order, unsigned max_links
     iter_info->curr     = order != H5_ITER_DEC ? (unsigned)gskip : ((max_links - 1) - (unsigned)gskip);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if (H5Giterate(group_id, ".", &gskip, group_iterate_old_cb, iter_info) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that we visited all the links */
     if (gskip != (int)max_links)
-        TEST_ERROR
+        TEST_ERROR;
     if (order == H5_ITER_INC) {
         for (v = 0; v < (max_links / 2); v++)
             if (iter_info->visited[v + (max_links / 2)] == FALSE)
-                TEST_ERROR
+                TEST_ERROR;
     } /* end if */
     else if (order == H5_ITER_DEC) {
         for (v = 0; v < (max_links / 2); v++)
             if (iter_info->visited[v] == FALSE)
-                TEST_ERROR
+                TEST_ERROR;
     } /* end if */
     else {
         unsigned nvisit = 0; /* # of links visited */
@@ -19967,7 +19969,7 @@ link_iterate_old_check(hid_t group_id, H5_iter_order_t order, unsigned max_links
                 nvisit++;
 
         if (nvisit != (max_links / 2))
-            TEST_ERROR
+            TEST_ERROR;
     }  /* end else */
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
 
@@ -19979,11 +19981,11 @@ link_iterate_old_check(hid_t group_id, H5_iter_order_t order, unsigned max_links
     iter_info->curr     = order != H5_ITER_DEC ? 0 : (max_links - 1);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if ((ret = H5Literate2(group_id, H5_INDEX_NAME, order, &skip, link_iterate_old_cb, iter_info)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ret != CORDER_ITER_STOP)
-        TEST_ERROR
+        TEST_ERROR;
     if (iter_info->ncalled != 3)
-        TEST_ERROR
+        TEST_ERROR;
 
 #ifndef H5_NO_DEPRECATED_SYMBOLS
     /* Iterate over links in group, stopping in the middle, with H5Giterate() */
@@ -19994,11 +19996,11 @@ link_iterate_old_check(hid_t group_id, H5_iter_order_t order, unsigned max_links
     iter_info->curr     = order != H5_ITER_DEC ? 0 : (max_links - 1);
     HDmemset(iter_info->visited, 0, sizeof(hbool_t) * iter_info->max_visit);
     if ((ret = H5Giterate(group_id, ".", &gskip, group_iterate_old_cb, iter_info)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ret != CORDER_ITER_STOP)
-        TEST_ERROR
+        TEST_ERROR;
     if (iter_info->ncalled != 3)
-        TEST_ERROR
+        TEST_ERROR;
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
 
     /* Check for iteration routine indicating failure */
@@ -20009,7 +20011,7 @@ link_iterate_old_check(hid_t group_id, H5_iter_order_t order, unsigned max_links
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for iteration w/bad location ID */
     skip = 0;
@@ -20019,7 +20021,7 @@ link_iterate_old_check(hid_t group_id, H5_iter_order_t order, unsigned max_links
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #ifndef H5_NO_DEPRECATED_SYMBOLS
     H5E_BEGIN_TRY
@@ -20028,7 +20030,7 @@ link_iterate_old_check(hid_t group_id, H5_iter_order_t order, unsigned max_links
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
 
     /* Success */
@@ -20064,36 +20066,36 @@ link_iterate_old(hid_t fapl)
     /* Allocate the "visited link" array */
     iter_info.max_visit = CORDER_NLINKS;
     if (NULL == (visited = (hbool_t *)HDmalloc(sizeof(hbool_t) * iter_info.max_visit)))
-        TEST_ERROR
+        TEST_ERROR;
     iter_info.visited = visited;
 
     /* Loop over operating in different orders */
     for (order = H5_ITER_INC; order <= H5_ITER_NATIVE; order++) {
         /* Print appropriate test message */
         if (order == H5_ITER_INC) {
-            TESTING("iterating over links by name index in increasing order in old-style group")
+            TESTING("iterating over links by name index in increasing order in old-style group");
         } /* end if */
         else if (order == H5_ITER_DEC) {
-            TESTING("iterating over links by name index in decreasing order in old-style group")
+            TESTING("iterating over links by name index in decreasing order in old-style group");
         } /* end else */
         else {
             HDassert(order == H5_ITER_NATIVE);
-            TESTING("iterating over links by name index in native order in old-style group")
+            TESTING("iterating over links by name index in native order in old-style group");
         } /* end else */
 
         /* Create file */
         h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
         if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create group with creation order tracking on */
         if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for iteration on empty group */
         /* (should be OK) */
         if (H5Literate2(group_id, H5_INDEX_NAME, order, NULL, link_iterate_old_cb, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create several links */
         for (u = 0; u < CORDER_NLINKS; u++) {
@@ -20104,14 +20106,14 @@ link_iterate_old(hid_t fapl)
 
             /* Create hard link, with group object */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Gclose(group_id2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Verify state of group (symbol table) */
         if (H5G__has_stab_test(group_id) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for out of bound iteration on old-style group */
         skip = (hsize_t)u;
@@ -20121,7 +20123,7 @@ link_iterate_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for iteration on creation order */
         /* (should fail) */
@@ -20132,19 +20134,19 @@ link_iterate_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Test iteration over links in group */
         if (link_iterate_old_check(group_id, order, u, &iter_info) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the group */
         if (H5Gclose(group_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file */
         if (H5Fclose(file_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end for */
@@ -20204,26 +20206,26 @@ open_by_idx_check(hid_t main_group_id, hid_t soft_group_id, hid_t mount_file_id,
         for (u = 0; u < max_links; u++) {
             /* Open the object */
             if ((obj_id = H5Oopen_by_idx(group_id, ".", idx_type, order, (hsize_t)u, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Get the object's information */
             if (H5Oget_info3(obj_id, &oi, H5O_INFO_BASIC) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check that the object is the correct one */
             if (order == H5_ITER_INC) {
                 if (H5Otoken_cmp(obj_id, &oi.token, &objno[u], &token_cmp) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (token_cmp)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else if (order == H5_ITER_DEC) {
                 unsigned dec_u = max_links - (u + 1); /* Decreasing mapped index */
 
                 if (H5Otoken_cmp(obj_id, &oi.token, &objno[dec_u], &token_cmp) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (token_cmp)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 /* XXX: What to do about native order? */
@@ -20231,7 +20233,7 @@ open_by_idx_check(hid_t main_group_id, hid_t soft_group_id, hid_t mount_file_id,
 
             /* Close object */
             if (H5Oclose(obj_id) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
     }     /* end for */
 
@@ -20239,41 +20241,41 @@ open_by_idx_check(hid_t main_group_id, hid_t soft_group_id, hid_t mount_file_id,
 
     /* Get the address of the root group in the file to mount */
     if (H5Oget_info3(mount_file_id, &oi, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&mnt_root_token, &oi.token, sizeof(mnt_root_token));
 
     /* Mount a file over a group in main group */
     mnt_idx = 2;
     HDsnprintf(mntname, sizeof(mntname), "/%s/filler %02u", CORDER_GROUP_NAME, mnt_idx);
     if (H5Fmount(main_group_id, mntname, mount_file_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the object that the file is mounted on */
     if ((obj_id = H5Oopen_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)mnt_idx, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the object's information */
     if (H5Oget_info3(obj_id, &oi, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the object is the root of the mounted file and not in the previous file */
     if (H5Otoken_cmp(obj_id, &oi.token, &mnt_root_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(obj_id, &oi.token, &objno[mnt_idx], &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close object */
     if (H5Oclose(obj_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount the file */
     if (H5Funmount(main_group_id, mntname) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return SUCCEED;
@@ -20315,20 +20317,20 @@ open_by_idx(hid_t fapl)
 
     /* Create group creation property list */
     if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties */
     if (H5Pget_link_phase_change(gcpl_id, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate object token array */
     if (NULL == (objno = (H5O_token_t *)HDmalloc(sizeof(H5O_token_t) * (max_compact * 2))))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file to mount */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((mount_file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop over operating on different indices on link fields */
     for (idx_type = H5_INDEX_NAME; idx_type <= H5_INDEX_CRT_ORDER; idx_type++) {
@@ -20341,71 +20343,71 @@ open_by_idx(hid_t fapl)
                     if (order == H5_ITER_INC) {
                         if (use_index)
                             TESTING("open object by creation order index in increasing order w/creation "
-                                    "order index")
+                                    "order index");
                         else
                             TESTING("open object by creation order index in increasing order w/o creation "
-                                    "order index")
+                                    "order index");
                     } /* end if */
                     else if (order == H5_ITER_DEC) {
                         if (use_index)
                             TESTING("open object by creation order index in decreasing order w/creation "
-                                    "order index")
+                                    "order index");
                         else
                             TESTING("open object by creation order index in decreasing order w/o creation "
-                                    "order index")
+                                    "order index");
                     } /* end else */
                     else {
                         HDassert(order == H5_ITER_NATIVE);
                         if (use_index)
                             TESTING(
-                                "open object by creation order index in native order w/creation order index")
+                                "open object by creation order index in native order w/creation order index");
                         else
                             TESTING("open object by creation order index in native order w/o creation order "
-                                    "index")
+                                    "index");
                     } /* end else */
                 }     /* end if */
                 else {
                     if (order == H5_ITER_INC) {
                         if (use_index)
-                            TESTING("open object by name index in increasing order w/creation order index")
+                            TESTING("open object by name index in increasing order w/creation order index");
                         else
-                            TESTING("open object by name index in increasing order w/o creation order index")
+                            TESTING("open object by name index in increasing order w/o creation order index");
                     } /* end if */
                     else if (order == H5_ITER_DEC) {
                         if (use_index)
-                            TESTING("open object by name index in decreasing order w/creation order index")
+                            TESTING("open object by name index in decreasing order w/creation order index");
                         else
-                            TESTING("open object by name index in decreasing order w/o creation order index")
+                            TESTING("open object by name index in decreasing order w/o creation order index");
                     } /* end else */
                     else {
                         HDassert(order == H5_ITER_NATIVE);
                         if (use_index)
-                            TESTING("open object by name index in native order w/creation order index")
+                            TESTING("open object by name index in native order w/creation order index");
                         else
-                            TESTING("open object by name index in native order w/o creation order index")
+                            TESTING("open object by name index in native order w/o creation order index");
                     } /* end else */
                 }     /* end else */
 
                 /* Create file */
                 h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
                 if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Set creation order tracking & indexing on group */
                 if (H5Pset_link_creation_order(gcpl_id, (H5P_CRT_ORDER_TRACKED |
                                                          (use_index ? H5P_CRT_ORDER_INDEXED : (unsigned)0))) <
                     0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create group with creation order tracking on */
                 if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) <
                     0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create group with creation order tracking on for soft links */
                 if ((soft_group_id =
                          H5Gcreate2(file_id, CORDER_SOFT_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Try to open on object in an empty group */
                 H5E_BEGIN_TRY
@@ -20414,7 +20416,7 @@ open_by_idx(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create several links, up to limit of compact form */
                 for (u = 0; u < max_compact; u++) {
@@ -20426,26 +20428,26 @@ open_by_idx(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve group's address on disk */
                     if (H5Oget_info3(group_id2, &oi, H5O_INFO_BASIC) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     objno[u] = oi.token;
 
                     /* Close group created */
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Create soft link in another group, to objects in main group */
                     HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
                     if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 }
 
                 /* Verify state of group (compact) */
                 if (H5G__has_links_test(group_id, NULL) != TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for out of bound open by index on compact group */
                 H5E_BEGIN_TRY
@@ -20454,11 +20456,11 @@ open_by_idx(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Verify opening objects by index */
                 if (open_by_idx_check(group_id, soft_group_id, mount_file_id, idx_type, order, u, objno) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create more links, to push group into dense form */
                 for (; u < (max_compact * 2); u++) {
@@ -20470,26 +20472,26 @@ open_by_idx(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve group's address on disk */
                     if (H5Oget_info3(group_id2, &oi, H5O_INFO_BASIC) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     objno[u] = oi.token;
 
                     /* Close group created */
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Create soft link in another group, to objects in main group */
                     HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
                     if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Verify state of group (dense) */
                 if (H5G__is_new_dense_test(group_id) != TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for out of bound open by index on compact group */
                 H5E_BEGIN_TRY
@@ -20498,21 +20500,21 @@ open_by_idx(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Verify opening objects by index */
                 if (open_by_idx_check(group_id, soft_group_id, mount_file_id, idx_type, order, u, objno) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the groups */
                 if (H5Gclose(group_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Gclose(soft_group_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the file */
                 if (H5Fclose(file_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 PASSED();
             } /* end for */
@@ -20521,11 +20523,11 @@ open_by_idx(hid_t fapl)
 
     /* Close the file for mounting */
     if (H5Fclose(mount_file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group creation property list */
     if (H5Pclose(gcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free resources */
     if (objno)
@@ -20585,26 +20587,26 @@ open_by_idx_check_old(hid_t main_group_id, hid_t soft_group_id, hid_t mount_file
         for (u = 0; u < max_links; u++) {
             /* Open the object */
             if ((obj_id = H5Oopen_by_idx(group_id, ".", idx_type, order, (hsize_t)u, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Get the object's information */
             if (H5Oget_info3(obj_id, &oi, H5O_INFO_BASIC) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check that the object is the correct one */
             if (order == H5_ITER_INC) {
                 if (H5Otoken_cmp(group_id, &oi.token, &objno[u], &cmp_value) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (0 != cmp_value)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else if (order == H5_ITER_DEC) {
                 unsigned dec_u = max_links - (u + 1); /* Decreasing mapped index */
 
                 if (H5Otoken_cmp(group_id, &oi.token, &objno[dec_u], &cmp_value) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (0 != cmp_value)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 /* XXX: What to do about native order? */
@@ -20612,7 +20614,7 @@ open_by_idx_check_old(hid_t main_group_id, hid_t soft_group_id, hid_t mount_file
 
             /* Close object */
             if (H5Oclose(obj_id) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
     }     /* end for */
 
@@ -20620,41 +20622,41 @@ open_by_idx_check_old(hid_t main_group_id, hid_t soft_group_id, hid_t mount_file
 
     /* Get the address of the root group in the file to mount */
     if (H5Oget_info3(mount_file_id, &oi, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     mnt_root_token = oi.token;
 
     /* Mount a file over a group in main group */
     mnt_idx = 2;
     HDsnprintf(mntname, sizeof(mntname), "/%s/filler %02u", CORDER_GROUP_NAME, mnt_idx);
     if (H5Fmount(main_group_id, mntname, mount_file_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the object that the file is mounted on */
     if ((obj_id = H5Oopen_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)mnt_idx, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the object's information */
     if (H5Oget_info3(obj_id, &oi, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the object is the root of the mounted file and not in the previous file */
     if (H5Otoken_cmp(group_id, &oi.token, &mnt_root_token, &cmp_value) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (0 != cmp_value)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(group_id, &oi.token, &objno[mnt_idx], &cmp_value) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (0 == cmp_value)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close object */
     if (H5Oclose(obj_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount the file */
     if (H5Funmount(main_group_id, mntname) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Success */
     return SUCCEED;
@@ -20692,35 +20694,35 @@ open_by_idx_old(hid_t fapl)
     /* Create file to mount */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((mount_file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop over operating in different orders */
     for (order = H5_ITER_INC; order <= H5_ITER_NATIVE; order++) {
         /* Print appropriate test message */
         if (order == H5_ITER_INC) {
-            TESTING("open object by name index in increasing order in old-style group")
+            TESTING("open object by name index in increasing order in old-style group");
         } /* end if */
         else if (order == H5_ITER_DEC) {
-            TESTING("open object by name index in decreasing order in old-style group")
+            TESTING("open object by name index in decreasing order in old-style group");
         } /* end else */
         else {
             HDassert(order == H5_ITER_NATIVE);
-            TESTING("open object by name index in native order in old-style group")
+            TESTING("open object by name index in native order in old-style group");
         } /* end else */
 
         /* Create file */
         h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
         if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create old-style group */
         if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create old-style group for soft links */
         if ((soft_group_id =
                  H5Gcreate2(file_id, CORDER_SOFT_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Try to open on object in an empty group */
         H5E_BEGIN_TRY
@@ -20729,7 +20731,7 @@ open_by_idx_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create several links */
         for (u = 0; u < CORDER_NLINKS; u++) {
@@ -20740,26 +20742,26 @@ open_by_idx_old(hid_t fapl)
 
             /* Create hard link, with group object */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Retrieve group's address on disk */
             if (H5Oget_info3(group_id2, &oi, H5O_INFO_BASIC) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             objno[u] = oi.token;
 
             /* Close group created */
             if (H5Gclose(group_id2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create soft link in another group, to objects in main group */
             HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
             if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Verify state of group (symbol table) */
         if (H5G__has_stab_test(group_id) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for out of bound open by index */
         H5E_BEGIN_TRY
@@ -20768,7 +20770,7 @@ open_by_idx_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for creation order index open */
         H5E_BEGIN_TRY
@@ -20777,28 +20779,28 @@ open_by_idx_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify opening objects by index */
         if (open_by_idx_check_old(group_id, soft_group_id, mount_file_id, H5_INDEX_NAME, order, u, objno) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the groups */
         if (H5Gclose(group_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(soft_group_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file */
         if (H5Fclose(file_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end for */
 
     /* Close the file for mounting */
     if (H5Fclose(mount_file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return SUCCEED;
 
@@ -20851,39 +20853,39 @@ object_info_check(hid_t main_group_id, hid_t soft_group_id, H5_index_t idx_type,
             /* Query the object's information, by name */
             if (H5Oget_info_by_name3(group_id, objname, &oinfo, H5O_INFO_BASIC | H5O_INFO_NUM_ATTRS,
                                      H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check that the object is the correct one */
             if (H5Otoken_cmp(group_id, &oinfo.token, &objno[u], &token_cmp) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (token_cmp)
-                TEST_ERROR
+                TEST_ERROR;
             if (oinfo.num_attrs != u)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Query the object's information, by index */
             if (H5Oget_info_by_idx3(group_id, ".", idx_type, order, (hsize_t)u, &oinfo,
                                     H5O_INFO_BASIC | H5O_INFO_NUM_ATTRS, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check that the object is the correct one */
             if (order == H5_ITER_INC) {
                 if (H5Otoken_cmp(group_id, &oinfo.token, &objno[u], &token_cmp) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (token_cmp)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (oinfo.num_attrs != u)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else if (order == H5_ITER_DEC) {
                 unsigned dec_u = max_links - (u + 1); /* Decreasing mapped index */
 
                 if (H5Otoken_cmp(group_id, &oinfo.token, &objno[dec_u], &token_cmp) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (token_cmp)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (oinfo.num_attrs != dec_u)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 /* XXX: What to do about native order? */
@@ -20933,19 +20935,19 @@ object_info(hid_t fapl)
 
     /* Create group creation property list */
     if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties */
     if (H5Pget_link_phase_change(gcpl_id, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate object token array */
     if (NULL == (objno = (H5O_token_t *)HDmalloc(sizeof(H5O_token_t) * (max_compact * 2))))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace for attributes */
     if ((space_id = H5Screate(H5S_SCALAR)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop over operating on different indices on link fields */
     for (idx_type = H5_INDEX_NAME; idx_type <= H5_INDEX_CRT_ORDER; idx_type++) {
@@ -20958,76 +20960,76 @@ object_info(hid_t fapl)
                     if (order == H5_ITER_INC) {
                         if (use_index)
                             TESTING("query object info by creation order index in increasing order "
-                                    "w/creation order index")
+                                    "w/creation order index");
                         else
                             TESTING("query object info by creation order index in increasing order w/o "
-                                    "creation order index")
+                                    "creation order index");
                     } /* end if */
                     else if (order == H5_ITER_DEC) {
                         if (use_index)
                             TESTING("query object info by creation order index in decreasing order "
-                                    "w/creation order index")
+                                    "w/creation order index");
                         else
                             TESTING("query object info by creation order index in decreasing order w/o "
-                                    "creation order index")
+                                    "creation order index");
                     } /* end else */
                     else {
                         HDassert(order == H5_ITER_NATIVE);
                         if (use_index)
                             TESTING("query object info by creation order index in native order w/creation "
-                                    "order index")
+                                    "order index");
                         else
                             TESTING("query object info by creation order index in native order w/o creation "
-                                    "order index")
+                                    "order index");
                     } /* end else */
                 }     /* end if */
                 else {
                     if (order == H5_ITER_INC) {
                         if (use_index)
                             TESTING(
-                                "query object info by name index in increasing order w/creation order index")
+                                "query object info by name index in increasing order w/creation order index");
                         else
                             TESTING("query object info by name index in increasing order w/o creation order "
-                                    "index")
+                                    "index");
                     } /* end if */
                     else if (order == H5_ITER_DEC) {
                         if (use_index)
                             TESTING(
-                                "query object info by name index in decreasing order w/creation order index")
+                                "query object info by name index in decreasing order w/creation order index");
                         else
                             TESTING("query object info by name index in decreasing order w/o creation order "
-                                    "index")
+                                    "index");
                     } /* end else */
                     else {
                         HDassert(order == H5_ITER_NATIVE);
                         if (use_index)
-                            TESTING("query object info by name index in native order w/creation order index")
+                            TESTING("query object info by name index in native order w/creation order index");
                         else
                             TESTING(
-                                "query object info by name index in native order w/o creation order index")
+                                "query object info by name index in native order w/o creation order index");
                     } /* end else */
                 }     /* end else */
 
                 /* Create file */
                 h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
                 if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Set creation order tracking & indexing on group */
                 if (H5Pset_link_creation_order(gcpl_id, (H5P_CRT_ORDER_TRACKED |
                                                          (use_index ? H5P_CRT_ORDER_INDEXED : (unsigned)0))) <
                     0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create group with creation order tracking on */
                 if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) <
                     0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create group with creation order tracking on for soft links */
                 if ((soft_group_id =
                          H5Gcreate2(file_id, CORDER_SOFT_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for out of bound query by index on empty group */
                 H5E_BEGIN_TRY
@@ -21037,7 +21039,7 @@ object_info(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create several links, up to limit of compact form */
                 for (u = 0; u < max_compact; u++) {
@@ -21050,11 +21052,11 @@ object_info(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve group's address on disk */
                     if (H5Oget_info3(group_id2, &oinfo, H5O_INFO_BASIC) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     objno[u] = oinfo.token;
 
                     /* Create attributes on new object */
@@ -21065,26 +21067,26 @@ object_info(hid_t fapl)
                         /* Create attribute */
                         if ((attr_id = H5Acreate2(group_id2, attrname, H5T_NATIVE_INT, space_id, H5P_DEFAULT,
                                                   H5P_DEFAULT)) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
 
                         /* Close attribute */
                         if (H5Aclose(attr_id) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end for */
 
                     /* Close group created */
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Create soft link in another group, to objects in main group */
                     HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
                     if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Verify state of group (compact) */
                 if (H5G__has_links_test(group_id, NULL) != TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for out of bound query by index */
                 H5E_BEGIN_TRY
@@ -21094,11 +21096,11 @@ object_info(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Verify querying objects by name */
                 if (object_info_check(group_id, soft_group_id, idx_type, order, u, objno) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create more links, to push group into dense form */
                 for (; u < (max_compact * 2); u++) {
@@ -21111,11 +21113,11 @@ object_info(hid_t fapl)
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
                         0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve group's address on disk */
                     if (H5Oget_info3(group_id2, &oinfo, H5O_INFO_BASIC) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     objno[u] = oinfo.token;
 
                     /* Create attributes on new object */
@@ -21126,26 +21128,26 @@ object_info(hid_t fapl)
                         /* Create attribute */
                         if ((attr_id = H5Acreate2(group_id2, attrname, H5T_NATIVE_INT, space_id, H5P_DEFAULT,
                                                   H5P_DEFAULT)) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
 
                         /* Close attribute */
                         if (H5Aclose(attr_id) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end for */
 
                     /* Close group created */
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Create soft link in another group, to objects in main group */
                     HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
                     if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Verify state of group (dense) */
                 if (H5G__is_new_dense_test(group_id) != TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for out of bound query by index */
                 H5E_BEGIN_TRY
@@ -21155,21 +21157,21 @@ object_info(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Verify querying objects by name */
                 if (object_info_check(group_id, soft_group_id, idx_type, order, u, objno) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the groups */
                 if (H5Gclose(group_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Gclose(soft_group_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the file */
                 if (H5Fclose(file_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 PASSED();
             } /* end for */
@@ -21178,9 +21180,9 @@ object_info(hid_t fapl)
 
     /* Free resources */
     if (H5Pclose(gcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (objno)
         HDfree(objno);
 
@@ -21240,39 +21242,39 @@ object_info_check_old(hid_t main_group_id, hid_t soft_group_id, H5_index_t idx_t
             /* Query the object's information, by name */
             if (H5Oget_info_by_name3(group_id, objname, &oinfo, H5O_INFO_BASIC | H5O_INFO_NUM_ATTRS,
                                      H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check that the object is the correct one */
             if (H5Otoken_cmp(group_id, &oinfo.token, &objno[u], &cmp_value) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (0 != cmp_value)
-                TEST_ERROR
+                TEST_ERROR;
             if (oinfo.num_attrs != u)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Query the object's information, by index */
             if (H5Oget_info_by_idx3(group_id, ".", idx_type, order, (hsize_t)u, &oinfo,
                                     H5O_INFO_BASIC | H5O_INFO_NUM_ATTRS, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check that the object is the correct one */
             if (order == H5_ITER_INC) {
                 if (H5Otoken_cmp(group_id, &oinfo.token, &objno[u], &cmp_value) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (0 != cmp_value)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (oinfo.num_attrs != u)
-                    TEST_ERROR
+                    TEST_ERROR;
             }
             else if (order == H5_ITER_DEC) {
                 unsigned dec_u = max_links - (u + 1); /* Decreasing mapped index */
 
                 if (H5Otoken_cmp(group_id, &oinfo.token, &objno[dec_u], &cmp_value) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (0 != cmp_value)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (oinfo.num_attrs != dec_u)
-                    TEST_ERROR
+                    TEST_ERROR;
             }
             else {
                 /* XXX: What to do about native order? */
@@ -21316,36 +21318,36 @@ object_info_old(hid_t fapl)
 
     /* Create dataspace for attributes */
     if ((space_id = H5Screate(H5S_SCALAR)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop over operating in different orders */
     for (order = H5_ITER_INC; order <= H5_ITER_NATIVE; order++) {
 
         /* Print appropriate test message */
         if (order == H5_ITER_INC) {
-            TESTING("query object info by name index in increasing order in old-style group")
+            TESTING("query object info by name index in increasing order in old-style group");
         } /* end if */
         else if (order == H5_ITER_DEC) {
-            TESTING("query object info by name index in decreasing order in old-style group")
+            TESTING("query object info by name index in decreasing order in old-style group");
         } /* end else */
         else {
             HDassert(order == H5_ITER_NATIVE);
-            TESTING("query object info by name index in native order in old-style group")
+            TESTING("query object info by name index in native order in old-style group");
         } /* end else */
 
         /* Create file */
         h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
         if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create old-style group */
         if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create old-style group for soft links */
         if ((soft_group_id =
                  H5Gcreate2(file_id, CORDER_SOFT_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for out of bound query by index on empty group */
         H5E_BEGIN_TRY
@@ -21355,7 +21357,7 @@ object_info_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create several links */
         for (u = 0; u < CORDER_NLINKS; u++) {
@@ -21367,11 +21369,11 @@ object_info_old(hid_t fapl)
 
             /* Create hard link, with group object */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Retrieve group's address on disk */
             if (H5Oget_info3(group_id2, &oinfo, H5O_INFO_BASIC) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             objno[u] = oinfo.token;
 
             /* Create attributes on new object */
@@ -21382,26 +21384,26 @@ object_info_old(hid_t fapl)
                 /* Create attribute */
                 if ((attr_id = H5Acreate2(group_id2, attrname, H5T_NATIVE_INT, space_id, H5P_DEFAULT,
                                           H5P_DEFAULT)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close attribute */
                 if (H5Aclose(attr_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end for */
 
             /* Close group created */
             if (H5Gclose(group_id2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create soft link in another group, to objects in main group */
             HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
             if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Verify state of group (symbol table) */
         if (H5G__has_stab_test(group_id) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for out of bound query by index */
         H5E_BEGIN_TRY
@@ -21411,7 +21413,7 @@ object_info_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for creation order index query */
         H5E_BEGIN_TRY
@@ -21421,28 +21423,28 @@ object_info_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify querying objects by name */
         if (object_info_check_old(group_id, soft_group_id, H5_INDEX_NAME, order, u, objno) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the groups */
         if (H5Gclose(group_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(soft_group_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file */
         if (H5Fclose(file_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end for */
 
     /* Free resources */
     if (H5Sclose(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return SUCCEED;
 
@@ -21492,11 +21494,11 @@ group_info(hid_t fapl)
 
     /* Create group creation property list */
     if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties */
     if (H5Pget_link_phase_change(gcpl_id, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop over operating on different indices on link fields */
     for (idx_type = H5_INDEX_NAME; idx_type <= H5_INDEX_CRT_ORDER; idx_type++) {
@@ -21509,75 +21511,76 @@ group_info(hid_t fapl)
                     if (order == H5_ITER_INC) {
                         if (use_index)
                             TESTING("query group info by creation order index in increasing order w/creation "
-                                    "order index")
+                                    "order index");
                         else
                             TESTING("query group info by creation order index in increasing order w/o "
-                                    "creation order index")
+                                    "creation order index");
                     } /* end if */
                     else if (order == H5_ITER_DEC) {
                         if (use_index)
                             TESTING("query group info by creation order index in decreasing order w/creation "
-                                    "order index")
+                                    "order index");
                         else
                             TESTING("query group info by creation order index in decreasing order w/o "
-                                    "creation order index")
+                                    "creation order index");
                     } /* end else */
                     else {
                         HDassert(order == H5_ITER_NATIVE);
                         if (use_index)
                             TESTING("query group info by creation order index in native order w/creation "
-                                    "order index")
+                                    "order index");
                         else
                             TESTING("query group info by creation order index in native order w/o creation "
-                                    "order index")
+                                    "order index");
                     } /* end else */
                 }     /* end if */
                 else {
                     if (order == H5_ITER_INC) {
                         if (use_index)
                             TESTING(
-                                "query group info by name index in increasing order w/creation order index")
+                                "query group info by name index in increasing order w/creation order index");
                         else
-                            TESTING(
-                                "query group info by name index in increasing order w/o creation order index")
+                            TESTING("query group info by name index in increasing order w/o creation order "
+                                    "index");
                     } /* end if */
                     else if (order == H5_ITER_DEC) {
                         if (use_index)
                             TESTING(
-                                "query group info by name index in decreasing order w/creation order index")
+                                "query group info by name index in decreasing order w/creation order index");
                         else
-                            TESTING(
-                                "query group info by name index in decreasing order w/o creation order index")
+                            TESTING("query group info by name index in decreasing order w/o creation order "
+                                    "index");
                     } /* end else */
                     else {
                         HDassert(order == H5_ITER_NATIVE);
                         if (use_index)
-                            TESTING("query group info by name index in native order w/creation order index")
+                            TESTING("query group info by name index in native order w/creation order index");
                         else
-                            TESTING("query group info by name index in native order w/o creation order index")
+                            TESTING(
+                                "query group info by name index in native order w/o creation order index");
                     } /* end else */
                 }     /* end else */
 
                 /* Create file */
                 h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
                 if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Set creation order tracking & indexing on group */
                 if (H5Pset_link_creation_order(gcpl_id, (H5P_CRT_ORDER_TRACKED |
                                                          (use_index ? H5P_CRT_ORDER_INDEXED : (unsigned)0))) <
                     0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create group with creation order tracking on */
                 if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) <
                     0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create group with creation order tracking on for soft links */
                 if ((soft_group_id =
                          H5Gcreate2(file_id, CORDER_SOFT_GROUP_NAME, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for out of bound query by index on empty group */
                 H5E_BEGIN_TRY
@@ -21587,7 +21590,7 @@ group_info(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create several links, up to limit of compact form */
                 for (u = 0; u < max_compact; u++) {
@@ -21598,43 +21601,43 @@ group_info(hid_t fapl)
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve group's information */
                     if (H5Gget_info(group_id2, &grp_info) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check (new/empty) group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_COMPACT)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve group's information */
                     if (H5Gget_info_by_name(group_id, objname, &grp_info, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check (new/empty) group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_COMPACT)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve group's information */
                     if (H5Gget_info_by_name(group_id2, ".", &grp_info, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check (new/empty) group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_COMPACT)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Create objects in new group created */
                     for (v = 0; v <= u; v++) {
@@ -21644,132 +21647,132 @@ group_info(hid_t fapl)
                         /* Create hard link, with group object */
                         if ((group_id3 =
                                  H5Gcreate2(group_id2, objname2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
 
                         /* Close group created */
                         if (H5Gclose(group_id3) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end for */
 
                     /* Retrieve group's information */
                     if (H5Gget_info(group_id2, &grp_info) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check (new) group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_COMPACT)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != (int64_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != (hsize_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve group's information */
                     if (H5Gget_info_by_name(group_id, objname, &grp_info, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check (new) group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_COMPACT)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != (int64_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != (hsize_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve group's information */
                     if (H5Gget_info_by_name(group_id2, ".", &grp_info, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check (new) group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_COMPACT)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != (int64_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != (hsize_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve group's information */
                     if (order != H5_ITER_NATIVE) {
                         if (order == H5_ITER_INC) {
                             if (H5Gget_info_by_idx(group_id, ".", idx_type, order, (hsize_t)u, &grp_info,
                                                    H5P_DEFAULT) < 0)
-                                TEST_ERROR
+                                TEST_ERROR;
                         } /* end if */
                         else {
                             if (H5Gget_info_by_idx(group_id, ".", idx_type, order, (hsize_t)0, &grp_info,
                                                    H5P_DEFAULT) < 0)
-                                TEST_ERROR
+                                TEST_ERROR;
                         } /* end else */
 
                         /* Check (new) group's information */
                         if (grp_info.storage_type != H5G_STORAGE_TYPE_COMPACT)
-                            TEST_ERROR
+                            TEST_ERROR;
                         if (grp_info.max_corder != (int64_t)(u + 1))
-                            TEST_ERROR
+                            TEST_ERROR;
                         if (grp_info.nlinks != (hsize_t)(u + 1))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end if */
 
                     /* Close group created */
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve main group's information */
                     if (H5Gget_info(group_id, &grp_info) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check main group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_COMPACT)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != (int64_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != (hsize_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve main group's information, by name */
                     if (H5Gget_info_by_name(file_id, CORDER_GROUP_NAME, &grp_info, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check main group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_COMPACT)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != (int64_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != (hsize_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve main group's information, by name */
                     if (H5Gget_info_by_name(group_id, ".", &grp_info, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check main group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_COMPACT)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != (int64_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != (hsize_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Create soft link in another group, to objects in main group */
                     HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
                     if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve soft link group's information, by name */
                     if (H5Gget_info(soft_group_id, &grp_info) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check soft link group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_COMPACT)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != (int64_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != (hsize_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Verify state of group (compact) */
                 if (H5G__has_links_test(group_id, NULL) != TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for out of bound query by index */
                 H5E_BEGIN_TRY
@@ -21779,7 +21782,7 @@ group_info(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Create more links, to push group into dense form */
                 for (; u < (max_compact * 2); u++) {
@@ -21790,43 +21793,43 @@ group_info(hid_t fapl)
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve group's information */
                     if (H5Gget_info(group_id2, &grp_info) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check (new/empty) group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_COMPACT)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve group's information, by name */
                     if (H5Gget_info_by_name(group_id, objname, &grp_info, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check (new/empty) group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_COMPACT)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve group's information, by name */
                     if (H5Gget_info_by_name(group_id2, ".", &grp_info, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check (new/empty) group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_COMPACT)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Create objects in new group created */
                     for (v = 0; v <= u; v++) {
@@ -21836,132 +21839,132 @@ group_info(hid_t fapl)
                         /* Create hard link, with group object */
                         if ((group_id3 =
                                  H5Gcreate2(group_id2, objname2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
 
                         /* Close group created */
                         if (H5Gclose(group_id3) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end for */
 
                     /* Retrieve group's information */
                     if (H5Gget_info(group_id2, &grp_info) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check (new) group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_DENSE)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != (int64_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != (hsize_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve group's information, by name */
                     if (H5Gget_info_by_name(group_id, objname, &grp_info, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check (new) group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_DENSE)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != (int64_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != (hsize_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve group's information, by name */
                     if (H5Gget_info_by_name(group_id2, ".", &grp_info, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check (new) group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_DENSE)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != (int64_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != (hsize_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve group's information */
                     if (order != H5_ITER_NATIVE) {
                         if (order == H5_ITER_INC) {
                             if (H5Gget_info_by_idx(group_id, ".", idx_type, order, (hsize_t)u, &grp_info,
                                                    H5P_DEFAULT) < 0)
-                                TEST_ERROR
+                                TEST_ERROR;
                         } /* end if */
                         else {
                             if (H5Gget_info_by_idx(group_id, ".", idx_type, order, (hsize_t)0, &grp_info,
                                                    H5P_DEFAULT) < 0)
-                                TEST_ERROR
+                                TEST_ERROR;
                         } /* end else */
 
                         /* Check (new) group's information */
                         if (grp_info.storage_type != H5G_STORAGE_TYPE_DENSE)
-                            TEST_ERROR
+                            TEST_ERROR;
                         if (grp_info.max_corder != (int64_t)(u + 1))
-                            TEST_ERROR
+                            TEST_ERROR;
                         if (grp_info.nlinks != (hsize_t)(u + 1))
-                            TEST_ERROR
+                            TEST_ERROR;
                     } /* end if */
 
                     /* Close group created */
                     if (H5Gclose(group_id2) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve main group's information */
                     if (H5Gget_info(group_id, &grp_info) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check main group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_DENSE)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != (int64_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != (hsize_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve main group's information, by name */
                     if (H5Gget_info_by_name(file_id, CORDER_GROUP_NAME, &grp_info, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check main group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_DENSE)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != (int64_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != (hsize_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve main group's information, by name */
                     if (H5Gget_info_by_name(group_id, ".", &grp_info, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check main group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_DENSE)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != (int64_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != (hsize_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Create soft link in another group, to objects in main group */
                     HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
                     if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Retrieve soft link group's information, by name */
                     if (H5Gget_info(soft_group_id, &grp_info) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check soft link group's information */
                     if (grp_info.storage_type != H5G_STORAGE_TYPE_DENSE)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.max_corder != (int64_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (grp_info.nlinks != (hsize_t)(u + 1))
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end for */
 
                 /* Verify state of group (dense) */
                 if (H5G__is_new_dense_test(group_id) != TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check for out of bound query by index */
                 H5E_BEGIN_TRY
@@ -21971,17 +21974,17 @@ group_info(hid_t fapl)
                 }
                 H5E_END_TRY;
                 if (ret >= 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the groups */
                 if (H5Gclose(group_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Gclose(soft_group_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the file */
                 if (H5Fclose(file_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 PASSED();
             } /* end for */
@@ -21990,7 +21993,7 @@ group_info(hid_t fapl)
 
     /* Free resources */
     if (H5Pclose(gcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return SUCCEED;
 
@@ -22036,29 +22039,29 @@ group_info_old(hid_t fapl)
     /* Loop over operating in different orders */
     for (order = H5_ITER_INC; order <= H5_ITER_NATIVE; order++) {
         if (order == H5_ITER_INC) {
-            TESTING("query group info by name index in increasing order in old-style group")
+            TESTING("query group info by name index in increasing order in old-style group");
         } /* end if */
         else if (order == H5_ITER_DEC) {
-            TESTING("query group info by name index in decreasing order in old-style group")
+            TESTING("query group info by name index in decreasing order in old-style group");
         } /* end else */
         else {
             HDassert(order == H5_ITER_NATIVE);
-            TESTING("query group info by name index in native order in old-style group")
+            TESTING("query group info by name index in native order in old-style group");
         } /* end else */
 
         /* Create file */
         h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
         if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create old-style group */
         if ((group_id = H5Gcreate2(file_id, CORDER_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create old-style group for soft links */
         if ((soft_group_id =
                  H5Gcreate2(file_id, CORDER_SOFT_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for out of bound query by index on empty group */
         H5E_BEGIN_TRY
@@ -22067,7 +22070,7 @@ group_info_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create several links */
         for (u = 0; u < CORDER_NLINKS; u++) {
@@ -22078,43 +22081,43 @@ group_info_old(hid_t fapl)
 
             /* Create hard link, with group object */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Retrieve group's information */
             if (H5Gget_info(group_id2, &grp_info) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check (new/empty) group's information */
             if (grp_info.storage_type != H5G_STORAGE_TYPE_SYMBOL_TABLE)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.max_corder != 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.nlinks != 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Retrieve group's information, by name */
             if (H5Gget_info_by_name(group_id, objname, &grp_info, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check (new/empty) group's information */
             if (grp_info.storage_type != H5G_STORAGE_TYPE_SYMBOL_TABLE)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.max_corder != 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.nlinks != 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Retrieve group's information, by name */
             if (H5Gget_info_by_name(group_id2, ".", &grp_info, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check (new/empty) group's information */
             if (grp_info.storage_type != H5G_STORAGE_TYPE_SYMBOL_TABLE)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.max_corder != 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.nlinks != 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create objects in new group created */
             for (v = 0; v <= u; v++) {
@@ -22123,132 +22126,132 @@ group_info_old(hid_t fapl)
 
                 /* Create hard link, with group object */
                 if ((group_id3 = H5Gcreate2(group_id2, objname2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close group created */
                 if (H5Gclose(group_id3) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end for */
 
             /* Retrieve group's information */
             if (H5Gget_info(group_id2, &grp_info) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check (new) group's information */
             if (grp_info.storage_type != H5G_STORAGE_TYPE_SYMBOL_TABLE)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.max_corder != 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.nlinks != (hsize_t)(u + 1))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Retrieve group's information, by name */
             if (H5Gget_info_by_name(group_id, objname, &grp_info, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check (new) group's information */
             if (grp_info.storage_type != H5G_STORAGE_TYPE_SYMBOL_TABLE)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.max_corder != 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.nlinks != (hsize_t)(u + 1))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Retrieve group's information, by name */
             if (H5Gget_info_by_name(group_id2, ".", &grp_info, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check (new) group's information */
             if (grp_info.storage_type != H5G_STORAGE_TYPE_SYMBOL_TABLE)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.max_corder != 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.nlinks != (hsize_t)(u + 1))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Retrieve group's information */
             if (order != H5_ITER_NATIVE) {
                 if (order == H5_ITER_INC) {
                     if (H5Gget_info_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)u, &grp_info,
                                            H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end if */
                 else {
                     if (H5Gget_info_by_idx(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, &grp_info,
                                            H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end else */
 
                 /* Check (new) group's information */
                 if (grp_info.storage_type != H5G_STORAGE_TYPE_SYMBOL_TABLE)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (grp_info.max_corder != 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (grp_info.nlinks != (hsize_t)(u + 1))
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
 
             /* Close group created */
             if (H5Gclose(group_id2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Retrieve main group's information */
             if (H5Gget_info(group_id, &grp_info) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check main group's information */
             if (grp_info.storage_type != H5G_STORAGE_TYPE_SYMBOL_TABLE)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.max_corder != 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.nlinks != (hsize_t)(u + 1))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Retrieve main group's information, by name */
             if (H5Gget_info_by_name(file_id, CORDER_GROUP_NAME, &grp_info, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check main group's information */
             if (grp_info.storage_type != H5G_STORAGE_TYPE_SYMBOL_TABLE)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.max_corder != 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.nlinks != (hsize_t)(u + 1))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Retrieve main group's information, by name */
             if (H5Gget_info_by_name(group_id, ".", &grp_info, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check main group's information */
             if (grp_info.storage_type != H5G_STORAGE_TYPE_SYMBOL_TABLE)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.max_corder != 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.nlinks != (hsize_t)(u + 1))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create soft link in another group, to objects in main group */
             HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
             if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Retrieve soft link group's information, by name */
             if (H5Gget_info(soft_group_id, &grp_info) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check soft link group's information */
             if (grp_info.storage_type != H5G_STORAGE_TYPE_SYMBOL_TABLE)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.max_corder != 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (grp_info.nlinks != (hsize_t)(u + 1))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         /* Verify state of group (old-style) */
         if (H5G__has_stab_test(group_id) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for out of bound query by index */
         H5E_BEGIN_TRY
@@ -22257,7 +22260,7 @@ group_info_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for bad index query by index group */
         H5E_BEGIN_TRY
@@ -22267,17 +22270,17 @@ group_info_old(hid_t fapl)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the groups */
         if (H5Gclose(group_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(soft_group_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file */
         if (H5Fclose(file_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end for */
@@ -22321,201 +22324,201 @@ timestamps(hid_t fapl)
     hbool_t           track_times;             /* The object timestamp setting */
 
     /* Print test message */
-    TESTING("timestamps on objects")
+    TESTING("timestamps on objects");
 
     /* Create group creation property list */
     if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the object timestamp setting */
     if (H5Pget_obj_track_times(gcpl_id, &track_times) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check default timestamp information */
     if (track_times != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set a non-default object timestamp setting */
     if (H5Pset_obj_track_times(gcpl_id, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the object timestamp setting */
     if (H5Pget_obj_track_times(gcpl_id, &track_times) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check default timestamp information */
     if (track_times != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file */
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
     if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group with non-default object timestamp setting */
     if ((group_id = H5Gcreate2(file_id, TIMESTAMP_GROUP_1, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group creation property list */
     if (H5Pclose(gcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group with default object timestamp setting */
     if ((group_id2 = H5Gcreate2(file_id, TIMESTAMP_GROUP_2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve the new groups' creation properties */
     if ((gcpl_id = H5Gget_create_plist(group_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gcpl_id2 = H5Gget_create_plist(group_id2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query & verify the object timestamp settings */
     if (H5Pget_obj_track_times(gcpl_id, &track_times) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (track_times != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_obj_track_times(gcpl_id2, &track_times) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (track_times != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the object information for each group */
     /* Generic info */
     if (H5Oget_info3(group_id, &oinfo, H5O_INFO_TIME) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(group_id2, &oinfo2, H5O_INFO_TIME) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Native file format info */
     if (H5Oget_native_info(group_id, &ninfo, H5O_NATIVE_INFO_HDR) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_native_info(group_id2, &ninfo2, H5O_NATIVE_INFO_HDR) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Sanity check object information for each group */
     /* Generic info */
     if (oinfo.atime != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (oinfo.mtime != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (oinfo.ctime != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (oinfo.btime != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (oinfo.atime == oinfo2.atime)
-        TEST_ERROR
+        TEST_ERROR;
     if (oinfo.mtime == oinfo2.mtime)
-        TEST_ERROR
+        TEST_ERROR;
     if (oinfo.ctime == oinfo2.ctime)
-        TEST_ERROR
+        TEST_ERROR;
     if (oinfo.btime == oinfo2.btime)
-        TEST_ERROR
+        TEST_ERROR;
     /* Native file format info */
     if ((ninfo.hdr.flags & H5O_HDR_STORE_TIMES) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((ninfo2.hdr.flags & H5O_HDR_STORE_TIMES) == 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ninfo.hdr.space.total >= ninfo2.hdr.space.total)
-        TEST_ERROR
+        TEST_ERROR;
     if (ninfo.hdr.space.meta >= ninfo2.hdr.space.meta)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the property lists */
     if (H5Pclose(gcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(gcpl_id2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the groups */
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(group_id2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file_id = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open groups */
     if ((group_id = H5Gopen2(file_id, TIMESTAMP_GROUP_1, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group_id2 = H5Gopen2(file_id, TIMESTAMP_GROUP_2, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the groups' creation properties */
     if ((gcpl_id = H5Gget_create_plist(group_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gcpl_id2 = H5Gget_create_plist(group_id2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query & verify the object timestamp settings */
     if (H5Pget_obj_track_times(gcpl_id, &track_times) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (track_times != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_obj_track_times(gcpl_id2, &track_times) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (track_times != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the object information for each group */
     if (H5Oget_info3(group_id, &oinfo, H5O_INFO_TIME) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(group_id2, &oinfo2, H5O_INFO_TIME) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Native file format info */
     if (H5Oget_native_info(group_id, &ninfo, H5O_NATIVE_INFO_HDR) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_native_info(group_id2, &ninfo2, H5O_NATIVE_INFO_HDR) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Sanity check object information for each group */
     /* Generic info */
     if (oinfo.atime != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (oinfo.mtime != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (oinfo.ctime != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (oinfo.btime != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (oinfo.atime == oinfo2.atime)
-        TEST_ERROR
+        TEST_ERROR;
     if (oinfo.mtime == oinfo2.mtime)
-        TEST_ERROR
+        TEST_ERROR;
     if (oinfo.ctime == oinfo2.ctime)
-        TEST_ERROR
+        TEST_ERROR;
     if (oinfo.btime == oinfo2.btime)
-        TEST_ERROR
+        TEST_ERROR;
     /* Native file format info */
     if ((ninfo.hdr.flags & H5O_HDR_STORE_TIMES) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((ninfo2.hdr.flags & H5O_HDR_STORE_TIMES) == 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ninfo.hdr.space.total >= ninfo2.hdr.space.total)
-        TEST_ERROR
+        TEST_ERROR;
     if (ninfo.hdr.space.meta >= ninfo2.hdr.space.meta)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the property lists */
     if (H5Pclose(gcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(gcpl_id2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the groups */
     if (H5Gclose(group_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(group_id2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -22562,16 +22565,16 @@ main(void)
 
     /* fapl2 uses "latest version bounds" */
     if ((fapl2 = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_libver_bounds(fapl2, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     for (minimize_dset_oh = 0; minimize_dset_oh <= 1; minimize_dset_oh++) {
         if (minimize_dset_oh) {
             HDprintf("\n-Testing with minimized dataset object headers-\n");
             dcpl_g = H5Pcreate(H5P_DATASET_CREATE);
             if (0 > dcpl_g)
-                TEST_ERROR
+                TEST_ERROR;
         }
         else {
             HDprintf("\n-Testing with unminimzed dataset object headers-\n");
@@ -22593,7 +22596,7 @@ main(void)
 
             /* always enter tests without external cache */
             if (H5Pset_elink_file_cache_size(my_fapl, 0) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* General tests... (on both old & new format groups */
             nerrors += mklinks(my_fapl, new_format) < 0 ? 1 : 0;
@@ -22641,12 +22644,12 @@ main(void)
                 for (efc = FALSE; efc <= TRUE; efc++) {
                     if (efc) {
                         if (H5Pset_elink_file_cache_size(my_fapl, 8) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                         HDprintf("\n---Testing with external file cache---\n");
                     } /* end if */
                     else {
                         if (H5Pset_elink_file_cache_size(my_fapl, 0) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                         HDprintf("\n---Testing without external file cache---\n");
                     } /* end else */
 

--- a/test/links.c
+++ b/test/links.c
@@ -10690,7 +10690,7 @@ external_link_win7(hid_t fapl, hbool_t new_format)
 
     if (new_format)
         TESTING(
-            "external links via main file's UNC local host/main drive/rel path(windows)(w/new group format)")
+            "external links via main file's UNC local host/main drive/rel path(windows)(w/new group format)");
     else
         TESTING("external links via main file's UNC local host/main drive/rel path(windows)");
 
@@ -10787,7 +10787,7 @@ external_link_win8(hid_t fapl, hbool_t new_format)
 
     if (new_format)
         TESTING(
-            "external links via target's Long UNC abs drive/abs path directly (windows)(w/new group format)")
+            "external links via target's Long UNC abs drive/abs path directly (windows)(w/new group format)");
     else
         TESTING("external links via target's Long UNC abs drive/abs path directly (windows)");
 

--- a/test/links_env.c
+++ b/test/links_env.c
@@ -63,14 +63,14 @@ external_link_env(hid_t fapl, hbool_t new_format)
         filename3[NAME_BUF_SIZE]; /* Holders for filename */
 
     if (new_format)
-        TESTING("external links via environment variable (w/new group format)")
+        TESTING("external links via environment variable (w/new group format)");
     else
-        TESTING("external links via environment variable")
+        TESTING("external links via environment variable");
 
     if ((envval = HDgetenv("HDF5_EXT_PREFIX")) == NULL)
         envval = "nomatch";
     if (HDstrcmp(envval, ".:tmp_links_env") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set up name for main file:"extlinks_env0" */
     h5_fixname(FILENAME[0], fapl, filename1, sizeof filename1);
@@ -80,30 +80,30 @@ external_link_env(hid_t fapl, hbool_t new_format)
 
     /* Create "tmp_links_env" directory */
     if (HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set up name (location) for the target file: "tmp_links_env/extlinks1" */
     h5_fixname(FILENAME[2], fapl, filename3, sizeof filename3);
 
     /* Create the target file in "tmp_links_env" directory */
     if ((fid = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing for target file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the main file */
     if ((fid = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create external link to target file */
     if (H5Lcreate_external(filename2, "/A", fid, "ext_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object through external link */
     H5E_BEGIN_TRY
@@ -121,9 +121,9 @@ external_link_env(hid_t fapl, hbool_t new_format)
 
     /* closing for main file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -174,7 +174,7 @@ main(void)
 
     /* Set the "use the latest version of the format" bounds for creating objects in the file */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     nerrors += external_link_env(fapl, TRUE) < 0 ? 1 : 0;
 

--- a/test/mf.c
+++ b/test/mf.c
@@ -165,32 +165,32 @@ check_stats(const H5F_t *f, const H5FS_t *frsp, H5FS_stat_t *state)
 
     /* Get statistics for free-space and verify they are correct */
     if (H5FS_stat_info(f, frsp, &frspace_stats) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (frspace_stats.tot_space != state->tot_space) {
         HDfprintf(stdout, "frspace_stats.tot_space = %" PRIuHSIZE ", state->tot_space = %" PRIuHSIZE "\n",
                   frspace_stats.tot_space, state->tot_space);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (frspace_stats.tot_sect_count != state->tot_sect_count) {
         HDfprintf(stdout,
                   "frspace_stats.tot_sect_count = %" PRIuHSIZE ", state->tot_sect_count = %" PRIuHSIZE "\n",
                   frspace_stats.tot_sect_count, state->tot_sect_count);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (frspace_stats.serial_sect_count != state->serial_sect_count) {
         HDfprintf(stdout,
                   "frspace_stats.serial_sect_count = %" PRIuHSIZE ", state->serial_sect_count = %" PRIuHSIZE
                   "\n",
                   frspace_stats.serial_sect_count, state->serial_sect_count);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (frspace_stats.ghost_sect_count != state->ghost_sect_count) {
         HDfprintf(stdout,
                   "frspace_stats.ghost_sect_count = %" PRIuHSIZE ", state->ghost_sect_count = %" PRIuHSIZE
                   "\n",
                   frspace_stats.ghost_sect_count, state->ghost_sect_count);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* All tests passed */
@@ -237,19 +237,19 @@ test_mf_eoa(const char *env_h5_drvr, hid_t fapl)
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
         if ((fapl_new = H5Pcopy(fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create the file to work on */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Turn off using meta/small data aggregator */
         H5Pset_meta_block_size(fapl_new, (hsize_t)0);
@@ -257,11 +257,11 @@ test_mf_eoa(const char *env_h5_drvr, hid_t fapl)
 
         /* Re-open the file with meta/small data setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
@@ -271,56 +271,56 @@ test_mf_eoa(const char *env_h5_drvr, hid_t fapl)
         /* nothing should be changed in meta_aggr */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &ma_size);
         if (new_ma_addr != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (addr1 < (haddr_t)file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         addr2 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE50);
 
         /* nothing should be changed in meta_aggr */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &ma_size);
         if (new_ma_addr != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (addr2 < (haddr_t)file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != (file_size + TBLOCK_SIZE30 + TBLOCK_SIZE50))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE30);
         H5MF_xfree(f, type, addr2, (hsize_t)TBLOCK_SIZE50);
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Pclose(fapl_new) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     } /* end if */
@@ -386,19 +386,19 @@ test_mf_eoa_shrink(const char *env_h5_drvr, hid_t fapl)
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
         if ((fapl_new = H5Pcopy(fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create the file to work on */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Turn off using meta/small data aggregator */
         H5Pset_meta_block_size(fapl_new, (hsize_t)0);
@@ -406,11 +406,11 @@ test_mf_eoa_shrink(const char *env_h5_drvr, hid_t fapl)
 
         /* Re-open the file with meta/small data setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
@@ -418,57 +418,57 @@ test_mf_eoa_shrink(const char *env_h5_drvr, hid_t fapl)
         addr = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE30);
 
         if (addr < (haddr_t)file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* nothing should be changed in meta_aggr */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
         if (new_ma_addr != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (new_ma_size != ma_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != (file_size + TBLOCK_SIZE30))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         /* should succeed */
         if (H5MF_try_shrink(f, type, addr, (hsize_t)TBLOCK_SIZE30) <= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* nothing should be changed in meta_aggr */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &ma_size);
         if (new_ma_addr != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (new_ma_size != ma_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -485,40 +485,40 @@ test_mf_eoa_shrink(const char *env_h5_drvr, hid_t fapl)
     if (suitable_vfd) {
         /* Re-open the file with meta/small data setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         addr = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE30);
 
         if (addr < (haddr_t)file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* should not succeed in shrinking */
         if (H5MF_try_shrink(f, type, addr, (hsize_t)TBLOCK_SIZE30 - 10) > 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* nothing should be changed in meta_aggr */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &ma_size);
         if (new_ma_addr != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (new_ma_size != ma_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != (file_size + TBLOCK_SIZE30))
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -535,35 +535,35 @@ test_mf_eoa_shrink(const char *env_h5_drvr, hid_t fapl)
     if (suitable_vfd) {
         /* Re-open the file with meta/small data setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         /* should not succeed in shrinking */
         if (H5MF_try_shrink(f, type, addr, (hsize_t)TBLOCK_SIZE30 + 10) > 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* nothing should be changed in meta_aggr */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &ma_size);
         if (new_ma_addr != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (new_ma_size != ma_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != (file_size + TBLOCK_SIZE30))
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -580,38 +580,38 @@ test_mf_eoa_shrink(const char *env_h5_drvr, hid_t fapl)
     if (suitable_vfd) {
         /* Re-open the file with meta/small data setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         /* should succeed in shrinking */
         if (H5MF_try_shrink(f, type, addr + 10, (hsize_t)(TBLOCK_SIZE30 - 10)) <= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* nothing should be changed in meta_aggr */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &ma_size);
         if (new_ma_addr != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (new_ma_size != ma_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != (file_size + 10))
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Pclose(fapl_new) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     } /* end if */
@@ -674,87 +674,87 @@ test_mf_eoa_extend(const char *env_h5_drvr, hid_t fapl)
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
         if ((fapl_new = H5Pcopy(fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create the file to work on */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of a file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Turn off using meta/small data aggregator */
         if (H5Pset_meta_block_size(fapl_new, (hsize_t)0) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Pset_small_data_block_size(fapl_new, (hsize_t)0) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Re-open the file with meta/small data setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         type = H5FD_MEM_SUPER;
         addr = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE30);
         if (addr < (haddr_t)file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* nothing should be changed in meta_aggr */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
         if (new_ma_addr != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != (file_size + TBLOCK_SIZE30))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* should succeed */
         was_extended =
             H5MF_try_extend(f, type, (haddr_t)addr, (hsize_t)TBLOCK_SIZE30, (hsize_t)TBLOCK_SIZE50);
 
         if (was_extended <= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* nothing should be changed in meta_aggr */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
         if (new_ma_addr != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != (file_size + TBLOCK_SIZE30 + TBLOCK_SIZE50))
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -771,15 +771,15 @@ test_mf_eoa_extend(const char *env_h5_drvr, hid_t fapl)
     if (suitable_vfd) {
         /* Re-open the file with meta/small data setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl_new)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
@@ -787,38 +787,38 @@ test_mf_eoa_extend(const char *env_h5_drvr, hid_t fapl)
         addr = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE30);
 
         if (addr < (haddr_t)file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* nothing should be changed in meta_aggr */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
         if (new_ma_addr != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         was_extended =
             H5MF_try_extend(f, type, (haddr_t)addr, (hsize_t)(TBLOCK_SIZE30 - 10), (hsize_t)(TBLOCK_SIZE50));
 
         /* should not succeed */
         if (was_extended > 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* nothing should be changed in meta_aggr */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
         if (new_ma_addr != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != file_size + TBLOCK_SIZE30)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Pclose(fapl_new) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     } /* end if */
@@ -870,9 +870,9 @@ test_mf_tmp(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
     hid_t fcpl  = -1; /* File creation property list */
 
     if (new_format)
-        TESTING("'temporary' file space allocation with new library format")
+        TESTING("'temporary' file space allocation with new library format");
     else
-        TESTING("'temporary' file space allocation with old library format")
+        TESTING("'temporary' file space allocation with old library format");
 
     /* Can't run this test with multi-file VFDs */
     if (HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
@@ -891,53 +891,53 @@ test_mf_tmp(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
         if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if (new_format) {
             /* Copy the file access property list */
             if ((fapl2 = H5Pcopy(fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Set the "use the latest version of the format" bounds for creating objects in the file */
             if (H5Pset_libver_bounds(fapl2, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_PAGE, FALSE, (hsize_t)1);
         } /* end if */
 
         /* Create the file to work on */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, new_format ? fapl2 : fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Retrieve the file's maxaddr */
         if (H5F__get_maxaddr_test(file, &maxaddr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate some temporary address space */
         if (HADDR_UNDEF == (tmp_addr = H5MF_alloc_tmp(f, (hsize_t)TBLOCK_SIZE30)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Check if temporary file address is valid */
         if (!H5F_IS_TMP_ADDR(f, tmp_addr))
-            TEST_ERROR
+            TEST_ERROR;
         if (tmp_addr < (haddr_t)(maxaddr - TBLOCK_SIZE30))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Reading & writing with a temporary address value should fail */
         H5E_BEGIN_TRY
@@ -946,14 +946,14 @@ test_mf_tmp(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
         }
         H5E_END_TRY;
         if (status >= 0)
-            TEST_ERROR
+            TEST_ERROR;
         H5E_BEGIN_TRY
         {
             status = H5F_block_write(f, H5FD_MEM_SUPER, tmp_addr, sizeof(buf), &buf);
         }
         H5E_END_TRY;
         if (status >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Freeing a temporary address value should fail */
         H5E_BEGIN_TRY
@@ -962,39 +962,39 @@ test_mf_tmp(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
         }
         H5E_END_TRY;
         if (status >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate 1/3 of the file as temporary address space */
         if (HADDR_UNDEF == (tmp_addr = H5MF_alloc_tmp(f, (hsize_t)(maxaddr / 3))))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (!H5F_IS_TMP_ADDR(f, tmp_addr))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate 1/3 of the file as normal address space */
         if (HADDR_UNDEF == (norm_addr = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)(maxaddr / 3))))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5F_IS_TMP_ADDR(f, norm_addr))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Test that pushing temporary space allocation into normal space fails */
         H5E_BEGIN_TRY
@@ -1003,7 +1003,7 @@ test_mf_tmp(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
         }
         H5E_END_TRY;
         if (H5F_addr_defined(check_addr))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Test that pushing normal space allocation into temporary space fails */
         H5E_BEGIN_TRY
@@ -1012,23 +1012,23 @@ test_mf_tmp(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
         }
         H5E_END_TRY;
         if (H5F_addr_defined(check_addr))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free the normal block (so the file doesn't blow up to a huge size) */
         if (H5MF_xfree(f, H5FD_MEM_DRAW, norm_addr, (hsize_t)(maxaddr / 3)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close the file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -1072,19 +1072,19 @@ test_mf_fs_start(hid_t fapl)
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
     if ((fapl_new = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file  */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Turn off using meta/small data aggregator */
     H5Pset_meta_block_size(fapl_new, (hsize_t)0);
@@ -1092,39 +1092,39 @@ test_mf_fs_start(hid_t fapl)
 
     /* Re-open the file with meta/small data setting */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
     if (H5MF__start_fstype(f, (H5F_mem_page_t)H5FD_MEM_SUPER) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (f->shared->fs_state[H5FD_MEM_SUPER] != H5F_FS_STATE_OPEN)
-        TEST_ERROR
+        TEST_ERROR;
     if (f->shared->fs_man[H5FD_MEM_SUPER]->client != H5FS_CLIENT_FILE_ID)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDmemset(&state, 0, sizeof(H5FS_stat_t));
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is the correct size */
     if (new_file_size != file_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pclose(fapl_new) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1186,19 +1186,19 @@ test_mf_fs_alloc_free(hid_t fapl)
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
     if ((fapl_new = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of a file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Turn off using meta/small data aggregator */
     H5Pset_meta_block_size(fapl_new, (hsize_t)0);
@@ -1206,27 +1206,27 @@ test_mf_fs_alloc_free(hid_t fapl)
 
     /* Re-open the file with meta/small data setting */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
     if (H5MF__start_fstype(f, (H5F_mem_page_t)H5FD_MEM_SUPER) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (f->shared->fs_state[H5FD_MEM_SUPER] != H5F_FS_STATE_OPEN)
-        TEST_ERROR
+        TEST_ERROR;
     if (f->shared->fs_man[H5FD_MEM_SUPER]->client != H5FS_CLIENT_FILE_ID)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create section A */
     sect_node = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE30);
 
     /* Add section A to free-space manager */
     if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(H5FS_stat_t));
     state.tot_space += TBLOCK_SIZE30;
@@ -1234,21 +1234,21 @@ test_mf_fs_alloc_free(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate a block of 30 */
     addr = H5MF_alloc(f, H5FD_MEM_SUPER, (hsize_t)TBLOCK_SIZE30);
 
     /* Verify that the allocated block is section A in free-space */
     if (addr != TBLOCK_ADDR70)
-        TEST_ERROR
+        TEST_ERROR;
 
     state.tot_space -= TBLOCK_SIZE30;
     state.tot_sect_count -= 1;
     state.serial_sect_count -= 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free the block to free-space */
     H5MF_xfree(f, H5FD_MEM_SUPER, addr, (hsize_t)TBLOCK_SIZE30);
@@ -1257,26 +1257,26 @@ test_mf_fs_alloc_free(hid_t fapl)
     state.tot_sect_count += 1;
     state.serial_sect_count += 1;
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Remove section A from free-space */
     if (H5MF__find_sect(f, H5FD_MEM_SUPER, (hsize_t)TBLOCK_SIZE30, f->shared->fs_man[H5FD_MEM_SUPER], &tmp) !=
         TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (tmp != TBLOCK_ADDR70)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is the correct size */
     if (new_file_size != file_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1284,27 +1284,27 @@ test_mf_fs_alloc_free(hid_t fapl)
 
     /* Re-open the file with meta/small data setting */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
     if (H5MF__start_fstype(f, (H5F_mem_page_t)H5FD_MEM_SUPER) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (f->shared->fs_state[H5FD_MEM_SUPER] != H5F_FS_STATE_OPEN)
-        TEST_ERROR
+        TEST_ERROR;
     if (f->shared->fs_man[H5FD_MEM_SUPER]->client != H5FS_CLIENT_FILE_ID)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create section A */
     sect_node = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE30);
 
     /* Add section A to free-space manager */
     if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(H5FS_stat_t));
     state.tot_space += TBLOCK_SIZE30;
@@ -1312,20 +1312,20 @@ test_mf_fs_alloc_free(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate a block of 20 */
     addr = H5MF_alloc(f, H5FD_MEM_SUPER, (hsize_t)(TBLOCK_SIZE20));
 
     /* Verify that the allocated block is section A in free-space manager */
     if (addr != TBLOCK_ADDR70)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* should still have 1 section of size 10 left in free-space manager */
     state.tot_space -= (TBLOCK_SIZE20);
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free the block to free-space manager */
     H5MF_xfree(f, H5FD_MEM_SUPER, addr, (hsize_t)(TBLOCK_SIZE20));
@@ -1333,26 +1333,26 @@ test_mf_fs_alloc_free(hid_t fapl)
     /* Still 1 section in free-space because of merging */
     state.tot_space += TBLOCK_SIZE20;
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Remove section A from free-space */
     if (H5MF__find_sect(f, H5FD_MEM_SUPER, (hsize_t)TBLOCK_SIZE30, f->shared->fs_man[H5FD_MEM_SUPER], &tmp) !=
         TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (tmp != TBLOCK_ADDR70)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is the correct size */
     if (new_file_size != file_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1360,27 +1360,27 @@ test_mf_fs_alloc_free(hid_t fapl)
 
     /* Re-open the file with meta/small data setting */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
     if (H5MF__start_fstype(f, (H5F_mem_page_t)H5FD_MEM_SUPER) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (f->shared->fs_state[H5FD_MEM_SUPER] != H5F_FS_STATE_OPEN)
-        TEST_ERROR
+        TEST_ERROR;
     if (f->shared->fs_man[H5FD_MEM_SUPER]->client != H5FS_CLIENT_FILE_ID)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create section A */
     sect_node = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE30);
 
     /* Add section A to free-space manager */
     if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(H5FS_stat_t));
     state.tot_space += TBLOCK_SIZE30;
@@ -1388,7 +1388,7 @@ test_mf_fs_alloc_free(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Allocate a block of 40.
@@ -1399,24 +1399,24 @@ test_mf_fs_alloc_free(hid_t fapl)
 
     /* Verify that the allocated block is not section A in free-space */
     if (addr == TBLOCK_ADDR70)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* free-space info should be the same  */
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Remove section A from free-space */
     if (H5MF__find_sect(f, H5FD_MEM_SUPER, (hsize_t)TBLOCK_SIZE30, f->shared->fs_man[H5FD_MEM_SUPER], &tmp) !=
         TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the block is section A in free-space */
     if (tmp != TBLOCK_ADDR70)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDmemset(&state, 0, sizeof(H5FS_stat_t));
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free the block of size 40 to free-space */
     H5MF_xfree(f, H5FD_MEM_SUPER, addr, (hsize_t)(TBLOCK_SIZE40));
@@ -1427,21 +1427,21 @@ test_mf_fs_alloc_free(hid_t fapl)
      * It is shrunk and freed because it is at end of file.
      */
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is the correct size */
     if (new_file_size != file_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pclose(fapl_new) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -1516,19 +1516,19 @@ test_mf_fs_extend(hid_t fapl)
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
     if ((fapl_new = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of a file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Turn off using meta/small data aggregator */
     H5Pset_meta_block_size(fapl_new, (hsize_t)0);
@@ -1536,27 +1536,27 @@ test_mf_fs_extend(hid_t fapl)
 
     /* Re-open the file with meta/small data setting */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
     if (H5MF__start_fstype(f, (H5F_mem_page_t)H5FD_MEM_SUPER) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (f->shared->fs_state[H5FD_MEM_SUPER] != H5F_FS_STATE_OPEN)
-        TEST_ERROR
+        TEST_ERROR;
     if (f->shared->fs_man[H5FD_MEM_SUPER]->client != H5FS_CLIENT_FILE_ID)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create section A */
     sect_node1 = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE30);
 
     /* Add section A to free-space manager */
     if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node1))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(H5FS_stat_t));
     state.tot_space += TBLOCK_SIZE30;
@@ -1564,35 +1564,35 @@ test_mf_fs_extend(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate a block of 30 */
     addr = H5MF_alloc(f, H5FD_MEM_SUPER, (hsize_t)TBLOCK_SIZE30);
 
     /* Verify that the allocated block is section A in free-space manager */
     if (addr != TBLOCK_ADDR70)
-        TEST_ERROR
+        TEST_ERROR;
 
     state.tot_space -= TBLOCK_SIZE30;
     state.tot_sect_count -= 1;
     state.serial_sect_count -= 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create section B */
     sect_node2 = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR100, (hsize_t)TBLOCK_SIZE50);
 
     /* Add section B to free-space manager */
     if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node2))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     state.tot_space += TBLOCK_SIZE50;
     state.tot_sect_count += 1;
     state.serial_sect_count += 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try to extend the allocated block */
     was_extended = H5MF_try_extend(f, H5FD_MEM_SUPER, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE30,
@@ -1600,7 +1600,7 @@ test_mf_fs_extend(hid_t fapl)
 
     /* should succeed */
     if (was_extended <= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Section B is removed from free-space manager */
     state.tot_space -= TBLOCK_SIZE50;
@@ -1608,7 +1608,7 @@ test_mf_fs_extend(hid_t fapl)
     state.serial_sect_count -= 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free the extended block to free-space manager */
     H5MF_xfree(f, H5FD_MEM_SUPER, addr, (hsize_t)(TBLOCK_SIZE30 + TBLOCK_SIZE50));
@@ -1619,26 +1619,26 @@ test_mf_fs_extend(hid_t fapl)
     state.serial_sect_count = 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Remove the extended block */
     if (H5MF__find_sect(f, H5FD_MEM_SUPER, (hsize_t)(TBLOCK_SIZE30 + TBLOCK_SIZE50),
                         f->shared->fs_man[H5FD_MEM_SUPER], &tmp) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (tmp != TBLOCK_ADDR70)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is the correct size */
     if (new_file_size != file_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1646,27 +1646,27 @@ test_mf_fs_extend(hid_t fapl)
 
     /* Re-open the file with meta/small data setting */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
     if (H5MF__start_fstype(f, (H5F_mem_page_t)H5FD_MEM_SUPER) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (f->shared->fs_state[H5FD_MEM_SUPER] != H5F_FS_STATE_OPEN)
-        TEST_ERROR
+        TEST_ERROR;
     if (f->shared->fs_man[H5FD_MEM_SUPER]->client != H5FS_CLIENT_FILE_ID)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create section A */
     sect_node1 = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE30);
 
     /* Add section A to free-space manager */
     if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node1))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(H5FS_stat_t));
     state.tot_space += TBLOCK_SIZE30;
@@ -1674,35 +1674,35 @@ test_mf_fs_extend(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate a block of 30 */
     addr = H5MF_alloc(f, H5FD_MEM_SUPER, (hsize_t)TBLOCK_SIZE30);
 
     /* Verify that the allocated block is section A in free-space manager */
     if (addr != TBLOCK_ADDR70)
-        TEST_ERROR
+        TEST_ERROR;
 
     state.tot_space -= TBLOCK_SIZE30;
     state.tot_sect_count -= 1;
     state.serial_sect_count -= 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create section B */
     sect_node2 = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR100, (hsize_t)TBLOCK_SIZE50);
 
     /* Add section B to free-space manager */
     if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node2))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     state.tot_space += TBLOCK_SIZE50;
     state.tot_sect_count += 1;
     state.serial_sect_count += 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try to extend the allocated block */
     was_extended = H5MF_try_extend(f, H5FD_MEM_SUPER, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE30,
@@ -1710,11 +1710,11 @@ test_mf_fs_extend(hid_t fapl)
 
     /* Should not be able to extend the allocated block */
     if (was_extended)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* free-space info should remain the same */
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free the allocated block A to free-space */
     H5MF_xfree(f, H5FD_MEM_SUPER, addr, (hsize_t)TBLOCK_SIZE30);
@@ -1724,26 +1724,26 @@ test_mf_fs_extend(hid_t fapl)
     state.tot_space += TBLOCK_SIZE30;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Remove the merged sections A & B from free-space */
     if (H5MF__find_sect(f, H5FD_MEM_SUPER, (hsize_t)(TBLOCK_SIZE30 + TBLOCK_SIZE50),
                         f->shared->fs_man[H5FD_MEM_SUPER], &tmp) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (tmp != addr)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is the correct size */
     if (new_file_size != file_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1751,27 +1751,27 @@ test_mf_fs_extend(hid_t fapl)
 
     /* Re-open the file with meta/small data setting */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
     if (H5MF__start_fstype(f, (H5F_mem_page_t)H5FD_MEM_SUPER) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (f->shared->fs_state[H5FD_MEM_SUPER] != H5F_FS_STATE_OPEN)
-        TEST_ERROR
+        TEST_ERROR;
     if (f->shared->fs_man[H5FD_MEM_SUPER]->client != H5FS_CLIENT_FILE_ID)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create section A */
     sect_node1 = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE30);
 
     /* Add section A to free-space manager */
     if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node1))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(H5FS_stat_t));
     state.tot_space += TBLOCK_SIZE30;
@@ -1779,35 +1779,35 @@ test_mf_fs_extend(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate a block of 30 */
     addr = H5MF_alloc(f, H5FD_MEM_SUPER, (hsize_t)TBLOCK_SIZE30);
 
     /* Verify that the allocated block is section A in free-space manager */
     if (addr != TBLOCK_ADDR70)
-        TEST_ERROR
+        TEST_ERROR;
 
     state.tot_space -= TBLOCK_SIZE30;
     state.tot_sect_count -= 1;
     state.serial_sect_count -= 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create section B */
     sect_node2 = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR100, (hsize_t)TBLOCK_SIZE50);
 
     /* Add section B to free-space manager */
     if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node2))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     state.tot_space += TBLOCK_SIZE50;
     state.tot_sect_count += 1;
     state.serial_sect_count += 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try to extend the allocated block */
     was_extended = H5MF_try_extend(f, H5FD_MEM_SUPER, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE30,
@@ -1815,12 +1815,12 @@ test_mf_fs_extend(hid_t fapl)
 
     /* Should succeed in extending the allocated block */
     if (was_extended <= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should have 1 section of size=10 left in free-space manager */
     state.tot_space -= (TBLOCK_SIZE40);
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free the extended block  */
     H5MF_xfree(f, H5FD_MEM_SUPER, addr, (hsize_t)(TBLOCK_SIZE30 + TBLOCK_SIZE40));
@@ -1829,26 +1829,26 @@ test_mf_fs_extend(hid_t fapl)
     state.tot_space += (TBLOCK_SIZE30 + TBLOCK_SIZE40);
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Remove the merged sections A & B from free-space */
     if (H5MF__find_sect(f, H5FD_MEM_SUPER, (hsize_t)(TBLOCK_SIZE30 + TBLOCK_SIZE50),
                         f->shared->fs_man[H5FD_MEM_SUPER], &tmp) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (tmp != addr)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is the correct size */
     if (new_file_size != file_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1856,20 +1856,20 @@ test_mf_fs_extend(hid_t fapl)
 
     /* Re-open the file with meta/small data setting */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
     if (H5MF__start_fstype(f, (H5F_mem_page_t)H5FD_MEM_SUPER) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (f->shared->fs_state[H5FD_MEM_SUPER] != H5F_FS_STATE_OPEN)
-        TEST_ERROR
+        TEST_ERROR;
     if (f->shared->fs_man[H5FD_MEM_SUPER]->client != H5FS_CLIENT_FILE_ID)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create section A */
     sect_node1 =
@@ -1877,7 +1877,7 @@ test_mf_fs_extend(hid_t fapl)
 
     /* Add section A of size=20 to free-space */
     if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node1))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(H5FS_stat_t));
     state.tot_space += (TBLOCK_SIZE30 - 10);
@@ -1885,35 +1885,35 @@ test_mf_fs_extend(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate a block of size=20 */
     addr = H5MF_alloc(f, H5FD_MEM_SUPER, (hsize_t)(TBLOCK_SIZE30 - 10));
 
     /* Verify that the allocated block is section A in free-space manager */
     if (addr != TBLOCK_ADDR70)
-        TEST_ERROR
+        TEST_ERROR;
 
     state.tot_space -= (TBLOCK_SIZE30 - 10);
     state.tot_sect_count -= 1;
     state.serial_sect_count -= 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create section B */
     sect_node2 = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR100, (hsize_t)TBLOCK_SIZE50);
 
     /* Add section B to free-space manager */
     if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node2))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     state.tot_space += TBLOCK_SIZE50;
     state.tot_sect_count += 1;
     state.serial_sect_count += 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try to extend the allocated block */
     was_extended = H5MF_try_extend(f, H5FD_MEM_SUPER, (haddr_t)TBLOCK_ADDR70, (hsize_t)(TBLOCK_SIZE30 - 10),
@@ -1921,11 +1921,11 @@ test_mf_fs_extend(hid_t fapl)
 
     /* Should not succeed in extending the allocated block */
     if (was_extended)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free-space info should be the same */
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free the allocated block */
     H5MF_xfree(f, H5FD_MEM_SUPER, addr, (hsize_t)(TBLOCK_SIZE30 - 10));
@@ -1935,34 +1935,34 @@ test_mf_fs_extend(hid_t fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Remove section A from free-space manager */
     if (H5MF__find_sect(f, H5FD_MEM_SUPER, (hsize_t)(TBLOCK_SIZE30 - 10), f->shared->fs_man[H5FD_MEM_SUPER],
                         &tmp) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (tmp != addr)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Remove section B from free-space manager */
     if (H5MF__find_sect(f, H5FD_MEM_SUPER, (hsize_t)TBLOCK_SIZE50, f->shared->fs_man[H5FD_MEM_SUPER], &tmp) !=
         TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((new_file_size = h5_get_file_size(filename, fapl_new)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is the correct size */
     if (new_file_size != file_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pclose(fapl_new) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2027,28 +2027,28 @@ test_mf_fs_absorb(const char *env_h5_drvr, hid_t fapl)
 
         /* Create the file to work on */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Start up H5FD_MEM_SUPER free-space manager */
         if (H5MF__start_fstype(f, (H5F_mem_page_t)H5FD_MEM_SUPER) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if (f->shared->fs_state[H5FD_MEM_SUPER] != H5F_FS_STATE_OPEN)
-            TEST_ERROR
+            TEST_ERROR;
         if (f->shared->fs_man[H5FD_MEM_SUPER]->client != H5FS_CLIENT_FILE_ID)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a section from meta_aggr */
         addr = H5MF_alloc(f, H5FD_MEM_SUPER, (hsize_t)TBLOCK_SIZE30);
@@ -2061,15 +2061,15 @@ test_mf_fs_absorb(const char *env_h5_drvr, hid_t fapl)
 
         /* Add a section to free-space that adjoins end of the aggregator */
         if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify that the section did absorb the aggregator */
         if (H5MF__find_sect(f, H5FD_MEM_SUPER, (hsize_t)(ma_addr + ma_size),
                             f->shared->fs_man[H5FD_MEM_SUPER], &tmp) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (tmp != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Restore info for aggregator */
         f->shared->meta_aggr.addr = ma_addr;
@@ -2079,7 +2079,7 @@ test_mf_fs_absorb(const char *env_h5_drvr, hid_t fapl)
         H5MF_xfree(f, H5FD_MEM_SUPER, addr, (hsize_t)TBLOCK_SIZE30);
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     } /* end if */
@@ -2094,20 +2094,20 @@ test_mf_fs_absorb(const char *env_h5_drvr, hid_t fapl)
     if (contig_addr_vfd) {
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Start up H5FD_MEM_SUPER free-space manager */
         if (H5MF__start_fstype(f, (H5F_mem_page_t)H5FD_MEM_SUPER) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if (f->shared->fs_state[H5FD_MEM_SUPER] != H5F_FS_STATE_OPEN)
-            TEST_ERROR
+            TEST_ERROR;
         if (f->shared->fs_man[H5FD_MEM_SUPER]->client != H5FS_CLIENT_FILE_ID)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a section from meta_aggr */
         addr = H5MF_alloc(f, H5FD_MEM_SUPER, (hsize_t)TBLOCK_SIZE30);
@@ -2121,15 +2121,15 @@ test_mf_fs_absorb(const char *env_h5_drvr, hid_t fapl)
 
         /* When adding, meta_aggr is absorbed onto the end of the section */
         if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify that the section did absorb the aggregator */
         if (H5MF__find_sect(f, H5FD_MEM_SUPER, (hsize_t)(ma_size + TBLOCK_SIZE30),
                             f->shared->fs_man[H5FD_MEM_SUPER], &tmp) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         if ((tmp + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* restore info to meta_aggr */
         f->shared->meta_aggr.addr = ma_addr;
@@ -2141,7 +2141,7 @@ test_mf_fs_absorb(const char *env_h5_drvr, hid_t fapl)
         H5MF_xfree(f, H5FD_MEM_DRAW, saddr, (hsize_t)TBLOCK_SIZE50);
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     } /* end if */
@@ -2204,89 +2204,89 @@ test_mf_aggr_alloc1(const char *env_h5_drvr, hid_t fapl)
 
         /* File creation property list template */
         if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Set to H5F_FSPACE_STRATEGY_AGGR strategy */
         if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_AGGR, FALSE, (hsize_t)1) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create the file to work on */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get the size of a file  */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate first block from meta_aggr */
         type = H5FD_MEM_SUPER;
         if ((addr1 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE30)) == HADDR_UNDEF)
-            TEST_ERROR
+            TEST_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if ((addr1 + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate second block from meta_aggr */
         if ((addr2 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE50)) == HADDR_UNDEF)
-            TEST_ERROR
+            TEST_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if ((addr2 + TBLOCK_SIZE50) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (ma_size != (TBLOCK_SIZE2048 - (TBLOCK_SIZE30 + TBLOCK_SIZE50)))
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != (file_size + TBLOCK_SIZE30 + TBLOCK_SIZE50))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free the two blocks: order matters because of H5F_FSPACE_STRATEGY_AGGR strategy */
         if (H5MF_xfree(f, type, addr2, (hsize_t)TBLOCK_SIZE50) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE30) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Pclose(fcpl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -2356,82 +2356,82 @@ test_mf_aggr_alloc2(const char *env_h5_drvr, hid_t fapl)
 
         /* Create the file to work on */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of a file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         type  = H5FD_MEM_SUPER;
         addr1 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE30);
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if ((addr1 + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         addr2 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE50);
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if ((addr2 + TBLOCK_SIZE50) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (ma_size != (TBLOCK_SIZE2048 - (TBLOCK_SIZE30 + TBLOCK_SIZE50)))
-            TEST_ERROR
+            TEST_ERROR;
 
         addr3 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE2058);
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if ((addr3 + TBLOCK_SIZE2058) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (ma_size != (TBLOCK_SIZE2048 - (TBLOCK_SIZE30 + TBLOCK_SIZE50)))
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         /* Unused space is freed from the end of the file */
         if (new_file_size != (file_size + TBLOCK_SIZE30 + TBLOCK_SIZE50 + TBLOCK_SIZE2058))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE30 + TBLOCK_SIZE50 + TBLOCK_SIZE2058);
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -2514,23 +2514,23 @@ test_mf_aggr_alloc3(const char *env_h5_drvr, hid_t fapl)
 
         /* Create the file to work on */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate first block from meta_aggr */
         type  = H5FD_MEM_SUPER;
@@ -2538,7 +2538,7 @@ test_mf_aggr_alloc3(const char *env_h5_drvr, hid_t fapl)
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if ((addr1 + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate second block from meta_aggr */
         addr2 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE50);
@@ -2546,18 +2546,18 @@ test_mf_aggr_alloc3(const char *env_h5_drvr, hid_t fapl)
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if ((addr2 + TBLOCK_SIZE50) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (ma_size != (TBLOCK_SIZE2048 - (TBLOCK_SIZE30 + TBLOCK_SIZE50)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate first block from sdata_aggr */
         stype  = H5FD_MEM_DRAW;
         saddr1 = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE30);
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if ((saddr1 + TBLOCK_SIZE30) != sdata_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (sdata_size != (TBLOCK_SIZE2048 - TBLOCK_SIZE30))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate third block, which is from  file allocation not from meta_aggr */
         addr3 = H5MF_alloc(f, type, (hsize_t)(TBLOCK_SIZE2058));
@@ -2566,20 +2566,20 @@ test_mf_aggr_alloc3(const char *env_h5_drvr, hid_t fapl)
 
         /* info for meta_aggr shouldn't be changed */
         if (addr3 != (sdata_addr + sdata_size))
-            TEST_ERROR
+            TEST_ERROR;
         if ((addr3 + TBLOCK_SIZE2058) == new_ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if ((new_ma_addr != ma_addr) || (new_ma_size != ma_size))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate fourth block, which should be from meta_aggr */
         addr4 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE50);
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if ((addr4 + TBLOCK_SIZE50) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (ma_size != (TBLOCK_SIZE2048 - (TBLOCK_SIZE30 + TBLOCK_SIZE50 + TBLOCK_SIZE50)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free all the allocated blocks */
         H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE30);
@@ -2589,15 +2589,15 @@ test_mf_aggr_alloc3(const char *env_h5_drvr, hid_t fapl)
         H5MF_xfree(f, stype, saddr1, (hsize_t)TBLOCK_SIZE30);
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -2682,23 +2682,23 @@ test_mf_aggr_alloc4(const char *env_h5_drvr, hid_t fapl)
 
         /* Create the file to work on */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file  */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate first block from meta_aggr */
         type  = H5FD_MEM_SUPER;
@@ -2707,47 +2707,47 @@ test_mf_aggr_alloc4(const char *env_h5_drvr, hid_t fapl)
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if ((addr1 + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (ma_size != (TBLOCK_SIZE2048 - TBLOCK_SIZE30))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate first block from sdata_aggr */
         stype  = H5FD_MEM_DRAW;
         saddr1 = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE30);
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if ((saddr1 + TBLOCK_SIZE30) != sdata_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate second block from sdata_aggr */
         saddr2 = H5MF_alloc(f, stype, (hsize_t)(TBLOCK_SIZE2048 - TBLOCK_SIZE30));
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if (saddr2 + (TBLOCK_SIZE2048 - TBLOCK_SIZE30) != sdata_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate third block from sdata_aggr */
         saddr3 = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE50);
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
 
         if ((saddr3 + TBLOCK_SIZE50) != sdata_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (sdata_size != (TBLOCK_SIZE2048 - TBLOCK_SIZE50))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate second block of 2058, which is from file allocation, not from meta_aggr */
         addr2 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE2058);
 
         if (addr2 != sdata_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* sdata_aggr is reset 0 */
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if ((sdata_addr != 0) && (sdata_size != 0))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* info is unchanged in meta_aggr */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
         if ((new_ma_addr != ma_addr) && (new_ma_size != ma_size))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free all the allocated blocks */
         H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE30);
@@ -2757,15 +2757,15 @@ test_mf_aggr_alloc4(const char *env_h5_drvr, hid_t fapl)
         H5MF_xfree(f, stype, saddr3, (hsize_t)TBLOCK_SIZE50);
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -2831,23 +2831,23 @@ test_mf_aggr_alloc5(const char *env_h5_drvr, hid_t fapl)
 
         /* Create the file to work on */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate first block from meta_aggr */
         type  = H5FD_MEM_SUPER;
@@ -2855,27 +2855,27 @@ test_mf_aggr_alloc5(const char *env_h5_drvr, hid_t fapl)
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if ((addr1 + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate second block from meta_aggr */
         addr2 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE50);
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if (addr2 + TBLOCK_SIZE50 != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (ma_size != (TBLOCK_SIZE2048 - (TBLOCK_SIZE30 + TBLOCK_SIZE50)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate third block from meta_aggr */
         addr3 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE1970);
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
 
         if (addr3 != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if ((addr3 + TBLOCK_SIZE1970) != new_ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (new_ma_size != (TBLOCK_SIZE2048 - (TBLOCK_SIZE1970 - ma_size)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free all the allocated blocks */
         H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE30);
@@ -2883,15 +2883,15 @@ test_mf_aggr_alloc5(const char *env_h5_drvr, hid_t fapl)
         H5MF_xfree(f, type, addr3, (hsize_t)TBLOCK_SIZE1970);
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -2969,23 +2969,23 @@ test_mf_aggr_alloc6(const char *env_h5_drvr, hid_t fapl)
 
         /* Create the file to work on */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         type = H5FD_MEM_SUPER;
 
@@ -2994,16 +2994,16 @@ test_mf_aggr_alloc6(const char *env_h5_drvr, hid_t fapl)
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if ((addr1 + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate second block from meta_aggr */
         addr2 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE50);
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if (addr2 + TBLOCK_SIZE50 != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (ma_size != (TBLOCK_SIZE2048 - (TBLOCK_SIZE30 + TBLOCK_SIZE50)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate first block from sdata_aggr */
         stype  = H5FD_MEM_DRAW;
@@ -3011,9 +3011,9 @@ test_mf_aggr_alloc6(const char *env_h5_drvr, hid_t fapl)
 
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if ((saddr1 + TBLOCK_SIZE30) != sdata_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (sdata_size != (TBLOCK_SIZE2048 - TBLOCK_SIZE30))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate third block from meta_aggr */
         addr3 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE1970);
@@ -3021,14 +3021,14 @@ test_mf_aggr_alloc6(const char *env_h5_drvr, hid_t fapl)
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
 
         if ((addr3 + TBLOCK_SIZE1970) != new_ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (addr3 != (sdata_addr + sdata_size))
-            TEST_ERROR
+            TEST_ERROR;
 
         if ((ma_addr + TBLOCK_SIZE1970) == new_ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (new_ma_size != (TBLOCK_SIZE2048 - TBLOCK_SIZE1970))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify that meta_aggr's unused space of 1968 is freed to free-space */
         HDmemset(&state, 0, sizeof(H5FS_stat_t));
@@ -3037,7 +3037,7 @@ test_mf_aggr_alloc6(const char *env_h5_drvr, hid_t fapl)
         state.serial_sect_count += 1;
 
         if (check_stats(f, f->shared->fs_man[type], &state))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free all the allocated blocks */
         H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE30);
@@ -3046,15 +3046,15 @@ test_mf_aggr_alloc6(const char *env_h5_drvr, hid_t fapl)
         H5MF_xfree(f, stype, saddr1, (hsize_t)TBLOCK_SIZE30);
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((new_file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (new_file_size != file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -3143,82 +3143,82 @@ test_mf_aggr_alloc7(const char *env_h5_drvr, hid_t fapl)
 
         /* Create the file to work on */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate the first block from meta_aggr */
         type  = H5FD_MEM_SUPER;
         addr1 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE30);
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if ((addr1 + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate the second block from meta_aggr */
         addr2 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE50);
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if (addr2 + TBLOCK_SIZE50 != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (ma_size != (TBLOCK_SIZE2048 - (TBLOCK_SIZE30 + TBLOCK_SIZE50)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate the first block from sdata_aggr */
         stype  = H5FD_MEM_DRAW;
         saddr1 = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE30);
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if ((saddr1 + TBLOCK_SIZE30) != sdata_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate the second block from sdata_aggr */
         saddr2 = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE2048 - TBLOCK_SIZE30);
 
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if ((saddr2 + (TBLOCK_SIZE2048 - TBLOCK_SIZE30)) != sdata_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (sdata_size != 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate the third block from sdata_aggr */
         saddr3 = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE50);
 
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if ((saddr3 + TBLOCK_SIZE50) != sdata_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (sdata_size != (TBLOCK_SIZE2048 - TBLOCK_SIZE50))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate the third block from meta_aggr */
         addr3 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE1970);
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if (addr3 != sdata_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if ((addr3 + TBLOCK_SIZE1970) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (ma_size != (TBLOCK_SIZE2048 - TBLOCK_SIZE1970))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* sdata_aggr info is reset to 0 */
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if (sdata_addr != HADDR_UNDEF)
-            TEST_ERROR
+            TEST_ERROR;
         if (sdata_size != 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify that meta_aggr's unused space of 1968 is freed to free-space */
         HDmemset(&state, 0, sizeof(H5FS_stat_t));
@@ -3227,7 +3227,7 @@ test_mf_aggr_alloc7(const char *env_h5_drvr, hid_t fapl)
         state.serial_sect_count += 1;
 
         if (check_stats(f, f->shared->fs_man[type], &state))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free all the allocated blocks */
         H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE30);
@@ -3238,15 +3238,15 @@ test_mf_aggr_alloc7(const char *env_h5_drvr, hid_t fapl)
         H5MF_xfree(f, stype, saddr3, (hsize_t)TBLOCK_SIZE50);
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (file_size != empty_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -3314,30 +3314,30 @@ test_mf_aggr_extend(const char *env_h5_drvr, hid_t fapl)
 
         /* Create the file to work on */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate the first block from meta_aggr */
         type = H5FD_MEM_SUPER;
         addr = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE30);
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if ((addr + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Adjust meta_aggr's info info for testing */
         f->shared->meta_aggr.addr = addr;
@@ -3350,14 +3350,14 @@ test_mf_aggr_extend(const char *env_h5_drvr, hid_t fapl)
 
         /* should succeed */
         if (!was_extended)
-            TEST_ERROR
+            TEST_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
 
         if (new_ma_addr != (addr + TBLOCK_SIZE50))
-            TEST_ERROR
+            TEST_ERROR;
         if (new_ma_size != (f->shared->meta_aggr.alloc_size - TBLOCK_SIZE50))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free the allocated blocks */
         H5MF_xfree(f, type, addr, (hsize_t)TBLOCK_SIZE50);
@@ -3367,14 +3367,14 @@ test_mf_aggr_extend(const char *env_h5_drvr, hid_t fapl)
 
         /* should succeed */
         if (!was_extended)
-            TEST_ERROR
+            TEST_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
 
         if (new_ma_addr != (addr + TBLOCK_SIZE700))
-            TEST_ERROR
+            TEST_ERROR;
         if (new_ma_size != (f->shared->meta_aggr.alloc_size * 2 - TBLOCK_SIZE700))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free the allocated blocks */
         H5MF_xfree(f, type, addr, (hsize_t)TBLOCK_SIZE700);
@@ -3384,28 +3384,28 @@ test_mf_aggr_extend(const char *env_h5_drvr, hid_t fapl)
 
         /* should succeed */
         if (!was_extended)
-            TEST_ERROR
+            TEST_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
 
         if (new_ma_addr != (addr + TBLOCK_SIZE2058))
-            TEST_ERROR
+            TEST_ERROR;
         if (new_ma_size != f->shared->meta_aggr.size)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free the allocated blocks */
         H5MF_xfree(f, type, addr, (hsize_t)TBLOCK_SIZE2058);
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (file_size != empty_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -3420,25 +3420,25 @@ test_mf_aggr_extend(const char *env_h5_drvr, hid_t fapl)
     if (contig_addr_vfd) {
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate the first block from meta_aggr */
         type = H5FD_MEM_SUPER;
         addr = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE30);
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if ((addr + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate the first block from sdata_aggr */
         stype = H5FD_MEM_DRAW;
         saddr = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE50);
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if ((saddr + TBLOCK_SIZE50) != sdata_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Adjust meta_aggr's info info for testing */
         f->shared->meta_aggr.addr = addr;
@@ -3450,14 +3450,14 @@ test_mf_aggr_extend(const char *env_h5_drvr, hid_t fapl)
         was_extended = H5MF_try_extend(f, type, (haddr_t)new_addr, (hsize_t)10, (hsize_t)(TBLOCK_SIZE50));
 
         if (!was_extended)
-            TEST_ERROR
+            TEST_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
 
         if (new_ma_addr != (addr + TBLOCK_SIZE50))
-            TEST_ERROR
+            TEST_ERROR;
         if (new_ma_size != (f->shared->meta_aggr.alloc_size - TBLOCK_SIZE50))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Restore info for meta_aggr */
         f->shared->meta_aggr.addr = ma_addr;
@@ -3467,15 +3467,15 @@ test_mf_aggr_extend(const char *env_h5_drvr, hid_t fapl)
         H5MF_xfree(f, stype, saddr, (hsize_t)TBLOCK_SIZE50);
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (file_size != empty_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -3490,25 +3490,25 @@ test_mf_aggr_extend(const char *env_h5_drvr, hid_t fapl)
     if (contig_addr_vfd) {
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate first block from meta_aggr */
         type = H5FD_MEM_SUPER;
         addr = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE30);
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if ((addr + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate first block from sdata_aggr */
         stype = H5FD_MEM_DRAW;
         saddr = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE50);
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if ((saddr + TBLOCK_SIZE50) != sdata_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Adjust meta_aggr's info info for testing */
         f->shared->meta_aggr.addr = addr;
@@ -3520,14 +3520,14 @@ test_mf_aggr_extend(const char *env_h5_drvr, hid_t fapl)
         was_extended = H5MF_try_extend(f, type, (haddr_t)new_addr, (hsize_t)10, (hsize_t)(TBLOCK_SIZE50));
 
         if (was_extended)
-            TEST_ERROR
+            TEST_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
 
         if (new_ma_addr != addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (new_ma_size != 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* restore info for meta_aggr */
         f->shared->meta_aggr.addr = ma_addr;
@@ -3537,15 +3537,15 @@ test_mf_aggr_extend(const char *env_h5_drvr, hid_t fapl)
         H5MF_xfree(f, stype, saddr, (hsize_t)TBLOCK_SIZE50);
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (file_size != empty_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -3612,23 +3612,23 @@ test_mf_aggr_absorb(const char *env_h5_drvr, hid_t fapl)
 
         /* Create the file to work on */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate block A from meta_aggr */
         type  = H5FD_MEM_SUPER;
@@ -3637,27 +3637,27 @@ test_mf_aggr_absorb(const char *env_h5_drvr, hid_t fapl)
         ma_addr = new_ma_addr - TBLOCK_SIZE30;
 
         if ((addr1 + TBLOCK_SIZE30) != new_ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* should succeed */
         if (H5MF_try_shrink(f, type, addr1, (hsize_t)TBLOCK_SIZE30) <= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
 
         if (new_ma_addr != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (file_size != empty_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -3672,11 +3672,11 @@ test_mf_aggr_absorb(const char *env_h5_drvr, hid_t fapl)
     if (contig_addr_vfd) {
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate block A from meta_aggr */
         type  = H5FD_MEM_SUPER;
@@ -3684,9 +3684,9 @@ test_mf_aggr_absorb(const char *env_h5_drvr, hid_t fapl)
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if ((addr1 + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (ma_size != (TBLOCK_SIZE2048 - TBLOCK_SIZE30))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate block B from sdata_aggr */
         stype  = H5FD_MEM_DRAW;
@@ -3696,33 +3696,33 @@ test_mf_aggr_absorb(const char *env_h5_drvr, hid_t fapl)
 
         /* should succeed */
         if (H5MF_try_shrink(f, stype, saddr1, (hsize_t)TBLOCK_SIZE50) <= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &new_sdata_addr, &new_sdata_size);
         if (new_sdata_addr != saddr1)
-            TEST_ERROR
+            TEST_ERROR;
         if (new_sdata_size != sdata_size + TBLOCK_SIZE50)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* meta_aggr info should be updated because the block is absorbed into the meta_aggr */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
         if (new_ma_addr != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
         if (new_ma_size != (ma_size))
-            TEST_ERROR
+            TEST_ERROR;
 
         H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE30);
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (file_size != empty_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -3737,11 +3737,11 @@ test_mf_aggr_absorb(const char *env_h5_drvr, hid_t fapl)
     if (contig_addr_vfd) {
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate block A from meta_aggr */
         type  = H5FD_MEM_SUPER;
@@ -3749,43 +3749,43 @@ test_mf_aggr_absorb(const char *env_h5_drvr, hid_t fapl)
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if ((addr1 + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate block B from meta_aggr */
         addr2 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE50);
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if ((addr2 + TBLOCK_SIZE50) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate block C from meta_aggr */
         addr3 = H5MF_alloc(f, type, (hsize_t)(TBLOCK_SIZE30 + TBLOCK_SIZE50));
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if ((addr3 + TBLOCK_SIZE30 + TBLOCK_SIZE50) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* should not succeed */
         if (H5MF_try_shrink(f, type, addr2, (hsize_t)TBLOCK_SIZE50) > 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* aggregator info should be the same as before */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
         if (new_ma_addr != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE30);
         H5MF_xfree(f, type, addr2, (hsize_t)TBLOCK_SIZE50);
         H5MF_xfree(f, type, addr3, (hsize_t)(TBLOCK_SIZE30 + TBLOCK_SIZE50));
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify the file is the correct size */
         if (file_size != empty_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -3868,34 +3868,34 @@ test_mf_align_eoa(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Turn off using meta/small data aggregator */
         if ((fapl1 = H5Pcopy(new_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         H5Pset_meta_block_size(fapl1, (hsize_t)0);
         H5Pset_small_data_block_size(fapl1, (hsize_t)0);
 
         /* Create the file to work on (without alignment) */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* get alignment setting */
         if (H5Pget_alignment(fapl1, NULL, &alignment) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file with alignment and meta/sdata setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl1)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* calculate fragment for alignment of block 30 */
         if ((tmp = (hsize_t)file_size % alignment))
@@ -3909,12 +3909,12 @@ test_mf_align_eoa(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr1 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* there should be nothing in the aggregator */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if (ma_addr || ma_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         HDmemset(&state, 0, sizeof(H5FS_stat_t));
         if (mis_align) {
@@ -3922,7 +3922,7 @@ test_mf_align_eoa(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
             state.tot_sect_count += 1;
             state.serial_sect_count += 1;
             if (check_stats(f, f->shared->fs_man[type], &state))
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         /* calculate fragment for alignment of block 50 */
@@ -3935,32 +3935,32 @@ test_mf_align_eoa(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr2 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* there should be nothing in the aggregator */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if (ma_addr || ma_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (mis_align) {
             state.tot_space += mis_align;
             state.tot_sect_count += 1;
             state.serial_sect_count += 1;
             if (check_stats(f, f->shared->fs_man[type], &state))
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE30);
         H5MF_xfree(f, type, addr2, (hsize_t)TBLOCK_SIZE50);
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if ((new_file_size = h5_get_file_size(filename, fapl1)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (new_file_size != file_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -3978,11 +3978,11 @@ test_mf_align_eoa(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     if (suitable_vfd) {
         /* Re-open the file with alignment and meta/sdata setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl1)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* allocate a block of 50 from meta_aggr */
         type  = H5FD_MEM_SUPER;
@@ -3990,35 +3990,35 @@ test_mf_align_eoa(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* address should be aligned */
         if (addr1 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if ((file_size = h5_get_file_size(filename, fapl1)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl1)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* shrink the block */
         if (H5MF_try_shrink(f, type, addr1, (hsize_t)TBLOCK_SIZE50) <= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if ((new_file_size = h5_get_file_size(filename, fapl1)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (new_file_size != (file_size - TBLOCK_SIZE50))
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -4036,11 +4036,11 @@ test_mf_align_eoa(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     if (suitable_vfd) {
         /* Re-open the file with alignment and meta/sdata setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl1)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* allocate a block of 50 */
         type  = H5FD_MEM_SUPER;
@@ -4048,38 +4048,38 @@ test_mf_align_eoa(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* address should be aligned */
         if (addr1 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if ((file_size = h5_get_file_size(filename, fapl1)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl1)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* try to extend the block */
         was_extended =
             H5MF_try_extend(f, type, (haddr_t)addr1, (hsize_t)TBLOCK_SIZE50, (hsize_t)TBLOCK_SIZE30);
 
         if (was_extended <= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if ((new_file_size = h5_get_file_size(filename, fapl1)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (new_file_size != (file_size + TBLOCK_SIZE30))
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     } /* end if */
@@ -4089,7 +4089,7 @@ test_mf_align_eoa(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     } /* end else */
 
     if (fapl1 >= 0 && H5Pclose(fapl1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     return (0);
 
@@ -4155,39 +4155,39 @@ test_mf_align_fs(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* get alignment setting */
     if (H5Pget_alignment(new_fapl, NULL, &alignment) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file with alignment setting */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, new_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
     if (H5MF__start_fstype(f, (H5F_mem_page_t)H5FD_MEM_SUPER) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (f->shared->fs_state[H5FD_MEM_SUPER] != H5F_FS_STATE_OPEN)
-        TEST_ERROR
+        TEST_ERROR;
     if (f->shared->fs_man[H5FD_MEM_SUPER]->client != H5FS_CLIENT_FILE_ID)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create section A */
     sect_node = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)alignment, (hsize_t)TBLOCK_SIZE50);
 
     /* Add section A to free-space manager */
     if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(H5FS_stat_t));
     state.tot_space += TBLOCK_SIZE50;
@@ -4195,23 +4195,23 @@ test_mf_align_fs(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate a block of 50 */
     addr = H5MF_alloc(f, H5FD_MEM_SUPER, (hsize_t)TBLOCK_SIZE50);
 
     /* Verify that the allocated block is section A in free-space */
     if (addr != (haddr_t)alignment)
-        TEST_ERROR
+        TEST_ERROR;
     if (addr % alignment)
-        TEST_ERROR
+        TEST_ERROR;
 
     state.tot_space -= TBLOCK_SIZE50;
     state.tot_sect_count -= 1;
     state.serial_sect_count -= 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free the block to free-space */
     H5MF_xfree(f, H5FD_MEM_SUPER, addr, (hsize_t)TBLOCK_SIZE50);
@@ -4220,10 +4220,10 @@ test_mf_align_fs(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     state.tot_sect_count += 1;
     state.serial_sect_count += 1;
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -4231,27 +4231,27 @@ test_mf_align_fs(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
     /* Re-open the file with alignment setting */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, new_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
     if (H5MF__start_fstype(f, (H5F_mem_page_t)H5FD_MEM_SUPER) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (f->shared->fs_state[H5FD_MEM_SUPER] != H5F_FS_STATE_OPEN)
-        TEST_ERROR
+        TEST_ERROR;
     if (f->shared->fs_man[H5FD_MEM_SUPER]->client != H5FS_CLIENT_FILE_ID)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create section A */
     sect_node = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE8000);
 
     /* Add section A to free-space manager */
     if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(&state, 0, sizeof(H5FS_stat_t));
     state.tot_space += TBLOCK_SIZE8000;
@@ -4259,14 +4259,14 @@ test_mf_align_fs(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate a block of 600 */
     addr = H5MF_alloc(f, H5FD_MEM_SUPER, (hsize_t)TBLOCK_SIZE600);
 
     /* Verify that the allocated block is aligned */
     if (addr % alignment)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* should have 1 more section in free-space */
     state.tot_space -= TBLOCK_SIZE600;
@@ -4274,20 +4274,20 @@ test_mf_align_fs(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     state.serial_sect_count += 1;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* try to extend the block */
     was_extended =
         H5MF_try_extend(f, H5FD_MEM_SUPER, (haddr_t)addr, (hsize_t)TBLOCK_SIZE600, (hsize_t)TBLOCK_SIZE200);
 
     if (was_extended <= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* space should be decreased by 200, # of sections remain the same */
     state.tot_space -= TBLOCK_SIZE200;
 
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free the block to free-space manager */
     H5MF_xfree(f, H5FD_MEM_SUPER, addr, (hsize_t)(TBLOCK_SIZE600 + TBLOCK_SIZE200));
@@ -4297,10 +4297,10 @@ test_mf_align_fs(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     state.tot_sect_count    = 1;
     state.serial_sect_count = 1;
     if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -4314,31 +4314,31 @@ test_mf_align_fs(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
                              HDstrcmp(env_h5_drvr, "multi") != 0 && HDstrcmp(env_h5_drvr, "direct") != 0);
     if (suitable_vfd) {
         if ((file_size = h5_get_file_size(filename, new_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file with alignment setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, new_fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Start up H5FD_MEM_SUPER free-space manager */
         if (H5MF__start_fstype(f, (H5F_mem_page_t)H5FD_MEM_SUPER) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if (f->shared->fs_state[H5FD_MEM_SUPER] != H5F_FS_STATE_OPEN)
-            TEST_ERROR
+            TEST_ERROR;
         if (f->shared->fs_man[H5FD_MEM_SUPER]->client != H5FS_CLIENT_FILE_ID)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create section A */
         sect_node = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE700);
 
         /* Add section A to free-space manager */
         if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         HDmemset(&state, 0, sizeof(H5FS_stat_t));
         state.tot_space += TBLOCK_SIZE700;
@@ -4346,7 +4346,7 @@ test_mf_align_fs(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
         state.serial_sect_count += 1;
 
         if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-            TEST_ERROR
+            TEST_ERROR;
         /*
          * Allocate a block of 40
          * Since free-space manager cannot fulfull the request because of alignment,
@@ -4356,11 +4356,11 @@ test_mf_align_fs(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* verify that the allocated block is from file allocation, not section A in free-space */
         if (!(addr >= (haddr_t)file_size))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 40 from file allocation */
         if ((tmp = (hsize_t)file_size % alignment))
@@ -4374,10 +4374,10 @@ test_mf_align_fs(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* free-space info should be the same  */
         if (check_stats(f, f->shared->fs_man[H5FD_MEM_SUPER], &state))
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     } /* end if */
@@ -4525,27 +4525,27 @@ test_mf_align_alloc1(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Create the file to work on (without alignment) */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* get alignment setting */
         if (H5Pget_alignment(new_fapl, NULL, &alignment) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file with alignment setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, new_fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* calculate fragment for alignment of block 30 */
         if ((tmp = (hsize_t)file_size % alignment))
@@ -4557,7 +4557,7 @@ test_mf_align_alloc1(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr1 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 30 is freed to free-space */
         HDmemset(&state, 0, sizeof(H5FS_stat_t));
@@ -4570,7 +4570,7 @@ test_mf_align_alloc1(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if ((addr1 + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 50 */
         mis_align = 0;
@@ -4582,7 +4582,7 @@ test_mf_align_alloc1(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr2 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 50 is freed to free-space */
         if (mis_align) {
@@ -4594,7 +4594,7 @@ test_mf_align_alloc1(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if ((addr2 + TBLOCK_SIZE50) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 80 */
         mis_align = 0;
@@ -4605,7 +4605,7 @@ test_mf_align_alloc1(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr3 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 80 is freed to free-space */
         if (mis_align) {
@@ -4617,7 +4617,7 @@ test_mf_align_alloc1(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if ((addr3 + TBLOCK_SIZE80) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 1970 */
         mis_align = 0;
@@ -4629,7 +4629,7 @@ test_mf_align_alloc1(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr4 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 1970 is freed to free-space */
         if (mis_align) {
@@ -4641,11 +4641,11 @@ test_mf_align_alloc1(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if ((addr4 + TBLOCK_SIZE1970) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify total size of free space after all the allocations */
         if (check_stats(f, f->shared->fs_man[type], &state))
-            TEST_ERROR
+            TEST_ERROR;
 
         H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE30);
         H5MF_xfree(f, type, addr2, (hsize_t)TBLOCK_SIZE50);
@@ -4653,7 +4653,7 @@ test_mf_align_alloc1(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
         H5MF_xfree(f, type, addr3, (hsize_t)TBLOCK_SIZE1970);
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     } /* end if */
@@ -4788,27 +4788,27 @@ test_mf_align_alloc2(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Create the file to work on (without alignment) */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* get alignment setting */
         if (H5Pget_alignment(new_fapl, NULL, &alignment) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file with alignment setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, new_fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* calculate fragment for alignment of block 30 */
         if ((tmp = (hsize_t)file_size % alignment))
@@ -4820,7 +4820,7 @@ test_mf_align_alloc2(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr1 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 30 is freed to free-space */
         HDmemset(&state, 0, sizeof(H5FS_stat_t) * H5FD_MEM_NTYPES);
@@ -4833,7 +4833,7 @@ test_mf_align_alloc2(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if ((addr1 + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 50 is freed to free-space */
         mis_align = 0;
@@ -4844,7 +4844,7 @@ test_mf_align_alloc2(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr2 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 50 is freed to free-space */
         if (mis_align) {
@@ -4856,7 +4856,7 @@ test_mf_align_alloc2(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if ((addr2 + TBLOCK_SIZE50) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /*
          * Calculate fragment for alignment of block 30 in sdata_aggr:
@@ -4888,13 +4888,13 @@ test_mf_align_alloc2(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (saddr1 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if (sdata_addr != (saddr1 + TBLOCK_SIZE30))
-            TEST_ERROR
+            TEST_ERROR;
 
         /*
          * Calculate fragment for the allocation of block 80 from meta_aggr:
@@ -4916,7 +4916,7 @@ test_mf_align_alloc2(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr3 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 80 is freed to free-space */
         if (mis_align) {
@@ -4928,17 +4928,17 @@ test_mf_align_alloc2(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if ((addr3 + TBLOCK_SIZE80) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify total size of free space after all the allocations */
         if (f->shared->fs_man[type]) {
             if (check_stats(f, f->shared->fs_man[type], &(state[type])))
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         if (f->shared->fs_man[stype]) {
             if (check_stats(f, f->shared->fs_man[stype], &(state[stype])))
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE30);
@@ -4947,7 +4947,7 @@ test_mf_align_alloc2(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
         H5MF_xfree(f, stype, saddr1, (hsize_t)TBLOCK_SIZE30);
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     } /* end if */
@@ -5134,27 +5134,27 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Create the file to work on (without alignment) */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* get alignment setting */
         if (H5Pget_alignment(new_fapl, NULL, &alignment) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file with alignment setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, new_fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* calculate fragment for alignment of block 30 */
         if ((tmp = (hsize_t)file_size % alignment))
@@ -5166,7 +5166,7 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr1 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 30 is freed to free-space */
         HDmemset(&state, 0, sizeof(H5FS_stat_t) * H5FD_MEM_NTYPES);
@@ -5178,7 +5178,7 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if ((addr1 + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 50 */
         mis_align = 0;
@@ -5190,7 +5190,7 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr2 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 50 is freed to free-space */
         if (mis_align) {
@@ -5201,7 +5201,7 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if ((addr2 + TBLOCK_SIZE50) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /*
          * Calculate fragment for alignment of block 30 in sdata_aggr:
@@ -5226,7 +5226,7 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (saddr1 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 30 for sdata_aggr is freed to free-space */
         if (mis_align) {
@@ -5237,7 +5237,7 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if (sdata_addr != (saddr1 + TBLOCK_SIZE30))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 50 in sdata_aggr */
         mis_align = 0;
@@ -5249,7 +5249,7 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (saddr2 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 50 for sdata_aggr is freed to free-space */
         if (mis_align) {
@@ -5260,7 +5260,7 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if (sdata_addr != (saddr2 + TBLOCK_SIZE50))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 80 in sdata_aggr */
         mis_align = 0;
@@ -5272,7 +5272,7 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (saddr3 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 80 for sdata_aggr is freed to free-space */
         if (mis_align) {
@@ -5283,7 +5283,7 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if ((saddr3 + TBLOCK_SIZE80) != sdata_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 1034 */
         mis_align = 0;
@@ -5295,7 +5295,7 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr3 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 1034 for meta_aggr is freed to free-space */
         if (mis_align) {
@@ -5319,21 +5319,21 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if ((addr3 + TBLOCK_SIZE1034) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify total size of free space after all allocations */
         if (f->shared->fs_man[type]) {
             if (check_stats(f, f->shared->fs_man[type], &(state[type])))
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         if (f->shared->fs_man[stype]) {
             if (check_stats(f, f->shared->fs_man[stype], &(state[stype])))
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     } /* end if */
@@ -5448,27 +5448,27 @@ test_mf_align_alloc4(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Create the file to work on (without alignment) */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file with alignment setting and meta/sdata setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, new_fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* get alignment setting */
         if (H5Pget_alignment(new_fapl, NULL, &alignment) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 30 */
         if ((tmp = (hsize_t)file_size % alignment))
@@ -5480,7 +5480,7 @@ test_mf_align_alloc4(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr1 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 30 is freed to free-space */
         HDmemset(&state, 0, sizeof(H5FS_stat_t));
@@ -5493,7 +5493,7 @@ test_mf_align_alloc4(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         saved_ma_size = ma_size;
         if ((addr1 + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 2058 */
         mis_align = 0;
@@ -5505,7 +5505,7 @@ test_mf_align_alloc4(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr2 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 2058 is freed to free-space */
         if (mis_align) {
@@ -5517,11 +5517,11 @@ test_mf_align_alloc4(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if ((addr2 + TBLOCK_SIZE2058) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* meta_aggr->size remains the same */
         if (ma_size != saved_ma_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 5 from meta_aggr */
         mis_align = 0;
@@ -5540,16 +5540,16 @@ test_mf_align_alloc4(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr3 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify total size of free space after all allocations */
         if (f->shared->fs_man[type]) {
             if (check_stats(f, f->shared->fs_man[type], &state))
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     } /* end if */
@@ -5667,27 +5667,27 @@ test_mf_align_alloc5(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Create the file to work on (without alignment) */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file with alignment setting and meta/sdata setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, new_fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* get alignment setting */
         if (H5Pget_alignment(new_fapl, NULL, &alignment) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 30 */
         if ((tmp = (hsize_t)file_size % alignment))
@@ -5699,12 +5699,12 @@ test_mf_align_alloc5(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr1 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
 
         if ((addr1 + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 30 is freed to free-space */
         HDmemset(&state, 0, sizeof(H5FS_stat_t) * H5FD_MEM_NTYPES);
@@ -5725,7 +5725,7 @@ test_mf_align_alloc5(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (saddr1 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment of alignment for block 30 in sdata_aggr is freed to free-space */
         if (mis_align) {
@@ -5736,7 +5736,7 @@ test_mf_align_alloc5(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if ((saddr1 + TBLOCK_SIZE30) != sdata_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 2058 from meta_aggr */
         mis_align = 0;
@@ -5748,7 +5748,7 @@ test_mf_align_alloc5(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr2 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 2058 is freed to free-space */
         if (mis_align) {
@@ -5760,26 +5760,26 @@ test_mf_align_alloc5(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
         /* Verify total size of free space after all allocations */
         if (f->shared->fs_man[type]) {
             if (check_stats(f, f->shared->fs_man[type], &(state[type])))
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         if (f->shared->fs_man[stype]) {
             if (check_stats(f, f->shared->fs_man[stype], &(state[stype])))
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         /* nothing is changed in meta_aggr */
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &new_ma_addr, &new_ma_size);
         if (new_ma_addr != ma_addr || new_ma_size != ma_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* nothing is changed in sdata_aggr */
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &new_sdata_addr, &new_sdata_size);
         if (new_sdata_addr != sdata_addr || new_sdata_size != sdata_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     } /* end if */
@@ -5938,27 +5938,27 @@ test_mf_align_alloc6(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Create the file to work on (without alignment) */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Re-open the file with alignment setting and meta/sdata setting */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, new_fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* get alignment setting */
         if (H5Pget_alignment(new_fapl, NULL, &alignment) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 30 */
         if ((tmp = (hsize_t)file_size % alignment))
@@ -5970,7 +5970,7 @@ test_mf_align_alloc6(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr1 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 30 in meta_aggr is freed to free-space */
         HDmemset(&state, 0, sizeof(H5FS_stat_t) * H5FD_MEM_NTYPES);
@@ -5982,7 +5982,7 @@ test_mf_align_alloc6(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         H5MF__aggr_query(f, &(f->shared->meta_aggr), &ma_addr, &ma_size);
         if ((addr1 + TBLOCK_SIZE30) != ma_addr)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 30 in sdata_aggr */
         mis_align = 0;
@@ -5995,7 +5995,7 @@ test_mf_align_alloc6(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (saddr1 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 30 in sdata_aggr is freed to free-space */
         if (mis_align) {
@@ -6006,7 +6006,7 @@ test_mf_align_alloc6(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if (sdata_addr != (saddr1 + TBLOCK_SIZE30))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 50 in sdata_aggr */
         mis_align = 0;
@@ -6018,7 +6018,7 @@ test_mf_align_alloc6(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (saddr2 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 50 in sdata_aggr is freed to free-space */
         if (mis_align) {
@@ -6029,7 +6029,7 @@ test_mf_align_alloc6(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if (sdata_addr != (saddr2 + TBLOCK_SIZE50))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 80 in sdata_aggr */
         mis_align = 0;
@@ -6041,7 +6041,7 @@ test_mf_align_alloc6(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (saddr3 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 80 in sdata_aggr is freed to free-space */
         if (mis_align) {
@@ -6052,7 +6052,7 @@ test_mf_align_alloc6(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
         if (sdata_addr != (saddr3 + TBLOCK_SIZE80))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* calculate fragment for alignment of block 2058 */
         /* remaining space in sdata_aggr is freed and shrunk */
@@ -6065,7 +6065,7 @@ test_mf_align_alloc6(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
 
         /* Verify that the allocated block is aligned */
         if (addr2 % alignment)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fragment for alignment of block 2058 is freed to free-space */
         if (mis_align) {
@@ -6078,23 +6078,23 @@ test_mf_align_alloc6(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
         H5MF__aggr_query(f, &(f->shared->sdata_aggr), &sdata_addr, &sdata_size);
 
         if (new_ma_addr != ma_addr && new_ma_size != ma_size)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (sdata_addr != HADDR_UNDEF || sdata_size != 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (f->shared->fs_man[type]) {
             if (check_stats(f, f->shared->fs_man[type], &(state[type])))
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         if (f->shared->fs_man[stype]) {
             if (check_stats(f, f->shared->fs_man[stype], &(state[stype])))
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     } /* end if */
@@ -6138,16 +6138,16 @@ test_mf_bug1(const char *env_h5_drvr, hid_t fapl)
 
     /* Copy fapl */
     if ((copied_fapl = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get metadata block size */
     if (H5Pget_meta_block_size(copied_fapl, &block_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set alignment to equal block size / 2 */
     align = block_size / 2;
     if (H5Pset_alignment(copied_fapl, 0, align) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for split or multi driver */
     if (!HDstrcmp(env_h5_drvr, "split"))
@@ -6162,19 +6162,19 @@ test_mf_bug1(const char *env_h5_drvr, hid_t fapl)
 
             /* Get current multi settings */
             if (H5Pget_fapl_multi(copied_fapl, NULL, memb_fapl_arr, NULL, NULL, NULL) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Set alignment. Note that it is the block size of the parent FAPL that
              * is important here. */
             if (H5Pset_alignment(memb_fapl_arr[H5FD_MEM_SUPER], 0, align) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Pset_alignment(memb_fapl_arr[H5FD_MEM_DRAW], 0, align) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Set split driver with new FAPLs */
             if (H5Pset_fapl_split(copied_fapl, "-m.h5", memb_fapl_arr[H5FD_MEM_SUPER], "-r.h5",
                                   memb_fapl_arr[H5FD_MEM_DRAW]) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
         else {
             H5FD_mem_t memb_map[H5FD_MEM_NTYPES];
@@ -6187,7 +6187,7 @@ test_mf_bug1(const char *env_h5_drvr, hid_t fapl)
             /* Get current multi settings */
             HDmemset(memb_name, 0, sizeof memb_name);
             if (H5Pget_fapl_multi(copied_fapl, memb_map, memb_fapl_arr, memb_name, memb_addr, &relax) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Populate memb_fapl_arr, patch memb_addr so member file addresses
              * are aligned */
@@ -6195,14 +6195,14 @@ test_mf_bug1(const char *env_h5_drvr, hid_t fapl)
                 /* Set alignment. Note that it is the block size of the parent FAPL that
                  * is important here. */
                 if (H5Pset_alignment(memb_fapl_arr[mt], 0, align) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 memb_addr[mt] = ((memb_addr[mt] + align - 1) / align) * align;
             } /* end for */
 
             /* Set multi driver with new FAPLs */
             if (H5Pset_fapl_multi(copied_fapl, memb_map, memb_fapl_arr, (const char *const *)memb_name,
                                   memb_addr, relax) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Free memb_name */
             for (mt = H5FD_MEM_DEFAULT; mt < H5FD_MEM_NTYPES; mt++)
@@ -6212,11 +6212,11 @@ test_mf_bug1(const char *env_h5_drvr, hid_t fapl)
 
     /* Reopen the file with alignment */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, copied_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate a block of size align from meta_aggr.  This should create an
      * aggregator that extends to the end of the file, with
@@ -6226,7 +6226,7 @@ test_mf_bug1(const char *env_h5_drvr, hid_t fapl)
 
     /* Verify that the allocated block is aligned */
     if (addr1 % align)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate a block of size align from meta_aggr.  This should force the
      * aggregator to extend to the end of the file, with 0 bytes remaining, and
@@ -6236,11 +6236,11 @@ test_mf_bug1(const char *env_h5_drvr, hid_t fapl)
 
     /* Verify that the allocated block is aligned */
     if (addr2 % align)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the allocated block is placed align after the previous */
     if ((addr2 - addr1) != align)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate a block of size block_size + 1 from meta_aggr.  This should
      * force the aggregator to extend to the end of the file, with 0 bytes
@@ -6250,12 +6250,12 @@ test_mf_bug1(const char *env_h5_drvr, hid_t fapl)
 
     /* Verify that the allocated block is aligned */
     if (addr1 % align)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the allocated block is placed block_size / 2 after the
      * previous */
     if ((addr1 - addr2) != align)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate a block of size 1.  This should extend the aggregator from
      * the previous allocation, and align the new block */
@@ -6264,21 +6264,21 @@ test_mf_bug1(const char *env_h5_drvr, hid_t fapl)
 
     /* Verify that the allocated block is aligned */
     if (addr2 % align)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the allocated block is placed 3 * (block_size / 2) after
      * the previous */
     if ((addr2 - addr1) != (3 * align))
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
     if (H5Pclose(copied_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return (0);
 
@@ -6334,226 +6334,226 @@ test_mf_fs_persist_split(void)
     if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
 
         if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
     /* Set up split driver */
     if (H5Pset_fapl_split(fapl, "-m.h5", H5P_DEFAULT, "-r.h5", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* File creation property list template */
     if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_FSM_AGGR, TRUE, (hsize_t)1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Allocate 4 blocks of type H5FD_MEM_SUPER */
     type = H5FD_MEM_SUPER;
     if (HADDR_UNDEF == (addr1 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE1)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (addr2 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE2)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (addr3 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE3)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (addr4 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE4)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Put block #1, #3 into H5FD_MEM_SUPER free-space manager */
     if (H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5MF_xfree(f, type, addr3, (hsize_t)TBLOCK_SIZE3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Allocate 4 blocks of type H5FD_MEM_DRAW */
     stype = H5FD_MEM_DRAW;
     if (HADDR_UNDEF == (saddr1 = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE1)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (saddr2 = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE2)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (saddr3 = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE3)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (saddr4 = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE4)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Put block #1, #3 into H5FD_MEM_DRAW free-space manager */
     if (H5MF_xfree(f, stype, saddr1, (hsize_t)TBLOCK_SIZE1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5MF_xfree(f, stype, saddr3, (hsize_t)TBLOCK_SIZE3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the H5FD_MEM_SUPER free-space manager is there */
     if (!H5F_addr_defined(f->shared->fs_addr[type]))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
     if (H5MF__open_fstype(f, (H5F_mem_page_t)type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get free-space info */
     if (H5FS_stat_info(f, f->shared->fs_man[type], &fs_stat) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify free-space info */
     if (fs_stat.tot_space < (TBLOCK_SIZE1 + TBLOCK_SIZE3))
-        TEST_ERROR
+        TEST_ERROR;
     if (fs_stat.serial_sect_count < 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve block #1 from H5FD_MEM_SUPER free-space manager; block #3 still in free-space */
     if (HADDR_UNDEF == (tmp_addr = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE1)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tmp_addr != addr1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the free-space manager for H5FD_MEM_DRAW is there */
     if (!H5F_addr_defined(f->shared->fs_addr[stype]))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Start up H5FD_MEM_DRAW free-space manager */
     if (H5MF__open_fstype(f, (H5F_mem_page_t)stype) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get free-space info */
     if (H5FS_stat_info(f, f->shared->fs_man[stype], &fs_stat) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify free-space info */
     if (fs_stat.tot_space < (TBLOCK_SIZE1 + TBLOCK_SIZE3))
-        TEST_ERROR
+        TEST_ERROR;
     if (fs_stat.serial_sect_count < 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve blocks #1 from H5FD_MEM_DRAW free-space manager */
     if (HADDR_UNDEF == (tmp_addr = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE1)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tmp_addr != saddr1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve blocks #3 from H5FD_MEM_DRAW free-space manager */
     if (HADDR_UNDEF == (tmp_addr = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE3)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tmp_addr != saddr3)
-        TEST_ERROR
+        TEST_ERROR;
     /* H5FD_MEM_DRAW free-space manager is going away at closing */
     /* works for this one because the freeing of sect_addr is to H5FD_MEM_SUPER fs, not against itself */
 
     /* Allocate 4 blocks of type H5FD_MEM_BTREE */
     btype = H5FD_MEM_BTREE;
     if (HADDR_UNDEF == (baddr5 = H5MF_alloc(f, btype, (hsize_t)TBLOCK_SIZE5)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (baddr6 = H5MF_alloc(f, btype, (hsize_t)TBLOCK_SIZE6)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (baddr7 = H5MF_alloc(f, btype, (hsize_t)TBLOCK_SIZE7)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (baddr8 = H5MF_alloc(f, btype, (hsize_t)TBLOCK_SIZE8)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Put block #5 & #7 into H5FD_MEM_BTREE free-space manager */
     if (H5MF_xfree(f, btype, baddr5, (hsize_t)TBLOCK_SIZE5) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5MF_xfree(f, btype, baddr7, (hsize_t)TBLOCK_SIZE7) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the free-space manager for H5FD_MEM_DRAW is not there */
     if (H5F_addr_defined(f->shared->fs_addr[stype]))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the free-space manager for H5FD_MEM_SUPER is there */
     if (!H5F_addr_defined(f->shared->fs_addr[type]))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
     if (H5MF__open_fstype(f, (H5F_mem_page_t)type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get free-space info */
     if (H5FS_stat_info(f, f->shared->fs_man[type], &fs_stat) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify free-space info */
     if (fs_stat.tot_space < (TBLOCK_SIZE3 + TBLOCK_SIZE5 + TBLOCK_SIZE7))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve block #3 from H5FD_MEM_SUPER free-space manager */
     if (HADDR_UNDEF == (tmp_addr = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE3)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tmp_addr != addr3)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve block #7 from H5FD_MEM_BTREE free-space manager */
     if (HADDR_UNDEF == (tmp_addr = H5MF_alloc(f, btype, (hsize_t)TBLOCK_SIZE7)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tmp_addr != baddr7)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* There should still be block #5 of H5FD_MEM_BTREE in H5FD_MEM_BTREE free-space manager */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the H5FD_MEM_SUPER free-space manager is there */
     if (!H5F_addr_defined(f->shared->fs_addr[type]))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
     if (H5MF__open_fstype(f, (H5F_mem_page_t)type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get free-space info */
     if (H5FS_stat_info(f, f->shared->fs_man[type], &fs_stat) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify free-space info */
     if (fs_stat.tot_space < TBLOCK_SIZE5)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(fcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -6652,13 +6652,13 @@ test_mf_fs_persist_multi(void)
 
     /* File creation property list template */
     if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_FSM_AGGR, TRUE, (hsize_t)1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     MULTI_SETUP(memb_map, memb_fapl, memb_name, memb_addr, sv)
 
@@ -6670,247 +6670,247 @@ test_mf_fs_persist_multi(void)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Allocate 4 blocks of type H5FD_MEM_SUPER */
     type = H5FD_MEM_SUPER;
     if (HADDR_UNDEF == (addr1 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE1)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (addr2 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE2)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (addr3 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE3)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (addr4 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE4)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Put block #1, #3 into H5FD_MEM_SUPER free-space manager */
     if (H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5MF_xfree(f, type, addr3, (hsize_t)TBLOCK_SIZE3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Allocate 4 blocks of type H5FD_MEM_DRAW */
     stype = H5FD_MEM_DRAW;
     if (HADDR_UNDEF == (saddr1 = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE1)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (saddr2 = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE2)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (saddr3 = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE3)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (saddr4 = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE4)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Put block #1, #3 into H5FD_MEM_DRAW free-space manager */
     if (H5MF_xfree(f, stype, saddr1, (hsize_t)TBLOCK_SIZE1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5MF_xfree(f, stype, saddr3, (hsize_t)TBLOCK_SIZE3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the H5FD_MEM_SUPER free-space manager is there */
     if (!H5F_addr_defined(f->shared->fs_addr[type]))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
     if (H5MF__open_fstype(f, (H5F_mem_page_t)type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get free-space info */
     if (H5FS_stat_info(f, f->shared->fs_man[type], &fs_stat) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify free-space info */
     if (fs_stat.tot_space < (TBLOCK_SIZE1 + TBLOCK_SIZE3))
-        TEST_ERROR
+        TEST_ERROR;
     if (fs_stat.serial_sect_count < 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve block #1 from H5FD_MEM_SUPER free-space manager; block #3 still in free-space */
     if (HADDR_UNDEF == (tmp_addr = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE1)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tmp_addr != addr1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the free-space manager for H5FD_MEM_DRAW is there */
     if (!H5F_addr_defined(f->shared->fs_addr[stype]))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Start up H5FD_MEM_DRAW free-space manager */
     if (H5MF__open_fstype(f, (H5F_mem_page_t)stype) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get free-space info */
     if (H5FS_stat_info(f, f->shared->fs_man[stype], &fs_stat) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify free-space info */
     if (fs_stat.tot_space < (TBLOCK_SIZE1 + TBLOCK_SIZE3))
-        TEST_ERROR
+        TEST_ERROR;
     if (fs_stat.serial_sect_count < 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve blocks #1 from H5FD_MEM_DRAW free-space manager */
     if (HADDR_UNDEF == (tmp_addr = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE1)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tmp_addr != saddr1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve blocks #3 from H5FD_MEM_DRAW free-space manager */
     if (HADDR_UNDEF == (tmp_addr = H5MF_alloc(f, stype, (hsize_t)TBLOCK_SIZE3)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tmp_addr != saddr3)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate 4 blocks of type H5FD_MEM_BTREE */
     btype = H5FD_MEM_BTREE;
     if (HADDR_UNDEF == (baddr1 = H5MF_alloc(f, btype, (hsize_t)TBLOCK_SIZE1)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (baddr2 = H5MF_alloc(f, btype, (hsize_t)TBLOCK_SIZE2)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (baddr3 = H5MF_alloc(f, btype, (hsize_t)TBLOCK_SIZE3)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (baddr4 = H5MF_alloc(f, btype, (hsize_t)TBLOCK_SIZE4)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Put block #1 & #3 into H5FD_MEM_BTREE free-space manager */
     if (H5MF_xfree(f, btype, baddr1, (hsize_t)TBLOCK_SIZE1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5MF_xfree(f, btype, baddr3, (hsize_t)TBLOCK_SIZE3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify that the free-space manager for H5FD_MEM_SUPER is there */
     if (!H5F_addr_defined(f->shared->fs_addr[type]))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
     if (H5MF__open_fstype(f, (H5F_mem_page_t)type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get free-space info */
     if (H5FS_stat_info(f, f->shared->fs_man[type], &fs_stat) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify free-space info */
     if (fs_stat.tot_space < TBLOCK_SIZE3)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve block #3 from H5FD_MEM_SUPER free-space manager */
     if (HADDR_UNDEF == (tmp_addr = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE3)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (tmp_addr != addr3)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the free-space manager for H5FD_MEM_DRAW is not there */
     if (H5F_addr_defined(f->shared->fs_addr[stype]))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the free-space manager for H5FD_MEM_BTREE is there */
     if (!H5F_addr_defined(f->shared->fs_addr[btype]))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Start up H5FD_MEM_BTREE free-space manager */
     if (H5MF__open_fstype(f, (H5F_mem_page_t)btype) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get free-space info */
     if (H5FS_stat_info(f, f->shared->fs_man[btype], &fs_stat) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify free-space info */
     if (fs_stat.tot_space < (TBLOCK_SIZE1 + TBLOCK_SIZE3))
-        TEST_ERROR
+        TEST_ERROR;
     if (fs_stat.serial_sect_count < 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Allocate 2 blocks of type H5FD_MEM_GHEAP */
     gtype = H5FD_MEM_GHEAP;
     if (HADDR_UNDEF == (gaddr2 = H5MF_alloc(f, gtype, (hsize_t)TBLOCK_SIZE2)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HADDR_UNDEF == (gaddr1 = H5MF_alloc(f, gtype, (hsize_t)TBLOCK_SIZE1)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Put block #2 into H5FD_MEM_GHEAP free-space manager */
     if (H5MF_xfree(f, gtype, gaddr2, (hsize_t)TBLOCK_SIZE2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* If H5FD_MEM_SUPER is there, should not find block #1 & #3 */
     if (H5F_addr_defined(f->shared->fs_addr[type])) {
         /* Start up H5FD_MEM_SUPER free-space manager */
         if (H5MF__open_fstype(f, (H5F_mem_page_t)type) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if ((node_found = H5FS_sect_find(f, f->shared->fs_man[type], (hsize_t)TBLOCK_SIZE1,
                                          (H5FS_section_info_t **)&node)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (node_found)
-            TEST_ERROR
+            TEST_ERROR;
 
         if ((node_found = H5FS_sect_find(f, f->shared->fs_man[type], (hsize_t)TBLOCK_SIZE3,
                                          (H5FS_section_info_t **)&node)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (node_found)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* Verify that the H5FD_MEM_GHEAP free-space manager is there */
     if (!H5F_addr_defined(f->shared->fs_addr[gtype]))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Start up H5FD_MEM_GHEAP free-space manager */
     if (H5MF__open_fstype(f, (H5F_mem_page_t)gtype) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get free-space info */
     if (H5FS_stat_info(f, f->shared->fs_man[gtype], &fs_stat) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify free-space info */
     if (fs_stat.tot_space < TBLOCK_SIZE2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(fcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -6948,32 +6948,32 @@ test_mf_fs_persist(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
     haddr_t     tmp_addr;                                 /* Temporary variable for address */
 
     if (new_format)
-        TESTING("File's free-space is persistent with new library format")
+        TESTING("File's free-space is persistent with new library format");
     else
-        TESTING("File's free-space is persistent with old library format")
+        TESTING("File's free-space is persistent with old library format");
 
     if (HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0) {
 
         /* File creation property list template */
         if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Copy the file access property list */
         if ((fapl2 = H5Pcopy(fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if (new_format) {
             /* Latest format */
             if (H5Pset_libver_bounds(fapl2, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             /* Set to paged aggregation and persisting free-space */
             if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_PAGE, TRUE, (hsize_t)1) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         }
         else {
             /* Setting: aggregation with persisting free-space */
             if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_FSM_AGGR, TRUE, (hsize_t)1) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         /* Set the filename to use for this test (dependent on fapl) */
@@ -6981,107 +6981,107 @@ test_mf_fs_persist(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
 
         /* Create the file to work on */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl2)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate 6 blocks */
         type = H5FD_MEM_SUPER;
         if (HADDR_UNDEF == (addr1 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE1)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (HADDR_UNDEF == (addr2 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE2)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (HADDR_UNDEF == (addr3 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE3)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (HADDR_UNDEF == (addr4 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE4)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (HADDR_UNDEF == (addr5 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE5)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (HADDR_UNDEF == (addr6 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE6)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Put block #1, #3, #5 to H5FD_MEM_SUPER free-space manager */
         if (H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE1) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5MF_xfree(f, type, addr3, (hsize_t)TBLOCK_SIZE3) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5MF_xfree(f, type, addr5, (hsize_t)TBLOCK_SIZE5) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl2)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         H5MF__alloc_to_fs_type(f->shared, type, TBLOCK_SIZE6, (H5F_mem_page_t *)&tt);
 
         /* Verify that H5FD_MEM_SUPER free-space manager is there */
         if (!H5F_addr_defined(f->shared->fs_addr[tt]))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Start up H5FD_MEM_SUPER free-space manager */
         if (!(f->shared->fs_man[tt]))
             if (H5MF__open_fstype(f, (H5F_mem_page_t)tt) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
         /* Get info for free-space manager */
         if (H5FS_stat_info(f, f->shared->fs_man[tt], &fs_stat) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify free-space info */
         if (fs_stat.tot_space < (TBLOCK_SIZE1 + TBLOCK_SIZE3 + TBLOCK_SIZE5))
-            TEST_ERROR
+            TEST_ERROR;
 
         if (fs_stat.serial_sect_count < 3)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Retrieve block #3 from H5FD_MEM_SUPER free-space manager */
         if (HADDR_UNDEF == (tmp_addr = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE3)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (tmp_addr != addr3)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Retrieve block #1 from H5FD_MEM_SUPER free-space manager */
         if (HADDR_UNDEF == (tmp_addr = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE1)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (tmp_addr != addr1)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify that H5FD_MEM_SUPER free-space manager is there */
         if (!H5F_addr_defined(f->shared->fs_addr[tt]))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Retrieve block #5 from H5FD_MEM_SUPER free-space manager */
         if (HADDR_UNDEF == (tmp_addr = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE5)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (tmp_addr != addr5)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Pclose(fcpl) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Pclose(fapl2) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     }
@@ -7124,9 +7124,9 @@ test_mf_fs_gone(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
     hbool_t     contig_addr_vfd;
 
     if (new_format)
-        TESTING("File's free-space is going away with new library format")
+        TESTING("File's free-space is going away with new library format");
     else
-        TESTING("File's free-space is going away with old library format")
+        TESTING("File's free-space is going away with old library format");
 
     /* Current VFD that does not support contiguous address space */
     contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
@@ -7135,142 +7135,142 @@ test_mf_fs_gone(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
 
         /* File creation property list template */
         if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Copy the file access property list */
         if ((fapl2 = H5Pcopy(fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if (new_format) {
             if (H5Pset_libver_bounds(fapl2, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         }
         else {
             if (H5Pset_libver_bounds(fapl2, H5F_LIBVER_V18, H5F_LIBVER_LATEST) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         }
 
         /* Set to aggregation and persisting free-space */
         if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_FSM_AGGR, TRUE, (hsize_t)1) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl2, filename, sizeof(filename));
 
         /* Create the file to work on */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl2)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate 4 blocks */
         type = H5FD_MEM_SUPER;
         if (HADDR_UNDEF == (addr1 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE1)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (HADDR_UNDEF == (addr2 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE2)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (HADDR_UNDEF == (addr3 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE3)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (HADDR_UNDEF == (addr4 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE4)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Put block #1, #3 to H5FD_MEM_SUPER free-space manager */
         if (H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE1) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5MF_xfree(f, type, addr3, (hsize_t)TBLOCK_SIZE3) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Retrieve block #1, #3 from H5FD_MEM_SUPER free-space manager */
         if (HADDR_UNDEF == (addr3 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE3)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (HADDR_UNDEF == (addr1 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE1)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl2)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         H5MF__alloc_to_fs_type(f->shared, type, TBLOCK_SIZE4, (H5F_mem_page_t *)&fs_type);
 
         /* Verify that the H5FD_MEM_SUPER free-space manager is not there */
         if (H5F_addr_defined(f->shared->fs_addr[fs_type]))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Put block #3 to H5FD_MEM_SUPER free-space manager */
         if (H5MF_xfree(f, type, addr3, (hsize_t)TBLOCK_SIZE3) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl2)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify that H5FD_MEM_SUPER free-space manager is there */
         if (!H5F_addr_defined(f->shared->fs_addr[fs_type]))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Start up H5FD_MEM_SUPER free-space manager */
         if (!(f->shared->fs_man[fs_type]))
             if (H5MF__open_fstype(f, (H5F_mem_page_t)fs_type) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
         /* Get info for H5FD_MEM_SUPER free-space manager */
         if (H5FS_stat_info(f, f->shared->fs_man[fs_type], &fs_stat) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if (!H5F_addr_defined(fs_stat.addr))
-            TEST_ERROR
+            TEST_ERROR;
 
         if (fs_stat.tot_space < TBLOCK_SIZE3)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate/free space accordingly so that the free-space manager will go away */
         if (new_format) {
             if (H5MF_xfree(f, type, addr4, (hsize_t)TBLOCK_SIZE4) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         }
         else {
             if (HADDR_UNDEF == (addrx = H5MF_alloc(f, type, (hsize_t)3)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         }
 
         /* The H5FD_MEM_SUPER free-space manager will go away at H5MF_close() */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Re-open the file */
         if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl2)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         /* Verify that the H5FD_MEM_SUPER free-space manager is not there */
         if (H5F_addr_defined(f->shared->fs_addr[fs_type]))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Closing */
         if (H5Fclose(file) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Pclose(fcpl) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Pclose(fapl2) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     }
@@ -7315,9 +7315,9 @@ test_mf_strat_thres_persist(const char *env_h5_drvr, hid_t fapl, hbool_t new_for
     hbool_t               contig_addr_vfd;
 
     if (new_format)
-        TESTING("File space strategy/persisting/threshold with new library format")
+        TESTING("File space strategy/persisting/threshold with new library format");
     else
-        TESTING("File space strategy/persisting/threshold with old library format")
+        TESTING("File space strategy/persisting/threshold with old library format");
 
     /* Current VFD that does not support contiguous address space */
     contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
@@ -7327,11 +7327,11 @@ test_mf_strat_thres_persist(const char *env_h5_drvr, hid_t fapl, hbool_t new_for
 
     /* Copy the file access property list */
     if ((fapl2 = H5Pcopy(fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (new_format)
         if (H5Pset_libver_bounds(fapl2, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
     /* Test with TRUE or FALSE for persisting free-space */
     for (fs_persist = FALSE; fs_persist <= TRUE; fs_persist++) {
@@ -7346,60 +7346,60 @@ test_mf_strat_thres_persist(const char *env_h5_drvr, hid_t fapl, hbool_t new_for
 
                 /* Create file-creation template */
                 if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Set default file space information */
                 if (H5Pset_file_space_strategy(fcpl, fs_type, (hbool_t)fs_persist, fs_threshold) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Create the file to work on */
                 if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl2)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Get a pointer to the internal file object */
                 if (NULL == (f = (H5F_t *)H5VL_object(file)))
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Allocate 6 blocks */
                 type = H5FD_MEM_SUPER;
                 if (HADDR_UNDEF == (addr1 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE1)))
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (HADDR_UNDEF == (addr2 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE2)))
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (HADDR_UNDEF == (addr3 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE3)))
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (HADDR_UNDEF == (addr4 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE4)))
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (HADDR_UNDEF == (addr5 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE5)))
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (HADDR_UNDEF == (addr6 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE6)))
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Put block #1, #3, #5 to H5FD_MEM_SUPER free-space manager */
                 if (H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE1) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5MF_xfree(f, type, addr3, (hsize_t)TBLOCK_SIZE3) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5MF_xfree(f, type, addr5, (hsize_t)TBLOCK_SIZE5) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Close the file */
                 if (H5Fclose(file) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Re-open the file */
                 if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl2)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Get a pointer to the internal file object */
                 if (NULL == (f = (H5F_t *)H5VL_object(file)))
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 H5MF__alloc_to_fs_type(f->shared, type, TBLOCK_SIZE6, (H5F_mem_page_t *)&tt);
 
                 /* Get a pointer to the internal file object */
                 if (NULL == (f = (H5F_t *)H5VL_object(file)))
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 if (f->shared->fs_persist) {
                     hssize_t         nsects;    /* # of free-space sections */
@@ -7408,12 +7408,12 @@ test_mf_strat_thres_persist(const char *env_h5_drvr, hid_t fapl, hbool_t new_for
 
                     /* Get the # of free-space sections in the file */
                     if ((nsects = H5Fget_free_sections(file, H5FD_MEM_DEFAULT, (size_t)0, NULL)) < 0)
-                        FAIL_STACK_ERROR
+                        FAIL_STACK_ERROR;
 
                     /* Verify no free-space sections */
                     /* paged aggregation has 1 section for last_small */
                     if (fs_threshold > TBLOCK_SIZE5 && nsects && fs_type != H5F_FSPACE_STRATEGY_PAGE)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     if (nsects) {
                         /* Allocate storage for the free space section information */
@@ -7424,27 +7424,27 @@ test_mf_strat_thres_persist(const char *env_h5_drvr, hid_t fapl, hbool_t new_for
                         /* Verify the size of free-space sections */
                         for (i = 0; i < nsects; i++)
                             if (sect_info[i].size < fs_threshold)
-                                TEST_ERROR
+                                TEST_ERROR;
                         if (sect_info)
                             HDfree(sect_info);
                     }
                 }
                 else {
                     if (H5F_addr_defined(f->shared->fs_addr[tt]))
-                        TEST_ERROR
+                        TEST_ERROR;
                 }
 
                 /* Closing */
                 if (H5Fclose(file) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5Pclose(fcpl) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
             } /* end for fs_type */
         }     /* end for fs_threshold */
     }         /* end for fs_persist */
 
     if (H5Pclose(fapl2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -7485,9 +7485,9 @@ test_mf_strat_thres_gone(const char *env_h5_drvr, hid_t fapl, hbool_t new_format
     hbool_t               contig_addr_vfd;
 
     if (new_format)
-        TESTING("File space merge/shrink for section size < threshold with new library format")
+        TESTING("File space merge/shrink for section size < threshold with new library format");
     else
-        TESTING("File space merge/shrink for section size < threshold with old library format")
+        TESTING("File space merge/shrink for section size < threshold with old library format");
 
     /* Current VFD that does not support contiguous address space */
     contig_addr_vfd = (hbool_t)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
@@ -7499,11 +7499,11 @@ test_mf_strat_thres_gone(const char *env_h5_drvr, hid_t fapl, hbool_t new_format
 
     /* Copy the file access property list */
     if ((fapl2 = H5Pcopy(fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (new_format)
         if (H5Pset_libver_bounds(fapl2, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
     /* Test with TRUE or FALSE for persisting free-space */
     for (fs_persist = FALSE; fs_persist <= TRUE; fs_persist++) {
@@ -7519,68 +7519,68 @@ test_mf_strat_thres_gone(const char *env_h5_drvr, hid_t fapl, hbool_t new_format
 
             /* Create file-creation template */
             if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Set default file space information */
             if (H5Pset_file_space_strategy(fcpl, fs_type, fs_persist, (hsize_t)TEST_THRESHOLD3) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create the file to work on */
             if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl2)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Get a pointer to the internal file object */
             if (NULL == (f = (H5F_t *)H5VL_object(file)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Allocate 6 blocks */
             type = H5FD_MEM_SUPER;
             if (HADDR_UNDEF == (addr1 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE1)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (HADDR_UNDEF == (addr2 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE2)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (HADDR_UNDEF == (addr3 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE3)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (HADDR_UNDEF == (addr4 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE4)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (HADDR_UNDEF == (addr5 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE5)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (HADDR_UNDEF == (addr6 = H5MF_alloc(f, type, (hsize_t)TBLOCK_SIZE6)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             H5MF__alloc_to_fs_type(f->shared, type, TBLOCK_SIZE6, (H5F_mem_page_t *)&tt);
 
             /* For paged aggregation, the section in the page at EOF for small meta fs is not shrunk away */
             if (fs_type == H5F_FSPACE_STRATEGY_PAGE)
                 if (H5FS_stat_info(f, f->shared->fs_man[tt], &fs_state) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
             /* Put block #3, #5 to H5FD_MEM_SUPER free-space manager */
             if (H5MF_xfree(f, type, addr3, (hsize_t)TBLOCK_SIZE3) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5MF_xfree(f, type, addr5, (hsize_t)TBLOCK_SIZE5) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             fs_state.tot_space += TBLOCK_SIZE3 + TBLOCK_SIZE5;
             fs_state.tot_sect_count += 2;
             fs_state.serial_sect_count += 2;
 
             if (check_stats(f, f->shared->fs_man[tt], &fs_state))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* section #2 is less than threshold but is merged into section #3 */
             if (H5MF_xfree(f, type, addr2, (hsize_t)TBLOCK_SIZE2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             fs_state.tot_space += TBLOCK_SIZE2;
             if (check_stats(f, f->shared->fs_man[tt], &fs_state))
-                TEST_ERROR
+                TEST_ERROR;
 
             if (H5MF_xfree(f, type, addr4, (hsize_t)TBLOCK_SIZE4) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if (H5MF_xfree(f, type, addr6, (hsize_t)TBLOCK_SIZE6) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* For paged aggregation, the sections in the page at EOF for small meta fs are merged but are not
              * shrunk away */
@@ -7592,11 +7592,11 @@ test_mf_strat_thres_gone(const char *env_h5_drvr, hid_t fapl, hbool_t new_format
             /* For old format: the sections at EOF are shrunk away */
             if (check_stats(f, f->shared->fs_man[tt],
                             (fs_type == H5F_FSPACE_STRATEGY_PAGE) ? &fs_state : &fs_state_zero))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* section #1 is less than threshold but is shrunk away */
             if (H5MF_xfree(f, type, addr1, (hsize_t)TBLOCK_SIZE1) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* For paged aggregation, the section in the page at EOF for small meta fs is not shrunk away */
             if (fs_type == H5F_FSPACE_STRATEGY_PAGE)
@@ -7605,35 +7605,35 @@ test_mf_strat_thres_gone(const char *env_h5_drvr, hid_t fapl, hbool_t new_format
             /* For old format: the sections at EOF are shrunk away */
             if (check_stats(f, f->shared->fs_man[tt],
                             (fs_type == H5F_FSPACE_STRATEGY_PAGE) ? &fs_state : &fs_state_zero))
-                TEST_ERROR
+                TEST_ERROR;
 
             if (H5Fclose(file) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Re-open the file */
             if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl2)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Get a pointer to the internal file object */
             if (NULL == (f = (H5F_t *)H5VL_object(file)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Free-space manager should be empty */
             if (!(fs_type == H5F_FSPACE_STRATEGY_PAGE && fs_persist))
                 if (H5F_addr_defined(f->shared->fs_addr[tt]))
-                    TEST_ERROR
+                    TEST_ERROR;
 
             /* Closing */
             if (H5Fclose(file) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             if (H5Pclose(fcpl) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         } /* end for fs_type */
     }     /* end for fs_persist */
 
     if (H5Pclose(fapl2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -7688,11 +7688,11 @@ test_dichotomy(hid_t fapl)
 
     /* Create the file to work on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Allocate the first block of type H5FD_MEM_SUPER */
     type  = H5FD_MEM_SUPER;
@@ -7713,7 +7713,7 @@ test_dichotomy(hid_t fapl)
 
     /* Verify that saddr1 is not addr1 */
     if (saddr2 == addr1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free the first block of type H5FD_MEM_DRAW */
     H5MF_xfree(f, stype, saddr1, (hsize_t)TBLOCK_SIZE30);
@@ -7723,10 +7723,10 @@ test_dichotomy(hid_t fapl)
 
     /* Verify that addr3 is not saddr1 */
     if (addr3 == saddr1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -7764,7 +7764,7 @@ set_multi_split(hid_t fapl, hsize_t pagesize, hbool_t is_multi_or_split)
 
     /* Get current split settings */
     if (H5Pget_fapl_multi(fapl, memb_map, memb_fapl_arr, memb_name, memb_addr, &relax) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (is_multi_or_split) {
         /* Set memb_addr aligned */
@@ -7780,7 +7780,7 @@ set_multi_split(hid_t fapl, hsize_t pagesize, hbool_t is_multi_or_split)
     /* Set multi driver with new FAPLs */
     if (H5Pset_fapl_multi(fapl, memb_map, memb_fapl_arr, (const char *const *)memb_name, memb_addr, relax) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free memb_name */
     for (mt = H5FD_MEM_DEFAULT; mt < H5FD_MEM_NTYPES; mt++)
@@ -7835,7 +7835,7 @@ test_page_alloc_xfree(const char *env_h5_drvr, hid_t fapl)
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
         if ((fapl_new = H5Pcopy(fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (multi || split)
             if (set_multi_split(fapl_new, 4096, split) < 0)
@@ -7847,19 +7847,19 @@ test_page_alloc_xfree(const char *env_h5_drvr, hid_t fapl)
 
             /* File creation property list */
             if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Set the strategy to paged aggregation */
             if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_PAGE, fs_persist, (hsize_t)1) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create the file to work on */
             if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl_new)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Get a pointer to the internal file object */
             if (NULL == (f = (H5F_t *)H5VL_object(fid)))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Allocate 3 small metadata blocks: addr1, addr2, addr3 */
             H5MF_alloc(f, H5FD_MEM_OHDR, (hsize_t)TBLOCK_SIZE30);
@@ -7875,9 +7875,9 @@ test_page_alloc_xfree(const char *env_h5_drvr, hid_t fapl)
                 /* Verify that the freed block with addr2 is found from the small metadata manager */
                 if (H5MF__find_sect(f, H5FD_MEM_OHDR, (hsize_t)TBLOCK_SIZE1034, f->shared->fs_man[fs_type],
                                     &found_addr) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (found_addr != addr2)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
 
             /* Allocate 2 small raw data blocks: saddr1, saddr2 */
@@ -7891,9 +7891,9 @@ test_page_alloc_xfree(const char *env_h5_drvr, hid_t fapl)
                 /* Verify that the freed block with saddr1 is found from the small raw data manager */
                 if (H5MF__find_sect(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE30,
                                     f->shared->fs_man[H5F_MEM_PAGE_DRAW], &found_addr) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (found_addr != saddr1)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
 
             /* Allocate 2 large data blocks: gaddr1, gaddr2 */
@@ -7909,29 +7909,29 @@ test_page_alloc_xfree(const char *env_h5_drvr, hid_t fapl)
                 /* Verify that the freed block with gaddr1 is found from the large data manager */
                 if (H5MF__find_sect(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE8192, f->shared->fs_man[fs_type],
                                     &found_addr) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (found_addr != gaddr1)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
 
             /* Close file */
             if (H5Fclose(fid) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close the property list */
             if (H5Pclose(fcpl) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             if (fs_persist) {
                 haddr_t prv_tag = HADDR_UNDEF;
 
                 /* Re-open the file */
                 if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl_new)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Get a pointer to the internal file object */
                 if (NULL == (f = (H5F_t *)H5VL_object(fid)))
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Set the freespace tag for the metadata cache */
                 H5AC_tag(H5AC__FREESPACE_TAG, &prv_tag);
@@ -7939,69 +7939,69 @@ test_page_alloc_xfree(const char *env_h5_drvr, hid_t fapl)
                 /* Verify that the large generic manager is there */
                 H5MF__alloc_to_fs_type(f->shared, H5FD_MEM_DRAW, TBLOCK_SIZE5000, (H5F_mem_page_t *)&fs_type);
                 if (!H5F_addr_defined(f->shared->fs_addr[fs_type]))
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Verify that the small metadata manager is there */
                 H5MF__alloc_to_fs_type(f->shared, H5FD_MEM_OHDR, f->shared->fs_page_size - 1,
                                        (H5F_mem_page_t *)&fs_type);
                 if (!H5F_addr_defined(f->shared->fs_addr[fs_type]))
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Set up to use the small metadata manager */
                 if (!(f->shared->fs_man[fs_type]))
                     if (H5MF__open_fstype(f, fs_type) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                 /* Verify that the freed block with addr2 is found from the small metadata manager */
                 if (H5MF__find_sect(f, H5FD_MEM_OHDR,
                                     (hsize_t)(f->shared->fs_page_size - (addr3 + TBLOCK_SIZE50)),
                                     f->shared->fs_man[fs_type], &found_addr) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 if (found_addr != (addr3 + TBLOCK_SIZE50))
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Verify that the small raw data manager is there */
                 if (!H5F_addr_defined(f->shared->fs_addr[H5F_MEM_PAGE_DRAW]))
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Set up to use the small raw data manager */
                 if (!(f->shared->fs_man[H5F_MEM_PAGE_DRAW]))
                     if (H5MF__open_fstype(f, H5F_MEM_PAGE_DRAW) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                 /* Verify that the freed block with saddr1 is found from the small raw data manager */
                 if (H5MF__find_sect(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE30,
                                     f->shared->fs_man[H5F_MEM_PAGE_DRAW], &found_addr) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (found_addr != saddr1)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 H5MF__alloc_to_fs_type(f->shared, H5FD_MEM_DRAW, TBLOCK_SIZE5000, (H5F_mem_page_t *)&fs_type);
 
                 if (!(f->shared->fs_man[fs_type]))
                     /* Set up to use the large data manager */
                     if (H5MF__open_fstype(f, fs_type) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                 /* Verify that the freed block with gaddr1 is found from the large data manager */
                 if (H5MF__find_sect(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE8192, f->shared->fs_man[fs_type],
                                     &found_addr) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (found_addr != gaddr1)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Reset the previous tag */
                 H5AC_tag(prv_tag, NULL);
 
                 /* Close file */
                 if (H5Fclose(fid) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if fs_persist */
         }     /* end for */
 
         if (H5Pclose(fapl_new) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     }
@@ -8064,55 +8064,55 @@ test_page_try_shrink(const char *env_h5_drvr, hid_t fapl)
 
         /* File creation property list */
         if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set the strategy to paged aggregation */
         if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_PAGE, FALSE, (hsize_t)1) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create the file to work on */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(fid)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate a small metadata block with addr1 */
         addr1 = H5MF_alloc(f, H5FD_MEM_OHDR, (hsize_t)TBLOCK_SIZE50);
 
         /* Try to shrink the block with addr1 */
         if ((status = H5MF_try_shrink(f, H5FD_MEM_OHDR, addr1, (hsize_t)TBLOCK_SIZE50)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Couldn't shrink due to the section (remaining space in the page) is in the small metadata
          * free-space manager */
         if (status == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a small raw data block with saddr1 */
         saddr1 = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE50);
 
         /* Try to shrink the block with saddr1 */
         if ((status = H5MF_try_shrink(f, H5FD_MEM_DRAW, saddr1, (hsize_t)TBLOCK_SIZE50)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Couldn't shrink due to the section (remaining space in the page) is in the small raw data
          * free-space manager */
         if (status == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a large data block with gaddr1 */
         gaddr1 = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE5000);
 
         /* Try to shrink the block with gaddr1 */
         if ((status = H5MF_try_shrink(f, H5FD_MEM_DRAW, gaddr1, (hsize_t)TBLOCK_SIZE5000)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Couldn't shrink due to the section (remaining space in the page) is in the large-sized free-space
          * manager */
         if (status == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free the block with saddr1--merge to become 1 page, then return to the large manager */
         H5MF_xfree(f, H5FD_MEM_DRAW, saddr1, (hsize_t)TBLOCK_SIZE50);
@@ -8121,19 +8121,19 @@ test_page_try_shrink(const char *env_h5_drvr, hid_t fapl)
         H5MF_xfree(f, H5FD_MEM_OHDR, gaddr1, (hsize_t)TBLOCK_SIZE5000);
 
         if (H5Fclose(fid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Should be on page boundary */
         if (file_size % TBLOCK_SIZE4096)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the property list */
         if (H5Pclose(fcpl) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     }
@@ -8194,19 +8194,19 @@ test_page_small_try_extend(const char *env_h5_drvr, hid_t fapl)
 
         /* File creation property list */
         if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set the strategy to paged aggregation */
         if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_PAGE, FALSE, (hsize_t)1) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create the file to work on */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(fid)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate a small metadata block with addr1 */
         addr1 = H5MF_alloc(f, H5FD_MEM_OHDR, (hsize_t)TBLOCK_SIZE98);
@@ -8216,7 +8216,7 @@ test_page_small_try_extend(const char *env_h5_drvr, hid_t fapl)
             H5MF_try_extend(f, H5FD_MEM_OHDR, (haddr_t)addr1, (hsize_t)TBLOCK_SIZE98, (hsize_t)3100);
         /* Should succeed */
         if (was_extended != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate 2 small metadata blocks with addr2 and addr3--will be on another metadata page */
         addr2 = H5MF_alloc(f, H5FD_MEM_OHDR, (hsize_t)TBLOCK_SIZE100);
@@ -8225,9 +8225,9 @@ test_page_small_try_extend(const char *env_h5_drvr, hid_t fapl)
         /* The block with addr2 should be page aligned */
         /* The block with addr3 resides right next to the block with addr2 */
         if (addr2 % TBLOCK_SIZE4096)
-            TEST_ERROR
+            TEST_ERROR;
         if (addr3 != (addr2 + TBLOCK_SIZE100))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free the block with addr2 */
         H5MF_xfree(f, H5FD_MEM_OHDR, addr2, (hsize_t)TBLOCK_SIZE100);
@@ -8238,7 +8238,7 @@ test_page_small_try_extend(const char *env_h5_drvr, hid_t fapl)
                                        (hsize_t)TBLOCK_SIZE100);
         /* Shouldn't succeed--should not cross page boundary */
         if (was_extended == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Try extending the block with addr1 into the free-space section that is big enough to fulfill the
          * request */
@@ -8246,7 +8246,7 @@ test_page_small_try_extend(const char *env_h5_drvr, hid_t fapl)
                                        (hsize_t)TBLOCK_SIZE50);
         /* Should succeed */
         if (was_extended != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free the block with addr1 */
         H5MF_xfree(f, H5FD_MEM_OHDR, addr1, (hsize_t)TBLOCK_SIZE3248);
@@ -8261,14 +8261,14 @@ test_page_small_try_extend(const char *env_h5_drvr, hid_t fapl)
                                        (hsize_t)TBLOCK_SIZE11);
         /* Shouldn't succeed */
         if (was_extended == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Try extending the block into the threshold with size < H5F_FILE_SPACE_PGEND_META_THRES */
         was_extended = H5MF_try_extend(f, H5FD_MEM_OHDR, (haddr_t)addr1, (hsize_t)TBLOCK_SIZE3286,
                                        (hsize_t)TBLOCK_SIZE2);
         /* Should succeed */
         if (was_extended != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free the block with addr3--will merge with the remaining sections to become a page and then free
          * the page */
@@ -8282,14 +8282,14 @@ test_page_small_try_extend(const char *env_h5_drvr, hid_t fapl)
                                        (hsize_t)TBLOCK_SIZE11);
         /* Shouldn't succeed */
         if (was_extended == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Try extending the block not crossing page boundary */
         was_extended = H5MF_try_extend(f, H5FD_MEM_DRAW, (haddr_t)saddr1, (hsize_t)TBLOCK_SIZE4086,
                                        (hsize_t)TBLOCK_SIZE10);
         /* Should succeed */
         if (was_extended != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* The extended block is now "large" in size */
         /* Try extending the block */
@@ -8297,7 +8297,7 @@ test_page_small_try_extend(const char *env_h5_drvr, hid_t fapl)
                                        (hsize_t)TBLOCK_SIZE10);
         /* Should succeed */
         if (was_extended != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Try extending the large-sized block */
         was_extended = H5MF_try_extend(f, H5FD_MEM_DRAW, (haddr_t)saddr1, (hsize_t)TBLOCK_SIZE4106,
@@ -8305,15 +8305,15 @@ test_page_small_try_extend(const char *env_h5_drvr, hid_t fapl)
         /* Should not succeed because the mis-aligned fragment in the page is in the large-sized free-space
          * manager */
         if (was_extended == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file */
         if (H5Fclose(fid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close the property list */
         if (H5Pclose(fcpl) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     }
@@ -8372,52 +8372,52 @@ test_page_large_try_extend(const char *env_h5_drvr, hid_t fapl)
 
         /* File creation property list */
         if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set the strategy to paged aggregation */
         if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_PAGE, FALSE, (hsize_t)1) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create the file to work on */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(fid)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate a large data block with gaddr1 */
         gaddr1 = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)6000);
 
         /* Should be page aligned */
         if (gaddr1 % TBLOCK_SIZE4096)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Extending the block with gaddr1 at EOF to become 2 pages */
         was_extended = H5MF_try_extend(f, H5FD_MEM_DRAW, (haddr_t)gaddr1, (hsize_t)TBLOCK_SIZE6000,
                                        (hsize_t)TBLOCK_SIZE2192);
         /* Should succeed */
         if (was_extended != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a large data block with gaddr2 */
         gaddr2 = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE8000);
         /* Should be page aligned */
         if (gaddr2 % TBLOCK_SIZE4096)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Try extending the block with gaddr1 */
         was_extended = H5MF_try_extend(f, H5FD_MEM_DRAW, (haddr_t)gaddr1, (hsize_t)TBLOCK_SIZE8192,
                                        (hsize_t)TBLOCK_SIZE50);
         /* Should not succeed */
         if (was_extended == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a large data block with gaddr3 */
         gaddr3 = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE8000);
         /* Should be page aligned */
         if (gaddr3 % TBLOCK_SIZE4096)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Try extending the block with gaddr2--there is a free-space section big enough to fulfill the
          * request */
@@ -8425,7 +8425,7 @@ test_page_large_try_extend(const char *env_h5_drvr, hid_t fapl)
                                        (hsize_t)TBLOCK_SIZE100);
         /* Should succeed */
         if (was_extended == FALSE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Try extending the block with gaddr2--there is no free-space section big enough to fulfill the
          * request */
@@ -8433,7 +8433,7 @@ test_page_large_try_extend(const char *env_h5_drvr, hid_t fapl)
                                        (hsize_t)TBLOCK_SIZE100);
         /* Should not succeed */
         if (was_extended == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Try extending the block with gaddr2--there is a free-space section big enough to fulfill the
          * request */
@@ -8441,7 +8441,7 @@ test_page_large_try_extend(const char *env_h5_drvr, hid_t fapl)
                                        (hsize_t)TBLOCK_SIZE90);
         /* Should succeed */
         if (was_extended == FALSE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Try extending the block with gaddr2 */
         /* There is no free-space section big enough to fulfill the request (request is <
@@ -8450,13 +8450,13 @@ test_page_large_try_extend(const char *env_h5_drvr, hid_t fapl)
                                        (hsize_t)TBLOCK_SIZE5);
         /* Should not succeed */
         if (was_extended == TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a large data block with gaddr4 */
         gaddr4 = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE5000);
         /* Should be page aligned */
         if (gaddr4 % TBLOCK_SIZE4096)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free the block with gaddr3--will merge with remaining free space to become 2 pages + section (size
          * 2) in previous page */
@@ -8468,15 +8468,15 @@ test_page_large_try_extend(const char *env_h5_drvr, hid_t fapl)
                                        (hsize_t)TBLOCK_SIZE5);
         /* Should succeed */
         if (was_extended == FALSE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close file */
         if (H5Fclose(fid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close the property list */
         if (H5Pclose(fcpl) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     }
@@ -8536,19 +8536,19 @@ test_page_large(const char *env_h5_drvr, hid_t fapl)
 
         /* File creation property list */
         if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set the strategy to paged aggregation */
         if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_PAGE, FALSE, (hsize_t)1) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create the file to work on */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(fid)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate a large data block with gaddr1 */
         /* 1 page + 1904 bytes; 2192 bytes in free-space manager */
@@ -8556,20 +8556,20 @@ test_page_large(const char *env_h5_drvr, hid_t fapl)
 
         /* Should be page aligned */
         if (gaddr1 % TBLOCK_SIZE4096)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a large data block with gaddr2--should be on another page */
         /* Allocate 1 page + 3904 bytes; 192 bytes in free-space manager */
         gaddr2 = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE8000);
         /* Should be page aligned */
         if (gaddr2 % TBLOCK_SIZE4096)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a large data block with gaddr3--should be on another page */
         /* Allocate 2 pages + 3808 bytes; 288 bytes in free-space manager */
         gaddr3 = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE12000);
         if (!H5F_addr_defined(gaddr3))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free the block with gaddr2 */
         /* Merged sections: 2192 + 8000 + 192 = 10384 */
@@ -8577,13 +8577,13 @@ test_page_large(const char *env_h5_drvr, hid_t fapl)
 
         /* Get free-space info */
         if (H5FS_stat_info(f, f->shared->fs_man[H5F_MEM_PAGE_GENERIC], &fs_stat) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Verify that the manager contains 2 free-space sections: 10384 and 288 */
         if (fs_stat.tot_sect_count != 2)
-            TEST_ERROR
+            TEST_ERROR;
         if (fs_stat.tot_space != (10384 + 288))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a large data block with gaddr4--there is a free-space section able to fulfill the request
          */
@@ -8592,18 +8592,18 @@ test_page_large(const char *env_h5_drvr, hid_t fapl)
 
         /* Should be page aligned */
         if (gaddr4 % TBLOCK_SIZE4096)
-            TEST_ERROR
+            TEST_ERROR;
         if (gaddr4 != gaddr2)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get free-space info */
         if (H5FS_stat_info(f, f->shared->fs_man[H5F_MEM_PAGE_GENERIC], &fs_stat) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         /* Verify that that there are 3 free-space sections */
         if (fs_stat.tot_sect_count != 3)
-            TEST_ERROR
+            TEST_ERROR;
         if (fs_stat.tot_space != (2192 + 3192 + 288))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free the two blocks with gaddr1 and gaddr4 */
         H5MF_xfree(f, H5FD_MEM_DRAW, gaddr1, (hsize_t)TBLOCK_SIZE6000);
@@ -8611,28 +8611,28 @@ test_page_large(const char *env_h5_drvr, hid_t fapl)
 
         /* Get free-space info */
         if (H5FS_stat_info(f, f->shared->fs_man[H5F_MEM_PAGE_GENERIC], &fs_stat) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         /* Verify that that there are 2 free-space sections: 16384 (4 pages) + 288 */
         if (fs_stat.tot_sect_count != 2)
-            TEST_ERROR
+            TEST_ERROR;
         if (fs_stat.tot_space != (16384 + 288))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close file */
         if (H5Fclose(fid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close the property list */
         if (H5Pclose(fcpl) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get the size of the file */
         if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Verify that file size end on a page boundary */
         if (file_size % TBLOCK_SIZE4096)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     }
@@ -8695,19 +8695,19 @@ test_page_small(const char *env_h5_drvr, hid_t fapl)
 
         /* File creation property list */
         if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set the strategy to paged aggregation */
         if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_PAGE, FALSE, (hsize_t)1) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create the file to work on */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(fid)))
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Allocate 2 small metadata blocks: addr1, addr2 */
         H5MF_alloc(f, H5FD_MEM_OHDR, (hsize_t)TBLOCK_SIZE30);
@@ -8717,44 +8717,44 @@ test_page_small(const char *env_h5_drvr, hid_t fapl)
         saddr1 = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE30);
         /* Should be on the second page and page aligned */
         if (saddr1 % TBLOCK_SIZE4096)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a small raw data block with saddr2 */
         saddr2 = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE50);
         /* Should not be page aligned */
         if (!(saddr2 % TBLOCK_SIZE4096))
-            TEST_ERROR
+            TEST_ERROR;
         /* Should be next to the block with saddr1 */
         if (saddr2 != (saddr1 + TBLOCK_SIZE30))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a small metadata block with addr3--there is no free-space section big enough to fulfill
          * the request */
         addr3 = H5MF_alloc(f, H5FD_MEM_OHDR, (hsize_t)TBLOCK_SIZE4020);
         /* Should be on the third page and page aligned */
         if (addr3 % TBLOCK_SIZE4096)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a small metadata block with addr4--there is a free-space section big enough to fulfill the
          * request */
         addr4 = H5MF_alloc(f, H5FD_MEM_OHDR, (hsize_t)TBLOCK_SIZE80);
         /* Should not be page aligned */
         if (!(addr4 % TBLOCK_SIZE4096))
-            TEST_ERROR
+            TEST_ERROR;
         /* Should be next to the block with addr2 */
         if (addr4 != (addr2 + TBLOCK_SIZE50))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a small metadata block with addr5--there is a free-space section big enough to fulfill the
          * request */
         addr5 = H5MF_alloc(f, H5FD_MEM_OHDR, (hsize_t)TBLOCK_SIZE40);
         /* Should not be page aligned */
         if (!(addr5 % TBLOCK_SIZE4096))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Should be next to the block with addr3 */
         if (addr5 != (addr3 + TBLOCK_SIZE4020))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a small metadata block with addr6--taking up the remaining space in the first page */
         if (family)
@@ -8776,18 +8776,18 @@ test_page_small(const char *env_h5_drvr, hid_t fapl)
 
         /* Verify that the large manager does contain a section with file space page size (default is 4096) */
         if (!f->shared->fs_man[H5F_MEM_PAGE_GENERIC])
-            TEST_ERROR
+            TEST_ERROR;
         if (H5FS_stat_info(f, f->shared->fs_man[H5F_MEM_PAGE_GENERIC], &fs_stat) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (fs_stat.tot_space != TBLOCK_SIZE4096)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a small metadata block with addr10--there is a free-space section big enough to fulfill
          * the request */
         addr10 = H5MF_alloc(f, H5FD_MEM_OHDR, (hsize_t)TBLOCK_SIZE3900);
         /* The block should be next to the block with addr9 */
         if (addr10 != (addr9 + TBLOCK_SIZE80))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate a small metadata block with addr11 */
         /* The current free-space section is unable to fulfill the request; obtain a page from the large
@@ -8795,15 +8795,15 @@ test_page_small(const char *env_h5_drvr, hid_t fapl)
         addr11 = H5MF_alloc(f, H5FD_MEM_OHDR, (hsize_t)TBLOCK_SIZE80);
         /* The address of the block should be the same the freed block with saddr1 */
         if (addr11 != saddr1)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close file */
         if (H5Fclose(fid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Close the property list */
         if (H5Pclose(fcpl) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         PASSED();
     }
@@ -8872,15 +8872,15 @@ test_page_alignment(const char *env_h5_drvr, hid_t fapl)
          */
 
         if ((fapl_new = H5Pcopy(fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* The alignment to use will be the library's default file space page size */
         if (H5Pset_libver_bounds(fapl_new, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set alignment value to 16 */
         if (H5Pset_alignment(fapl_new, (hsize_t)0, (hsize_t)TEST_ALIGN16) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (split || multi) {
             hid_t      memb_fapl;
@@ -8893,22 +8893,22 @@ test_page_alignment(const char *env_h5_drvr, hid_t fapl)
 
             /* Create fapl */
             if ((memb_fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Set alignment */
             if (H5Pset_alignment(memb_fapl, 0, (hsize_t)TEST_ALIGN16) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             HDmemset(memb_name, 0, sizeof memb_name);
 
             if (split) {
                 /* Set split driver with new FAPLs */
                 if (H5Pset_fapl_split(fapl_new, "-m.h5", memb_fapl, "-r.h5", memb_fapl) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Get current multi settings */
                 if (H5Pget_fapl_multi(fapl_new, memb_map, memb_fapl_arr, memb_name, memb_addr, &relax) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Set memb_addr aligned */
                 memb_addr[H5FD_MEM_SUPER] =
@@ -8919,12 +8919,12 @@ test_page_alignment(const char *env_h5_drvr, hid_t fapl)
                 /* Set split driver with new FAPLs */
                 if (H5Pset_fapl_multi(fapl_new, memb_map, memb_fapl_arr, (const char *const *)memb_name,
                                       memb_addr, relax) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             }
             else {
                 /* Get current multi settings */
                 if (H5Pget_fapl_multi(fapl_new, memb_map, NULL, memb_name, memb_addr, &relax) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Populate memb_fapl_arr */
                 /* Set memb_addr aligned */
@@ -8937,7 +8937,7 @@ test_page_alignment(const char *env_h5_drvr, hid_t fapl)
                 /* Set multi driver with new FAPLs */
                 if (H5Pset_fapl_multi(fapl_new, memb_map, memb_fapl_arr, (const char *const *)memb_name,
                                       memb_addr, relax) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
             } /* end else */
 
@@ -8947,25 +8947,25 @@ test_page_alignment(const char *env_h5_drvr, hid_t fapl)
 
             /* Close memb_fapl */
             if (H5Pclose(memb_fapl) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
 
         /* File creation property list */
         if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Set the strategy to paged aggregation and persisting free space */
         /* The alignment to use will be the library's default file space page size */
         if (H5Pset_file_space_strategy(fcpl, H5F_FSPACE_STRATEGY_PAGE, TRUE, (hsize_t)1) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create the file to work on */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl_new)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(fid)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate 2 small raw data blocks */
         saddr1 = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE30);
@@ -8973,11 +8973,11 @@ test_page_alignment(const char *env_h5_drvr, hid_t fapl)
 
         /* Should be on the second page and page aligned on 4096 (default file space page size) */
         if (saddr1 % TBLOCK_SIZE4096)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Should be next to the block with saddr1 */
         if (saddr2 != (saddr1 + TBLOCK_SIZE30))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate 2 large raw data blocks */
         gaddr1 = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE5000);
@@ -8985,19 +8985,19 @@ test_page_alignment(const char *env_h5_drvr, hid_t fapl)
 
         /* Should be on the 3rd page and page aligned */
         if (gaddr1 % TBLOCK_SIZE4096)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Should be on the 4th page and page aligned */
         if (gaddr2 % TBLOCK_SIZE4096)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the file creation property list */
         if (H5Pclose(fcpl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close file */
         if (H5Fclose(fid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /*
          * Case 2: Verify that the alignment in use is the alignment set
@@ -9006,18 +9006,18 @@ test_page_alignment(const char *env_h5_drvr, hid_t fapl)
         /* fapl_new has latest format and H5Pset_alignment set */
         /* Disable small data block mechanism */
         if (H5Pset_small_data_block_size(fapl_new, (hsize_t)0) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         /* Disable metadata block mechanism */
         if (H5Pset_meta_block_size(fapl_new, (hsize_t)0) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create the file to work on */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_new)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(fid)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate 2 small metadata blocks */
         addr1 = H5MF_alloc(f, H5FD_MEM_SUPER, (hsize_t)TBLOCK_SIZE30);
@@ -9025,12 +9025,12 @@ test_page_alignment(const char *env_h5_drvr, hid_t fapl)
 
         /* Should be aligned on 16 */
         if (addr1 % TEST_ALIGN16 || addr2 % TEST_ALIGN16)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* addr2 should be right next to the block with addr1 */
         if ((addr1 + TBLOCK_SIZE30) % TEST_ALIGN16)
             if (addr2 != (((addr1 + TBLOCK_SIZE30) / TEST_ALIGN16) + 1) * TEST_ALIGN16)
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Allocate 2 small raw data blocks */
         saddr1 = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE80);
@@ -9038,23 +9038,23 @@ test_page_alignment(const char *env_h5_drvr, hid_t fapl)
 
         /* Should be aligned on 16 */
         if (saddr1 % TEST_ALIGN16 || saddr2 % TEST_ALIGN16)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (!multi && !split) {
             /* saddr1 should be right next to the block with addr2 */
             if ((addr2 + TBLOCK_SIZE50) % TEST_ALIGN16)
                 if (saddr1 != (((addr2 + TBLOCK_SIZE50) / TEST_ALIGN16) + 1) * TEST_ALIGN16)
-                    TEST_ERROR
+                    TEST_ERROR;
         }
 
         /* saddr2 should be right next to the block with saddr1 */
         if ((saddr1 + TBLOCK_SIZE80) % TEST_ALIGN16)
             if (saddr2 != (((saddr1 + TBLOCK_SIZE80) / TEST_ALIGN16) + 1) * TEST_ALIGN16)
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Close file */
         if (H5Fclose(fid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /*
          * Case 3: Verify that the alignment in use is the alignment set
@@ -9062,23 +9062,23 @@ test_page_alignment(const char *env_h5_drvr, hid_t fapl)
          */
         /* File creation property list */
         if ((fcpl2 = H5Pcreate(H5P_FILE_CREATE)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Set file space page size */
         if (H5Pset_file_space_page_size(fcpl2, (hsize_t)TBLOCK_SIZE8192) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Set strategy to H5F_FSPACE_STRATEGY_AGGR but meta/raw data block is 0 as set in fapl_new */
         if (H5Pset_file_space_strategy(fcpl2, H5F_FSPACE_STRATEGY_AGGR, FALSE, (hsize_t)1) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* fapl_new has latest format, H5Pset_alignment set, and disable meta/raw block */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl2, fapl_new)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get a pointer to the internal file object */
         if (NULL == (f = (H5F_t *)H5VL_object(fid)))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Allocate 2 small raw data blocks */
         saddr1 = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE30);
@@ -9086,38 +9086,38 @@ test_page_alignment(const char *env_h5_drvr, hid_t fapl)
 
         /* Should be aligned on 16 */
         if (saddr1 % TEST_ALIGN16)
-            TEST_ERROR
+            TEST_ERROR;
         if (saddr2 % TEST_ALIGN16)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* saddr2 should be right next to the block with saddr1 */
         if ((saddr1 + TBLOCK_SIZE30) % TEST_ALIGN16)
             if (saddr2 != (((saddr1 + TBLOCK_SIZE30) / TEST_ALIGN16) + 1) * TEST_ALIGN16)
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Allocate a large raw data block */
         gaddr1 = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE5000);
 
         /* Should be aligned on 16 */
         if (gaddr1 % TEST_ALIGN16)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* gaddr1 is right next to the block with saddr2 */
         if ((saddr2 + TBLOCK_SIZE50) % TEST_ALIGN16)
             if (gaddr1 != (((saddr2 + TBLOCK_SIZE50) / TEST_ALIGN16) + 1) * TEST_ALIGN16)
-                TEST_ERROR
+                TEST_ERROR;
 
         /* There is no free-space manager involved for H5F_FSPACE_STRATEGY_AGGR strategy */
         if (f->shared->fs_man[H5FD_MEM_DRAW] || f->shared->fs_man[H5FD_MEM_SUPER])
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Closing */
         if (H5Fclose(fid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(fcpl2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(fapl_new) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         PASSED();
     }
@@ -9161,12 +9161,12 @@ main(void)
 
     /* Push API context */
     if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = TRUE;
 
     /* Make a copy of the FAPL before adjusting the alignment */
     if ((new_fapl = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* For old library format--interaction with file allocation */
     nerrors += test_mf_eoa(env_h5_drvr, fapl);
     nerrors += test_mf_eoa_shrink(env_h5_drvr, fapl);
@@ -9198,12 +9198,12 @@ main(void)
         switch (curr_test) {
             case TEST_NORMAL: /* set alignment = 1024 */
                 if (H5Pset_alignment(new_fapl, (hsize_t)0, (hsize_t)TEST_ALIGN1024) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 break;
 
             case TEST_AGGR_SMALL: /* set alignment = 4096 */
                 if (H5Pset_alignment(new_fapl, (hsize_t)0, (hsize_t)TEST_ALIGN4096) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 break;
 
             case TEST_NTESTS:
@@ -9275,12 +9275,12 @@ main(void)
     nerrors += test_mf_bug1(env_h5_drvr, fapl);
 
     if (H5Pclose(new_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     h5_cleanup(FILENAME, fapl);
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = FALSE;
 
     if (nerrors)

--- a/test/mount.c
+++ b/test/mount.c
@@ -55,43 +55,43 @@ setup(hid_t fapl)
     /* file 1 */
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(H5Gcreate2(file, "/mnt1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(H5Gcreate2(file, "/mnt1/file1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(H5Gcreate2(file, "/mnt_unlink", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(H5Gcreate2(file, "/mnt_move_a", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_hard(file, "/mnt1/file1", H5L_SAME_LOC, "/file1", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_hard(file, "/mnt1", H5L_SAME_LOC, "/mnt1_link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* file 2 */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(H5Gcreate2(file, "/file2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(H5Gcreate2(file, "/rename_a", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(H5Gcreate2(file, "/rename_b", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(H5Gcreate2(file, "/rename_a/x", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* file 3 */
     h5_fixname(FILENAME[2], fapl, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     return 0;
 
@@ -133,19 +133,19 @@ test_basic(hid_t fapl)
 
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0 ||
         (file2 = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fmount(file1, "/mnt1", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((grp = H5Gopen2(file1, "/mnt1/file2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(grp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Funmount(file1, "/mnt1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -193,11 +193,11 @@ test_illegal(hid_t fapl)
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0 ||
         (file2 = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0 ||
         (file3 = H5Fopen(filename3, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((file1b = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((file3b = H5Fopen(filename3, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Try mounting a file on itself */
     H5E_BEGIN_TRY
@@ -208,7 +208,7 @@ test_illegal(hid_t fapl)
     if (status >= 0) {
         H5_FAILED();
         HDputs("    Mounting a file on itself should have failed.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /*
@@ -217,9 +217,9 @@ test_illegal(hid_t fapl)
      * the root of file2 and the mount will succeed.
      */
     if ((mnt = H5Gopen2(file1, "/mnt1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fmount(mnt, ".", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     H5E_BEGIN_TRY
     {
         status = H5Fmount(mnt, ".", file3, H5P_DEFAULT);
@@ -228,12 +228,12 @@ test_illegal(hid_t fapl)
     if (status >= 0) {
         H5_FAILED();
         HDputs("    Mounting two files at one mount point should have failed.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Funmount(mnt, ".") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(mnt) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Try mounting the same file opened twice at the same place.
@@ -242,9 +242,9 @@ test_illegal(hid_t fapl)
      * end up mounting file3b at the root of file3 and the mount will succeed.
      */
     if ((mnt = H5Gopen2(file1, "/mnt1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fmount(mnt, ".", file3, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     H5E_BEGIN_TRY
     {
         status = H5Fmount(mnt, ".", file3b, H5P_DEFAULT);
@@ -253,16 +253,16 @@ test_illegal(hid_t fapl)
     if (status >= 0) {
         H5_FAILED();
         HDputs("    Mounting same file opened twice at one mount point should have failed.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Funmount(mnt, ".") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(mnt) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Try to create a "weak" cycle */
     if (H5Fmount(file1, "/mnt1", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     H5E_BEGIN_TRY
     {
         status = H5Fmount(file2, "/mnt1/file2", file1b, H5P_DEFAULT);
@@ -271,22 +271,22 @@ test_illegal(hid_t fapl)
     if (status >= 0) {
         H5_FAILED();
         HDputs("    Creating a cycle with mount points should have failed.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Funmount(file1, "/mnt1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close everything and return */
     if (H5Fclose(file1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1b) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file3b) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -335,13 +335,13 @@ test_samefile(hid_t fapl)
 
     /* Open the files */
     if ((file1a = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((file1b = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((file2 = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((file3 = H5Fopen(filename3, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Try mounting different files at the same place in each of the "top"
@@ -351,36 +351,36 @@ test_samefile(hid_t fapl)
      * end up mounting file4 at the root of file3 and the mount will succeed.
      */
     if ((mnt1a = H5Gopen2(file1a, "/mnt1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gget_info(mnt1a, &grp_info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (grp_info.mounted)
-        FAIL_PUTS_ERROR("    Group shouldn't have 'mounted' flag set.")
+        FAIL_PUTS_ERROR("    Group shouldn't have 'mounted' flag set.");
     if ((mnt1b = H5Gopen2(file1b, "/mnt1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gget_info(mnt1b, &grp_info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (grp_info.mounted)
-        FAIL_PUTS_ERROR("    Group shouldn't have 'mounted' flag set.")
+        FAIL_PUTS_ERROR("    Group shouldn't have 'mounted' flag set.");
     if (H5Fmount(mnt1a, ".", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gget_info(mnt1a, &grp_info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!grp_info.mounted)
-        FAIL_PUTS_ERROR("    Group should have 'mounted' flag set.")
+        FAIL_PUTS_ERROR("    Group should have 'mounted' flag set.");
     H5E_BEGIN_TRY
     {
         status = H5Fmount(mnt1b, ".", file3, H5P_DEFAULT);
     }
     H5E_END_TRY;
     if (status >= 0)
-        FAIL_PUTS_ERROR("    Mounting different files at one mount point should have failed.")
+        FAIL_PUTS_ERROR("    Mounting different files at one mount point should have failed.");
     if (H5Funmount(mnt1a, ".") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(mnt1a) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(mnt1b) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Try mounting same files at the same place in each of the "top"
@@ -390,46 +390,46 @@ test_samefile(hid_t fapl)
      * end up mounting file4 at the root of file3 and the mount will succeed.
      */
     if ((mnt1a = H5Gopen2(file1a, "/mnt1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gget_info(mnt1a, &grp_info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (grp_info.mounted)
-        FAIL_PUTS_ERROR("    Group shouldn't have 'mounted' flag set.")
+        FAIL_PUTS_ERROR("    Group shouldn't have 'mounted' flag set.");
     if ((mnt1b = H5Gopen2(file1b, "/mnt1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gget_info(mnt1b, &grp_info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (grp_info.mounted)
-        FAIL_PUTS_ERROR("    Group shouldn't have 'mounted' flag set.")
+        FAIL_PUTS_ERROR("    Group shouldn't have 'mounted' flag set.");
     if (H5Fmount(mnt1a, ".", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gget_info(mnt1a, &grp_info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (!grp_info.mounted)
-        FAIL_PUTS_ERROR("    Group should have 'mounted' flag set.")
+        FAIL_PUTS_ERROR("    Group should have 'mounted' flag set.");
     H5E_BEGIN_TRY
     {
         status = H5Fmount(mnt1b, ".", file2, H5P_DEFAULT);
     }
     H5E_END_TRY;
     if (status >= 0)
-        FAIL_PUTS_ERROR("    Mounting same files at one mount point should have failed.")
+        FAIL_PUTS_ERROR("    Mounting same files at one mount point should have failed.");
     if (H5Funmount(mnt1a, ".") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(mnt1a) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(mnt1b) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close everything and return */
     if (H5Fclose(file1a) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1b) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -480,15 +480,15 @@ test_hide(hid_t fapl)
 
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0 ||
         (file2 = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get information about file1:/mnt1/file1 for later */
     if (H5Oget_info_by_name3(file1, "/mnt1/file1", &oi1, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Build the virtual file */
     if (H5Fmount(file1, "/mnt1", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Original names under file1:/mnt1 should not be accessible */
     H5E_BEGIN_TRY
@@ -499,7 +499,7 @@ test_hide(hid_t fapl)
     if (grp >= 0) {
         H5_FAILED();
         HDputs("    Name is still accessible under mount point.");
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /*
@@ -507,14 +507,14 @@ test_hide(hid_t fapl)
      * other names.  This is a rather stupid test but demonstrates a point.
      */
     if (H5Oget_info_by_name3(file1, "/file1", &oi2, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     same_obj = TRUE;
     if (oi1.fileno == oi2.fileno) {
         int token_cmp;
 
         if (H5Otoken_cmp(file1, &oi1.token, &oi2.token, &token_cmp) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (token_cmp)
             same_obj = FALSE;
     }
@@ -524,16 +524,16 @@ test_hide(hid_t fapl)
     if (!same_obj) {
         H5_FAILED();
         HDputs("    Hard link failed for hidden object.");
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* Unmount and close objects */
     if (H5Funmount(file1, "/mnt1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -581,29 +581,29 @@ test_assoc(hid_t fapl)
     /* Open the files */
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0 ||
         (file2 = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get information about the root of file2 */
     if (H5Oget_info3(file2, &oi1, H5O_INFO_BASIC) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the virtual file */
     if (H5Fmount(file1, "/mnt1", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Get info about the mount point -- should be the same as the root group
      * of file2.
      */
     if (H5Oget_info_by_name3(file1, "/mnt1", &oi2, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     same_obj = TRUE;
     if (oi1.fileno == oi2.fileno) {
         int token_cmp;
 
         if (H5Otoken_cmp(file1, &oi1.token, &oi2.token, &token_cmp) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (token_cmp)
             same_obj = FALSE;
     }
@@ -613,16 +613,16 @@ test_assoc(hid_t fapl)
     if (!same_obj) {
         H5_FAILED();
         HDputs("    Association failed.");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Shut down */
     if (H5Funmount(file1, "/mnt1_link") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -668,30 +668,30 @@ test_mntlnk(hid_t fapl)
     /* Build the virtual file */
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0 ||
         (file2 = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fmount(file1, "/mnt1", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Can we see file2:/file2 as both file1:/mnt1/file2 and
      * file1:/mnt1_link/file2?
      */
     if ((grp = H5Gopen2(file1, "/mnt1/file2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(grp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((grp = H5Gopen2(file1, "/mnt1_link/file2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(grp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Unlink using second name */
     if (H5Funmount(file1, "/mnt1_link") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -739,13 +739,13 @@ test_move(hid_t fapl)
     /* Build the virtual file */
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0 ||
         (file2 = H5Fopen(filename2, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fmount(file1, "/mnt1", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* First rename an object in the mounted file, then try it across files */
     if (H5Lmove(file1, "/mnt1/rename_a/x", H5L_SAME_LOC, "/mnt1/rename_b/y", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     H5E_BEGIN_TRY
     {
         status = H5Lmove(file1, "/mnt1/rename_b/y", H5L_SAME_LOC, "/y", H5P_DEFAULT, H5P_DEFAULT);
@@ -754,16 +754,16 @@ test_move(hid_t fapl)
     if (status >= 0) {
         H5_FAILED();
         HDputs("    Moving an object across files shouldn't have been possible");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Shut down */
     if (H5Funmount(file1, "/mnt1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -808,29 +808,29 @@ test_preopen(hid_t fapl)
 
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0 ||
         (file2 = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open something under the mount point */
     if ((grp = H5Gopen2(file1, "/mnt1/file1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Build the virtual file */
     if (H5Fmount(file1, "/mnt1", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Now access the thing we previously opened */
     if (H5Oget_info3(grp, &oinfo, H5O_INFO_BASIC) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Shut down */
     if (H5Funmount(file1, "/mnt1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(grp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -879,33 +879,33 @@ test_postopen(hid_t fapl)
     /* Create the virtual file */
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0 ||
         (file2 = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fmount(file1, "/mnt1", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open some object in the mounted file */
     if ((grp = H5Gopen2(file1, "/mnt1/file2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Unmount the file */
     if (H5Funmount(file1, "/mnt1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Now access the thing we previously opened */
     if (H5Oget_info3(grp, &oinfo, H5O_INFO_BASIC) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Try accessing it from the file */
     if (H5Oget_info_by_name3(file2, "/file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Shut down */
     if (H5Gclose(grp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -954,7 +954,7 @@ test_unlink(hid_t fapl)
     /* Open files */
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0 ||
         (file2 = H5Fopen(filename2, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Opening the mount point before mounting opens the group in the parent
@@ -962,11 +962,11 @@ test_unlink(hid_t fapl)
      * opening the root group of the child file.
      */
     if ((mnt = H5Gopen2(file1, "/mnt_unlink", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fmount(file1, "/mnt_unlink", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((root = H5Gopen2(file1, "/mnt_unlink", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * "/file2" of file2 should be visible as an absolute name through either
@@ -975,13 +975,13 @@ test_unlink(hid_t fapl)
      * than the group mounted there.
      */
     if (H5Oget_info_by_name3(file1, "/mnt_unlink/file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_info_by_name3(mnt, "/mnt_unlink/file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_info_by_name3(root, "/mnt_unlink/file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_info_by_name3(root, "file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     H5E_BEGIN_TRY
     {
         status = H5Oget_info_by_name3(mnt, "file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT);
@@ -990,19 +990,19 @@ test_unlink(hid_t fapl)
     if (status >= 0) {
         H5_FAILED();
         HDputs("    Incorrect traversal from mount point!");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Unlink the mount point */
     if (H5Ldelete(file1, "/mnt_unlink", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * We should still be able to get to "/file2" of file2 by starting at
      * `root' which is still open, but not by name.
      */
     if (H5Oget_info_by_name3(root, "file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     H5E_BEGIN_TRY
     {
         status = H5Oget_info_by_name3(mnt, "file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT);
@@ -1011,7 +1011,7 @@ test_unlink(hid_t fapl)
     if (status >= 0) {
         H5_FAILED();
         HDputs("    Traversal through mount point should not have worked!");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     H5E_BEGIN_TRY
     {
@@ -1021,7 +1021,7 @@ test_unlink(hid_t fapl)
     if (status >= 0) {
         H5_FAILED();
         HDputs("    Traversal through mount point should not have worked!");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /*
@@ -1037,7 +1037,7 @@ test_unlink(hid_t fapl)
     if (status >= 0) {
         H5_FAILED();
         HDprintf("    %d: Unmount by name should not have been allowed!\n", __LINE__);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     H5E_BEGIN_TRY
     {
@@ -1047,20 +1047,20 @@ test_unlink(hid_t fapl)
     if (status >= 0) {
         H5_FAILED();
         HDprintf("    %d: Unmount by name should not have been allowed!\n", __LINE__);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Funmount(mnt, ".") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close files */
     if (H5Gclose(mnt) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(root) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -1107,25 +1107,25 @@ test_mvmpt(hid_t fapl)
     /* Build the virtual file */
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0 ||
         (file2 = H5Fopen(filename2, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fmount(file1, "/mnt_move_a", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Rename the mount point */
     if (H5Lmove(file1, "/mnt_move_a", H5L_SAME_LOC, "/mnt_move_b", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Access something under the new name */
     if (H5Oget_info_by_name3(file1, "/mnt_move_b/file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Shut down */
     if (H5Funmount(file1, "/mnt_move_b") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -1174,9 +1174,9 @@ test_interlink(hid_t fapl)
     /* Build the virtual file */
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0 ||
         (file2 = H5Fopen(filename2, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fmount(file1, "/mnt1", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Try an interfile hard link directly */
     H5E_BEGIN_TRY
@@ -1187,7 +1187,7 @@ test_interlink(hid_t fapl)
     if (status >= 0) {
         H5_FAILED();
         HDputs("    Interfile hard link should not have been allowed!");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Try an interfile hard link by renaming something */
@@ -1199,7 +1199,7 @@ test_interlink(hid_t fapl)
     if (status >= 0) {
         H5_FAILED();
         HDputs("    Interfile renaming should not have been allowed!");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
 /* Commented this code out until Jira issue #7638 is resolved.  Once that
@@ -1209,11 +1209,11 @@ test_interlink(hid_t fapl)
 #ifdef NOT_NOW
     /* Try an interfile hard link by sharing a data type */
     if ((type = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tcommit2(file1, "/type1", type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((space = H5Screate_simple(1, cur_dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     H5E_BEGIN_TRY
     {
         dset = H5Dcreate2(file1, "/mnt1/file2/dset", type, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -1222,14 +1222,14 @@ test_interlink(hid_t fapl)
     if (dset >= 0) {
         H5_FAILED();
         HDputs("    Dataset and shared type must be in the same file!");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Close IDs */
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 #else  /* NOT_NOW */
     SKIPPED();
     HDputs("    Test skipped due file pointer sharing issue (Jira 7638).");
@@ -1237,11 +1237,11 @@ test_interlink(hid_t fapl)
 
     /* Shut down */
     if (H5Funmount(file1, "/mnt1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -1292,41 +1292,41 @@ test_uniformity(hid_t fapl)
     /* Build the virtual file */
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0 ||
         (file2 = H5Fopen(filename2, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fmount(file1, "/mnt1", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Access some things from the file1 handle */
     if (H5Oget_info_by_name3(file1, "/", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_info_by_name3(file1, "/mnt1", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_info_by_name3(file1, "mnt1", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_info_by_name3(file1, "/mnt1/file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_info_by_name3(file1, "mnt1/file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Access the same things from the file2 handle */
     if (H5Oget_info_by_name3(file2, "/", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_info_by_name3(file2, "/mnt1", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_info_by_name3(file2, "mnt1", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_info_by_name3(file2, "/mnt1/file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_info_by_name3(file2, "mnt1/file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Shut down */
     if (H5Funmount(file1, "/mnt1") < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -1371,49 +1371,49 @@ test_close(hid_t fapl)
     /* Build the virtual file */
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0 ||
         (file2 = H5Fopen(filename2, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fmount(file1, "/mnt1", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Close file1 unmounting it from the virtual file.  Objects in file1 are
      * still accessible through the file2 handle.
      */
     if (H5Fclose(file1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_info_by_name3(file2, "/mnt1", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0) {
         H5_FAILED();
         HDputs("    File1 contents are not accessible!");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     /* Build the virtual file again */
     if ((file1 = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0 ||
         (file2 = H5Fopen(filename2, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fmount(file1, "/mnt1", file2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Close file2.  It is not actually closed because it's a child of file1.
      */
     if (H5Fclose(file2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_info_by_name3(file1, "/mnt1/file2", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     /* Shut down */
@@ -1480,30 +1480,30 @@ test_mount_after_close(hid_t fapl)
       /A/B/T                   -> /A
     */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((gidA = H5Gcreate2(fid1, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((gidAB = H5Gcreate2(gidA, "B", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Mount point */
     if ((gidABM = H5Gcreate2(gidAB, "M", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Soft link */
     if (H5Lcreate_soft("./M/X/Y", gidAB, "C", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Soft link */
     if (H5Lcreate_soft("/A", gidAB, "T", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close groups and file */
     if (H5Gclose(gidABM) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gidAB) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gidA) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create second file and dataset "D" in it. */
     /* h5ls shows: */
@@ -1513,38 +1513,38 @@ test_mount_after_close(hid_t fapl)
        /X/Y/D                   Dataset {4, 5}
      */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     dims[0] = NX;
     dims[1] = NY;
     if ((sid = H5Screate_simple(RANK, dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((gidX = H5Gcreate2(fid2, "/X", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((gidXY = H5Gcreate2(gidX, "Y", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did = H5Dcreate2(gidXY, "D", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Soft link */
     if (H5Lcreate_soft("./Y", gidX, "T", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write data to the dataset. */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, bm) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close all identifiers. */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gidXY) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gidX) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Beginning of the actual test code */
 
@@ -1552,93 +1552,93 @@ test_mount_after_close(hid_t fapl)
      * Reopen both files
      */
     if ((fid1 = H5Fopen(filename1, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /*
      *  Open /A/B to use as a mount point
      */
     if ((gidAB = H5Gopen2(fid1, "/A/B", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      *  Close the parent file. This keeps the file open because of the other handle on the group within
      */
     /* We close the file (it should stay open from the group) */
     if (H5Fclose(fid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Mount second file under G in the first file.
      */
     if (H5Fmount(gidAB, "M", fid2, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open "normal" group in mounted file */
     /* (This shows we successfully mounted) */
     if ((gidABMX = H5Gopen2(gidAB, "M/X", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     *objname = '\0';
     if (H5Iget_name(gidABMX, objname, (size_t)NAME_BUF_SIZE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(objname, "/A/B/M/X") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close object in mounted file */
     if (H5Gclose(gidABMX) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open group in mounted file through softlink */
     if ((gidABC = H5Gopen2(gidAB, "C", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     *objname = '\0';
     if (H5Iget_name(gidABC, objname, (size_t)NAME_BUF_SIZE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(objname, "/A/B/C") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close object in mounted file */
     if (H5Gclose(gidABC) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open group in original file through softlink */
     if ((gidABT = H5Gopen2(gidAB, "T", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     *objname = '\0';
     if (H5Iget_name(gidABT, objname, (size_t)NAME_BUF_SIZE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(objname, "/A/B/T") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close object in original file */
     if (H5Gclose(gidABT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open "normal" dataset in mounted file */
     if ((didABMXYD = H5Dopen2(gidAB, "M/X/Y/D", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check name */
     *objname = '\0';
     if (H5Iget_name(didABMXYD, objname, (size_t)NAME_BUF_SIZE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(objname, "/A/B/M/X/Y/D") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close object in mounted file */
     if (H5Dclose(didABMXYD) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Gclose(gidAB) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Shut down */
     PASSED();
@@ -1706,63 +1706,63 @@ test_mount_after_unmount(hid_t fapl)
 
     /* Create first file and some groups in it. */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gidA = H5Gcreate2(fid1, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gidAM = H5Gcreate2(gidA, "M", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidAM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gidB = H5Gcreate2(fid1, "B", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gidBM = H5Gcreate2(gidB, "M", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidBM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidB) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create second file and a group in it. */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gidX = H5Gcreate2(fid2, "/X", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gidXM = H5Gcreate2(gidX, "M", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidXM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gidXX = H5Gcreate2(gidX, "X", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidXX) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidX) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create third file and a group in it. */
     if ((fid3 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gidY = H5Gcreate2(fid3, "/Y", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create fourth file and a group in it. */
     if ((fid4 = H5Fcreate(filename4, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gidZ = H5Gcreate2(fid4, "/Z", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidZ) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Beginning of the actual test code */
 
@@ -1770,140 +1770,140 @@ test_mount_after_unmount(hid_t fapl)
      * Reopen all three files
      */
     if ((fid1 = H5Fopen(filename1, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid3 = H5Fopen(filename3, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid4 = H5Fopen(filename4, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      *  Open /A & /B to use as a mount points
      */
     if ((gidA = H5Gopen2(fid1, "/A", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gidB = H5Gopen2(fid1, "/B", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Mount second file on /A/M in the first file.
      */
     if (H5Fmount(gidA, "M", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group in mounted file */
     /* (This shows we successfully mounted) */
     if ((gidAMXX = H5Gopen2(gidA, "M/X/X", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name */
     *objname = '\0';
     if (H5Iget_name(gidAMXX, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/A/M/X/X") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group in mounted file #2 */
     if ((gidAMX = H5Gopen2(gidA, "M/X", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount third file */
     if (H5Fmount(gidAMX, "M", fid3, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group in mounted file #3 */
     /* (This shows we successfully mounted) */
     if ((gidAMXMY = H5Gopen2(gidAMX, "M/Y", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name */
     *objname = '\0';
     if (H5Iget_name(gidAMXMY, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/A/M/X/M/Y") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount second file */
     if (H5Funmount(fid1, "/A/M") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name */
     *objname = '\0';
     if (H5Iget_name(gidAMXMY, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/X/M/Y") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Rename object in file #3 that is "disconnected" from name hierarchy */
     /* (It is "disconnected" because it's parent file has been unmounted) */
     if (H5Lmove(gidAMX, "M/Y", gidAMX, "M/Z", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in file #3 */
     if (H5Gclose(gidAMXMY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open group in file #3 */
     if ((gidAMXMY = H5Gopen2(gidAMX, "M/Z", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name again */
     *objname = '\0';
     if (H5Iget_name(gidAMXMY, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/X/M/Z") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount fourth file */
     if (H5Fmount(gidB, "M", fid4, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group in mounted file */
     /* (This shows we successfully mounted) */
     if ((gidBMZ = H5Gopen2(gidB, "M/Z", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name */
     *objname = '\0';
     if (H5Iget_name(gidBMZ, objname, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(objname, "/B/M/Z") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount third file */
     if (H5Funmount(fid2, "/X/M") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount fourth file */
     if (H5Funmount(fid1, "/B/M") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close objects in mounted files */
     if (H5Gclose(gidBMZ) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidAMXMY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidAMXX) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidAMX) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close objects in original file */
     if (H5Gclose(gidB) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close files */
     if (H5Fclose(fid4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Shut down */
     PASSED();
@@ -1967,104 +1967,104 @@ test_missing_unmount(hid_t fapl)
 
     /* Create file #1 */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gcreate2(fid1, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #2 */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidE = H5Gcreate2(fid2, "E", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #3 */
     if ((fid3 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidM = H5Gcreate2(fid3, "M", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open files and mount file #2 in file #1 and file #3 in file #2 */
     if ((fid1 = H5Fopen(filename1, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gopen2(fid1, "A", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fmount(gidA, ".", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group in mounted file */
     if ((gidAE = H5Gopen2(fid2, "A/E", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #2 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid3 = H5Fopen(filename3, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fmount(gidAE, ".", fid3, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group in mounted file */
     if ((gidAEM = H5Gopen2(fid3, "A/E/M", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #3 */
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* (Still have all file #2 & #3 mounted and groups open in all three files) */
 
     /* Unmount file #2 & #3 */
     if (H5Funmount(gidAE, ".") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Skip unmounting file #2 from file #1 */
 
     /* Close groups in mounted file */
     if (H5Gclose(gidAEM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidAE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in top file */
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     PASSED();
@@ -2117,87 +2117,87 @@ test_hold_open_file(hid_t fapl)
 
     /* Create file #1 */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gcreate2(fid1, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #2 */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidM = H5Gcreate2(fid2, "M", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open files and mount file #2 in file #1 */
     if ((fid1 = H5Fopen(filename1, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gopen2(fid1, "A", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fmount(gidA, ".", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidAM = H5Gopen2(fid1, "A/M", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #2 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in mounted file */
     if (H5Gclose(gidAM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to open group in mounted file */
     /* (Should work because file is still mounted) */
     if ((gidAM = H5Gopen2(fid1, "A/M", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in mounted file */
     if (H5Gclose(gidAM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to open group in mounted file */
     /* (Should work because file is still mounted) */
     if ((gidAM = H5Gopen2(gidA, "/A/M", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in mounted file */
     if (H5Gclose(gidAM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount file #2 */
     if (H5Funmount(gidA, ".") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in top file */
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     PASSED();
@@ -2247,111 +2247,111 @@ test_hold_open_group(hid_t fapl)
 
     /* Create file #1 */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gcreate2(fid1, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #2 */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidM = H5Gcreate2(fid2, "M", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open files and mount file #2 in file #1 */
     if ((fid1 = H5Fopen(filename1, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gopen2(fid1, "A", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fmount(gidA, ".", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidAM = H5Gopen2(fid1, "A/M", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #2 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in parent file */
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Keep fid1 & gidAM open, everything else closed */
 
     /* Retry to opening group in mounted file */
     /* (Should work because file is still mounted) */
     if ((gidAM2 = H5Gopen2(fid1, "A/M", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in mounted file */
     if (H5Gclose(gidAM2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close original group in mount file */
     if (H5Gclose(gidAM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to open group in mounted file */
     /* (Should work because file is still mounted) */
     if ((gidAM2 = H5Gopen2(fid1, "/A/M", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get ID of file #2 */
     if ((fid2 = H5Iget_file_id(gidAM2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in mounted file */
     if (H5Gclose(gidAM2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to open group in mounted file */
     /* (Should work because file is still mounted) */
     if ((gidAM2 = H5Gopen2(fid2, "/A/M", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #2 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to open group in parent file */
     /* (Should work because files should be mounted together) */
     if ((gid = H5Gopen2(gidAM2, "/", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in mounted file */
     if (H5Gclose(gidAM2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in parent file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     PASSED();
@@ -2405,47 +2405,47 @@ test_fcdegree_same(hid_t fapl)
 
     /* Create file #1 */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gcreate2(fid1, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #2 */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidM = H5Gcreate2(fid2, "M", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open files and mount file #2 in file #1 */
     if ((fid1 = H5Fopen(filename1, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gopen2(fid1, "A", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create FAPL & set file close degree for file #2 to be different */
     if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set file close mode to H5F_CLOSE_STRONG */
     if (H5Pset_fclose_degree(fapl_id, H5F_CLOSE_STRONG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try mounting file with different file close degree (should fail) */
     H5E_BEGIN_TRY
@@ -2454,49 +2454,49 @@ test_fcdegree_same(hid_t fapl)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set file close mode to H5F_CLOSE_WEAK */
     if (H5Pset_fclose_degree(fapl_id, H5F_CLOSE_WEAK) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #2 & re-open with same file close degree as file #1 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try mounting files again (should work now) */
     if (H5Fmount(gidA, ".", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify opening group in mounted file */
     if ((gidAM = H5Gopen2(fid1, "A/M", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in mounted file */
     if (H5Gclose(gidAM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in parent file */
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #2 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close FAPL ID */
     if (H5Pclose(fapl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     PASSED();
@@ -2549,59 +2549,59 @@ test_fcdegree_semi(hid_t fapl)
 
     /* Create file #1 */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gcreate2(fid1, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #2 */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidM = H5Gcreate2(fid2, "M", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create FAPL & set file close degree to be "semi" */
     if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set file close mode to H5F_CLOSE_SEMI */
     if (H5Pset_fclose_degree(fapl_id, H5F_CLOSE_SEMI) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open files and mount file #2 in file #1 */
     if ((fid1 = H5Fopen(filename1, H5F_ACC_RDONLY, fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gopen2(fid1, "A", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount files together */
     if (H5Fmount(gidA, ".", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify opening group in mounted file */
     if ((gidAM = H5Gopen2(fid1, "A/M", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #1 (should succeed, since file #2 is open still) */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try closing file #2 (should fail, since there are still objects open) */
     H5E_BEGIN_TRY
@@ -2610,11 +2610,11 @@ test_fcdegree_semi(hid_t fapl)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in parent file */
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Try closing file #2 (should still fail, since there are still objects open in child file) */
     H5E_BEGIN_TRY
@@ -2623,23 +2623,23 @@ test_fcdegree_semi(hid_t fapl)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in mounted file */
     if (H5Gclose(gidAM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #2 (should succeed now) */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close FAPL ID */
     if (H5Pclose(fapl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     PASSED();
@@ -2693,69 +2693,69 @@ test_fcdegree_strong(hid_t fapl)
 
     /* Create file #1 */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gcreate2(fid1, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #2 */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidM = H5Gcreate2(fid2, "M", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create FAPL & set file close degree to be "strong" */
     if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set file close mode to H5F_CLOSE_STRONG */
     if (H5Pset_fclose_degree(fapl_id, H5F_CLOSE_STRONG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open files and mount file #2 in file #1 */
     if ((fid1 = H5Fopen(filename1, H5F_ACC_RDONLY, fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gopen2(fid1, "A", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount files together */
     if (H5Fmount(gidA, ".", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group in mounted file */
     if ((gidAM = H5Gopen2(fid1, "A/M", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that objects are still open */
     if (H5Oget_info3(gidA, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(gidAM, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #2 (should close open objects also) */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that objects are closed */
     H5E_BEGIN_TRY
@@ -2764,22 +2764,22 @@ test_fcdegree_strong(hid_t fapl)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         ret = H5Oget_info3(gidAM, &oinfo, H5O_INFO_BASIC);
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close FAPL ID */
     if (H5Pclose(fapl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     PASSED();
@@ -2835,71 +2835,71 @@ test_acc_perm(hid_t fapl)
 
     /* Create file #1 */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gcreate2(fid1, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #2 */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidM = H5Gcreate2(fid2, "M", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open files and mount file #2 in file #1 */
     if ((fid1 = H5Fopen(filename1, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gopen2(fid1, "A", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get and verify file name */
     if (H5Fget_name(gidA, name, NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(name, filename1) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get and verify file name */
     if (H5Fget_name(fid2, name, NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(name, filename2) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount files together */
     if (H5Fmount(gidA, ".", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get and verify file name */
     if (H5Fget_name(fid2, name, NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(name, filename2) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group in mounted file */
     if ((gidAM = H5Gopen2(fid1, "A/M", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get and verify file name */
     if (H5Fget_name(gidAM, name, NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(name, filename2) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to create objects in read only file (should fail) */
     H5E_BEGIN_TRY
@@ -2908,48 +2908,48 @@ test_acc_perm(hid_t fapl)
     }
     H5E_END_TRY;
     if (bad_id >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5E_BEGIN_TRY
     {
         bad_id = H5Gcreate2(fid1, "/A/L", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     }
     H5E_END_TRY;
     if (bad_id >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to create objects in read/write file (should succeed) */
     if ((gidB = H5Gcreate2(fid2, "/B", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidB) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* (Note that this object should get created in the "hidden" group for "A" in parent file) */
     if ((gidC = H5Gcreate2(gidA, "C", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #3 (it will have R/W permissions) */
     if ((fid3 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount file #3 on file #2 */
     if (H5Fmount(gidAM, ".", fid3, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to create objects in read/write file (should succeed) */
     if ((gidAMZ = H5Gcreate2(fid1, "/A/M/Z", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get and verify file name */
     if (H5Fget_name(gidAMZ, name, NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(name, filename3) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close object in file #3 */
     if (H5Gclose(gidAMZ) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to create objects in read only file again (should fail) */
     H5E_BEGIN_TRY
@@ -2958,31 +2958,31 @@ test_acc_perm(hid_t fapl)
     }
     H5E_END_TRY;
     if (bad_id >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in mounted file */
     if (H5Gclose(gidAM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in parent file */
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #3 */
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #2 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     PASSED();
@@ -3040,167 +3040,167 @@ test_mult_mount(hid_t fapl)
 
     /* Create file #1 */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gcreate2(fid1, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidB = H5Gcreate2(fid1, "B", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidB) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #2 */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidM = H5Gcreate2(fid2, "M", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidN = H5Gcreate2(fid2, "N", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidN) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #3 */
     if ((fid3 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidS = H5Gcreate2(fid3, "S", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidS) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidT = H5Gcreate2(fid3, "T", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open files and mount file #2 in file #1 */
     if ((fid1 = H5Fopen(filename1, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gopen2(fid1, "A", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidB = H5Gopen2(fid1, "B", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount files together */
     if (H5Fmount(gidA, ".", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group in mounted file */
     if ((gidAM = H5Gopen2(fid1, "A/M", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open file #3 again */
     if ((fid3 = H5Fopen(filename3, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount file #3 on file #2 */
     if (H5Fmount(gidAM, ".", fid3, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open file #3 */
     if ((fid3_2 = H5Freopen(fid3)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount file #3 on file #1 also */
     if (H5Fmount(gidB, ".", fid3_2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object in file #3 through file #2 mount path */
     if ((gidAMT = H5Gopen2(fid1, "A/M/T", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name */
     *name = '\0';
     if (H5Iget_name(gidAMT, name, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(name, "/A/M/T") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object in file #3 */
     if ((gidU = H5Gcreate2(gidAMT, "U", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidU) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object in file #3 through file #1 mount path */
     if ((gidBS = H5Gopen2(fid1, "B/S", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name */
     *name = '\0';
     if (H5Iget_name(gidBS, name, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(name, "/B/S") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open object created in file #3 through file #1 mount path */
     if ((gidU = H5Gopen2(gidBS, "/B/T/U", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidU) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close groups in file #3 */
     if (H5Gclose(gidBS) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidAMT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in file #2 */
     if (H5Gclose(gidAM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close groups in file #1 */
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidB) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #3 IDs */
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid3_2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #2 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     PASSED();
@@ -3264,94 +3264,94 @@ test_nested_survive(hid_t fapl)
 
     /* Create file #1 */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gcreate2(fid1, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #2 */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidM = H5Gcreate2(fid2, "M", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #3 */
     if ((fid3 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidS = H5Gcreate2(fid3, "S", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidS) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open files and mount file #2 in file #1 */
     if ((fid1 = H5Fopen(filename1, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gopen2(fid1, "A", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount files together */
     if (H5Fmount(gidA, ".", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group in mounted file */
     if ((gidAM = H5Gopen2(fid1, "A/M", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open file #3 again */
     if ((fid3 = H5Fopen(filename3, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount file #3 on file #2 */
     if (H5Fmount(gidAM, ".", fid3, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object in file #3 through file #1 mount path */
     if ((gidAMS = H5Gopen2(fid1, "A/M/S", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in file #3 */
     if (H5Gclose(gidAMS) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name */
     *name = '\0';
     if ((name_len = H5Iget_name(gidAM, name, (size_t)NAME_BUF_SIZE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_len == 0 || HDstrcmp(name, "/A/M") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount file #2 from file #1 */
     if (H5Funmount(gidA, ".") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name */
     *name = '\0';
     if ((name_len = H5Iget_name(gidAM, name, (size_t)NAME_BUF_SIZE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_len != 0 || HDstrcmp(name, "") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object in file #3 through file #1 mount path (should fail) */
     H5E_BEGIN_TRY
@@ -3360,65 +3360,65 @@ test_nested_survive(hid_t fapl)
     }
     H5E_END_TRY;
     if (gidAMS >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object in file #3 through file #2 mount path */
     if ((gidMS = H5Gopen2(fid2, "M/S", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name */
     *name = '\0';
     if (H5Iget_name(gidMS, name, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(name, "/M/S") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in file #3 */
     if (H5Gclose(gidMS) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-mount file #2 on file #1 */
     if (H5Fmount(gidA, ".", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object in file #3 through file #1 mount path again */
     if ((gidAMS = H5Gopen2(fid1, "A/M/S", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name */
     *name = '\0';
     if (H5Iget_name(gidAMS, name, (size_t)NAME_BUF_SIZE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(name, "/A/M/S") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in file #3 */
     if (H5Gclose(gidAMS) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in file #2 */
     if (H5Gclose(gidAM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close groups in file #1 */
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #3 IDs */
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #2 */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     PASSED();
@@ -3475,61 +3475,61 @@ test_close_parent(hid_t fapl)
 
     /* Create file #1 */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gcreate2(fid1, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #2 */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidM = H5Gcreate2(fid2, "M", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open files and mount file #2 in file #1 */
     if ((fid1 = H5Fopen(filename1, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gopen2(fid1, "A", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount files together */
     if (H5Fmount(gidA, ".", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group in mounted file */
     if ((gidM = H5Gopen2(fid1, "A/M", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group in file #1 */
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close files #1 & #2 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Both underlying shared files should be open still */
     H5F_sfile_assert_num(2);
@@ -3537,27 +3537,27 @@ test_close_parent(hid_t fapl)
     /* Check the name of "M" is still defined */
     *name = '\0';
     if ((name_len = H5Iget_name(gidM, name, (size_t)NAME_BUF_SIZE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_len == 0 || HDstrcmp(name, "/A/M") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount file #2 from file #1, closing file #1 */
     if (H5Funmount(gidM, "/A") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the name of "M" is defined in its file */
     *name = '\0';
     if ((name_len = H5Iget_name(gidM, name, (size_t)NAME_BUF_SIZE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_len == 0 || HDstrcmp(name, "/M") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Just file #2's underlying shared file should be open still */
     H5F_sfile_assert_num(1);
 
     /* Close group in file #2, letting file #2 close */
     if (H5Gclose(gidM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All underlying shared file structs should be closed */
     H5F_sfile_assert_num(0);
@@ -3659,216 +3659,216 @@ test_cut_graph(hid_t fapl)
 
     /* Create file #1 & it's groups */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gcreate2(fid1, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidB = H5Gcreate2(fid1, "B", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidB) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #2 & it's groups */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidD = H5Gcreate2(fid2, "D", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidD) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidE = H5Gcreate2(fid2, "E", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #3 & it's groups */
     if ((fid3 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidH = H5Gcreate2(fid3, "H", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidH) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidI = H5Gcreate2(fid3, "I", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidI) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #4 & it's group */
     if ((fid4 = H5Fcreate(filename4, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidK = H5Gcreate2(fid4, "K", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidK) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #5 & it's group */
     if ((fid5 = H5Fcreate(filename5, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidM = H5Gcreate2(fid5, "M", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid5) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #6 & it's group */
     if ((fid6 = H5Fcreate(filename6, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidO = H5Gcreate2(fid6, "O", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidO) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid6) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #7 & it's group */
     if ((fid7 = H5Fcreate(filename7, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidQ = H5Gcreate2(fid7, "Q", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidQ) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid7) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open files and build mount hierarchy */
     if ((fid1 = H5Fopen(filename1, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount file #2 at /A */
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fmount(fid1, "/A", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount file #3 at /B */
     if ((fid3 = H5Fopen(filename3, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fmount(fid1, "/B", fid3, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount file #4 at /A/D */
     if ((fid4 = H5Fopen(filename4, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fmount(fid1, "/A/D", fid4, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount file #5 at /A/E */
     if ((fid5 = H5Fopen(filename5, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fmount(fid1, "/A/E", fid5, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid5) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount file #6 at /B/H */
     if ((fid6 = H5Fopen(filename6, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fmount(fid1, "/B/H", fid6, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid6) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount file #7 at /B/H */
     if ((fid7 = H5Fopen(filename7, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fmount(fid1, "/B/I", fid7, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid7) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object in file #5 */
     if ((gidM = H5Gopen2(fid1, "A/E/M", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name */
     *name = '\0';
     if ((name_len = H5Iget_name(gidM, name, (size_t)NAME_BUF_SIZE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_len == 0 || HDstrcmp(name, "/A/E/M") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object in file #7 */
     if ((gidQ = H5Gopen2(fid1, "B/I/Q", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check name */
     *name = '\0';
     if ((name_len = H5Iget_name(gidQ, name, (size_t)NAME_BUF_SIZE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_len == 0 || HDstrcmp(name, "/B/I/Q") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a new file ID for file #5 */
     if ((fid5 = H5Iget_file_id(gidM)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the number of objects currently open */
     if ((obj_count = H5Fget_obj_count(fid5, H5F_OBJ_ALL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (obj_count != 2) /* one object and the file ID */
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close ID on file #5 */
     if (H5Fclose(fid5) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get a new file ID for file #7 */
     if ((fid7 = H5Iget_file_id(gidQ)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the number of objects currently open */
     if ((obj_count = H5Fget_obj_count(fid7, H5F_OBJ_ALL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (obj_count != 2) /* one object and the file ID */
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close ID on file #7 */
     if (H5Fclose(fid7) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount file #2 from file #1, cutting the graph */
     if (H5Funmount(gidM, "/A") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to open an object in file #4, from file #1 */
     H5E_BEGIN_TRY
@@ -3877,21 +3877,21 @@ test_cut_graph(hid_t fapl)
     }
     H5E_END_TRY;
     if (gidK >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object in file #4 from file #5 */
     if ((gidK = H5Gopen2(gidM, "/D/K", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the name of "K" is correct */
     *name = '\0';
     if ((name_len = H5Iget_name(gidK, name, (size_t)NAME_BUF_SIZE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_len == 0 || HDstrcmp(name, "/D/K") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidK) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to open an object in file #6, from file #5 */
     H5E_BEGIN_TRY
@@ -3900,49 +3900,49 @@ test_cut_graph(hid_t fapl)
     }
     H5E_END_TRY;
     if (gidO >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object in file #6 from file #7 */
     if ((gidO = H5Gopen2(gidQ, "/B/H/O", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the name of "O" is correct */
     *name = '\0';
     if ((name_len = H5Iget_name(gidO, name, (size_t)NAME_BUF_SIZE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_len == 0 || HDstrcmp(name, "/B/H/O") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidO) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the name of "M" is defined in its file */
     *name = '\0';
     if ((name_len = H5Iget_name(gidM, name, (size_t)NAME_BUF_SIZE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_len == 0 || HDstrcmp(name, "/E/M") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the name of "Q" is still defined */
     *name = '\0';
     if ((name_len = H5Iget_name(gidQ, name, (size_t)NAME_BUF_SIZE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_len == 0 || HDstrcmp(name, "/B/I/Q") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all seven underlying files are still opened */
     H5F_sfile_assert_num(7);
 
     /* Close "M" in file #5, which should close files 2, 4 & 5 */
     if (H5Gclose(gidM) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that only four underlying files are still opened */
     H5F_sfile_assert_num(4);
 
     /* Unmount file #3 from file #1, cutting the graph */
     if (H5Funmount(gidQ, "/B") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that only three underlying files are still opened */
     /* (File #1 should close after being cut off from the graph) */
@@ -3951,27 +3951,27 @@ test_cut_graph(hid_t fapl)
     /* Check the name of "Q" is defined in its file */
     *name = '\0';
     if ((name_len = H5Iget_name(gidQ, name, (size_t)NAME_BUF_SIZE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_len == 0 || HDstrcmp(name, "/I/Q") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open object in file #6 from file #7 */
     if ((gidO = H5Gopen2(gidQ, "/H/O", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the name of "O" is correct */
     *name = '\0';
     if ((name_len = H5Iget_name(gidO, name, (size_t)NAME_BUF_SIZE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_len == 0 || HDstrcmp(name, "/H/O") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gidO) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close last object and let files 3, 6 & 7 close */
     if (H5Gclose(gidQ) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that all underlying shared files have been closed now */
     H5F_sfile_assert_num(0);
@@ -4042,70 +4042,70 @@ test_symlink(hid_t fapl)
 
     /* Create file #1 & it's groups */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidA = H5Gcreate2(fid1, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidB = H5Gcreate2(fid1, "B", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidB) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create soft link to mounted object */
     if (H5Lcreate_soft("./A/D/H", fid1, "L", H5P_DEFAULT, H5P_DEFAULT) < 0) /* Soft link */
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #2 & it's groups */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidD = H5Gcreate2(fid2, "D", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidD) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidE = H5Gcreate2(fid2, "E", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #3 & it's groups */
     if ((fid3 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidH = H5Gcreate2(fid3, "H", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidH) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gidI = H5Gcreate2(fid3, "I", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gidI) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open files and build mount hierarchy */
     if ((fid1 = H5Fopen(filename1, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount file #2 at /A */
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fmount(fid1, "/A", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to open an object in file #3 (should fail) */
     H5E_BEGIN_TRY
@@ -4114,37 +4114,37 @@ test_symlink(hid_t fapl)
     }
     H5E_END_TRY;
     if (gidL >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount file #3 at /A/D */
     if ((fid3 = H5Fopen(filename3, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fmount(fid1, "/A/D", fid3, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open soft link to object in file #3 */
     if ((gidL = H5Gopen2(fid1, "L", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the name of "L" is correct */
     *name = '\0';
     if ((name_len = H5Iget_name(gidL, name, (size_t)NAME_BUF_SIZE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (name_len == 0 || HDstrcmp(name, "/L") != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #1 */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that all 3 underlying shared files are still open */
     H5F_sfile_assert_num(3);
 
     /* Close object opened through soft link */
     if (H5Gclose(gidL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that all underlying shared files have been closed now */
     H5F_sfile_assert_num(0);
@@ -4203,33 +4203,33 @@ test_sharedacc(hid_t fapl)
 
     /* Create file #1 & its group */
     if ((fid1[0] = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid1[0], "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #2 & its group */
     if ((fid2[0] = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gcreate2(fid2[0], "B", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test mount before reopen, then using reopened handle for access */
     if (H5Fmount(fid1[0], "/A", fid2[0], H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid1[1] = H5Freopen(fid1[0])) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2[1] = H5Freopen(fid2[0])) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid = H5Gopen2(fid1[1], "/A/B", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Funmount(fid1[1], "/A") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* "Brute force" test of all possible ways of mounting, accessing, and
      * unmounting files with multiple handles (mount after reopen) */
@@ -4237,26 +4237,26 @@ test_sharedacc(hid_t fapl)
         for (j = 0; j < 2; j++)
             for (k = 0; k < 2; k++) {
                 if (H5Fmount(fid1[i], "/A", fid2[j], H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if ((gid = H5Gopen2(fid1[k], "/A/B", H5P_DEFAULT)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Gclose(gid) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Funmount(fid1[k], "/A") < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             }
 
     /* Close file IDs */
     for (i = 0; i < 2; i++) {
         if (H5Fclose(fid1[i]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Fclose(fid2[i]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     PASSED();
@@ -4308,112 +4308,112 @@ test_sharedclose(hid_t fapl)
 
     /* Create file #1a & its group */
     if ((fid1a = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid1 = H5Gcreate2(fid1a, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #1b & its groups */
     if ((fid1b = H5Freopen(fid1a)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid2 = H5Gcreate2(fid1b, "B", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid3 = H5Gcreate2(fid1b, "B/C", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #2 */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #3 */
     if ((fid3 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount file #2 to file #1a */
     if (H5Fmount(gid1, ".", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount file #3 to file #1b */
     if (H5Fmount(gid2, ".", fid3, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #1b.  It should be held open by the groups in it. */
     if (H5Fclose(fid1b) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #3.  It should be held open by the groups in its parent. */
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group B in file #1b.  This should not close file #1b and #3. */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that file #3 is still open */
     H5F_sfile_assert_num(3);
 
     /* Close group B/C in file #1b.  This should close file #1b and #3. */
     if (H5Gclose(gid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that file #3 has been closed */
     H5F_sfile_assert_num(2);
 
     /* Unmount file 2 and close the rest of the handles */
     if (H5Funmount(fid1a, "A") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid1a) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     /* Create file #1 & its group */
     if ((fid1a = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid1 = H5Gcreate2(fid1a, "A", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #1b & its group */
     if ((fid1b = H5Freopen(fid1a)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid2 = H5Gcreate2(fid1b, "B", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file #2 */
     if ((fid2 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Mount file #2 to file #1 */
     if (H5Fmount(fid1a, "A", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file #1b.  It should be held open by the group in it. */
     if (H5Fclose(fid1b) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the group in file #1b.  This should close file # 1b. */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unmount file 2 and close the rest of the handles */
     if (H5Funmount(fid1a, "A") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid1a) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     PASSED();
@@ -4468,109 +4468,109 @@ test_multisharedclose(hid_t fapl)
 
     /* Create master file with three groups to serve as mount points */
     if ((fid1 = H5Fcreate(filename4, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(H5Gcreate2(fid1, "mnt1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(H5Gcreate2(fid1, "mnt2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(H5Gcreate2(fid1, "mnt3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create child file with group */
     if ((fid1 = H5Fcreate(filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(H5Gcreate2(fid1, "grp", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create child file with group */
     if ((fid1 = H5Fcreate(filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(H5Gcreate2(fid1, "grp", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create child file with group */
     if ((fid1 = H5Fcreate(filename3, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(H5Gcreate2(fid1, "grp", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open master and child 1 and mount child 1 to master */
     if ((fid1 = H5Fopen(filename4, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fopen(filename1, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fmount(fid1, "mnt1", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group in child 1 */
     if ((gid1 = H5Gopen2(fid1, "mnt1/grp", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close both files.  They will be held open by gid1 */
     if (H5Idec_ref(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Idec_ref(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open master and child 2 and mount child 2 to master */
     if ((fid1 = H5Fopen(filename4, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fmount(fid1, "mnt2", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group in child 2 */
     if ((gid2 = H5Gopen2(fid1, "mnt2/grp", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close both files.  They will be held open by gid2 */
     if (H5Idec_ref(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Idec_ref(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open master and child 3 and mount child 3 to master */
     if ((fid1 = H5Fopen(filename4, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fopen(filename3, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fmount(fid1, "mnt3", fid2, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the group in child 3 */
     if ((gid3 = H5Gopen2(fid1, "mnt3/grp", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close both files.  They will be held open by gid3 */
     if (H5Idec_ref(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Idec_ref(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close gid1.  This will close child 1. */
     if (H5Idec_ref(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close gid2.  This will close child 2. */
     if (H5Idec_ref(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close gid3.  This will close child 3 and the master file. */
     if (H5Idec_ref(gid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that all file IDs have been closed */
     if (H5I_nmembers(H5I_FILE) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     H5F_sfile_assert_num(0);
 
     PASSED();

--- a/test/mtime.c
+++ b/test/mtime.c
@@ -196,7 +196,7 @@ main(void)
 
     /* Verify symbol table messages are cached */
     if (h5_verify_cached_stabs(FILENAME, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* All looks good */
     HDputs("All modification time tests passed.");

--- a/test/ntypes.c
+++ b/test/ntypes.c
@@ -136,7 +136,7 @@ test_atomic_dtype(hid_t file)
     /* Read the dataset back.  The temporary buffer is for special platforms
      * like Cray. */
     if (NULL == (tmp = HDmalloc((size_t)(DIM0 * DIM1 * H5Tget_size(native_type)))))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dread(dataset, native_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, tmp) < 0)
         TEST_ERROR;
@@ -553,7 +553,7 @@ test_compound_dtype2(hid_t file)
     /* Read the dataset back.  Temporary buffer is for special platforms like
      * Cray */
     if (NULL == (tmp = HDmalloc(DIM0 * DIM1 * H5Tget_size(native_type))))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (bkg = HDcalloc(sizeof(s1), DIM0 * DIM1)))
         TEST_ERROR;
 
@@ -776,9 +776,9 @@ test_compound_dtype(hid_t file)
     /* Read the dataset back.  Temporary buffer is for special platforms like
      * Cray */
     if (NULL == (tmp = HDmalloc(DIM0 * DIM1 * H5Tget_size(native_type))))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (bkg = HDcalloc(sizeof(s1), DIM0 * DIM1)))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dread(dataset, native_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, tmp) < 0)
         TEST_ERROR;
@@ -1420,7 +1420,7 @@ test_enum_dtype(hid_t file)
     /* Read the dataset back.  Temporary buffer is for special platforms like
      * Cray */
     if (NULL == (tmp = HDmalloc(DIM0 * DIM1 * H5Tget_size(native_type))))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dread(dataset, native_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, tmp) < 0)
         TEST_ERROR;
@@ -1593,7 +1593,7 @@ test_array_dtype(hid_t file)
     /* Read the dataset back. Temporary buffer is for special platforms like
      * Cray */
     if (NULL == (tmp = HDmalloc(DIM0 * DIM1 * H5Tget_size(native_type))))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dread(dataset, native_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, tmp) < 0)
         TEST_ERROR;
@@ -1752,7 +1752,7 @@ test_array_dtype2(hid_t file)
     /* Read the dataset back.  Temporary buffer is for special platforms like
      * Cray */
     if (NULL == (tmp = HDmalloc(DIM0 * DIM1 * H5Tget_size(native_type))))
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dread(dataset, native_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, tmp) < 0)
         TEST_ERROR;
@@ -1875,7 +1875,7 @@ test_vl_dtype(hid_t file)
 
     /* Create a VL datatype for disk storage */
     if ((tid = H5Tvlen_create(tid2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a dataset */
     if ((dataset = H5Dcreate2(file, DSET_VL_NAME, tid, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -1943,7 +1943,7 @@ test_vl_dtype(hid_t file)
             /* use temporary buffer to convert datatype.  This is for special
              * platforms like Cray */
             if (NULL == (tmp = (void **)HDmalloc(t2->len * sizeof(unsigned int))))
-                TEST_ERROR
+                TEST_ERROR;
             HDmemcpy(tmp, t2->p, t2->len * H5Tget_size(nat_super_type));
 
             if (H5Tconvert(nat_super_type, H5T_NATIVE_UINT, t2->len, tmp, NULL, H5P_DEFAULT) < 0)
@@ -2321,9 +2321,9 @@ test_refer_dtype(hid_t file)
 
     /* Allocate write & read buffers */
     if (NULL == (wbuf = (hobj_ref_t *)HDmalloc(MAX(sizeof(unsigned), sizeof(hobj_ref_t)))))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (rbuf = (hobj_ref_t *)HDmalloc(MAX(sizeof(unsigned), sizeof(hobj_ref_t)))))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace for datasets */
     if ((sid1 = H5Screate_simple(SPACE1_RANK, dims1, NULL)) < 0)
@@ -2331,7 +2331,7 @@ test_refer_dtype(hid_t file)
 
     /* Create a group */
     if ((group = H5Gcreate2(file, "Group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a datatype to refer to */
     if ((tid1 = H5Tcreate(H5T_COMPOUND, sizeof(s1_t))) < 0)
@@ -2496,9 +2496,9 @@ test_refer_dtype2(hid_t file)
 
     /* Allocate write & read buffers */
     if (NULL == (dwbuf = (uint8_t *)HDmalloc(sizeof(uint8_t) * SPACE2_DIM1 * SPACE2_DIM2)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (drbuf = (uint8_t *)HDcalloc(sizeof(uint8_t), SPACE2_DIM1 * SPACE2_DIM2)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace for datasets */
     if ((sid2 = H5Screate_simple(SPACE2_RANK, dims2, NULL)) < 0)
@@ -2973,33 +2973,33 @@ test_ninteger(void)
      */
     /* create a file using default properties */
     if ((fid1 = H5Fcreate("tstint1.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* create a data space */
     if ((sid1 = H5Screate_simple(rank, dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* create dcpl  */
     if ((dcpl1 = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* create a dataset */
     if ((did1 = H5Dcreate2(fid1, "dset", H5T_NATIVE_INT, sid1, H5P_DEFAULT, dcpl1, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* write */
     if (H5Dwrite(did1, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* close  */
     if (H5Sclose(sid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*-------------------------------------------------------------------------
      * step 2: open and create another file copying the data from file1
@@ -3008,78 +3008,78 @@ test_ninteger(void)
 
     /* open */
     if ((fid1 = H5Fopen("tstint1.h5", H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open dataset */
     if ((did1 = H5Dopen2(fid1, "dset", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((sid1 = H5Dget_space(did1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* get dcpl */
     if ((dcpl1 = H5Dget_create_plist(did1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* get file datatype */
     if ((tid1 = H5Dget_type(did1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* get native datatype */
     if ((nid1 = H5Tget_native_type(tid1, H5T_DIR_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* get size */
     if (H5Tget_size(nid1) == 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* get rank */
     if ((rank = H5Sget_simple_extent_ndims(sid1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     HDmemset(dims, 0, sizeof dims);
 
     /* get dimension */
     if (H5Sget_simple_extent_dims(sid1, dims, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* read */
     if (H5Dread(did1, nid1, H5S_ALL, H5S_ALL, H5P_DEFAULT, chk) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* create a file using default properties */
     if ((fid2 = H5Fcreate("tstint2.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* create a dataset using the native type */
     if ((did2 = H5Dcreate2(fid2, "dset", nid1, sid1, H5P_DEFAULT, dcpl1, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* write */
     if (H5Dwrite(did2, nid1, H5S_ALL, H5S_ALL, H5P_DEFAULT, chk) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* get dcpl */
     if ((dcpl2 = H5Dget_create_plist(did2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* get file datatype */
     if ((tid2 = H5Dget_type(did2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* get native datatype */
     if ((nid2 = H5Tget_native_type(tid2, H5T_DIR_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* check */
     if (H5Tget_precision(nid1) != H5Tget_precision(nid2)) {
         HDprintf("    Precision differ.\n");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* compare dataset creation property lists */
     if (H5Pequal(dcpl1, dcpl2) <= 0) {
         HDprintf("    Property lists differ.\n");
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* check */
@@ -3088,32 +3088,32 @@ test_ninteger(void)
             H5_FAILED();
             HDprintf("    Read different values than written.\n");
             HDprintf("    At index %d\n", i);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
 
     /* close  */
     if (H5Sclose(sid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(tid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(tid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(nid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(nid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;

--- a/test/objcopy.c
+++ b/test/objcopy.c
@@ -285,40 +285,40 @@ attach_ref_attr(hid_t file_id, hid_t loc_id)
 
     /* creates two simple datasets */
     if ((sid = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((sid_ref = H5Screate_simple(1, dims_ref, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did1 = H5Dcreate2(file_id, dsetname1, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did1, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did2 = H5Dcreate2(file_id, dsetname2, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did2, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create an attribute with two object references */
     if (H5Rcreate(&ref[0], file_id, dsetname1, H5R_OBJECT, (hid_t)-1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate(&ref[1], file_id, dsetname2, H5R_OBJECT, (hid_t)-1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((aid = H5Acreate2(loc_id, "obj_ref_attr", H5T_STD_REF_OBJ, sid_ref, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Awrite(aid, H5T_STD_REF_OBJ, ref) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid_ref) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -369,53 +369,53 @@ attach_reg_ref_attr(hid_t file_id, hid_t loc_id)
 
     /* create a 2D dataset */
     if ((space_id = H5Screate_simple(rank, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((spacer_id = H5Screate_simple(rankr, dimsr, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dsetv_id = H5Dcreate2(file_id, dsetnamev, H5T_NATIVE_INT, space_id, H5P_DEFAULT, H5P_DEFAULT,
                                H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dsetv_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create reg_ref of block selection */
     if (H5Sselect_hyperslab(space_id, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate(&ref[0], file_id, dsetnamev, H5R_DATASET_REGION, space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create reg_ref of point selection */
     if (H5Sselect_none(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sselect_elements(space_id, H5S_SELECT_SET, num_points, (const hsize_t *)coord) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate(&ref[1], file_id, dsetnamev, H5R_DATASET_REGION, space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create reg_ref attribute */
     if ((aid = H5Acreate2(loc_id, "reg_ref_attr", H5T_STD_REF_DSETREG, spacer_id, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Awrite(aid, H5T_STD_REF_DSETREG, ref) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach the reg_ref attribute to the dataset itself */
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((aid = H5Acreate2(dsetv_id, "reg_ref_attr", H5T_STD_REF_DSETREG, spacer_id, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Awrite(aid, H5T_STD_REF_DSETREG, ref) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Sclose(spacer_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dsetv_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -469,77 +469,77 @@ create_reg_ref_dataset(hid_t file_id, hid_t loc_id)
     hid_t           pid         = (-1);
 
     if ((space_id = H5Screate_simple(rank, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((spacer_id = H5Screate_simple(rankr, dimsr, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dsetv_id = H5Dcreate2(file_id, dsetnamev, H5T_NATIVE_INT, space_id, H5P_DEFAULT, H5P_DEFAULT,
                                H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dsetv_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dsetr_id = H5Dcreate2(loc_id, dsetnamer, H5T_STD_REF_DSETREG, spacer_id, H5P_DEFAULT, H5P_DEFAULT,
                                H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     start[0] = 0;
     start[1] = 3;
     count[0] = 2;
     count[1] = 3;
     if (H5Sselect_hyperslab(space_id, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate(&ref[0], file_id, dsetnamev, H5R_DATASET_REGION, space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sselect_none(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sselect_elements(space_id, H5S_SELECT_SET, num_points, (const hsize_t *)coord) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate(&ref[1], file_id, dsetnamev, H5R_DATASET_REGION, space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dsetr_id, H5T_STD_REF_DSETREG, H5S_ALL, H5S_ALL, H5P_DEFAULT, ref) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dsetr_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set compact plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_layout(pid, H5D_COMPACT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((dsetr_id = H5Dcreate2(loc_id, dsetnamer1, H5T_STD_REF_DSETREG, spacer_id, H5P_DEFAULT, pid,
                                H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dsetr_id, H5T_STD_REF_DSETREG, H5S_ALL, H5S_ALL, H5P_DEFAULT, ref) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dsetr_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set comp & chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 1, &chunk_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_deflate(pid, 9) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((dsetr_id = H5Dcreate2(loc_id, dsetnamer2, H5T_STD_REF_DSETREG, spacer_id, H5P_DEFAULT, pid,
                                H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dsetr_id, H5T_STD_REF_DSETREG, H5S_ALL, H5S_ALL, H5P_DEFAULT, ref) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dsetr_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Sclose(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(spacer_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dsetv_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -792,97 +792,97 @@ compare_attribute(hid_t aid, hid_t aid2, hid_t pid, const void *wbuf, hid_t obj_
 
     /* Check the character sets are equal */
     if (H5Aget_info(aid, &ainfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aget_info(aid2, &ainfo2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ainfo.cset != ainfo2.cset)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the creation orders are equal (if appropriate) */
     if (ainfo.corder_valid != ainfo2.corder_valid)
-        TEST_ERROR
+        TEST_ERROR;
     if (ainfo.corder_valid)
         if (ainfo.corder != ainfo2.corder)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Check the datatypes are equal */
 
     /* Open the datatype for the source attribute */
     if ((tid = H5Aget_type(aid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the datatype for the destination attribute */
     if ((tid2 = H5Aget_type(aid2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that both datatypes are committed/not committed */
     if ((is_committed = H5Tcommitted(tid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((is_committed2 = H5Tcommitted(tid2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (is_committed != is_committed2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compare the datatypes */
     if (H5Tequal(tid, tid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Determine the size of datatype (for later) */
     if ((elmt_size = H5Tget_size(tid)) == 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the dataspaces are equal */
 
     /* Open the dataspace for the source attribute */
     if ((sid = H5Aget_space(aid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the dataspace for the destination attribute */
     if ((sid2 = H5Aget_space(aid2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compare the dataspaces */
     if (H5Sextent_equal(sid, sid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Determine the number of elements in dataspace (for later) */
     if ((nelmts = H5Sget_simple_extent_npoints(sid2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the raw data is equal */
 
     /* Allocate & initialize space for the raw data buffers */
     if ((rbuf = HDcalloc(elmt_size, (size_t)nelmts)) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
     if ((rbuf2 = HDcalloc(elmt_size, (size_t)nelmts)) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read data from the source attribute */
     if (H5Aread(aid, tid, rbuf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read data from the destination attribute */
     if (H5Aread(aid2, tid2, rbuf2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check raw data read in against data written out */
     if (wbuf) {
         if (!compare_data(aid, (hid_t)0, pid, tid, (size_t)nelmts, wbuf, rbuf, obj_owner))
-            TEST_ERROR
+            TEST_ERROR;
         if (!compare_data(aid2, (hid_t)0, pid, tid2, (size_t)nelmts, wbuf, rbuf2, obj_owner))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     /* Don't have written data, just compare data between the two attributes */
     else if (!compare_data(aid, aid2, pid, tid, (size_t)nelmts, rbuf, rbuf2, obj_owner))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen data, if necessary */
     if (H5Tdetect_class(tid, H5T_VLEN) == TRUE)
         if (H5Treclaim(tid, sid, H5P_DEFAULT, rbuf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if (H5Tdetect_class(tid2, H5T_VLEN) == TRUE)
         if (H5Treclaim(tid2, sid2, H5P_DEFAULT, rbuf2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Release raw data buffers */
     HDfree(rbuf);
@@ -892,19 +892,19 @@ compare_attribute(hid_t aid, hid_t aid2, hid_t pid, const void *wbuf, hid_t obj_
 
     /* close the source dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataspace */
     if (H5Sclose(sid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination datatype */
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return TRUE;
 
@@ -949,23 +949,23 @@ compare_std_attributes(hid_t oid, hid_t oid2, hid_t pid)
     /* Retrieve the object copy flags from the property list, if it's non-DEFAULT */
     if (pid != H5P_DEFAULT) {
         if (H5Pget_copy_object(pid, &cpy_flags) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else
         cpy_flags = 0;
 
     /* Check the number of attributes on source dataset */
     if (H5Oget_info3(oid, &oinfo1, H5O_INFO_NUM_ATTRS) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the number of attributes on destination dataset */
     if (H5Oget_info3(oid2, &oinfo2, H5O_INFO_NUM_ATTRS) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (cpy_flags & H5O_COPY_WITHOUT_ATTR_FLAG) {
         /* Check that the destination has no attributes */
         if (oinfo2.num_attrs != 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else {
         char     attr_name[ATTR_NAME_LEN]; /* Attribute name */
@@ -973,28 +973,28 @@ compare_std_attributes(hid_t oid, hid_t oid2, hid_t pid)
 
         /* Compare the number of attributes */
         if (oinfo1.num_attrs != oinfo2.num_attrs)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check the attributes are equal */
         for (i = 0; i < (unsigned)oinfo1.num_attrs; i++) {
             if ((aid = H5Aopen_by_idx(oid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, (hsize_t)i, H5P_DEFAULT,
                                       H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Aget_name(aid, (size_t)ATTR_NAME_LEN, attr_name) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             if ((aid2 = H5Aopen(oid2, attr_name, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check the attributes are equal */
             if (!compare_attribute(aid, aid2, pid, NULL, oid))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close the attributes */
             if (H5Aclose(aid) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Aclose(aid2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
     }     /* end if */
 
@@ -1031,7 +1031,7 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
 
     /* Check size of each element */
     if ((elmt_size = H5Tget_size(tid)) == 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* If the type is a compound containing a vlen, loop over all elements for
      * each compound member.  Compounds containing reference  are not supported
@@ -1048,7 +1048,7 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
 
         /* Get number of members in compound */
         if ((nmembs = H5Tget_nmembers(tid)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Loop over members */
         for (memb_idx = 0; memb_idx < (unsigned)nmembs; memb_idx++) {
@@ -1058,11 +1058,11 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
 
             /* Get member id */
             if ((memb_id = H5Tget_member_type(tid, memb_idx)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Get member size */
             if ((memb_size = H5Tget_size(memb_id)) == 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Set up pointers to member in the first element */
             memb1 = (const uint8_t *)buf1 + memb_off;
@@ -1074,7 +1074,7 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
 
                 /* Get base type of vlen datatype */
                 if ((base_id = H5Tget_super(memb_id)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Iterate over all elements, recursively calling this function
                  * for each */
@@ -1082,14 +1082,14 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
                     /* Check vlen lengths */
                     if (((const hvl_t *)((const void *)memb1))->len !=
                         ((const hvl_t *)((const void *)memb2))->len)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check vlen data */
                     if (!compare_data(parent1, parent2, pid, base_id,
                                       ((const hvl_t *)((const void *)memb1))->len,
                                       ((const hvl_t *)((const void *)memb1))->p,
                                       ((const hvl_t *)((const void *)memb2))->p, obj_owner))
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Update member pointers */
                     memb1 += elmt_size;
@@ -1104,7 +1104,7 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
                 /* Iterate over all elements, calling memcmp() for each */
                 for (elmt = 0; elmt < nelmts; elmt++) {
                     if (HDmemcmp(memb1, memb2, memb_size) != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Update member pointers */
                     memb1 += elmt_size;
@@ -1120,11 +1120,11 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
 
         /* Check for "simple" vlen datatype */
         if (H5Tget_class(tid) != H5T_VLEN)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get base type of vlen datatype */
         if ((base_tid = H5Tget_super(tid)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Loop over elements in buffers */
         vl_buf1 = (const hvl_t *)buf1;
@@ -1132,23 +1132,23 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
         for (u = 0; u < nelmts; u++, vl_buf1++, vl_buf2++) {
             /* Check vlen lengths */
             if (vl_buf1->len != vl_buf2->len)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check vlen data */
             if (!compare_data(parent1, parent2, pid, base_tid, vl_buf1->len, vl_buf1->p, vl_buf2->p,
                               obj_owner))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         if (H5Tclose(base_tid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else if (H5Tdetect_class(tid, H5T_REFERENCE) == TRUE) {
         size_t u; /* Local index variable */
 
         /* Check for "simple" reference datatype */
         if (H5Tget_class(tid) != H5T_REFERENCE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for object or region reference */
         if (H5Tequal(tid, H5T_STD_REF_OBJ) > 0) {
@@ -1163,17 +1163,17 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
 
                 /* Check for types of objects handled */
                 if (H5Rget_obj_type2(parent1, H5R_OBJECT, ref_buf1, &obj1_type) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Rget_obj_type2(parent2, H5R_OBJECT, ref_buf2, &obj2_type) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (obj1_type != obj2_type)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Open referenced objects */
                 if ((obj1_id = H5Rdereference2(parent1, H5P_DEFAULT, H5R_OBJECT, ref_buf1)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if ((obj2_id = H5Rdereference2(parent2, H5P_DEFAULT, H5R_OBJECT, ref_buf2)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* break the infinite loop when the ref_object points to itself */
                 if (obj_owner > 0) {
@@ -1181,16 +1181,16 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
                     int         token_cmp;
 
                     if (H5Oget_info3(obj_owner, &oinfo1, H5O_INFO_BASIC) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Oget_info3(obj1_id, &oinfo2, H5O_INFO_BASIC) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Otoken_cmp(obj1_id, &oinfo1.token, &oinfo2.token, &token_cmp) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (!token_cmp) {
                         if (H5Oclose(obj1_id) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                         if (H5Oclose(obj2_id) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                         return TRUE;
                     }
                 }
@@ -1199,17 +1199,17 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
                 switch (obj1_type) {
                     case H5O_TYPE_DATASET:
                         if (compare_datasets(obj1_id, obj2_id, pid, NULL) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
                         break;
 
                     case H5O_TYPE_GROUP:
                         if (compare_groups(obj1_id, obj2_id, pid, -1, 0) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
                         break;
 
                     case H5O_TYPE_NAMED_DATATYPE:
                         if (H5Tequal(obj1_id, obj2_id) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
                         break;
 
                     case H5O_TYPE_MAP:
@@ -1218,14 +1218,14 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
                     case H5O_TYPE_UNKNOWN:
                     case H5O_TYPE_NTYPES:
                     default:
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end switch */
 
                 /* Close objects */
                 if (H5Oclose(obj1_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Oclose(obj2_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end for */
         }     /* end if */
         else if (H5Tequal(tid, H5T_STD_REF_DSETREG) > 0) {
@@ -1241,17 +1241,17 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
 
                 /* Check for types of objects handled */
                 if (H5Rget_obj_type2(parent1, H5R_DATASET_REGION, ref_buf1, &obj1_type) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Rget_obj_type2(parent2, H5R_DATASET_REGION, ref_buf2, &obj2_type) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (obj1_type != obj2_type)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Open referenced objects */
                 if ((obj1_id = H5Rdereference2(parent1, H5P_DEFAULT, H5R_DATASET_REGION, ref_buf1)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if ((obj2_id = H5Rdereference2(parent2, H5P_DEFAULT, H5R_DATASET_REGION, ref_buf2)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* break the infinite loop when the ref_object points to itself */
                 if (obj_owner > 0) {
@@ -1259,16 +1259,16 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
                     int         token_cmp;
 
                     if (H5Oget_info3(obj_owner, &oinfo1, H5O_INFO_BASIC) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Oget_info3(obj1_id, &oinfo2, H5O_INFO_BASIC) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Otoken_cmp(obj1_id, &oinfo1.token, &oinfo2.token, &token_cmp) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (!token_cmp) {
                         if (H5Oclose(obj1_id) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                         if (H5Oclose(obj2_id) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                         return TRUE;
                     }
                 }
@@ -1277,17 +1277,17 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
                 switch (obj1_type) {
                     case H5O_TYPE_DATASET:
                         if (compare_datasets(obj1_id, obj2_id, pid, NULL) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
                         break;
 
                     case H5O_TYPE_GROUP:
                         if (compare_groups(obj1_id, obj2_id, pid, -1, 0) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
                         break;
 
                     case H5O_TYPE_NAMED_DATATYPE:
                         if (H5Tequal(obj1_id, obj2_id) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
                         break;
 
                     case H5O_TYPE_MAP:
@@ -1296,37 +1296,37 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
                     case H5O_TYPE_UNKNOWN:
                     case H5O_TYPE_NTYPES:
                     default:
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end switch */
 
                 /* Close objects */
                 if (H5Oclose(obj1_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Oclose(obj2_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Get regions for referenced datasets */
                 if ((obj1_sid = H5Rget_region(parent1, H5R_DATASET_REGION, ref_buf1)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if ((obj2_sid = H5Rget_region(parent2, H5R_DATASET_REGION, ref_buf2)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Check if dataspaces are the same shape */
                 if (H5Sselect_shape_same(obj1_sid, obj2_sid) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close dataspaces */
                 if (H5Sclose(obj1_sid) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Sclose(obj2_sid) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end for */
         }     /* end if */
         else
-            TEST_ERROR
+            TEST_ERROR;
     } /* end else */
     else if (HDmemcmp(buf1, buf2, (elmt_size * nelmts)) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Data should be the same. :-) */
     return TRUE;
@@ -1367,81 +1367,81 @@ compare_datasets(hid_t did, hid_t did2, hid_t pid, const void *wbuf)
 
     /* Open the datatype for the source dataset */
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the datatype for the destination dataset */
     if ((tid2 = H5Dget_type(did2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that both datatypes are committed/not committed */
     if ((is_committed = H5Tcommitted(tid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((is_committed2 = H5Tcommitted(tid2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (is_committed != is_committed2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compare the datatypes */
     if (H5Tequal(tid, tid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Determine the size of datatype (for later) */
     if ((elmt_size = H5Tget_size(tid)) == 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the dataspaces are equal */
 
     /* Open the dataspace for the source dataset */
     if ((sid = H5Dget_space(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the dataspace for the destination dataset */
     if ((sid2 = H5Dget_space(did2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compare the dataspaces */
     if (H5Sextent_equal(sid, sid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Determine the number of elements in dataspace (for later) */
     if ((nelmts = H5Sget_simple_extent_npoints(sid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the dataset creation property lists are equal */
 
     /* Open the dataset creation property list for the source dataset */
     if ((dcpl = H5Dget_create_plist(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the dataset creation property list for the destination dataset */
     if ((dcpl2 = H5Dget_create_plist(did2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compare the rest of the dataset creation property lists */
     if (H5Pequal(dcpl, dcpl2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the number of filters on dataset (for later) */
     if ((nfilters = H5Pget_nfilters(dcpl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset creation property list */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset creation property list */
     if (H5Pclose(dcpl2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the allocated storage is the same */
 
     /* Check that the space allocation status is the same */
     if (H5Dget_space_status(did, &space_status) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dget_space_status(did2, &space_status2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (space_status != space_status2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the space used is the same */
     /* (Don't check if the dataset is filtered (i.e. compressed, etc.) and
@@ -1455,41 +1455,41 @@ compare_datasets(hid_t did, hid_t did2, hid_t pid, const void *wbuf)
         hsize_t storage_size2 = H5Dget_storage_size(did2); /* 2nd Dataset's raw data storage size */
 
         if (storage_size != storage_size2)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Check the raw data is equal */
 
     /* Allocate & initialize space for the raw data buffers */
     if ((rbuf = HDcalloc(elmt_size, (size_t)nelmts)) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
     if ((rbuf2 = HDcalloc(elmt_size, (size_t)nelmts)) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read data from datasets */
     if (H5Dread(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dread(did2, tid2, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check raw data read in against data written out */
     if (wbuf) {
         if (!compare_data(did, (hid_t)0, pid, tid, (size_t)nelmts, wbuf, rbuf, did))
-            TEST_ERROR
+            TEST_ERROR;
         if (!compare_data(did2, (hid_t)0, pid, tid2, (size_t)nelmts, wbuf, rbuf2, did2))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     /* Don't have written data, just compare data between the two datasets */
     else if (!compare_data(did, did2, pid, tid, (size_t)nelmts, rbuf, rbuf2, did))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen data, if necessary */
     if (H5Tdetect_class(tid, H5T_VLEN) == TRUE)
         if (H5Treclaim(tid, sid, H5P_DEFAULT, rbuf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if (H5Tdetect_class(tid2, H5T_VLEN) == TRUE)
         if (H5Treclaim(tid2, sid2, H5P_DEFAULT, rbuf2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Release raw data buffers */
     HDfree(rbuf);
@@ -1499,23 +1499,23 @@ compare_datasets(hid_t did, hid_t did2, hid_t pid, const void *wbuf)
 
     /* close the source dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataspace */
     if (H5Sclose(sid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination datatype */
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the attributes are equal */
     if (compare_std_attributes(did, did2, pid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Datasets should be the same. :-) */
     return TRUE;
@@ -1561,23 +1561,23 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
     /* Retrieve the object copy flags from the property list, if it's non-DEFAULT */
     if (pid != H5P_DEFAULT) {
         if (H5Pget_copy_object(pid, &cpy_flags) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else
         cpy_flags = 0;
 
     /* Check if both groups have the same # of objects */
     if (H5Gget_info(gid, &ginfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gget_info(gid2, &ginfo2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((cpy_flags & H5O_COPY_SHALLOW_HIERARCHY_FLAG) && depth == 0) {
         if (ginfo2.nlinks != 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else {
         if (ginfo.nlinks != ginfo2.nlinks)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Check contents of groups */
@@ -1592,20 +1592,20 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
             /* Check name of objects */
             if (H5Lget_name_by_idx(gid, ".", H5_INDEX_NAME, H5_ITER_INC, idx, objname, (size_t)NAME_BUF_SIZE,
                                    H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Lget_name_by_idx(gid2, ".", H5_INDEX_NAME, H5_ITER_INC, idx, objname2,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (HDstrcmp(objname, objname2) != 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Get link info */
             if (H5Lget_info2(gid, objname, &linfo, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Lget_info2(gid2, objname2, &linfo2, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (linfo.type != linfo2.type)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Extra checks for "real" objects */
             if (linfo.type == H5L_TYPE_HARD) {
@@ -1616,20 +1616,20 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
                 /* Compare some pieces of the object info */
                 /* Get data model object info */
                 if (H5Oget_info_by_name3(gid, objname, &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Oget_info_by_name3(gid2, objname2, &oinfo2, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Get native object info */
                 if (H5Oget_native_info_by_name(gid, objname, &ninfo, H5O_NATIVE_INFO_HDR, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Oget_native_info_by_name(gid2, objname2, &ninfo2, H5O_NATIVE_INFO_HDR, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 if (oinfo.type != oinfo2.type)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (oinfo.rc != oinfo2.rc)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* If NULL messages are preserved, the number of messages
                  * should be the same in the destination.
@@ -1640,7 +1640,7 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
                     if (ninfo.hdr.nmesgs != ninfo2.hdr.nmesgs)
                         ;
                     else if (ninfo.hdr.nmesgs < ninfo2.hdr.nmesgs)
-                        TEST_ERROR
+                        TEST_ERROR;
                 }
 
                 /* Check for object already having been compared */
@@ -1651,28 +1651,28 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
 
                 /* Open objects */
                 if ((oid = H5Oopen(gid, objname, H5P_DEFAULT)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if ((oid2 = H5Oopen(gid2, objname2, H5P_DEFAULT)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Compare objects within group */
                 switch (oinfo.type) {
                     case H5O_TYPE_GROUP:
                         /* Compare groups */
                         if (compare_groups(oid, oid2, pid, depth - 1, copy_flags) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
                         break;
 
                     case H5O_TYPE_DATASET:
                         /* Compare datasets */
                         if (compare_datasets(oid, oid2, pid, NULL) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
                         break;
 
                     case H5O_TYPE_NAMED_DATATYPE:
                         /* Compare datatypes */
                         if (H5Tequal(oid, oid2) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
                         break;
 
                     case H5O_TYPE_MAP:
@@ -1687,14 +1687,14 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
 
                 /* Close objects */
                 if (H5Oclose(oid) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Oclose(oid2) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 /* Check that both links are the same size */
                 if (linfo.u.val_size != linfo2.u.val_size)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Compare link values */
                 if (linfo.type == H5L_TYPE_SOFT ||
@@ -1705,13 +1705,13 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
                     /* Get link values */
                     HDassert(linfo.u.val_size <= NAME_BUF_SIZE);
                     if (H5Lget_val(gid, objname, linkval, (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Lget_val(gid2, objname2, linkval2, (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Compare link data */
                     if (HDmemcmp(linkval, linkval2, linfo.u.val_size) != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end else-if */
                 else {
                     HDassert(0 && "Unknown type of link");
@@ -1722,7 +1722,7 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
 
     /* Check if the attributes are equal */
     if (compare_std_attributes(gid, gid2, pid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Groups should be the same. :-) */
     return TRUE;
@@ -1757,19 +1757,19 @@ compare_idx_type(hid_t fapl, hid_t did, H5D_chunk_index_t new_type, H5D_chunk_in
 
     /* Get the chunk index type */
     if (H5D__layout_idx_type_test(did, &idx_type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if we are using the latest version of the format */
     if (H5Pget_libver_bounds(fapl, &low, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify index type */
     if (low == H5F_LIBVER_LATEST) {
         if (idx_type != new_type)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else if (idx_type != old_type)
-        TEST_ERROR
+        TEST_ERROR;
 
     return TRUE;
 error:
@@ -1808,68 +1808,68 @@ test_copy_named_datatype(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t d
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create named datatype */
     if ((H5Tcommit2(fid_src, NAME_DATATYPE_SIMPLE, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the datatype from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATATYPE_SIMPLE, fid_dst, NAME_DATATYPE_SIMPLE, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the datatype for copy */
     if ((tid = H5Topen2(fid_src, NAME_DATATYPE_SIMPLE, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the copied datatype */
     if ((tid2 = H5Topen2(fid_dst, NAME_DATATYPE_SIMPLE, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Compare the datatypes */
     if (H5Tequal(tid, tid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination datatype */
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -1918,68 +1918,68 @@ test_copy_named_datatype_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create named datatype */
     if ((H5Tcommit2(fid_src, NAME_DATATYPE_VL, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the datatype from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATATYPE_VL, fid_dst, NAME_DATATYPE_VL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the datatype for copy */
     if ((tid = H5Topen2(fid_src, NAME_DATATYPE_VL, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the copied datatype */
     if ((tid2 = H5Topen2(fid_dst, NAME_DATATYPE_VL, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Compare the datatypes */
     if (H5Tequal(tid, tid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination datatype */
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -2028,76 +2028,76 @@ test_copy_named_datatype_vl_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, h
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create first vlen datatype */
     if ((tid = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create second (nested) vlen datatype */
     if ((tid2 = H5Tvlen_create(tid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create named datatype */
     if ((H5Tcommit2(fid_src, NAME_DATATYPE_VL_VL, tid2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the first datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the second datatype */
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the datatype from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATATYPE_VL_VL, fid_dst, NAME_DATATYPE_VL_VL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the datatype for copy */
     if ((tid = H5Topen2(fid_src, NAME_DATATYPE_VL_VL, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the copied datatype */
     if ((tid2 = H5Topen2(fid_dst, NAME_DATATYPE_VL_VL, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Compare the datatypes */
     if (H5Tequal(tid, tid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination datatype */
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -2154,100 +2154,100 @@ test_copy_named_datatype_attr_self(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fap
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create named datatype */
     if ((H5Tcommit2(fid_src, NAME_DATATYPE_SIMPLE, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create attribute */
     if ((aid = H5Acreate2(tid, "attr_self", tid, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach other attributes to the dataset */
     if (test_copy_attach_attributes(tid, tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the attribute */
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the datatype from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATATYPE_SIMPLE, fid_dst, NAME_DATATYPE_SIMPLE, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source datatype */
     if ((tid = H5Topen2(fid_src, NAME_DATATYPE_SIMPLE, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the copied datatype */
     if ((tid2 = H5Topen2(fid_dst, NAME_DATATYPE_SIMPLE, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Compare the datatypes */
     if (H5Tequal(tid, tid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination attribute */
     if ((aid = H5Aopen(tid2, "attr_self", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination attribute's datatype */
     if ((tid = H5Aget_type(aid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* verify that the attribute's datatype is committed */
     if (H5Tcommitted(tid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* verify that the tokens of the datatypes are the same */
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid2, &oinfo2, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     same_type = TRUE;
     if (oinfo.fileno == oinfo2.fileno) {
         int token_cmp;
         if (H5Otoken_cmp(tid2, &oinfo.token, &oinfo2.token, &token_cmp) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (token_cmp)
             same_type = FALSE;
     }
@@ -2255,30 +2255,30 @@ test_copy_named_datatype_attr_self(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fap
         same_type = FALSE;
 
     if (!same_type)
-        FAIL_PUTS_ERROR("destination attribute does not use the same committed datatype")
+        FAIL_PUTS_ERROR("destination attribute does not use the same committed datatype");
 
     /* Verify that there are only 2 links int he destination root group */
     if (H5Gget_info(fid_dst, &ginfo) < 0)
         if (ginfo.nlinks != 2)
-            FAIL_PUTS_ERROR("unexpected number of links in destination root group")
+            FAIL_PUTS_ERROR("unexpected number of links in destination root group");
 
     /* close the attribute */
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatypes */
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -2338,7 +2338,7 @@ test_copy_dataset_simple(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t d
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -2346,77 +2346,77 @@ test_copy_dataset_simple(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t d
 
     /* create 2D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create 2D int dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -2478,7 +2478,7 @@ test_copy_dataset_versionbounds(hid_t fcpl_src, hid_t fapl_src)
 
     /* Create a file access property list for destination file */
     if ((fapl_dst = h5_fileaccess()) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize the filenames */
     h5_fixname(FILENAME[4], fapl_src, src_fname, sizeof src_fname);
@@ -2490,7 +2490,7 @@ test_copy_dataset_versionbounds(hid_t fcpl_src, hid_t fapl_src)
     /* Create source file */
     fid_src = H5Fcreate(src_fname, H5F_ACC_TRUNC, fcpl_src, fapl_src);
     if (fid_src < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -2498,41 +2498,41 @@ test_copy_dataset_versionbounds(hid_t fcpl_src, hid_t fapl_src)
 
     /* Create 2D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create 2D int dataset in SRC file */
     did_src =
         H5Dcreate2(fid_src, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     if (did_src < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Write data into SRC file */
     ret = H5Dwrite(did_src, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the internal dset ptr to get the fill version for verifying later */
     if ((dsetp = (H5D_t *)H5VL_object(did_src)) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     srcdset_layoutversion = dsetp->shared->layout.version;
 
     /* Close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(did_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the source file with read-only */
     fid_src = H5Fopen(src_fname, H5F_ACC_RDONLY, fapl_src);
     if (fid_src < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop through all the combinations of low/high library format bounds,
        skipping invalid combinations.  Create a destination file and copy the
@@ -2553,12 +2553,12 @@ test_copy_dataset_versionbounds(hid_t fcpl_src, hid_t fapl_src)
             /* Create destination file */
             fid_dst = H5Fcreate(dst_fname, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_dst);
             if (fid_dst < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create an uncopied object in destination file so that tokens
                in source and destination files aren't the same */
             if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Try to copy the dataset */
             H5E_BEGIN_TRY
@@ -2573,53 +2573,53 @@ test_copy_dataset_versionbounds(hid_t fcpl_src, hid_t fapl_src)
                 /* Failure is valid if layout version of source dataset is
                    greater than destination */
                 if (srcdset_layoutversion <= H5O_layout_ver_bounds[high])
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close the DST file before continue */
                 if (H5Fclose(fid_dst) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 continue;
             }
 
             /* Close the DST file */
             if (H5Fclose(fid_dst) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Open destination file */
             fid_dst = H5Fopen(dst_fname, H5F_ACC_RDWR, fapl_dst);
             if (fid_dst < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Open the datasets to compare */
             did_src = H5Dopen2(fid_src, NAME_DATASET_SIMPLE, H5P_DEFAULT);
             if (did_src < 0)
-                TEST_ERROR
+                TEST_ERROR;
             did_dst = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT);
             if (did_dst < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check if the datasets are equal */
             if (compare_datasets(did_src, did_dst, H5P_DEFAULT, buf) != TRUE)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close the datasets */
             if (H5Dclose(did_dst) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Dclose(did_src) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close the DST file */
             if (H5Fclose(fid_dst) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
         } /* for high */
     }     /* for low */
 
     /* Close property list and source file */
     if (H5Pclose(fapl_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -2678,7 +2678,7 @@ test_copy_dataset_simple_samefile(hid_t fcpl, hid_t fapl)
 
     /* create source file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -2686,64 +2686,64 @@ test_copy_dataset_simple_samefile(hid_t fcpl, hid_t fapl)
 
     /* create 2D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create 2D int dataset at SRC file */
     if ((did = H5Dcreate2(fid, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-write */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid, NAME_DATASET_SIMPLE, fid, NAME_DATASET_SIMPLE2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid, NAME_DATASET_SIMPLE2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -2804,7 +2804,7 @@ test_copy_dataset_simple_empty(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, h
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -2812,78 +2812,78 @@ test_copy_dataset_simple_empty(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, h
 
     /* create 2D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create 2D int dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (!test_open) {
 
         /* close the dataset */
         if (H5Dclose(did) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* close the SRC file */
         if (H5Fclose(fid_src) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* open the source file with read-only */
         if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (!test_open) {
         /* open the dataset for copy */
         if ((did = H5Dopen2(fid_src, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -2948,96 +2948,96 @@ test_copy_dataset_compound(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tcreate(H5T_COMPOUND, sizeof(comp_t))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(tid, "int_name", HOFFSET(comp_t, a), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(tid, "double_name", HOFFSET(comp_t, d), H5T_NATIVE_DOUBLE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_COMPOUND, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_COMPOUND, fid_dst, NAME_DATASET_COMPOUND, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_COMPOUND, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_COMPOUND, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -3105,7 +3105,7 @@ test_copy_dataset_chunked(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t 
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set 1-D dataspace dimensions */
     dim1d[0]     = DIM_SIZE_1;
@@ -3113,38 +3113,38 @@ test_copy_dataset_chunked(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t 
 
     /* create 1-D dataspace */
     if ((sid = H5Screate_simple(1, dim1d, max_dim1d)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 1, chunk_dim1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create 1-D dataset: chunked, non-filterd, with data
@@ -3153,38 +3153,38 @@ test_copy_dataset_chunked(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t 
      */
     /* create 1-D dataspace */
     if ((sid = H5Screate_simple(1, dim1d, dim1d)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 1, dim1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED_SINGLE, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set 2-D dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -3192,59 +3192,59 @@ test_copy_dataset_chunked(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t 
 
     /* create 2-D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 2, chunk_dim2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED2, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set allocation time to early */
     if (H5Pset_alloc_time(pid, H5D_ALLOC_TIME_EARLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED3, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create 2-D dataset: chunked, non-filterd, with data, dims=chunk dims,
@@ -3253,62 +3253,62 @@ test_copy_dataset_chunked(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t 
 
     /* create 2-D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist to be the same as dims2d */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 2, dim2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED2_SINGLE, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create 2-D dataset: chunked, non-filterd, with data, dims=chunk dims,
      *               H5D_ALLOC_TIME_EARLY
      */
     if (H5Pset_alloc_time(pid, H5D_ALLOC_TIME_EARLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED3_SINGLE, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create 2-D dataset: chunked, non-filterd, with data, dims=max dims=chunk dims,
@@ -3316,254 +3316,254 @@ test_copy_dataset_chunked(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t 
      */
     /* create 2-D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, dim2d)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist to be the same as dims2d */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 2, dim2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_alloc_time(pid, H5D_ALLOC_TIME_LATE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED4_SINGLE, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the datasets from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED, fid_dst, NAME_DATASET_CHUNKED, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED2, fid_dst, NAME_DATASET_CHUNKED2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED3, fid_dst, NAME_DATASET_CHUNKED3, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED_SINGLE, fid_dst, NAME_DATASET_CHUNKED_SINGLE, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED2_SINGLE, fid_dst, NAME_DATASET_CHUNKED2_SINGLE, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED3_SINGLE, fid_dst, NAME_DATASET_CHUNKED3_SINGLE, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED4_SINGLE, fid_dst, NAME_DATASET_CHUNKED4_SINGLE, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the 1-D destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_EARRAY, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf1d) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the 1-D destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_SINGLE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf1d) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the 2-D dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_FARRAY, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf2d) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the 2-D dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED3, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED3, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_NONE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf2d) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the 2-D dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED2_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED2_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_SINGLE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf2d) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the 2-D dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED3_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED3_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_SINGLE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf2d) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the 2-D dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED4_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED4_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_SINGLE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf2d) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -3622,7 +3622,7 @@ test_copy_dataset_chunked_empty(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, 
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set 1-D dataspace dimensions */
     dim1d[0]     = DIM_SIZE_1;
@@ -3630,34 +3630,34 @@ test_copy_dataset_chunked_empty(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, 
 
     /* create 1-D dataspace */
     if ((sid = H5Screate_simple(1, dim1d, max_dim1d)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 1, chunk_dim1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * create 1-D dataset: chunked, empty, non-filtered,
@@ -3669,34 +3669,34 @@ test_copy_dataset_chunked_empty(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, 
 
     /* create 1-D dataspace */
     if ((sid = H5Screate_simple(1, dim1d, dim1d)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 1, dim1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED_SINGLE, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set 2-D dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -3704,51 +3704,51 @@ test_copy_dataset_chunked_empty(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, 
 
     /* create 2-D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 2, chunk_dim2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED2, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set allocation time to early */
     if (H5Pset_alloc_time(pid, H5D_ALLOC_TIME_EARLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED3, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * create 2-D dataset: chunked, empty, non-filtered,
@@ -3761,26 +3761,26 @@ test_copy_dataset_chunked_empty(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, 
 
     /* create 2-D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 2, dim2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED2_SINGLE, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * create 2-D dataset: chunked, empty, non-filtered, dims=chunk dims
@@ -3788,28 +3788,28 @@ test_copy_dataset_chunked_empty(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, 
      */
     /* Set allocation time to early */
     if (H5Pset_alloc_time(pid, H5D_ALLOC_TIME_EARLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED3_SINGLE, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * create 2-D dataset: chunked, empty, non-filtered,
@@ -3822,251 +3822,251 @@ test_copy_dataset_chunked_empty(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, 
 
     /* create 2-D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, dim2d)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 2, dim2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set allocation time to late */
     if (H5Pset_alloc_time(pid, H5D_ALLOC_TIME_LATE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED4_SINGLE, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the datasets from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED, fid_dst, NAME_DATASET_CHUNKED, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED_SINGLE, fid_dst, NAME_DATASET_CHUNKED_SINGLE, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED2, fid_dst, NAME_DATASET_CHUNKED2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED2_SINGLE, fid_dst, NAME_DATASET_CHUNKED2_SINGLE, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED3, fid_dst, NAME_DATASET_CHUNKED3, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED3_SINGLE, fid_dst, NAME_DATASET_CHUNKED3_SINGLE, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED4_SINGLE, fid_dst, NAME_DATASET_CHUNKED4_SINGLE, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset NAME_DATASET_CHUNKED in SRC file */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied dataset NAME_DATASET_CHUNKED at destination */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_EARRAY, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset NAME_DATASET_CHUNKED_SINGLE in SRC file */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied dataset NAME_DATASET_CHUNKED_SINGLE at destination */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_SINGLE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset NAME_DATASET_CHUNKED2 in SRC file */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied dataset NAME_DATASET_CHUNKED2 at destination */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_FARRAY, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset "NAME_DATASET_CHUNKED2_SINGLE in SRC file */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED2_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied dataset NAME_DATASET_CHUNKED2_SINGLE at destination */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED2_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_SINGLE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset NAME_DATASET_CHUNKED3 in SRC file */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED3, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied dataset NAME_DATASET_CHUNKED3 at destinaion */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED3, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_NONE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset NAME_DATASET_CHUNKED3_SINGLE in SRC file */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED3_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied dataset NAME_DATASET_CHUNKED3_SINGLE at destination */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED3_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_SINGLE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset NAME_DATASET_CHUNKED4_SINGLE in SRC file */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED4_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied dataset NAME_DATASET_CHUNKED4_SINGLE at destination */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED4_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_SINGLE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -4138,7 +4138,7 @@ test_copy_dataset_chunked_sparse(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set 1-D dataspace dimensions */
     dim1d[0]     = DIM_SIZE_1;
@@ -4146,41 +4146,41 @@ test_copy_dataset_chunked_sparse(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
 
     /* create 1-D dataspace */
     if ((sid = H5Screate_simple(1, dim1d, max_dim1d)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 1, chunk_dim1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set extended dataset dimensions */
     new_dim1d[0] = DIM_SIZE_1 * 2;
 
     /* Extend dataset's dimensions */
     if (H5Dset_extent(did, new_dim1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Change 1-D dataspace dimensions */
     dim1d[0]     = DIM_SIZE_1;
@@ -4188,43 +4188,43 @@ test_copy_dataset_chunked_sparse(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
 
     /* create 1-D dataspace */
     if ((sid = H5Screate_simple(1, dim1d, max_dim1d)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set allocation time to early */
     if (H5Pset_alloc_time(pid, H5D_ALLOC_TIME_EARLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED3, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set extended dataset dimensions */
     new_dim1d[0] = DIM_SIZE_1 * 2;
 
     /* Extend dataset's dimensions */
     if (H5Dset_extent(did, new_dim1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set 2-D dataspace dimensions */
     dim2d[0]     = DIM_SIZE_1;
@@ -4234,26 +4234,26 @@ test_copy_dataset_chunked_sparse(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
 
     /* create 2-D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, max_dim2d)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 2, chunk_dim2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED2, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set extended dataset dimensions */
     new_dim2d[0] = DIM_SIZE_1 * 2;
@@ -4261,15 +4261,15 @@ test_copy_dataset_chunked_sparse(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
 
     /* Extend dataset's dimensions */
     if (H5Dset_extent(did, new_dim2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Change 2-D dataspace dimensions */
     dim2d[0]     = DIM_SIZE_1;
@@ -4279,28 +4279,28 @@ test_copy_dataset_chunked_sparse(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
 
     /* create 2-D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, max_dim2d)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set allocation time to early */
     if (H5Pset_alloc_time(pid, H5D_ALLOC_TIME_EARLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED4, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set extended dataset dimensions */
     new_dim2d[0] = DIM_SIZE_1 * 2;
@@ -4308,146 +4308,146 @@ test_copy_dataset_chunked_sparse(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
 
     /* Extend dataset's dimensions */
     if (H5Dset_extent(did, new_dim2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the datasets from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED, fid_dst, NAME_DATASET_CHUNKED, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED2, fid_dst, NAME_DATASET_CHUNKED2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED3, fid_dst, NAME_DATASET_CHUNKED3, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED4, fid_dst, NAME_DATASET_CHUNKED4, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_EARRAY, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_BT2, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED3, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED3, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_NONE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED4, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED4, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the array index type is correct */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_NONE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -4519,7 +4519,7 @@ test_copy_dataset_compressed(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -4527,61 +4527,61 @@ test_copy_dataset_compressed(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid
 
     /* create dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set comp & chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 2, chunk_dim2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_deflate(pid, 9) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set allocation time to early */
     if (H5Pset_alloc_time(pid, H5D_ALLOC_TIME_EARLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED2, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * create 2-D dataset: chunked, filtered, with data
@@ -4589,32 +4589,32 @@ test_copy_dataset_compressed(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid
      */
     /* create dataspace */
     if ((sid = H5Screate_simple(2, dim2d, dim2d)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set comp & chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 2, dim2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_deflate(pid, 9) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED2_SINGLE, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * create 2-D dataset: chunked, filtered, with data
@@ -4622,36 +4622,36 @@ test_copy_dataset_compressed(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid
      */
     /* create dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set allocation time to early */
     if (H5Pset_alloc_time(pid, H5D_ALLOC_TIME_EARLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED3_SINGLE, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * create 2-D dataset: chunked, filtered, with data
@@ -4659,210 +4659,210 @@ test_copy_dataset_compressed(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid
      */
     /* create dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set comp & chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 2, dim2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_deflate(pid, 9) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set allocation time to late */
     if (H5Pset_alloc_time(pid, H5D_ALLOC_TIME_LATE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED4_SINGLE, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED, fid_dst, NAME_DATASET_CHUNKED, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED2, fid_dst, NAME_DATASET_CHUNKED2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED2_SINGLE, fid_dst, NAME_DATASET_CHUNKED2_SINGLE, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED3_SINGLE, fid_dst, NAME_DATASET_CHUNKED3_SINGLE, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED4_SINGLE, fid_dst, NAME_DATASET_CHUNKED4_SINGLE, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the source and destination files for verification */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_FARRAY, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_FARRAY, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset NAME_DATASET_CHUNKED2_SINGLE at source */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED2_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied dataset NAME_DATASET_CHUNKED2_SINGLE at destination */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED2_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_SINGLE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset NAME_DATASET_CHUNKED3_SINGLE at source */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED3_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied dataset NAME_DATASET_CHUNKED3_SINGLE at destination */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED3_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_SINGLE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset NAME_DATASET_CHUNKED4_SINGLE at source */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED4_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied dataset NAME_DATASET_CHUNKED4_SINGLE at destination */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED4_SINGLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_SINGLE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 #endif /* H5_HAVE_FILTER_DEFLATE */
@@ -4948,7 +4948,7 @@ test_copy_dataset_no_edge_filt(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, h
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -4956,100 +4956,100 @@ test_copy_dataset_no_edge_filt(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, h
 
     /* create dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set comp & chunk plist, and disable partial chunk filters */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 2, chunk_dim2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_deflate(pid, 9) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk_opts(pid, H5D_CHUNK_DONT_FILTER_PARTIAL_CHUNKS) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (!test_open) {
 
         /* close the dataset */
         if (H5Dclose(did) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* close the SRC file */
         if (H5Fclose(fid_src) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* open the source file with read-only */
         if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED, fid_dst, NAME_DATASET_CHUNKED, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (!test_open) {
         /* open the dataset for copy */
         if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Pset_chunk_opts() will set layout version to 4 which will use latest indexing available */
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_FARRAY, H5D_CHUNK_IDX_FARRAY) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 #endif /* H5_HAVE_FILTER_DEFLATE */
@@ -5121,7 +5121,7 @@ test_copy_dataset_compact(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t 
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -5129,91 +5129,91 @@ test_copy_dataset_compact(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t 
 
     /* create dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set compact plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_layout(pid, H5D_COMPACT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_COMPACT, H5T_NATIVE_FLOAT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (!test_open) {
         /* close the dataset */
         if (H5Dclose(did) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* close the SRC file */
         if (H5Fclose(fid_src) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* open the source file with read-only */
         if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_COMPACT, fid_dst, NAME_DATASET_COMPACT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (!test_open) {
         /* open the dataset for copy */
         if ((did = H5Dopen2(fid_src, NAME_DATASET_COMPACT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_COMPACT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -5277,91 +5277,91 @@ test_copy_dataset_external(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set dataset creation plist */
     size = DIM_SIZE_1 * sizeof(int);
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_external(pid, FILE_EXT, (off_t)0, size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_EXTERNAL, H5T_NATIVE_INT, sid, H5P_DEFAULT, pid,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close external plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_EXTERNAL, fid_dst, NAME_DATASET_EXTERNAL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_EXTERNAL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_EXTERNAL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -5422,91 +5422,91 @@ test_copy_dataset_named_dtype(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hi
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create named datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_src, NAME_DATATYPE_SIMPLE, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_NAMED_DTYPE, tid, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_NAMED_DTYPE, fid_dst, NAME_DATASET_NAMED_DTYPE, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_NAMED_DTYPE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_NAMED_DTYPE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -5568,111 +5568,111 @@ test_copy_dataset_named_dtype_hier(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fap
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group to place all objects in */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create named datatype _inside_ hierarchy to copy */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(gid, NAME_DATATYPE_SIMPLE, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create first dataset at SRC file */
     if ((did = H5Dcreate2(gid, NAME_DATASET_NAMED_DTYPE, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create second dataset at SRC file */
     if ((did = H5Dcreate2(gid, NAME_DATASET_NAMED_DTYPE2, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_dst, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the group for copy */
     if ((gid = H5Gopen2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the destination group */
     if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if the groups are equal */
     if (compare_groups(gid, gid2, H5P_DEFAULT, -1, 0) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -5736,111 +5736,111 @@ test_copy_dataset_named_dtype_hier_outside(hid_t fcpl_src, hid_t fcpl_dst, hid_t
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group to place all objects in */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create named datatype _outside_ hierarchy to copy */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_src, NAME_DATATYPE_SIMPLE, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create first dataset at SRC file */
     if ((did = H5Dcreate2(gid, NAME_DATASET_NAMED_DTYPE, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create second dataset at SRC file */
     if ((did = H5Dcreate2(gid, NAME_DATASET_NAMED_DTYPE2, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_dst, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the group for copy */
     if ((gid = H5Gopen2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the destination group */
     if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if the groups are equal */
     if (compare_groups(gid, gid2, H5P_DEFAULT, -1, 0) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -5912,114 +5912,114 @@ test_copy_dataset_multi_ohdr_chunks(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fa
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group to place all objects in */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create first dataset at SRC file */
     if ((did = H5Dcreate2(gid, NAME_DATASET_MULTI_OHDR, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create second dataset at SRC file */
     if ((did2 = H5Dcreate2(gid, NAME_DATASET_MULTI_OHDR2, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                            H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did2, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add attributes to datasets in a way that creates lots of chunks */
     if (test_copy_attach_paired_attributes(did, did2, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the first dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (!test_open) {
 
         /* close the second dataset */
         if (H5Dclose(did2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* close group */
         if (H5Gclose(gid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* close the SRC file */
         if (H5Fclose(fid_src) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* open the source file with read-only */
         if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_dst, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (test_open) {
         /* close the second dataset */
         if (H5Dclose(did2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
         /* open the group for copy */
         if ((gid = H5Gopen2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the destination group */
     if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if the groups are equal */
     if (compare_groups(gid, gid2, H5P_DEFAULT, -1, 0) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -6082,114 +6082,114 @@ test_copy_dataset_attr_named_dtype(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fap
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group to place all objects in */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create named datatype _outside_ hierarchy to copy */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_src, NAME_DATATYPE_SIMPLE, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create first dataset at SRC file */
     if ((did = H5Dcreate2(gid, NAME_DATASET_MULTI_OHDR, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create second dataset at SRC file */
     if ((did2 = H5Dcreate2(gid, NAME_DATASET_MULTI_OHDR2, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did2, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add attributes to datasets in a way that creates lots of chunks */
     if (test_copy_attach_paired_attributes(did, did2, tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the first dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the second dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_dst, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the group for copy */
     if ((gid = H5Gopen2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the destination group */
     if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if the groups are equal */
     if (compare_groups(gid, gid2, H5P_DEFAULT, -1, 0) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -6257,99 +6257,99 @@ test_copy_dataset_contig_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_VL, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_VL, fid_dst, NAME_DATASET_VL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen buffer */
     if (H5Tdetect_class(tid, H5T_VLEN) == TRUE) {
         if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_vlen_mem_manager(dxpl_id, NULL, NULL, NULL, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Treclaim(tid, sid, dxpl_id, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(dxpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -6419,153 +6419,153 @@ test_copy_dataset_chunked_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 1, chunk_dim1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_VL, tid, sid, H5P_DEFAULT, pid, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set allocation time to early */
     if (H5Pset_alloc_time(pid, H5D_ALLOC_TIME_EARLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_VL2, tid, sid, H5P_DEFAULT, pid, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_VL, fid_dst, NAME_DATASET_VL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_VL2, fid_dst, NAME_DATASET_VL2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_FARRAY, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_VL2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_VL2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_NONE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen buffer */
     if (H5Tdetect_class(tid, H5T_VLEN) == TRUE) {
         if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_vlen_mem_manager(dxpl_id, NULL, NULL, NULL, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Treclaim(tid, sid, dxpl_id, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(dxpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -6635,109 +6635,109 @@ test_copy_dataset_compact_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set compact plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_layout(pid, H5D_COMPACT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_VL, tid, sid, H5P_DEFAULT, pid, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close compact plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_VL, fid_dst, NAME_DATASET_VL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen buffer */
     if (H5Tdetect_class(tid, H5T_VLEN) == TRUE) {
         if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_vlen_mem_manager(dxpl_id, NULL, NULL, NULL, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Treclaim(tid, sid, dxpl_id, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(dxpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -6794,7 +6794,7 @@ test_copy_attribute_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -6802,84 +6802,84 @@ test_copy_attribute_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst
 
     /* create 2D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create 2D int dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach VL attribute to the dataset */
     if (test_copy_attach_attribute_vl(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the attributes are equal */
 
     if ((aid = H5Aopen_by_idx(did, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, (hsize_t)0, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((aid2 = H5Aopen_by_idx(did2, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, (hsize_t)0, H5P_DEFAULT,
                                H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (compare_attribute(aid, aid2, H5P_DEFAULT, NULL, did) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -7010,60 +7010,60 @@ compare_attribute_compound_vlstr(hid_t loc, hid_t loc2)
     /* Open the attributes attached to the objects */
     if ((aid = H5Aopen_by_idx(loc, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, (hsize_t)0, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((aid2 = H5Aopen_by_idx(loc2, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, (hsize_t)0, H5P_DEFAULT,
                                H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the attributes' datatypes */
     if ((tid = H5Aget_type(aid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((tid2 = H5Aget_type(aid2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the attributes' dataspaces */
     if ((sid = H5Aget_space(aid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sid2 = H5Aget_space(aid2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read the attributes */
     if (H5Aread(aid, tid, &rbuf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Aread(aid2, tid2, &rbuf2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Compare the attributes' data */
     if (rbuf.i != rbuf2.i)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrlen(rbuf.v) != HDstrlen(rbuf2.v))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDmemcmp(rbuf.v, rbuf2.v, HDstrlen(rbuf.v)) != 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Reclaim vlen buffer */
     if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_vlen_mem_manager(dxpl_id, NULL, NULL, NULL, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Treclaim(tid, sid, dxpl_id, &rbuf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Treclaim(tid, sid, dxpl_id, &rbuf2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dxpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataspaces */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(sid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the attributes */
     if (H5Aclose(aid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Aclose(aid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     return TRUE;
 
 error:
@@ -7123,7 +7123,7 @@ test_copy_attribute_compound_vlstr(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fap
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -7131,104 +7131,104 @@ test_copy_attribute_compound_vlstr(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fap
 
     /* create 2D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* create 2D int dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* attach an attribute to the dataset */
     if (attach_attribute_compound_vlstr(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* create a group */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_EMPTY, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* attach attribute to the group */
     if (attach_attribute_compound_vlstr(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* close the group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the src dataset */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* compare the data of the attributes attached to the two datasets */
     if (compare_attribute_compound_vlstr(did, did2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* close the datasets */
     if (H5Dclose(did2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Copy the group */
     if (H5Ocopy(fid_src, NAME_GROUP_EMPTY, fid_dst, NAME_GROUP_EMPTY, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the src group */
     if ((gid = H5Gopen2(fid_src, NAME_GROUP_EMPTY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Open the destination group */
     if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_EMPTY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* compare the data of the attributes attached to the two groups */
     if (compare_attribute_compound_vlstr(gid, gid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* close the groups */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(gid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -7311,7 +7311,7 @@ test_copy_dataset_compressed_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, 
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -7319,104 +7319,104 @@ test_copy_dataset_compressed_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, 
 
     /* create dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set comp & chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 2, chunk_dim2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_deflate(pid, 9) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED, tid, sid, H5P_DEFAULT, pid, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED, fid_dst, NAME_DATASET_CHUNKED, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CHUNKED, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen buffer */
     if (H5Tdetect_class(tid, H5T_VLEN) == TRUE) {
         if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_vlen_mem_manager(dxpl_id, NULL, NULL, NULL, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Treclaim(tid, sid, dxpl_id, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(dxpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 #endif /* H5_HAVE_FILTER_DEFLATE */
@@ -7473,68 +7473,68 @@ test_copy_group_empty(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create group at the SRC file */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_EMPTY, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the group */
     if (test_copy_attach_attributes(gid, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the group from SRC to DST */
     if (H5Ocopy(fid_src, NAME_GROUP_EMPTY, fid_dst, NAME_GROUP_EMPTY, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the group for copy */
     if ((gid = H5Gopen2(fid_src, NAME_GROUP_EMPTY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the destination group */
     if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_EMPTY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if the groups are equal */
     if (compare_groups(gid, gid2, H5P_DEFAULT, -1, 0) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -7594,15 +7594,15 @@ test_copy_root_group(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_f
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create group at the SRC file */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the group */
     if (test_copy_attach_attributes(gid, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -7610,87 +7610,87 @@ test_copy_root_group(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_f
 
     /* create dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add a dataset to the group */
     if ((did = H5Dcreate2(fid_src, NAME_GROUP_DATASET, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create a sub-group */
     if ((gid_sub = H5Gcreate2(fid_src, NAME_GROUP_SUB, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid_sub) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create another  sub-group */
     if ((gid_sub = H5Gcreate2(fid_src, NAME_GROUP_SUB_2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid_sub) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the group from SRC to DST */
     if (H5Ocopy(fid_src, "/", fid_dst, "/root_from_src", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the group for copy */
     if ((gid = H5Gopen2(fid_src, "/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the destination group */
     if ((gid2 = H5Gopen2(fid_dst, "/root_from_src", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if the groups are equal */
     if (compare_groups(gid, gid2, H5P_DEFAULT, -1, 0) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -7753,15 +7753,15 @@ test_copy_group(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fapl)
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create group at the SRC file */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the group */
     if (test_copy_attach_attributes(gid, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -7769,87 +7769,87 @@ test_copy_group(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fapl)
 
     /* create dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add a dataset to the group */
     if ((did = H5Dcreate2(fid_src, NAME_GROUP_DATASET, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create a sub-group */
     if ((gid_sub = H5Gcreate2(fid_src, NAME_GROUP_SUB, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid_sub) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create another  sub-group */
     if ((gid_sub = H5Gcreate2(fid_src, NAME_GROUP_SUB_2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid_sub) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the group from SRC to DST */
     if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_dst, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the group for copy */
     if ((gid = H5Gopen2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the destination group */
     if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if the groups are equal */
     if (compare_groups(gid, gid2, H5P_DEFAULT, -1, 0) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -7913,15 +7913,15 @@ test_copy_group_deep(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_f
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create group at the SRC file */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the group */
     if (test_copy_attach_attributes(gid, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -7929,18 +7929,18 @@ test_copy_group_deep(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_f
 
     /* create dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create nested sub-groups & datasets */
     for (i = 0; i < NUM_SUB_GROUPS; i++) {
         HDsprintf(objname, "Group #%d", i);
         if ((gid_sub = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         for (j = 0; j < NUM_SUB_GROUPS; j++) {
             HDsprintf(objname, "Group #%d", j);
             if ((gid_sub2 = H5Gcreate2(gid_sub, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             for (k = 0; k < NUM_DATASETS; k++) {
                 HDsprintf(objname, "Dataset #%d", k);
@@ -7948,77 +7948,77 @@ test_copy_group_deep(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_f
                 /* add a dataset to the group */
                 if ((did = H5Dcreate2(gid_sub2, objname, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                                       H5P_DEFAULT)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Dclose(did) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end for */
 
             if (H5Gclose(gid_sub2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         if (H5Gclose(gid_sub) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the group from SRC to DST */
     if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_dst, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the group for copy */
     if ((gid = H5Gopen2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the destination group */
     if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if the groups are equal */
     if (compare_groups(gid, gid2, H5P_DEFAULT, -1, 0) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -8071,87 +8071,87 @@ test_copy_group_loop(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_f
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create group at the SRC file */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the group */
     if (test_copy_attach_attributes(gid, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create sub-groups */
     if ((gid_sub = H5Gcreate2(gid, NAME_GROUP_SUB, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gid_sub2 = H5Gcreate2(gid, NAME_GROUP_SUB_SUB, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create link to top group */
     if (H5Lcreate_hard(gid, ".", gid_sub2, NAME_GROUP_LOOP, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close sub sub group */
     if (H5Gclose(gid_sub2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close sub group */
     if (H5Gclose(gid_sub) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the group from SRC to DST */
     if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_dst, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the group for copy */
     if ((gid = H5Gopen2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the destination group */
     if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if the groups are equal */
     if (compare_groups(gid, gid2, H5P_DEFAULT, -1, 0) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -8210,101 +8210,101 @@ test_copy_group_wide_loop(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t 
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create group at the SRC file */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the group */
     if (test_copy_attach_attributes(gid, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create wide sub-group hierarchy, with multiple links to higher groups */
     for (u = 0; u < NUM_WIDE_LOOP_GROUPS; u++) {
         HDsprintf(objname, "%s-%u", NAME_GROUP_SUB, u);
         if ((gid_sub = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         for (v = 0; v < NUM_WIDE_LOOP_GROUPS; v++) {
             HDsprintf(objname, "%s-%u", NAME_GROUP_SUB_SUB2, v);
             if ((gid_sub2 = H5Gcreate2(gid_sub, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create link to top group */
             if (H5Lcreate_hard(gid, ".", gid_sub2, NAME_GROUP_LOOP, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create link to sub-group */
             if (H5Lcreate_hard(gid_sub, ".", gid_sub2, NAME_GROUP_LOOP2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create link to self :-) */
             if (H5Lcreate_hard(gid_sub2, ".", gid_sub2, NAME_GROUP_LOOP3, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* close sub sub group */
             if (H5Gclose(gid_sub2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         } /* end for */
 
         /* close sub group */
         if (H5Gclose(gid_sub) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* close the group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the group from SRC to DST */
     if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_dst, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the group for copy */
     if ((gid = H5Gopen2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open the destination group */
     if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if the groups are equal */
     if (compare_groups(gid, gid2, H5P_DEFAULT, -1, 0) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -8373,23 +8373,23 @@ test_copy_group_links(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create file to hold external dataset */
     if ((fid_ext = H5Fcreate(ext_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create groups at the SRC file.  Group 2 will hold dangling links. */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_LINK, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid2 = H5Gcreate2(fid_src, NAME_GROUP_LINK2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the groups */
     if (test_copy_attach_attributes(gid, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (test_copy_attach_attributes(gid2, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -8397,22 +8397,22 @@ test_copy_group_links(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_
 
     /* create dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add a dataset to the group */
     if ((did = H5Dcreate2(fid_src, NAME_LINK_DATASET, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now create a 1-D dataset in an external file */
     /* Set dataspace dimensions */
@@ -8420,61 +8420,61 @@ test_copy_group_links(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add a dataset to the external file */
     if ((did = H5Dcreate2(fid_ext, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* make a hard link to the dataset */
     if (H5Lcreate_hard(fid_src, NAME_LINK_DATASET, H5L_SAME_LOC, NAME_LINK_HARD, H5P_DEFAULT, H5P_DEFAULT) <
         0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* make a soft link to the dataset */
     if (H5Lcreate_soft(NAME_LINK_DATASET, fid_src, NAME_LINK_SOFT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* make an external link to the external dataset */
     if (H5Lcreate_external(ext_filename, NAME_DATASET_SIMPLE, fid_src, NAME_LINK_EXTERN, H5P_DEFAULT,
                            H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* make a dangling soft link */
     if (H5Lcreate_soft("nowhere", fid_src, NAME_LINK_SOFT_DANGLE2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* make a dangling external link */
     if (H5Lcreate_external("no_file", "no_object", fid_src, NAME_LINK_EXTERN_DANGLE2, H5P_DEFAULT,
                            H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* close the groups */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC and EXT files */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid_ext) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the object copy plist */
     if ((plid = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop over all configurations (expand soft/external links) */
     for (expand_soft = 0; expand_soft <= 1; expand_soft++) {
@@ -8486,32 +8486,32 @@ test_copy_group_links(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_
             if (expand_ext)
                 copy_options |= H5O_COPY_EXPAND_EXT_LINK_FLAG;
             if (H5Pset_copy_object(plid, copy_options) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* open the source file with read-only */
             if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* create destination file */
             if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create an uncopied object in destination file so that tokens in source and destination files
              * aren't the same */
             if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* copy the group from SRC to DST */
             if (H5Ocopy(fid_src, NAME_GROUP_LINK, fid_dst, NAME_GROUP_LINK, plid, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* open the group for copy */
             if ((gid = H5Gopen2(fid_src, NAME_GROUP_LINK, H5P_DEFAULT)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* open the destination group */
             if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_LINK, H5P_DEFAULT)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* If expand_soft is set to true, verify that the soft link is now a
              * hard link, and compare the expanded dataset, then delete it and
@@ -8519,29 +8519,29 @@ test_copy_group_links(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_
             if (expand_soft) {
                 /* Check link type */
                 if (H5Lget_info2(fid_dst, NAME_LINK_SOFT, &linfo, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (linfo.type != H5L_TYPE_HARD)
-                    FAIL_PUTS_ERROR("Soft link was not expanded to a hard link")
+                    FAIL_PUTS_ERROR("Soft link was not expanded to a hard link");
 
                 /* Compare datasets */
                 if ((did = H5Dopen2(fid_src, NAME_LINK_DATASET, H5P_DEFAULT)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if ((did2 = H5Dopen2(fid_dst, NAME_LINK_SOFT, H5P_DEFAULT)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Delete expanded dataset, add soft link */
                 if (H5Ldelete(fid_dst, NAME_LINK_SOFT, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Lcreate_soft(NAME_LINK_DATASET, fid_dst, NAME_LINK_SOFT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close datasets */
                 if (H5Dclose(did) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Dclose(did2) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
 
             /* If expand_ext is set to true, verify that the external link is
@@ -8550,83 +8550,83 @@ test_copy_group_links(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_
             if (expand_ext) {
                 /* Check link type */
                 if (H5Lget_info2(fid_dst, NAME_LINK_EXTERN, &linfo, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (linfo.type != H5L_TYPE_HARD)
-                    FAIL_PUTS_ERROR("External link was not expanded to a hard link")
+                    FAIL_PUTS_ERROR("External link was not expanded to a hard link");
 
                 /* Compare datasets */
                 if ((fid_ext = H5Fopen(ext_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if ((did = H5Dopen2(fid_ext, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if ((did2 = H5Dopen2(fid_dst, NAME_LINK_EXTERN, H5P_DEFAULT)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Delete expanded dataset, add external link */
                 if (H5Ldelete(fid_dst, NAME_LINK_EXTERN, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Lcreate_external(ext_filename, NAME_DATASET_SIMPLE, fid_dst, NAME_LINK_EXTERN,
                                        H5P_DEFAULT, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Close datasets and external file */
                 if (H5Dclose(did) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Dclose(did2) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Fclose(fid_ext) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
 
             /* Check if the groups are equal */
             if (compare_groups(gid, gid2, H5P_DEFAULT, -1, 0) != TRUE)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* close the destination group */
             if (H5Gclose(gid2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* close the source group */
             if (H5Gclose(gid) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Now try to copy the group containing the dangling link.  They
              * should always be copied as the same type of link, never expanded
              * to hard links. */
             if (H5Ocopy(fid_src, NAME_GROUP_LINK2, fid_dst, NAME_GROUP_LINK2, plid, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Open the original and copied groups */
             if ((gid = H5Gopen2(fid_src, NAME_GROUP_LINK2, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_LINK2, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Compare the groups */
             if (compare_groups(gid, gid2, H5P_DEFAULT, -1, 0) != TRUE)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close groups */
             if (H5Gclose(gid2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Gclose(gid) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* close the SRC file */
             if (H5Fclose(fid_src) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* close the DST file */
             if (H5Fclose(fid_dst) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
     }     /* end for */
 
     /* Close the object copy plist */
     if (H5Pclose(plid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -8699,15 +8699,15 @@ test_copy_soft_link(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fa
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create group at the SRC file */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_LINK, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the group */
     if (test_copy_attach_attributes(gid, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -8715,83 +8715,83 @@ test_copy_soft_link(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fa
 
     /* create dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add a dataset to the group */
     if ((did = H5Dcreate2(fid_src, NAME_LINK_DATASET, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* close the group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* make a soft link to the dataset */
     if (H5Lcreate_soft(NAME_LINK_DATASET, fid_src, NAME_LINK_SOFT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (!test_open) {
         /* close the dataset */
         if (H5Dclose(did) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* close the SRC file */
         if (H5Fclose(fid_src) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* open the source file with read-only */
         if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_LINK_SOFT, fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (!test_open) {
         /* open the dataset through the soft link for copy */
         if ((did = H5Dopen2(fid_src, NAME_LINK_SOFT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -8854,15 +8854,15 @@ test_copy_ext_link(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fap
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create group at the SRC file */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_LINK, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the group */
     if (test_copy_attach_attributes(gid, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -8870,92 +8870,92 @@ test_copy_ext_link(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fap
 
     /* create dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add a dataset to the group */
     if ((did = H5Dcreate2(fid_src, NAME_LINK_DATASET, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* close the group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create file to hold external links to the src file */
     if ((fid_ext = H5Fcreate(ext_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create group in the file that will hold the external link */
     if ((gid = H5Gcreate2(fid_ext, NAME_GROUP_LINK, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an external link to the dataset in the source file */
     if (H5Lcreate_external(src_filename, NAME_LINK_DATASET, fid_ext, NAME_LINK_EXTERN, H5P_DEFAULT,
                            H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the group and file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid_ext) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the "extern" file with read-only */
     if ((fid_ext = H5Fopen(ext_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_ext, NAME_LINK_EXTERN, fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset through the external link */
     if ((did = H5Dopen2(fid_ext, NAME_LINK_EXTERN, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the EXT file */
     if (H5Fclose(fid_ext) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -9017,7 +9017,7 @@ test_copy_exist(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fapl)
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -9025,49 +9025,49 @@ test_copy_exist(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fapl)
 
     /* create 2D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create 2D int dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* try to copy the dataset from SRC to DST again (should fail) */
     H5E_BEGIN_TRY
@@ -9076,15 +9076,15 @@ test_copy_exist(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fapl)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -9145,7 +9145,7 @@ test_copy_path(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fapl)
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -9153,45 +9153,45 @@ test_copy_path(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fapl)
 
     /* create 2D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create 2D int dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST (should fail - intermediate groups not there) */
     H5E_BEGIN_TRY
@@ -9200,55 +9200,55 @@ test_copy_path(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fapl)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the intermediate groups in destination file */
     if ((gid = H5Gcreate2(fid_dst, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gid = H5Gcreate2(fid_dst, NAME_GROUP_SUB, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((gid = H5Gcreate2(fid_dst, NAME_GROUP_SUB_SUB, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST, using full path */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SUB_SUB, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_SUB_SUB, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -9297,39 +9297,39 @@ test_copy_same_file_named_datatype(hid_t fcpl_src, hid_t fapl)
 
     /* create source file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl_src, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create named datatype */
     if ((H5Tcommit2(fid, NAME_DATATYPE_SIMPLE, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the datatype from SRC to DST */
     if (H5Ocopy(fid, NAME_DATATYPE_SIMPLE, fid, NAME_DATATYPE_SIMPLE2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied datatype */
     if ((tid2 = H5Topen2(fid, NAME_DATATYPE_SIMPLE2, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Compare the datatypes */
     if (H5Tequal(tid, tid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination datatype */
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -9386,64 +9386,64 @@ test_copy_old_layout(hid_t fcpl_dst, hid_t fapl, hbool_t test_open)
 
     /* Setup */
     if ((src_fapl = h5_fileaccess_flags(H5_FILEACCESS_LIBVER)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open source file (read-only) */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close source FAPL */
     if (H5Pclose(src_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (test_open) {
         /* open the source dataset */
         if ((did = H5Dopen2(fid_src, NAME_OLD_FORMAT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_OLD_FORMAT, fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (!test_open) {
         /* open the source dataset */
         if ((did = H5Dopen2(fid_src, NAME_OLD_FORMAT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -9509,121 +9509,121 @@ test_copy_dataset_compact_named_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fap
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* make a copy of the datatype for later use */
     if ((tid_copy = H5Tcopy(tid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* named datatype */
     if ((H5Tcommit2(fid_src, NAME_DATATYPE_VL, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set compact plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_layout(pid, H5D_COMPACT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_VL, tid, sid, H5P_DEFAULT, pid, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close compact plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_VL, fid_dst, NAME_DATASET_VL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen buffer */
     if (H5Tdetect_class(tid_copy, H5T_VLEN) == TRUE) {
         if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_vlen_mem_manager(dxpl_id, NULL, NULL, NULL, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Treclaim(tid_copy, sid, dxpl_id, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(dxpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close datatype */
     if (H5Tclose(tid_copy) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -9693,111 +9693,111 @@ test_copy_dataset_contig_named_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* make a copy of the datatype for later use */
     if ((tid_copy = H5Tcopy(tid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* named datatype */
     if ((H5Tcommit2(fid_src, NAME_DATATYPE_VL, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_VL, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_VL, fid_dst, NAME_DATASET_VL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen buffer */
     if (H5Tdetect_class(tid_copy, H5T_VLEN) == TRUE) {
         if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_vlen_mem_manager(dxpl_id, NULL, NULL, NULL, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Treclaim(tid_copy, sid, dxpl_id, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(dxpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close datatype */
     if (H5Tclose(tid_copy) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -9877,126 +9877,126 @@ test_copy_dataset_chunked_named_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fap
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* make a copy of the datatype for later use */
     if ((tid_copy = H5Tcopy(tid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* named datatype */
     if ((H5Tcommit2(fid_src, NAME_DATATYPE_VL, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 1, chunk_dim1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_VL, tid, sid, H5P_DEFAULT, pid, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close compact plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (!test_open) {
 
         /* close the dataset */
         if (H5Dclose(did) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* close the SRC file */
         if (H5Fclose(fid_src) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* open the source file with read-only */
         if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_VL, fid_dst, NAME_DATASET_VL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (!test_open) {
         /* open the dataset for copy */
         if ((did = H5Dopen2(fid_src, NAME_DATASET_VL, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen buffer */
     if (H5Tdetect_class(tid_copy, H5T_VLEN) == TRUE) {
         if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_vlen_mem_manager(dxpl_id, NULL, NULL, NULL, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Treclaim(tid_copy, sid, dxpl_id, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(dxpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close datatype */
     if (H5Tclose(tid_copy) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -10068,123 +10068,123 @@ test_copy_dataset_compressed_named_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* make a copy of the datatype for later use */
     if ((tid_copy = H5Tcopy(tid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* named datatype */
     if ((H5Tcommit2(fid_src, NAME_DATATYPE_VL, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 1, chunk_dim1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_deflate(pid, 9) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_VL, tid, sid, H5P_DEFAULT, pid, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close compact plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_VL, fid_dst, NAME_DATASET_VL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen buffer */
     if (H5Tdetect_class(tid_copy, H5T_VLEN) == TRUE) {
         if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_vlen_mem_manager(dxpl_id, NULL, NULL, NULL, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Treclaim(tid_copy, sid, dxpl_id, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(dxpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close datatype */
     if (H5Tclose(tid_copy) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -10268,115 +10268,115 @@ test_copy_dataset_compact_vl_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, 
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create nested VL datatype */
     if ((tid2 = H5Tvlen_create(tid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set compact plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_layout(pid, H5D_COMPACT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_VL_VL, tid2, sid, H5P_DEFAULT, pid, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid2, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close compact plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_VL_VL, fid_dst, NAME_DATASET_VL_VL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_VL_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_VL_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen buffer */
     if (H5Tdetect_class(tid2, H5T_VLEN) == TRUE) {
         if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_vlen_mem_manager(dxpl_id, NULL, NULL, NULL, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Treclaim(tid2, sid, dxpl_id, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(dxpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -10445,14 +10445,14 @@ test_copy_dataset_contig_vl_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, h
         buf[i].p = HDmalloc((i + 1) * sizeof(hvl_t));
         if (buf[i].p == NULL) {
             TestErrPrintf("Cannot allocate memory for VL data! i=%u\n", i);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
         buf[i].len = i + 1;
         for (tvl = (hvl_t *)buf[i].p, j = 0; j < (i + 1); j++, tvl++) {
             tvl->p = HDmalloc((j + 1) * sizeof(unsigned int));
             if (tvl->p == NULL) {
                 TestErrPrintf("Cannot allocate memory for VL data! i=%u, j=%u\n", i, j);
-                TEST_ERROR
+                TEST_ERROR;
             } /* end if */
             tvl->len = j + 1;
             for (k = 0; k < (j + 1); k++)
@@ -10469,117 +10469,117 @@ test_copy_dataset_contig_vl_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, h
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create nested VL datatype */
     if ((tid2 = H5Tvlen_create(tid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set compact plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_VL_VL, tid2, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid2, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close compact plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (!test_open) {
         /* close the dataset */
         if (H5Dclose(did) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* close the SRC file */
         if (H5Fclose(fid_src) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* open the source file with read-only */
         if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_VL_VL, fid_dst, NAME_DATASET_VL_VL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (!test_open) {
         /* open the dataset for copy */
         if ((did = H5Dopen2(fid_src, NAME_DATASET_VL_VL, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_VL_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen buffer */
     if (H5Tdetect_class(tid2, H5T_VLEN) == TRUE) {
         if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_vlen_mem_manager(dxpl_id, NULL, NULL, NULL, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Treclaim(tid2, sid, dxpl_id, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(dxpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -10640,14 +10640,14 @@ test_copy_dataset_chunked_vl_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, 
         buf[i].p = HDmalloc((i + 1) * sizeof(hvl_t));
         if (buf[i].p == NULL) {
             TestErrPrintf("Cannot allocate memory for VL data! i=%u\n", i);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
         buf[i].len = i + 1;
         for (tvl = (hvl_t *)buf[i].p, j = 0; j < (i + 1); j++, tvl++) {
             tvl->p = HDmalloc((j + 1) * sizeof(unsigned int));
             if (tvl->p == NULL) {
                 TestErrPrintf("Cannot allocate memory for VL data! i=%u, j=%u\n", i, j);
-                TEST_ERROR
+                TEST_ERROR;
             } /* end if */
             tvl->len = j + 1;
             for (k = 0; k < (j + 1); k++)
@@ -10664,157 +10664,157 @@ test_copy_dataset_chunked_vl_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, 
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create nested VL datatype */
     if ((tid2 = H5Tvlen_create(tid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 1, chunk_dim1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_VL_VL, tid2, sid, H5P_DEFAULT, pid, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid2, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set allocation time to early */
     if (H5Pset_alloc_time(pid, H5D_ALLOC_TIME_EARLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_VL_VL2, tid2, sid, H5P_DEFAULT, pid, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid2, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_VL_VL, fid_dst, NAME_DATASET_VL_VL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_VL_VL2, fid_dst, NAME_DATASET_VL_VL2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_VL_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_VL_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_FARRAY, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_VL_VL2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_VL_VL2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (compare_idx_type(src_fapl, did2, H5D_CHUNK_IDX_NONE, H5D_CHUNK_IDX_BTREE) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen buffer */
     if (H5Tdetect_class(tid2, H5T_VLEN) == TRUE) {
         if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_vlen_mem_manager(dxpl_id, NULL, NULL, NULL, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Treclaim(tid2, sid, dxpl_id, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(dxpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -10884,14 +10884,14 @@ test_copy_dataset_compressed_vl_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fap
         buf[i].p = HDmalloc((i + 1) * sizeof(hvl_t));
         if (buf[i].p == NULL) {
             TestErrPrintf("Cannot allocate memory for VL data! i=%u\n", i);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
         buf[i].len = i + 1;
         for (tvl = (hvl_t *)buf[i].p, j = 0; j < (i + 1); j++, tvl++) {
             tvl->p = HDmalloc((j + 1) * sizeof(unsigned int));
             if (tvl->p == NULL) {
                 TestErrPrintf("Cannot allocate memory for VL data! i=%u, j=%u\n", i, j);
-                TEST_ERROR
+                TEST_ERROR;
             } /* end if */
             tvl->len = j + 1;
             for (k = 0; k < (j + 1); k++)
@@ -10908,120 +10908,120 @@ test_copy_dataset_compressed_vl_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fap
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create nested VL datatype */
     if ((tid2 = H5Tvlen_create(tid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 1, chunk_dim1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_deflate(pid, 9) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_VL_VL, tid2, sid, H5P_DEFAULT, pid, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid2, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close compact plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (!test_open) {
 
         /* close the dataset */
         if (H5Dclose(did) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* close the SRC file */
         if (H5Fclose(fid_src) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* open the source file with read-only */
         if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_VL_VL, fid_dst, NAME_DATASET_VL_VL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (!test_open) {
         /* open the dataset for copy */
         if ((did = H5Dopen2(fid_src, NAME_DATASET_VL_VL, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_VL_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen buffer */
     if (H5Tdetect_class(tid2, H5T_VLEN) == TRUE) {
         if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_vlen_mem_manager(dxpl_id, NULL, NULL, NULL, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Treclaim(tid2, sid, dxpl_id, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(dxpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -11104,110 +11104,110 @@ test_copy_dataset_contig_cmpd_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid2 = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Tcreate(H5T_COMPOUND, sizeof(cmpd_vl_t))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(tid, "a", HOFFSET(cmpd_vl_t, a), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(tid, "b", HOFFSET(cmpd_vl_t, b), tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(tid, "c", HOFFSET(cmpd_vl_t, c), H5T_NATIVE_DOUBLE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CMPD_VL, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_CMPD_VL, fid_dst, NAME_DATASET_CMPD_VL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CMPD_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CMPD_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen buffer */
     if (H5Tdetect_class(tid, H5T_VLEN) == TRUE) {
         if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_vlen_mem_manager(dxpl_id, NULL, NULL, NULL, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Treclaim(tid, sid, dxpl_id, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(dxpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close datatype */
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -11280,119 +11280,119 @@ test_copy_dataset_chunked_cmpd_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid2 = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Tcreate(H5T_COMPOUND, sizeof(cmpd_vl_t))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(tid, "a", HOFFSET(cmpd_vl_t, a), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(tid, "b", HOFFSET(cmpd_vl_t, b), tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(tid, "c", HOFFSET(cmpd_vl_t, c), H5T_NATIVE_DOUBLE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 1, chunk_dim1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CMPD_VL, tid, sid, H5P_DEFAULT, pid, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close chunk plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_CMPD_VL, fid_dst, NAME_DATASET_CMPD_VL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CMPD_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CMPD_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen buffer */
     if (H5Tdetect_class(tid, H5T_VLEN) == TRUE) {
         if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_vlen_mem_manager(dxpl_id, NULL, NULL, NULL, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Treclaim(tid, sid, dxpl_id, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(dxpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close datatype */
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -11465,119 +11465,119 @@ test_copy_dataset_compact_cmpd_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid2 = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Tcreate(H5T_COMPOUND, sizeof(cmpd_vl_t))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(tid, "a", HOFFSET(cmpd_vl_t, a), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(tid, "b", HOFFSET(cmpd_vl_t, b), tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(tid, "c", HOFFSET(cmpd_vl_t, c), H5T_NATIVE_DOUBLE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set compact plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_layout(pid, H5D_COMPACT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_CMPD_VL, tid, sid, H5P_DEFAULT, pid, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close compact plist */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_CMPD_VL, fid_dst, NAME_DATASET_CMPD_VL, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the dataset for copy */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_CMPD_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination dataset */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_CMPD_VL, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen buffer */
     if (H5Tdetect_class(tid, H5T_VLEN) == TRUE) {
         if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_vlen_mem_manager(dxpl_id, NULL, NULL, NULL, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Treclaim(tid, sid, dxpl_id, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(dxpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close datatype */
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -11648,131 +11648,131 @@ test_copy_null_ref(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fap
 
     /* Create source file */
     if ((fid1 = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object reference dataset at SRC file */
     if ((did1 = H5Dcreate2(fid1, "obj_ref_dset", H5T_STD_REF_OBJ, sid, H5P_DEFAULT, H5P_DEFAULT,
                            H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create region reference dataset at SRC file */
     if ((did2 = H5Dcreate2(fid1, "reg_ref_dset", H5T_STD_REF_DSETREG, sid, H5P_DEFAULT, H5P_DEFAULT,
                            H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create references */
     if (H5Rcreate(&obj_buf[0], did1, ".", H5R_OBJECT, (hid_t)-1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate(&obj_buf[1], did2, ".", H5R_OBJECT, (hid_t)-1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate(&reg_buf[0], did1, ".", H5R_DATASET_REGION, sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate(&reg_buf[1], did2, ".", H5R_DATASET_REGION, sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Write data into file */
     if (H5Dwrite(did1, H5T_STD_REF_OBJ, H5S_ALL, H5S_ALL, H5P_DEFAULT, obj_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did2, H5T_STD_REF_DSETREG, H5S_ALL, H5S_ALL, H5P_DEFAULT, reg_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close datasets */
     if (H5Dclose(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create middle file */
     if ((fid2 = H5Fcreate(mid_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Copy the source file to the middle file.  Note the expand references
      * flag is not set. */
     if (H5Ocopy(fid1, "/", fid2, "/A", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close source file */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open copied datasets */
     if ((did1 = H5Dopen2(fid2, "/A/obj_ref_dset", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did2 = H5Dopen2(fid2, "/A/reg_ref_dset", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read copied datasets */
     if (H5Dread(did1, H5T_STD_REF_OBJ, H5S_ALL, H5S_ALL, H5P_DEFAULT, obj_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dread(did2, H5T_STD_REF_DSETREG, H5S_ALL, H5S_ALL, H5P_DEFAULT, reg_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the references contain only "0" bytes */
     if (HDmemcmp(obj_buf, zeros, sizeof(obj_buf)) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDmemcmp(reg_buf, zeros, sizeof(reg_buf)) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close datasets */
     if (H5Dclose(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create destination file */
     if ((fid1 = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object copy property list */
     if ((pid = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set the "expand references" flag */
     if (H5Pset_copy_object(pid, H5O_COPY_EXPAND_REFERENCE_FLAG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Copy the middle file to the destination file.  Note the expand references
      * flag *is* set, even though the references are now NULL. */
     if (H5Ocopy(fid2, "/", fid1, "/AA", pid, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close source file */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open copied datasets */
     if ((did1 = H5Dopen2(fid1, "/AA/A/obj_ref_dset", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did2 = H5Dopen2(fid1, "/AA/A/reg_ref_dset", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read copied datasets */
     if (H5Dread(did1, H5T_STD_REF_OBJ, H5S_ALL, H5S_ALL, H5P_DEFAULT, obj_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dread(did2, H5T_STD_REF_DSETREG, H5S_ALL, H5S_ALL, H5P_DEFAULT, reg_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the references contain only "0" bytes */
     if (HDmemcmp(obj_buf, zeros, sizeof(obj_buf)) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDmemcmp(reg_buf, zeros, sizeof(reg_buf)) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -11846,142 +11846,142 @@ test_copy_null_ref_open(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t ds
 
     /* Create source file */
     if ((fid1 = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(dcpl, 1, chunk_dim1d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_deflate(dcpl, 9) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk_opts(dcpl, H5D_CHUNK_DONT_FILTER_PARTIAL_CHUNKS) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object reference dataset at SRC file */
     if ((did1 = H5Dcreate2(fid1, "obj_ref_dset", H5T_STD_REF_OBJ, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create region reference dataset at SRC file */
     if ((did2 = H5Dcreate2(fid1, "reg_ref_dset", H5T_STD_REF_DSETREG, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create references */
     if (H5Rcreate(&obj_buf[0], did1, ".", H5R_OBJECT, (hid_t)-1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate(&obj_buf[1], did2, ".", H5R_OBJECT, (hid_t)-1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate(&reg_buf[0], did1, ".", H5R_DATASET_REGION, sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate(&reg_buf[1], did2, ".", H5R_DATASET_REGION, sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Write data into file */
     if (H5Dwrite(did1, H5T_STD_REF_OBJ, H5S_ALL, H5S_ALL, H5P_DEFAULT, obj_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did2, H5T_STD_REF_DSETREG, H5S_ALL, H5S_ALL, H5P_DEFAULT, reg_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create middle file */
     if ((fid2 = H5Fcreate(mid_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Copy the source file to the middle file.  Note the expand references
      * flag is not set. */
     if (H5Ocopy(fid1, "/", fid2, "/A", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close datasets in source file */
     if (H5Dclose(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close source file */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open copied datasets */
     if ((did3 = H5Dopen2(fid2, "/A/obj_ref_dset", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did4 = H5Dopen2(fid2, "/A/reg_ref_dset", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read copied datasets */
     if (H5Dread(did3, H5T_STD_REF_OBJ, H5S_ALL, H5S_ALL, H5P_DEFAULT, obj_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dread(did4, H5T_STD_REF_DSETREG, H5S_ALL, H5S_ALL, H5P_DEFAULT, reg_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the references contain only "0" bytes */
     if (HDmemcmp(obj_buf, zeros, sizeof(obj_buf)) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDmemcmp(reg_buf, zeros, sizeof(reg_buf)) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create destination file */
     if ((fid3 = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object copy property list */
     if ((pid = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set the "expand references" flag */
     if (H5Pset_copy_object(pid, H5O_COPY_EXPAND_REFERENCE_FLAG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Copy the middle file to the destination file.  Note the expand references
      * flag *is* set, even though the references are now NULL. */
     if (H5Ocopy(fid2, "/", fid3, "/AA", pid, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close datasets in middle file */
     if (H5Dclose(did3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the middle file */
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open copied datasets */
     if ((did5 = H5Dopen2(fid3, "/AA/A/obj_ref_dset", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did6 = H5Dopen2(fid3, "/AA/A/reg_ref_dset", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read copied datasets */
     if (H5Dread(did5, H5T_STD_REF_OBJ, H5S_ALL, H5S_ALL, H5P_DEFAULT, obj_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dread(did6, H5T_STD_REF_DSETREG, H5S_ALL, H5S_ALL, H5P_DEFAULT, reg_buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that the references contain only "0" bytes */
     if (HDmemcmp(obj_buf, zeros, sizeof(obj_buf)) != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDmemcmp(reg_buf, zeros, sizeof(reg_buf)) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did5) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did6) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -12040,91 +12040,91 @@ test_copy_attr_crt_order(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t d
 
     /* Create source file */
     if ((fid1 = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create GCPL */
     if ((gcplid = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group with creation order tracked */
     if (H5Pset_attr_creation_order(gcplid, H5P_CRT_ORDER_TRACKED) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid1 = H5Gcreate2(fid1, NAME_GROUP_TOP, H5P_DEFAULT, gcplid, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add attributes to group */
     if (test_copy_attach_attributes(gid1, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group */
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group with creation order tracked and indexed */
     if (H5Pset_attr_creation_order(gcplid, H5P_CRT_ORDER_TRACKED | H5P_CRT_ORDER_INDEXED) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid1 = H5Gcreate2(fid1, NAME_GROUP_TOP2, H5P_DEFAULT, gcplid, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add attributes to group */
     if (test_copy_attach_attributes(gid1, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group */
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close GCPL */
     if (H5Pclose(gcplid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create destination file */
     if ((fid2 = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Copy the groups to the destination file */
     if (H5Ocopy(fid1, NAME_GROUP_TOP, fid2, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid1, NAME_GROUP_TOP2, fid2, NAME_GROUP_TOP2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open groups with creation order tracked */
     if ((gid1 = H5Gopen2(fid1, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid2 = H5Gopen2(fid2, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compare the attributes */
     if (compare_std_attributes(gid1, gid2, H5P_DEFAULT) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close groups */
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open groups with creation order tracked and indexed */
     if ((gid1 = H5Gopen2(fid1, NAME_GROUP_TOP2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((gid2 = H5Gopen2(fid2, NAME_GROUP_TOP2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compare the attributes */
     if (compare_std_attributes(gid1, gid2, H5P_DEFAULT) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close groups */
     if (H5Gclose(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -12175,10 +12175,10 @@ test_copy_committed_datatype_merge(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fap
     int          token_cmp;
 
     if (reopen) {
-        TESTING("H5Ocopy(): merging committed datatypes with reopen")
+        TESTING("H5Ocopy(): merging committed datatypes with reopen");
     } /* end if */
     else
-        TESTING("H5Ocopy(): merging committed datatypes")
+        TESTING("H5Ocopy(): merging committed datatypes");
 
     /* set initial data values */
     for (i = 0; i < DIM_SIZE_1; i++)
@@ -12194,92 +12194,92 @@ test_copy_committed_datatype_merge(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fap
 
     /* create source files */
     if ((fid_src1 = H5Fcreate(src1_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid_src2 = H5Fcreate(src2_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate source file 1
      */
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* committed datatype */
     if ((H5Tcommit2(fid_src1, NAME_DATATYPE_SIMPLE, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src1, NAME_DATASET_SIMPLE, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file 1 */
     if (H5Fclose(fid_src1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate source file 2
      */
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* committed datatype */
     if ((H5Tcommit2(fid_src2, NAME_DATATYPE_SIMPLE, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src2, NAME_DATASET_SIMPLE, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file 1 */
     if (H5Fclose(fid_src2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source files with read-only */
     if ((fid_src1 = H5Fopen(src1_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid_src2 = H5Fopen(src2_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create ocpl and set merge named dtype flag */
     if ((ocpypl_id = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_copy_object(ocpypl_id, H5O_COPY_MERGE_COMMITTED_DTYPE_FLAG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * First copy each entire file to the destination file (each with their own
@@ -12287,85 +12287,85 @@ test_copy_committed_datatype_merge(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fap
      */
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy SRC1 to DST */
     if (H5Ocopy(fid_src1, "/", fid_dst, NAME_GROUP_TOP, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy SRC2 to DST */
     if (H5Ocopy(fid_src2, "/", fid_dst, NAME_GROUP_TOP2, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Open SRC1 committed dtype, get token */
     if ((tid = H5Topen2(fid_dst, NAME_GROUP_TOP "/" NAME_DATATYPE_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open SRC1 dset dtype, check token */
     if ((did = H5Dopen2(fid_dst, NAME_GROUP_TOP "/" NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open SRC2 committed dtype, check token */
     if ((tid = H5Topen2(fid_dst, NAME_GROUP_TOP2 "/" NAME_DATATYPE_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open SRC2 dset dtype, check token */
     if ((did = H5Dopen2(fid_dst, NAME_GROUP_TOP2 "/" NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close destination file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Now copy only the datasets to the destination file, and verify the committed
@@ -12373,75 +12373,75 @@ test_copy_committed_datatype_merge(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fap
      */
     /* recreate destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy SRC1 to DST */
     if (H5Ocopy(fid_src1, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy SRC2 to DST */
     if (H5Ocopy(fid_src2, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE2, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Open SRC1 dset dtype, get token */
     if ((did = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open SRC2 dset dtype, check token */
     if ((did = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close destination file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC files */
     if (H5Fclose(fid_src1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid_src2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close property list */
     if (H5Pclose(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -12493,9 +12493,9 @@ test_copy_committed_datatype_merge_same_file(hid_t fcpl, hid_t fapl, hbool_t reo
     int          token_cmp;
 
     if (reopen)
-        TESTING("H5Ocopy(): merging committed datatypes to the source file with reopen")
+        TESTING("H5Ocopy(): merging committed datatypes to the source file with reopen");
     else
-        TESTING("H5Ocopy(): merging committed datatypes to the source file")
+        TESTING("H5Ocopy(): merging committed datatypes to the source file");
 
     /* set initial data values */
     for (i = 0; i < DIM_SIZE_1; i++)
@@ -12509,94 +12509,94 @@ test_copy_committed_datatype_merge_same_file(hid_t fcpl, hid_t fapl, hbool_t reo
 
     /* create file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate first group
      */
     /* Create group */
     if ((gid = H5Gcreate2(fid, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* committed datatype */
     if ((H5Tcommit2(fid, NAME_GROUP_TOP "/" NAME_DATATYPE_SIMPLE, tid, H5P_DEFAULT, H5P_DEFAULT,
                     H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid, NAME_GROUP_TOP "/" NAME_DATASET_SIMPLE, tid, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate second group
      */
     /* Create group */
     if ((gid = H5Gcreate2(fid, NAME_GROUP_TOP2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* committed datatype */
     if ((H5Tcommit2(fid, NAME_GROUP_TOP2 "/" NAME_DATATYPE_SIMPLE, tid, H5P_DEFAULT, H5P_DEFAULT,
                     H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid, NAME_GROUP_TOP2 "/" NAME_DATASET_SIMPLE, tid, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create ocpl and set merge committed dtype flag */
     if ((ocpypl_id = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_copy_object(ocpypl_id, H5O_COPY_MERGE_COMMITTED_DTYPE_FLAG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * First copy each group to the destination group 3 (each with their own
@@ -12606,136 +12606,136 @@ test_copy_committed_datatype_merge_same_file(hid_t fcpl, hid_t fapl, hbool_t reo
      */
     /* Create destination group */
     if ((gid = H5Gcreate2(fid, NAME_GROUP_TOP3, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy group 1 to DST */
     if (H5Ocopy(fid, NAME_GROUP_TOP, fid, NAME_GROUP_TOP3 "/" NAME_GROUP_TOP, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy group 2 to DST */
     if (H5Ocopy(fid, NAME_GROUP_TOP2, fid, NAME_GROUP_TOP3 "/" NAME_GROUP_TOP2, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Open group 1 source committed dtype, get token */
     if ((tid = H5Topen2(fid, NAME_GROUP_TOP "/" NAME_DATATYPE_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group 1 source dset dtype, check token */
     if ((did = H5Dopen2(fid, NAME_GROUP_TOP "/" NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group 1 committed dtype, check token */
     if ((tid = H5Topen2(fid, NAME_GROUP_TOP3 "/" NAME_GROUP_TOP "/" NAME_DATATYPE_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group 1 dset dtype, check token */
     if ((did = H5Dopen2(fid, NAME_GROUP_TOP3 "/" NAME_GROUP_TOP "/" NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group 2 source committed dtype, get token and make sure it is
      * different from group 1 source committed dtype */
     if ((tid = H5Topen2(fid, NAME_GROUP_TOP2 "/" NAME_DATATYPE_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group 2 source dset dtype, check token */
     if ((did = H5Dopen2(fid, NAME_GROUP_TOP2 "/" NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group 2 committed dtype, check token */
     if ((tid = H5Topen2(fid, NAME_GROUP_TOP3 "/" NAME_GROUP_TOP2 "/" NAME_DATATYPE_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group 2 dset dtype, check token */
     if ((did = H5Dopen2(fid, NAME_GROUP_TOP3 "/" NAME_GROUP_TOP2 "/" NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Now copy only the datasets to the destination group, and verify the committed
@@ -12743,102 +12743,102 @@ test_copy_committed_datatype_merge_same_file(hid_t fcpl, hid_t fapl, hbool_t reo
      */
     /* Create destination group */
     if ((gid = H5Gcreate2(fid, NAME_GROUP_TOP4, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy SRC1 to DST */
     if (H5Ocopy(fid, NAME_GROUP_TOP "/" NAME_DATASET_SIMPLE, fid, NAME_GROUP_TOP4 "/" NAME_DATASET_SIMPLE,
                 ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy SRC2 to DST */
     if (H5Ocopy(fid, NAME_GROUP_TOP2 "/" NAME_DATASET_SIMPLE, fid, NAME_GROUP_TOP4 "/" NAME_DATASET_SIMPLE2,
                 ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Open group 1 source dset dtype, get token */
     if ((did = H5Dopen2(fid, NAME_GROUP_TOP "/" NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group 1 dset dtype, check token */
     if ((did = H5Dopen2(fid, NAME_GROUP_TOP4 "/" NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group 2 source dset dtype, get token and make sure it is
      * different from group 1 source dset dtype */
     if ((did = H5Dopen2(fid, NAME_GROUP_TOP2 "/" NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open group 2 dset dtype, check token */
     if ((did = H5Dopen2(fid, NAME_GROUP_TOP4 "/" NAME_DATASET_SIMPLE2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close property list */
     if (H5Pclose(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -12890,9 +12890,9 @@ test_copy_committed_dt_merge_sugg(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl
     int          token_cmp;
 
     if (reopen)
-        TESTING("H5Ocopy(): merging committed datatypes with suggestions and reopen")
+        TESTING("H5Ocopy(): merging committed datatypes with suggestions and reopen");
     else
-        TESTING("H5Ocopy(): merging committed datatypes with suggestions")
+        TESTING("H5Ocopy(): merging committed datatypes with suggestions");
 
     /* set initial data values */
     for (i = 0; i < DIM_SIZE_1; i++)
@@ -12907,90 +12907,90 @@ test_copy_committed_dt_merge_sugg(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate source file
      */
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* committed datatype */
     if ((H5Tcommit2(fid_src, NAME_DATATYPE_SIMPLE, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_SIMPLE, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate destination file
      */
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* committed datatype "a" */
     if ((H5Tcommit2(fid_dst, "/a", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* committed datatype "b" */
     if ((H5Tcommit2(fid_dst, "/b", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create ocpl and set merge committed dtype flag */
     if ((ocpypl_id = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_copy_object(ocpypl_id, H5O_COPY_MERGE_COMMITTED_DTYPE_FLAG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * First copy dataset using "/b" as a suggestion, and verify that it uses
@@ -12998,52 +12998,52 @@ test_copy_committed_dt_merge_sugg(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl
      */
     /* Add datatype suggestion */
     if (H5Padd_merge_committed_dtype_path(ocpypl_id, "/b") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy SRC dset to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Open committed dtype "b", get token */
     if ((tid = H5Topen2(fid_dst, "/b", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open dset dtype, check token */
     if ((did = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close destination file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Now free suggestions, copy dataset without any suggestions, and verify
@@ -13051,91 +13051,91 @@ test_copy_committed_dt_merge_sugg(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl
      */
     /* Free suggestions */
     if (H5Pfree_merge_committed_dtype_paths(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete destination dataset */
 
     /* copy SRC dset to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE2, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Open committed dtype "a", get token */
     if ((tid = H5Topen2(fid_dst, "/a", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open dset 2 dtype, check token */
     if ((did = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open committed dtype "b", get token */
     if ((tid = H5Topen2(fid_dst, "/b", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open dset dtype, check token */
     if ((did = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close destination file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close property list */
     if (H5Pclose(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -13190,9 +13190,9 @@ test_copy_committed_dt_merge_attr(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl
     int          token_cmp;
 
     if (reopen)
-        TESTING("H5Ocopy(): merging committed datatypes with attributes and reopen")
+        TESTING("H5Ocopy(): merging committed datatypes with attributes and reopen");
     else
-        TESTING("H5Ocopy(): merging committed datatypes with attributes")
+        TESTING("H5Ocopy(): merging committed datatypes with attributes");
 
     /* set initial data values */
     for (i = 0; i < DIM_SIZE_1; i++)
@@ -13207,98 +13207,98 @@ test_copy_committed_dt_merge_attr(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate source file
      */
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* committed datatype */
     if ((H5Tcommit2(fid_src, NAME_DATATYPE_SIMPLE, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_SIMPLE, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate destination file
      */
     /* Create group */
     if ((gid = H5Gcreate2(fid_dst, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create anonymous committed datatype */
     if ((H5Tcommit_anon(fid_dst, tid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create attribute at SRC file */
     if ((aid = H5Acreate2(gid, "attr", tid, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Awrite(aid, tid, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the attribute */
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create ocpl and set merge committed dtype flag */
     if ((ocpypl_id = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_copy_object(ocpypl_id, H5O_COPY_MERGE_COMMITTED_DTYPE_FLAG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Copy dataset and verify that it uses the same committed datatype as the
@@ -13306,64 +13306,64 @@ test_copy_committed_dt_merge_attr(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl
      */
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy SRC dset to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Open attribute dtype, get token */
     if ((aid = H5Aopen_by_name(fid_dst, NAME_GROUP_TOP, "attr", H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Aget_type(aid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open dset dtype, check token */
     if ((did = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close destination file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close property list */
     if (H5Pclose(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -13466,9 +13466,9 @@ test_copy_cdt_hier_merge(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t d
     int         token_cmp;
 
     if (reopen)
-        TESTING("H5Ocopy(): hier. of committed datatypes and merging with reopen")
+        TESTING("H5Ocopy(): hier. of committed datatypes and merging with reopen");
     else
-        TESTING("H5Ocopy(): hier. of committed datatypes and merging ")
+        TESTING("H5Ocopy(): hier. of committed datatypes and merging ");
 
     /* set initial data values */
     for (i = 0; i < DIM_SIZE_1; i++)
@@ -13485,385 +13485,385 @@ test_copy_cdt_hier_merge(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t d
      * Populate source file
      */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and commit committed datatype (int) to root group */
     if ((f_tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_src, ROOT_NDT_INT, f_tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group /g0 */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and commit committed datatype (short) to group /g0 */
     if ((g_tid = H5Tcopy(H5T_NATIVE_SHORT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(gid, GROUP_NDT_SHORT, g_tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset of native int in /g0 */
     if ((did = H5Dcreate2(gid, SRC_DSET1, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data to dataset */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset of committed datatype (short) in /g0 */
     if ((did = H5Dcreate2(gid, SRC_NDT_DSET2, g_tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data to dataset */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset of committed datatype (int) in /g0 */
     if ((did = H5Dcreate2(gid, SRC_NDT_DSET3, f_tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data to dataset */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatypes */
     if (H5Tclose(f_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(g_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate destination file
      */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create group /uncopied */
     if ((gid = H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and commit anonymous datatype (short) to /uncopied */
     if ((anon_tid = H5Tcopy(H5T_NATIVE_SHORT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit_anon(gid, anon_tid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create attribute of anon ndt (short) in /uncopied */
     if ((aid = H5Acreate2(gid, DST_ATTR_ANON_SHORT, anon_tid, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the attribute */
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(anon_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and commit anonymous datatype (int) to /uncopied */
     if ((anon_tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit_anon(gid, anon_tid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create attribute of anon ndt (int) in /uncopied */
     if ((aid = H5Acreate2(gid, DST_ATTR_ANON_INT, anon_tid, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the attribute */
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(anon_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create ocpl and set merge committed datatype flag */
     if ((ocpypl_id = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_copy_object(ocpypl_id, H5O_COPY_MERGE_COMMITTED_DTYPE_FLAG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 1 : copy / in SRC file to DST file
      */
     if (H5Ocopy(fid_src, "/", fid_dst, SRC_ROOT_GROUP, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get token of committed datatype at root group */
     if ((tid = H5Topen2(fid_dst, SRC_ROOT_GROUP "/" ROOT_NDT_INT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token_int, &oinfo.token, sizeof(exp_token_int));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get token of committed datatype at /g0 */
     if ((tid = H5Topen2(fid_dst, SRC_ROOT_GROUP NAME_GROUP_TOP "/" GROUP_NDT_SHORT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token_short, &oinfo.token, sizeof(exp_token_short));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* verify the datatype of first dataset is not committed */
     if ((did = H5Dopen2(fid_dst, SRC_ROOT_GROUP NAME_GROUP_TOP "/" SRC_DSET1, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommitted(tid))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check token of datatype for second dataset */
     if ((did = H5Dopen2(fid_dst, SRC_ROOT_GROUP NAME_GROUP_TOP "/" SRC_NDT_DSET2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token_short, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check token of datatype for third dataset */
     if ((did = H5Dopen2(fid_dst, SRC_ROOT_GROUP NAME_GROUP_TOP "/" SRC_NDT_DSET3, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token_int, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 2: copy /g0 in SRC to DST
      */
     if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_dst, NAME_GROUP_TOP, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get token of committed datatype at /g0 */
     if ((tid = H5Topen2(fid_dst, NAME_GROUP_TOP "/" GROUP_NDT_SHORT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token_short, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* verify the datatype of first dataset is not committed */
     if ((did = H5Dopen2(fid_dst, NAME_GROUP_TOP "/" SRC_DSET1, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommitted(tid))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check token of datatype for second dataset */
     if ((did = H5Dopen2(fid_dst, NAME_GROUP_TOP "/" SRC_NDT_DSET2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token_short, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check token of datatype for third dataset */
     if ((did = H5Dopen2(fid_dst, NAME_GROUP_TOP "/" SRC_NDT_DSET3, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token_int, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 3: copy datasets in /g0 at SRC to DST group /uncopied
      */
     if (H5Ocopy(fid_src, NAME_GROUP_TOP "/" SRC_DSET1, fid_dst, NAME_GROUP_UNCOPIED "/" SRC_DSET1, ocpypl_id,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_GROUP_TOP "/" SRC_NDT_DSET2, fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_DSET2,
                 ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_GROUP_TOP "/" SRC_NDT_DSET3, fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_DSET3,
                 ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open attribute with anon ndt (short), get token */
     if ((aid = H5Aopen_by_name(fid_dst, NAME_GROUP_UNCOPIED, DST_ATTR_ANON_SHORT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Aget_type(aid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token_short, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open attribute with anon ndt (int), get token */
     if ((aid = H5Aopen_by_name(fid_dst, NAME_GROUP_UNCOPIED, DST_ATTR_ANON_INT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Aget_type(aid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token_int, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* verify the datatype of first dataset is not committed */
     if ((did = H5Dopen2(fid_dst, NAME_GROUP_UNCOPIED "/" SRC_DSET1, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tcommitted(tid))
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check token of datatype for second dataset */
     if ((did = H5Dopen2(fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_DSET2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token_short, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check token of datatype for third dataset */
     if ((did = H5Dopen2(fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_DSET3, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token_int, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close property list */
     if (H5Pclose(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -13933,9 +13933,9 @@ test_copy_cdt_merge_cdt(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t ds
     int         token_cmp;
 
     if (reopen)
-        TESTING("H5Ocopy(): merging various committed datatypes with reopen")
+        TESTING("H5Ocopy(): merging various committed datatypes with reopen");
     else
-        TESTING("H5Ocopy(): merging various committed datatypes")
+        TESTING("H5Ocopy(): merging various committed datatypes");
 
     /* Initialize the filenames */
     h5_fixname(FILENAME[0], src_fapl, src_filename, sizeof src_filename);
@@ -13948,252 +13948,252 @@ test_copy_cdt_merge_cdt(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t ds
      * Populate source file
      */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create committed datatype (short) */
     if ((tid1 = H5Tcopy(H5T_NATIVE_SHORT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_src, SRC_NDT_SHORT, tid1, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create committed datatype (float) */
     if ((tid2 = H5Tcopy(H5T_NATIVE_FLOAT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_src, SRC_NDT_FLOAT, tid2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create committed datatype (int) */
     if ((tid3 = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_src, SRC_NDT_INT, tid3, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create an attribute of committed datatype (int); attach to committed datatype (int) */
     if ((aid = H5Acreate2(tid3, SRC_ATTR, tid3, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create committed datatype (double) */
     if ((tid4 = H5Tcopy(H5T_NATIVE_DOUBLE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_src, SRC_NDT_DOUBLE, tid4, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create an anonymous committed datatype (short) */
     if ((tid5 = H5Tcopy(H5T_NATIVE_SHORT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit_anon(fid_src, tid5, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create an attribute of anon ndt (short); attach to committed datatype (double) */
     if ((aid = H5Acreate2(tid4, SRC_ATTR, tid5, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the committed datatypes */
     if (H5Tclose(tid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid5) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate destination file
      */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create committed datatype (integer) */
     if ((tid1 = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_dst, DST_NDT_INT, tid1, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create committed datatype (float) */
     if ((tid2 = H5Tcopy(H5T_NATIVE_FLOAT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_dst, DST_NDT_FLOAT, tid2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create an attribute of native integer; attach to committed datatype (float) */
     if ((aid = H5Acreate2(tid2, DST_ATTR, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create committed datatype (double) */
     if ((tid3 = H5Tcopy(H5T_NATIVE_DOUBLE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_dst, DST_NDT_DOUBLE, tid3, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create anonymous committed datatype (short) */
     if ((tid4 = H5Tcopy(H5T_NATIVE_SHORT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit_anon(fid_dst, tid4, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create an attribute of anon ndt (short); attach to ndt (double) */
     if ((aid = H5Acreate2(tid3, DST_ATTR, tid4, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the committed datatypes */
     if (H5Tclose(tid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create ocpl and set merge committed dtype flag */
     if ((ocpypl_id = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_copy_object(ocpypl_id, H5O_COPY_MERGE_COMMITTED_DTYPE_FLAG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy everything in SRC to DST */
     if (H5Ocopy(fid_src, "/", fid_dst, SRC_ROOT_GROUP, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Verification
      */
     /* get token of committed datatype: /src_root/src_ndt_double */
     if ((tid = H5Topen2(fid_dst, "/" SRC_ROOT_GROUP "/" SRC_NDT_DOUBLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get token of committed datatype: /dst_ndt_double */
     if ((tid = H5Topen2(fid_dst, "/" DST_NDT_DOUBLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get token of committed datatype: /src_root/src_ndt_float */
     if ((tid = H5Topen2(fid_dst, "/" SRC_ROOT_GROUP "/" SRC_NDT_FLOAT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get token of committed datatype: /dst_ndt_float */
     if ((tid = H5Topen2(fid_dst, "/" DST_NDT_FLOAT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get token of committed datatype: /src_root/src_ndt_int */
     if ((tid = H5Topen2(fid_dst, "/" SRC_ROOT_GROUP "/" SRC_NDT_INT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get token of committed datatype: /dst_ndt_int */
     if ((tid = H5Topen2(fid_dst, "/" DST_NDT_INT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get token of committed datatype: /src_root/src_ndt_short */
     if ((tid = H5Topen2(fid_dst, "/" SRC_ROOT_GROUP "/" SRC_NDT_SHORT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open attribute; get its dtype; get dtype's token: /src_root/src_ndt_double/dst_attr */
     if ((aid = H5Aopen_by_name(fid_dst, "/" SRC_ROOT_GROUP "/" SRC_NDT_DOUBLE, DST_ATTR, H5P_DEFAULT,
                                H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Aget_type(aid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the files */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the object copy property list */
     if (H5Pclose(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -14243,9 +14243,9 @@ test_copy_cdt_merge_suggs(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t 
     int         token_cmp;
 
     if (reopen)
-        TESTING("H5Ocopy(): merging committed datatypes with suggestions and reopen")
+        TESTING("H5Ocopy(): merging committed datatypes with suggestions and reopen");
     else
-        TESTING("H5Ocopy(): merging committed datatypes with suggestions")
+        TESTING("H5Ocopy(): merging committed datatypes with suggestions");
 
     /* Initialize the filenames */
     h5_fixname(FILENAME[0], src_fapl, src_filename, sizeof src_filename);
@@ -14259,21 +14259,21 @@ test_copy_cdt_merge_suggs(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t 
      */
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create committed datatype: "/src_ndt_int" */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_src, SRC_NDT_INT, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate destination file
@@ -14281,241 +14281,241 @@ test_copy_cdt_merge_suggs(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t 
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create committed datatype: "/dst_ndt_int"  */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_dst, DST_NDT_INT, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group /uncopied */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 1
      */
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create ocpl and set merge committed dtype flag */
     if ((ocpypl_id = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_copy_object(ocpypl_id, H5O_COPY_MERGE_COMMITTED_DTYPE_FLAG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy "/src_ndt_int" from SRC file to "/uncopied/src_ndt_int" at DST file */
     if (H5Ocopy(fid_src, SRC_NDT_INT, fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_INT, ocpypl_id, H5P_DEFAULT) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* open committed dtype "/dst_ndt_int", get its token */
     if ((tid = H5Topen2(fid_dst, DST_NDT_INT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check token of "/uncopied/src_ndt_int" */
     if ((tid = H5Topen2(fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_INT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 2
      */
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add committed datatype search suggestion: "/uncopied/src_ndt_int" */
     if (H5Padd_merge_committed_dtype_path(ocpypl_id, NAME_GROUP_UNCOPIED "/" SRC_NDT_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy "/src_ndt_int" from SRC file to "/src_ndt_int" at DST file */
     if (H5Ocopy(fid_src, SRC_NDT_INT, fid_dst, SRC_NDT_INT, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* open committed dtype "/uncopied/src_ndt_int", get its token */
     if ((tid = H5Topen2(fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_INT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check token of "/src_ndt_int" */
     if ((tid = H5Topen2(fid_dst, SRC_NDT_INT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 3
      */
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* remove "/uncopied/src_ndt_int" from DST file */
     if (H5Ldelete(fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_INT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy "/src_ndt_int" from SRC file to "/uncopied/src_ndt_int" at DST file */
     /* use default ocpypl_id -- without merging and suggestion */
     if (H5Ocopy(fid_src, SRC_NDT_INT, fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_INT, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy "/src_ndt_int" from SRC file to "/src_ndt_int2" at DST file */
     /* copy with merging and search suggestion: "/uncopied/src_ndt_int" */
     if (H5Ocopy(fid_src, SRC_NDT_INT, fid_dst, SRC_NDT_INT2, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Open committed dtype "/uncopied/src_ndt_int", get its token */
     if ((tid = H5Topen2(fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_INT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check token of "/src_ndt_int2" */
     if ((tid = H5Topen2(fid_dst, SRC_NDT_INT2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 4
      */
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add committed datatype search suggestion */
     if (H5Padd_merge_committed_dtype_path(ocpypl_id, DST_NDT_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy "src_ndt_int" from SRC file to "/uncopied/src_ndt_int2" at DST file */
     /* copy with merging and search suggestion: "/dst_ndt_int, /uncopied/src_ndt_int" */
     if (H5Ocopy(fid_src, SRC_NDT_INT, fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_INT2, ocpypl_id, H5P_DEFAULT) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Open committed dtype "/dst_dt_int", get its token */
     if ((tid = H5Topen2(fid_dst, DST_NDT_INT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check token of "/uncopied/src_ndt_int2" */
     if ((tid = H5Topen2(fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_INT2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close property list */
     if (H5Pclose(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -14563,9 +14563,9 @@ test_copy_cdt_merge_dset_suggs(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, h
     int          token_cmp;
 
     if (reopen)
-        TESTING("H5Ocopy(): merging committed datatypes of datasets with suggestions and reopen")
+        TESTING("H5Ocopy(): merging committed datatypes of datasets with suggestions and reopen");
     else
-        TESTING("H5Ocopy(): merging committed datatypes of datasets with suggestions")
+        TESTING("H5Ocopy(): merging committed datatypes of datasets with suggestions");
 
     /* set initial data values */
     for (i = 0; i < DIM_SIZE_1; i++)
@@ -14583,313 +14583,313 @@ test_copy_cdt_merge_dset_suggs(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, h
      */
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create committed datatype: "/src_ndt_int" */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_src, SRC_NDT_INT, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset */
     if ((did = H5Dcreate2(fid_src, SRC_NDT_DSET, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data to dataset */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate destination file
      */
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create committed datatype: "/dst_ndt_int" */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_dst, DST_NDT_INT, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group "/uncopied" */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 1
      */
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create ocpl and set merge committed dtype flag */
     if ((ocpypl_id = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_copy_object(ocpypl_id, H5O_COPY_MERGE_COMMITTED_DTYPE_FLAG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy "/src_ndt_dset" from SRC file to "/uncopied/src_ndt_dset" at DST file */
     if (H5Ocopy(fid_src, SRC_NDT_DSET, fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_DSET, ocpypl_id,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Open committed dtype "/dst_ndt_int", get its token */
     if ((tid = H5Topen2(fid_dst, DST_NDT_INT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check token of datatype for the copied dataset: "/uncopied/src_ndt_dset"  */
     if ((did = H5Dopen2(fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_DSET, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 2
      */
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add committed datatype search suggestion: "/uncopied/src_ndt_dset" */
     if (H5Padd_merge_committed_dtype_path(ocpypl_id, NAME_GROUP_UNCOPIED "/" SRC_NDT_DSET) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy "/src_ndt_dset" from SRC file to "/src_ndt_dset" at DST file */
     if (H5Ocopy(fid_src, SRC_NDT_DSET, fid_dst, SRC_NDT_DSET, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Open committed dtype dataset "/uncopied/src_ndt_dset", get its datatype token */
     if ((did = H5Dopen2(fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_DSET, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check token of datatype for the copied dataset: "/src_ndt_dset" */
     if ((did = H5Dopen2(fid_dst, SRC_NDT_DSET, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 3
      */
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* remove "/uncopied/src_ndt_dset" */
     if (H5Ldelete(fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_DSET, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy "src_ndt_dset" from SRC file to "/uncopied/src_ndt_dset" at DST file */
     /* use default ocpypl_id -- without merging and suggestion */
     if (H5Ocopy(fid_src, SRC_NDT_DSET, fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_DSET, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy "src_ndt_dset" from SRC file to "/src_ndt_dset2" at DST file */
     /* use merging and suggested searching path: "/uncopied/src_ndt_dset" */
     if (H5Ocopy(fid_src, SRC_NDT_DSET, fid_dst, SRC_NDT_DSET2, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* open the copied dataset: /uncopied/src_ndt_dset", get its token  */
     if ((did = H5Dopen2(fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_DSET, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check token of datatype for the copied dataset: "/src_ndt_dset2" */
     if ((did = H5Dopen2(fid_dst, SRC_NDT_DSET2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 4
      */
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add committed datatype search suggestion: "/src_ndt_dset" */
     if (H5Padd_merge_committed_dtype_path(ocpypl_id, SRC_NDT_DSET) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy /src_ndt_dset from SRC file to /uncopied/src_ndt_dset2 at DST */
     /* use merging and suggested search paths: "/src_ndt_dset, /uncopied/src_ndt_dset" */
     if (H5Ocopy(fid_src, SRC_NDT_DSET, fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_DSET2, ocpypl_id,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* open the copied dataset: "/src_ndt_dset", get its datatype token */
     if ((did = H5Dopen2(fid_dst, SRC_NDT_DSET, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check token of datatype for the copied dataset: /uncopied/src_ndt_dset2 */
     if ((did = H5Dopen2(fid_dst, NAME_GROUP_UNCOPIED "/" SRC_NDT_DSET2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close property list */
     if (H5Pclose(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -14938,9 +14938,9 @@ test_copy_cdt_merge_all_suggs(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hi
     char    dst_filename[NAME_BUF_SIZE];
 
     if (reopen)
-        TESTING("H5Ocopy(): merging different committed datatypes with suggestions and reopen")
+        TESTING("H5Ocopy(): merging different committed datatypes with suggestions and reopen");
     else
-        TESTING("H5Ocopy(): merging different committed datatypes with suggestions")
+        TESTING("H5Ocopy(): merging different committed datatypes with suggestions");
 
     /* Initialize the filenames */
     h5_fixname(FILENAME[0], src_fapl, src_filename, sizeof src_filename);
@@ -14955,80 +14955,80 @@ test_copy_cdt_merge_all_suggs(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hi
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set dataspace dimension, create dataspace */
     dim1d[0] = DIM_SIZE_1;
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create a group */
     if ((gid = H5Gcreate2(fid_src, SRC_GRP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create committed datatype in group */
     if ((tid = H5Tcopy(H5T_NATIVE_SHORT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(gid, SRC_NDT_SHORT, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create first dataset in group */
     if ((did = H5Dcreate2(gid, SRC_NDT_DSET, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create committed datatype in group */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(gid, SRC_NDT_INT, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create second dataset in group */
     if ((did = H5Dcreate2(gid, SRC_NDT_DSET2, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create third dataset in group */
     if ((did = H5Dcreate2(gid, SRC_DSET, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get datatype */
     if ((tid_short = H5Topen2(fid_src, "/" SRC_GRP "/" SRC_NDT_SHORT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create an attribute attached to the dataset */
     if ((aid = H5Acreate2(did, SRC_ATTR, tid_short, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid_short) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate DST file
@@ -15036,484 +15036,484 @@ test_copy_cdt_merge_all_suggs(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hi
 
     /* create DST file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set dataspace dimension, create dataspace */
     dim1d[0] = DIM_SIZE_2;
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create committed datatype in root group */
     if ((tid = H5Tcopy(H5T_NATIVE_SHORT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_dst, DST_NDT_SHORT, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create committed datatype in root group */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_dst, DST_NDT_INT, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create an attribute attached to committed datatype */
     if ((aid = H5Acreate2(tid, DST_ATTR, tid, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create committed datatype in root group */
     if ((tid = H5Tcopy(H5T_NATIVE_FLOAT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_dst, DST_NDT_FLOAT, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create an attribute attached to committed datatype */
     if ((aid = H5Acreate2(tid, DST_ATTR, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create a group */
     if ((gid = H5Gcreate2(fid_dst, DST_GRP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create a committed datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(gid, DST_NDT_INT, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create an attribute attached to committed datatype */
     if ((aid = H5Acreate2(gid, DST_ATTR, tid, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create an attribute attached to group */
     if ((aid = H5Acreate2(gid, DST_ATTR2, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create a group */
     if ((gid = H5Gcreate2(fid_dst, DST_GRP2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create a committed datatype in group */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(gid, DST_NDT_INT, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create an attribute attached to group */
     if ((aid = H5Acreate2(gid, DST_ATTR, tid, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create a committed datatype in group */
     if ((tid = H5Tcopy(H5T_NATIVE_SHORT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(gid, DST_NDT_SHORT, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create a committed datatype at root group */
     if ((tid = H5Tcopy(H5T_NATIVE_DOUBLE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((H5Tcommit2(fid_dst, DST_NDT_DOUBLE, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get datatype */
     if ((tid_short = H5Topen2(fid_dst, "/" DST_GRP2 "/" DST_NDT_SHORT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create an attribute attached to committed datatype */
     if ((aid = H5Acreate2(tid, DST_ATTR, tid_short, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid_short) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 1
      */
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create ocpl and set merge committed dtype flag */
     if ((ocpypl_id = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_copy_object(ocpypl_id, H5O_COPY_MERGE_COMMITTED_DTYPE_FLAG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy "/src_grp/src_ndt_dset2" from SRC file to DST file */
     if (H5Ocopy(fid_src, "/" SRC_GRP "/" SRC_NDT_DSET2, fid_dst, "A_src_dset2", ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* get datatype for attribute attached to the group */
     if ((aid = H5Aopen_by_name(fid_dst, DST_GRP, DST_ATTR, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((exp_tid = H5Aget_type(aid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open datatype of dataset */
     if ((did = H5Dopen2(fid_dst, "A_src_dset2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* should be the same */
     if (!H5Tequal(exp_tid, tid))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Tclose(exp_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 2
      */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add committed datatype search suggestion */
     if (H5Padd_merge_committed_dtype_path(ocpypl_id, "/" DST_GRP2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy "/src_grp/src_ndt_dset2" from SRC file to DST file */
     if (H5Ocopy(fid_src, "/" SRC_GRP "/" SRC_NDT_DSET2, fid_dst, "B_src_dset2", ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* get datatype for attribute attached to the group */
     if ((aid = H5Aopen_by_name(fid_dst, DST_GRP2, DST_ATTR, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((exp_tid = H5Aget_type(aid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open datatype of dataset */
     if ((did = H5Dopen2(fid_dst, "B_src_dset2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* should be the same */
     if (!H5Tequal(exp_tid, tid))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Tclose(exp_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 3
      */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add another committed datatype search suggestion */
     if (H5Padd_merge_committed_dtype_path(ocpypl_id, "/" DST_GRP "/" DST_NDT_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy "/src_grp/src_ndt_dset2" from SRC file to DST file */
     if (H5Ocopy(fid_src, "/" SRC_GRP "/" SRC_NDT_DSET2, fid_dst, "C_src_dset2", ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* open committed dtype "/dst_grp/dst_dt_int", get its token */
     if ((exp_tid = H5Topen2(fid_dst, "/" DST_GRP "/" DST_NDT_INT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open datatype of dataset */
     if ((did = H5Dopen2(fid_dst, "C_src_dset2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* should be the same */
     if (!H5Tequal(exp_tid, tid))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Tclose(exp_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 4
      */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* delete the group */
     if (H5Ldelete(fid_dst, "/" DST_GRP, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* free the search suggestion paths */
     if (H5Pfree_merge_committed_dtype_paths(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy "/src_grp/src_ndt_dset2" from SRC file to DST file */
     if (H5Ocopy(fid_src, "/" SRC_GRP "/" SRC_NDT_DSET2, fid_dst, "D_src_dset2", ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* open datatype of dataset */
     if ((exp_did = H5Dopen2(fid_dst, "A_src_dset2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((exp_tid = H5Dget_type(exp_did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open datatype of dataset */
     if ((did = H5Dopen2(fid_dst, "C_src_dset2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* should be the same */
     if (!H5Tequal(exp_tid, tid))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open datatype of dataset */
     if ((did = H5Dopen2(fid_dst, "D_src_dset2", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* should be the same */
     if (!H5Tequal(exp_tid, tid))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Tclose(exp_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(exp_did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 5
      */
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add committed datatype search suggestion */
     if (H5Padd_merge_committed_dtype_path(ocpypl_id, "/" DST_NDT_DOUBLE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy "/src_grp/src_ndt_dset" from SRC file to DST file */
     if (H5Ocopy(fid_src, "/" SRC_GRP "/" SRC_NDT_DSET, fid_dst, "A_src_dset", ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* open attribute's dtype attached to committed datatype /dst_ndt_double */
     if ((aid = H5Aopen_by_name(fid_dst, DST_NDT_DOUBLE, DST_ATTR, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((exp_tid = H5Aget_type(aid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open datatype of dataset, check token */
     if ((did = H5Dopen2(fid_dst, "A_src_dset", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* should be the same */
     if (!H5Tequal(exp_tid, tid))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(exp_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 6
      */
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add committed datatype search suggestion */
     if (H5Padd_merge_committed_dtype_path(ocpypl_id, "/" DST_NDT_SHORT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy "/src_grp/src_ndt_dset" from SRC file to DST file */
     if (H5Ocopy(fid_src, "/" SRC_GRP "/" SRC_NDT_DSET, fid_dst, "B_src_dset", ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* open committed dtype "/dst_ndt_short" */
     if ((exp_tid = H5Topen2(fid_dst, "/" DST_NDT_SHORT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open datatype of dataset, check token */
     if ((did = H5Dopen2(fid_dst, "B_src_dset", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* should be the same */
     if (!H5Tequal(exp_tid, tid))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* closing */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(exp_tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close property list */
     if (H5Pclose(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -15584,9 +15584,9 @@ test_copy_set_mcdt_search_cb(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid
     int               token_cmp;
 
     if (reopen)
-        TESTING("H5Ocopy(): H5Pset_mcdt_search_cb and reopen")
+        TESTING("H5Ocopy(): H5Pset_mcdt_search_cb and reopen");
     else
-        TESTING("H5Ocopy(): H5Pset_mcdt_search_cb")
+        TESTING("H5Ocopy(): H5Pset_mcdt_search_cb");
 
     /* set initial data values */
     for (i = 0; i < DIM_SIZE_1; i++)
@@ -15601,94 +15601,94 @@ test_copy_set_mcdt_search_cb(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate source file
      */
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* named datatype */
     if ((H5Tcommit2(fid_src, NAME_DATATYPE_SIMPLE, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_SIMPLE, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied group in destination file */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate destination file
      */
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* committed datatype "a" */
     if ((H5Tcommit2(fid_dst, "/a", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* committed datatype "b" */
     if ((H5Tcommit2(fid_dst, "/b", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create ocpl and set merge committed dtype flag */
     if ((ocpypl_id = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_copy_object(ocpypl_id, H5O_COPY_MERGE_COMMITTED_DTYPE_FLAG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * First copy dataset using "/b" as a suggestion, and verify that it uses
@@ -15696,52 +15696,52 @@ test_copy_set_mcdt_search_cb(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid
      */
     /* Add datatype suggestion */
     if (H5Padd_merge_committed_dtype_path(ocpypl_id, "/b") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy SRC dset to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Open committed dtype "b", get token */
     if ((tid = H5Topen2(fid_dst, "/b", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open dset dtype, check token */
     if ((did = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close destination file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Set callback to continue the search
@@ -15751,64 +15751,64 @@ test_copy_set_mcdt_search_cb(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid
 
     /* Free suggestions */
     if (H5Pfree_merge_committed_dtype_paths(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add datatype suggestion to group "/uncopied" */
     if (H5Padd_merge_committed_dtype_path(ocpypl_id, NAME_GROUP_UNCOPIED) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Continue the global search */
     if (H5Pset_mcdt_search_cb(ocpypl_id, mcdt_search_cb, &cb_udata) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy SRC dset to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE2, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify callback has been called exactly once */
     if (cb_udata.called != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Open committed dtype "a", get token */
     if ((tid = H5Topen2(fid_dst, "/a", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open copied dataset and its dtype, check token */
     if ((did = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close destination file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Stop the search, default action is to create an anonymous committed datatype
@@ -15818,77 +15818,77 @@ test_copy_set_mcdt_search_cb(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid
 
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy SRC dset to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE3, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify callback has been called exactly once */
     if (cb_udata.called != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Open committed dtype "a", get token */
     if ((tid = H5Topen2(fid_dst, "/a", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the copied dataset and get its dtype, tokens should not be equal */
     if ((did = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE3, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open committed dtype "b", get token */
     if ((tid = H5Topen2(fid_dst, "/b", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the copied dataset and get its dtype, tokens should not be equal */
     if ((did = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE3, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close destination file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Stop the search, default action is to create an anonymous committed datatype.
@@ -15899,97 +15899,97 @@ test_copy_set_mcdt_search_cb(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid
 
     /* Free suggestions */
     if (H5Pfree_merge_committed_dtype_paths(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete dataset */
     if (H5Ldelete(fid_dst, NAME_DATASET_SIMPLE3, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy SRC dset to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE3, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify callback has been called exactly once */
     if (cb_udata.called != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Open committed dtype "a", get token */
     if ((tid = H5Topen2(fid_dst, "/a", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the copied dataset and get its dtype, tokens should not be equal */
     if ((did = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE3, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open committed dtype "b", get token */
     if ((tid = H5Topen2(fid_dst, "/b", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDmemcpy(&exp_token, &oinfo.token, sizeof(exp_token));
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the copied dataset and get its dtype, tokens should not be equal */
     if ((did = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE3, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_info3(tid, &oinfo, H5O_INFO_BASIC) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Otoken_cmp(tid, &oinfo.token, &exp_token, &token_cmp) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!token_cmp)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close destination file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close property list */
     if (H5Pclose(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -16059,9 +16059,9 @@ test_copy_set_get_mcdt_search_cb(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
     H5O_mcdt_search_ret_t *mcdt_udata_p = NULL; /* Pointer to user data for callback */
 
     if (reopen)
-        TESTING("H5Ocopy(): H5Pset/get_mcdt_search_cb and reopen")
+        TESTING("H5Ocopy(): H5Pset/get_mcdt_search_cb and reopen");
     else
-        TESTING("H5Ocopy(): H5Pset/get_mcdt_search_cb")
+        TESTING("H5Ocopy(): H5Pset/get_mcdt_search_cb");
 
     /* set initial data values */
     for (i = 0; i < DIM_SIZE_1; i++)
@@ -16076,94 +16076,94 @@ test_copy_set_get_mcdt_search_cb(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim1d[0] = DIM_SIZE_1;
 
     /* create dataspace */
     if ((sid = H5Screate_simple(1, dim1d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate source file
      */
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* committed datatype */
     if ((H5Tcommit2(fid_src, NAME_DATATYPE_SIMPLE, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create dataset at SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_SIMPLE, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data into file */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied group in destination file */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Populate destination file
      */
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* committed datatype "a" */
     if ((H5Tcommit2(fid_dst, "/a", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* committed datatype "b" */
     if ((H5Tcommit2(fid_dst, "/b", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create ocpl and set merge committed dtype flag */
     if ((ocpypl_id = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_copy_object(ocpypl_id, H5O_COPY_MERGE_COMMITTED_DTYPE_FLAG) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * First copy dataset using "/b" as a suggestion, and verify that it uses
@@ -16171,36 +16171,36 @@ test_copy_set_get_mcdt_search_cb(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
      */
     /* Add datatype suggestion */
     if (H5Padd_merge_committed_dtype_path(ocpypl_id, "/b") < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy SRC dset to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Verify "get" routine functionality */
     if (H5Pget_mcdt_search_cb(ocpypl_id, &mcdt_cb, (void **)&mcdt_udata_p) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (mcdt_cb != NULL)
-        TEST_ERROR
+        TEST_ERROR;
     if (mcdt_udata_p != NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close destination file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Set callback to continue the search
@@ -16209,30 +16209,30 @@ test_copy_set_get_mcdt_search_cb(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
 
     /* Free suggestions */
     if (H5Pfree_merge_committed_dtype_paths(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add datatype suggestion to group "/uncopied" */
     if (H5Padd_merge_committed_dtype_path(ocpypl_id, NAME_GROUP_UNCOPIED) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Continue the global search */
     if (H5Pset_mcdt_search_cb(ocpypl_id, mcdt_search_cbA, &mcdt_udataA) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy SRC dset to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE2, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     mcdt_cb      = NULL;
@@ -16240,16 +16240,16 @@ test_copy_set_get_mcdt_search_cb(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
 
     /* Verify "get" routine functionality */
     if (H5Pget_mcdt_search_cb(ocpypl_id, &mcdt_cb, (void **)&mcdt_udata_p) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (mcdt_cb != mcdt_search_cbA)
-        TEST_ERROR
+        TEST_ERROR;
     if (mcdt_udata_p != &mcdt_udataA)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close destination file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Stop the search, default action is to create an anonymous committed datatype
@@ -16257,22 +16257,22 @@ test_copy_set_get_mcdt_search_cb(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
     mcdt_udataB = H5O_MCDT_SEARCH_STOP;
 
     if (H5Pset_mcdt_search_cb(ocpypl_id, mcdt_search_cbA, &mcdt_udataB) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy SRC dset to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE3, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     mcdt_cb      = NULL;
@@ -16280,42 +16280,42 @@ test_copy_set_get_mcdt_search_cb(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
 
     /* Verify "get" routine functionality */
     if (H5Pget_mcdt_search_cb(ocpypl_id, &mcdt_cb, (void **)&mcdt_udata_p) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (mcdt_cb != mcdt_search_cbA)
-        TEST_ERROR
+        TEST_ERROR;
     if (mcdt_udata_p != &mcdt_udataB)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close destination file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free suggestions */
     if (H5Pfree_merge_committed_dtype_paths(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pset_mcdt_search_cb(ocpypl_id, mcdt_search_cbB, &mcdt_udataB) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open destination file */
     if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete dataset */
     if (H5Ldelete(fid_dst, NAME_DATASET_SIMPLE3, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy SRC dset to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE3, ocpypl_id, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (reopen) {
         /* Reopen file */
         if (H5Fclose(fid_dst) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((fid_dst = H5Fopen(dst_filename, H5F_ACC_RDONLY, dst_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     mcdt_cb      = NULL;
@@ -16323,28 +16323,28 @@ test_copy_set_get_mcdt_search_cb(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl,
 
     /* Verify "get" routine functionality */
     if (H5Pget_mcdt_search_cb(ocpypl_id, &mcdt_cb, (void **)&mcdt_udata_p) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (mcdt_cb != mcdt_search_cbB)
-        TEST_ERROR
+        TEST_ERROR;
     if (mcdt_udata_p != &mcdt_udataB)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close destination file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close property list */
     if (H5Pclose(ocpypl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -16384,7 +16384,7 @@ test_copy_iterate_cb(hid_t loc_id, const char *name, const H5L_info2_t H5_ATTR_U
     hid_t dst_loc_id = *((hid_t *)op_data);
 
     if (H5Ocopy(loc_id, name, dst_loc_id, name, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return (H5_ITER_CONT);
 
@@ -16413,46 +16413,46 @@ test_copy_iterate(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fapl
 
     /* Create source file */
     if ((fid1 = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create groups */
     for (i = 0; i < 9; i++) {
         HDsnprintf(grp_name, sizeof(grp_name), "grp%d", i);
         if ((gid = H5Gcreate2(fid1, grp_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(gid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Create destination file */
     if ((fid2 = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close files */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reopen files */
     if ((fid1 = H5Fopen(src_filename, H5F_ACC_RDWR, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fopen(dst_filename, H5F_ACC_RDWR, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Iterate over links in the root group, copying each object */
     if ((gid = H5Gopen2(fid1, "/", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Literate2(gid, H5_INDEX_NAME, H5_ITER_INC, NULL, test_copy_iterate_cb, &fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -16515,15 +16515,15 @@ test_copy_option(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fapl,
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create group at the SRC file */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the group */
     if (test_copy_attach_attributes(gid, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -16531,80 +16531,80 @@ test_copy_option(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fapl,
 
     /* create dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add a dataset to the top group */
     if ((did = H5Dcreate2(gid, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create a sub-group */
     if ((gid_sub = H5Gcreate2(fid_src, NAME_GROUP_SUB, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add a dataset to the sub group */
     if ((did = H5Dcreate2(gid_sub, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create sub-sub-group */
     if ((gid_sub_sub = H5Gcreate2(gid_sub, NAME_GROUP_SUB_SUB2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add a dataset to the sub sub group */
     if ((did = H5Dcreate2(gid_sub_sub, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gid_sub_sub) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gid_sub) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((flag & H5O_COPY_EXPAND_SOFT_LINK_FLAG) > 0) {
         /* Create group to copy */
         if ((gid = H5Gcreate2(fid_src, NAME_GROUP_LINK, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Lcreate_soft(NAME_DATASET_SUB_SUB, fid_src, NAME_LINK_SOFT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Lcreate_soft("nowhere", fid_src, NAME_LINK_SOFT_DANGLE, H5P_DEFAULT, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Gclose(gid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create group to compare with */
         if ((gid = H5Gcreate2(fid_src, NAME_GROUP_LINK2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Lcreate_hard(fid_src, NAME_DATASET_SUB_SUB, H5L_SAME_LOC, NAME_LINK_SOFT2, H5P_DEFAULT,
                            H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Lcreate_soft("nowhere", fid_src, NAME_LINK_SOFT_DANGLE2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Gclose(gid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     if ((flag & H5O_COPY_EXPAND_EXT_LINK_FLAG) > 0) {
@@ -16614,220 +16614,220 @@ test_copy_option(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fapl,
 
         /* Create the external file and dataset */
         if ((fid_ext = H5Fcreate(ext_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((did = H5Dcreate2(fid_ext, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Dclose(did) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Fclose(fid_ext) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create group to copy */
         if (!(flag & H5O_COPY_EXPAND_SOFT_LINK_FLAG)) {
             if ((gid = H5Gcreate2(fid_src, NAME_GROUP_LINK, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
         else if ((gid = H5Gopen2(fid_src, NAME_GROUP_LINK, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Lcreate_external(ext_filename, NAME_DATASET_SIMPLE, fid_src, NAME_LINK_EXTERN, H5P_DEFAULT,
                                H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Lcreate_external("no_file", "no_object", fid_src, NAME_LINK_EXTERN_DANGLE, H5P_DEFAULT,
                                H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(gid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create group to compare with */
         if (!(flag & H5O_COPY_EXPAND_SOFT_LINK_FLAG)) {
             if ((gid = H5Gcreate2(fid_src, NAME_GROUP_LINK2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
         else if ((gid = H5Gopen2(fid_src, NAME_GROUP_LINK2, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((did = H5Dcreate2(fid_src, NAME_LINK_EXTERN2, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Lcreate_external("no_file", "no_object", fid_src, NAME_LINK_EXTERN_DANGLE2, H5P_DEFAULT,
                                H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Dclose(did) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(gid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close dataspace */
         if (H5Sclose(sid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     if ((flag & H5O_COPY_EXPAND_REFERENCE_FLAG) > 0) {
         if ((gid_ref = H5Gcreate2(fid_src, NAME_GROUP_REF, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* create an attribute of object references */
         if (attach_ref_attr(fid_src, gid_ref) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* create an attribute of region references */
         if (attach_reg_ref_attr(fid_src, gid_ref) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* create a dataset of region references */
         if (create_reg_ref_dataset(fid_src, gid_ref) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close group holding reference objects */
         if (H5Gclose(gid_ref) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     /* (except when expanding soft links */
     if ((flag & H5O_COPY_EXPAND_SOFT_LINK_FLAG) > 0) {
         if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDWR, src_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination
        files aren't the same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create property to pass copy options */
     if ((pid = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set options for object copy */
     if (H5Pset_copy_object(pid, flag) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify object copy flags */
     if (H5Pget_copy_object(pid, &cpy_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (cpy_flags != flag)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the group from SRC to DST */
     if (crt_intermediate_grp) {
         /* Create link creation plist to pass in intermediate group creation */
         if ((lcpl_id = H5Pcreate(H5P_LINK_CREATE)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_create_intermediate_group(lcpl_id, TRUE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_dst, "/new_g0/new_g00", pid, lcpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Pclose(lcpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* open the group for copy */
         if ((gid = H5Gopen2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* open the destination group */
         if ((gid2 = H5Gopen2(fid_dst, "/new_g0/new_g00", H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     else if (((flag & H5O_COPY_EXPAND_SOFT_LINK_FLAG) > 0) || ((flag & H5O_COPY_EXPAND_EXT_LINK_FLAG) > 0)) {
         if (H5Ocopy(fid_src, NAME_GROUP_LINK, fid_dst, NAME_GROUP_LINK, pid, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if ((flag & H5O_COPY_EXPAND_SOFT_LINK_FLAG) > 0)
             /* Unlink dataset to copy from original location */
             /* (So group comparison works properly) */
             if (H5Ldelete(fid_src, NAME_DATASET_SUB_SUB, H5P_DEFAULT) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
         /* open the group for copy */
         if ((gid = H5Gopen2(fid_src, NAME_GROUP_LINK2, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* open the destination group */
         if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_LINK, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     else if (flag & (H5O_COPY_WITHOUT_ATTR_FLAG | H5O_COPY_PRESERVE_NULL_FLAG)) {
         if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_dst, NAME_GROUP_TOP, pid, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* open the group for copy */
         if ((gid = H5Gopen2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* open the destination group */
         if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     else if (flag & H5O_COPY_SHALLOW_HIERARCHY_FLAG) {
         if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_dst, NAME_GROUP_TOP, pid, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* open the group for copy */
         if ((gid = H5Gopen2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* open the destination group */
         if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set the copy depth */
         depth = 1;
     }
     else if ((flag & H5O_COPY_EXPAND_REFERENCE_FLAG) > 0) {
         if (H5Ocopy(fid_src, NAME_GROUP_REF, fid_dst, NAME_GROUP_REF, pid, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* open the group for copy */
         if ((gid = H5Gopen2(fid_src, NAME_GROUP_REF, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* open the destination group */
         if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_REF, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     else {
         /* Unknown flag */
-        TEST_ERROR
+        TEST_ERROR;
     } /* end else */
 
     /* Check if the groups are equal */
     if (compare_groups(gid, gid2, pid, depth, flag) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close properties */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -16930,16 +16930,16 @@ test_copy_dataset_open(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination files aren't the
      * same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -16947,35 +16947,35 @@ test_copy_dataset_open(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst
 
     /* create 2D dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 2, chunk_dim2d) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create 2D dataset in SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create 2D chunked dataset in SRC file */
     if ((did2 = H5Dcreate2(fid_src, NAME_DATASET_CHUNKED, H5T_NATIVE_INT, sid, H5P_DEFAULT, pid,
                            H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data to the dataset */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did2, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the dataset */
     if (test_copy_attach_attributes(did, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (test_copy_attach_attributes(did2, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test case 1
@@ -16986,134 +16986,134 @@ test_copy_dataset_open(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst
      */
     /* copy the opened dataset to another location in SRC file */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_src, NAME_DATASET_SIMPLE2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED, fid_src, NAME_DATASET_CHUNKED2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied dataset */
     if ((did3 = H5Dopen2(fid_src, NAME_DATASET_SIMPLE2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did4 = H5Dopen2(fid_src, NAME_DATASET_CHUNKED2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did3, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (compare_datasets(did2, did4, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the copied dataset */
     if (H5Dclose(did3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Copy to another file
      */
     /* copy the opened dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED, fid_dst, NAME_DATASET_CHUNKED, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied dataset in DST file */
     if ((did3 = H5Dopen2(fid_dst, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did4 = H5Dopen2(fid_dst, NAME_DATASET_CHUNKED, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did3, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (compare_datasets(did2, did4, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the copied dataset in DST file */
     if (H5Dclose(did3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset in SRC file */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test case 2
      */
     /* reopen the dataset in SRC file */
     if ((did = H5Dopen2(fid_src, NAME_DATASET_SIMPLE, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did2 = H5Dopen2(fid_src, NAME_DATASET_CHUNKED, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write another set of data to the dataset */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, newbuf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did2, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, newbuf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Copy within the same file
      */
     /* copy the opened dataset to another location in SRC file */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_src, "NEW_DATASET_SIMPLE", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED, fid_src, "NEW_DATASET_CHUNKED", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied dataset */
     if ((did3 = H5Dopen2(fid_src, "NEW_DATASET_SIMPLE", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did4 = H5Dopen2(fid_src, "NEW_DATASET_CHUNKED", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did3, H5P_DEFAULT, newbuf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (compare_datasets(did2, did4, H5P_DEFAULT, newbuf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the copied dataset in SRC file */
     if (H5Dclose(did3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /*
      * Copy to another file
      */
     /* copy the opened dataset from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_SIMPLE, fid_dst, "NEW_DATASET_SIMPLE", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Ocopy(fid_src, NAME_DATASET_CHUNKED, fid_dst, "NEW_DATASET_CHUNKED", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied dataset in DST file */
     if ((did3 = H5Dopen2(fid_dst, "NEW_DATASET_SIMPLE", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did4 = H5Dopen2(fid_dst, "NEW_DATASET_CHUNKED", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did3, H5P_DEFAULT, newbuf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (compare_datasets(did2, did4, H5P_DEFAULT, newbuf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the copied dataset in DST file */
     if (H5Dclose(did3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset at SRC file */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test case 3
@@ -17121,15 +17121,15 @@ test_copy_dataset_open(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst
 
     /* make a copy of the datatype */
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* commit the datatype */
     if ((H5Tcommit2(fid_src, NAME_DATATYPE_SIMPLE, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the committed datatype */
     tid = H5Topen2(fid_src, NAME_DATATYPE_SIMPLE, H5P_DEFAULT);
@@ -17137,11 +17137,11 @@ test_copy_dataset_open(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst
     /* create 2D dataset with the opened committed datatype in SRC file */
     if ((did = H5Dcreate2(fid_src, NAME_DATASET_NAMED_DTYPE, tid, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data to the dataset */
     if (H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Copy within the same file
@@ -17149,19 +17149,19 @@ test_copy_dataset_open(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst
     /* copy the opened dataset (with the opened committed datatype) to another location in SRC file */
     if (H5Ocopy(fid_src, NAME_DATASET_NAMED_DTYPE, fid_src, NAME_DATASET_NAMED_DTYPE2, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied dataset */
     if ((did2 = H5Dopen2(fid_src, NAME_DATASET_NAMED_DTYPE2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the copied dataset in SRC file */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Copy to another file
@@ -17169,104 +17169,104 @@ test_copy_dataset_open(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst
     /* copy the opened dataset (with the opened committed datatype) from SRC to DST */
     if (H5Ocopy(fid_src, NAME_DATASET_NAMED_DTYPE, fid_dst, NAME_DATASET_NAMED_DTYPE2, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied dataset in DST file */
     if ((did2 = H5Dopen2(fid_dst, NAME_DATASET_NAMED_DTYPE2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the datasets are equal */
     if (compare_datasets(did, did2, H5P_DEFAULT, buf) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the copied dataset in DST file */
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset at SRC file */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the committed datatype at SRC file */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test case 4
      */
     /* create a group in SRC file */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the group */
     if (test_copy_attach_attributes(gid, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create 2D int dataset in the group at SRC file */
     if ((did = H5Dcreate2(gid, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write data to the dataset */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /*
      * Copy within the same file
      */
     /* copy the opened group (together with opened dataset) to another location in SRC file */
     if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_src, "COPIED_GROUP", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied group at SRC */
     if ((gid2 = H5Gopen2(fid_src, "COPIED_GROUP", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the groups are equal */
     if (compare_groups(gid, gid2, H5P_DEFAULT, -1, 0) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST dataset */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Copy to another file
      */
     /* copy the opened group (together with opened dataset) to DST file */
     if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_dst, "COPIED_GROUP", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the copied group at DST */
     if ((gid2 = H5Gopen2(fid_dst, "COPIED_GROUP", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the groups are equal */
     if (compare_groups(gid, gid2, H5P_DEFAULT, -1, 0) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the group in DST file */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the group in SRC file */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the dataset in SRC file */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -17328,27 +17328,27 @@ main(void)
 
     /* Copy the file access property list */
     if ((fapl2 = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set the "use the latest version of the format" bounds for creating objects in the file */
     if (H5Pset_libver_bounds(fapl2, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an FCPL with sharing enabled */
     if ((fcpl_shared = H5Pcreate(H5P_FILE_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_shared_mesg_nindexes(fcpl_shared, 1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_shared_mesg_index(fcpl_shared, 0, H5O_SHMESG_ALL_FLAG, 10) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Obtain the default attribute storage phase change values */
     if ((ocpl = H5Pcreate(H5P_OBJECT_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_attr_phase_change(ocpl, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(ocpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test in all configurations */
     for (configuration = 0; configuration <= MAX_CONFIGURATION; configuration++) {

--- a/test/objcopy_ref.c
+++ b/test/objcopy_ref.c
@@ -190,44 +190,44 @@ attach_ref_attr(hid_t file_id, hid_t loc_id)
 
     /* creates two simple datasets */
     if ((sid = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((sid_ref = H5Screate_simple(1, dims_ref, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did1 = H5Dcreate2(file_id, dsetname1, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did1, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did2 = H5Dcreate2(file_id, dsetname2, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did2, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create an attribute with two object references */
     if (H5Rcreate_object(file_id, dsetname1, H5P_DEFAULT, &ref[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate_object(file_id, dsetname2, H5P_DEFAULT, &ref[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((aid = H5Acreate2(loc_id, "obj_ref_attr", H5T_STD_REF, sid_ref, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Awrite(aid, H5T_STD_REF, ref) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid_ref) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rdestroy(&ref[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rdestroy(&ref[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -280,55 +280,55 @@ attach_reg_ref_attr(hid_t file_id, hid_t loc_id)
 
     /* create a 2D dataset */
     if ((space_id = H5Screate_simple(rank, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((spacer_id = H5Screate_simple(rankr, dimsr, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dsetv_id = H5Dcreate2(file_id, dsetnamev, H5T_NATIVE_INT, space_id, H5P_DEFAULT, H5P_DEFAULT,
                                H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dsetv_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create reg_ref of block selection */
     if (H5Sselect_hyperslab(space_id, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate_region(file_id, dsetnamev, space_id, H5P_DEFAULT, &ref[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create reg_ref of point selection */
     if (H5Sselect_none(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sselect_elements(space_id, H5S_SELECT_SET, num_points, (const hsize_t *)coord) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate_region(file_id, dsetnamev, space_id, H5P_DEFAULT, &ref[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create reg_ref attribute */
     if ((aid = H5Acreate2(loc_id, "reg_ref_attr", H5T_STD_REF, spacer_id, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Awrite(aid, H5T_STD_REF, ref) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach the reg_ref attribute to the dataset itself */
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((aid = H5Acreate2(dsetv_id, "reg_ref_attr", H5T_STD_REF, spacer_id, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Awrite(aid, H5T_STD_REF, ref) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Sclose(spacer_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dsetv_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aclose(aid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rdestroy(&ref[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rdestroy(&ref[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -384,81 +384,81 @@ create_reg_ref_dataset(hid_t file_id, hid_t loc_id)
     hid_t      pid         = (-1);
 
     if ((space_id = H5Screate_simple(rank, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((spacer_id = H5Screate_simple(rankr, dimsr, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dsetv_id = H5Dcreate2(file_id, dsetnamev, H5T_NATIVE_INT, space_id, H5P_DEFAULT, H5P_DEFAULT,
                                H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dsetv_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dsetr_id = H5Dcreate2(loc_id, dsetnamer, H5T_STD_REF, spacer_id, H5P_DEFAULT, H5P_DEFAULT,
                                H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     start[0] = 0;
     start[1] = 3;
     count[0] = 2;
     count[1] = 3;
     if (H5Sselect_hyperslab(space_id, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate_region(file_id, dsetnamev, space_id, H5P_DEFAULT, &ref[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sselect_none(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sselect_elements(space_id, H5S_SELECT_SET, num_points, (const hsize_t *)coord) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rcreate_region(file_id, dsetnamev, space_id, H5P_DEFAULT, &ref[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dsetr_id, H5T_STD_REF, H5S_ALL, H5S_ALL, H5P_DEFAULT, ref) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dsetr_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set compact plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_layout(pid, H5D_COMPACT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((dsetr_id = H5Dcreate2(loc_id, dsetnamer1, H5T_STD_REF, spacer_id, H5P_DEFAULT, pid, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dsetr_id, H5T_STD_REF, H5S_ALL, H5S_ALL, H5P_DEFAULT, ref) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dsetr_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create and set comp & chunk plist */
     if ((pid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(pid, 1, &chunk_size) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_deflate(pid, 9) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((dsetr_id = H5Dcreate2(loc_id, dsetnamer2, H5T_STD_REF, spacer_id, H5P_DEFAULT, pid, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(dsetr_id, H5T_STD_REF, H5S_ALL, H5S_ALL, H5P_DEFAULT, ref) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dsetr_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Sclose(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(spacer_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dsetv_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rdestroy(&ref[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Rdestroy(&ref[1]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -576,97 +576,97 @@ compare_attribute(hid_t aid, hid_t aid2, hid_t pid, const void *wbuf, hid_t obj_
 
     /* Check the character sets are equal */
     if (H5Aget_info(aid, &ainfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Aget_info(aid2, &ainfo2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ainfo.cset != ainfo2.cset)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the creation orders are equal (if appropriate) */
     if (ainfo.corder_valid != ainfo2.corder_valid)
-        TEST_ERROR
+        TEST_ERROR;
     if (ainfo.corder_valid)
         if (ainfo.corder != ainfo2.corder)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Check the datatypes are equal */
 
     /* Open the datatype for the source attribute */
     if ((tid = H5Aget_type(aid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the datatype for the destination attribute */
     if ((tid2 = H5Aget_type(aid2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that both datatypes are committed/not committed */
     if ((is_committed = H5Tcommitted(tid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((is_committed2 = H5Tcommitted(tid2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (is_committed != is_committed2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compare the datatypes */
     if (H5Tequal(tid, tid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Determine the size of datatype (for later) */
     if ((elmt_size = H5Tget_size(tid)) == 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the dataspaces are equal */
 
     /* Open the dataspace for the source attribute */
     if ((sid = H5Aget_space(aid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the dataspace for the destination attribute */
     if ((sid2 = H5Aget_space(aid2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compare the dataspaces */
     if (H5Sextent_equal(sid, sid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Determine the number of elements in dataspace (for later) */
     if ((nelmts = H5Sget_simple_extent_npoints(sid2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the raw data is equal */
 
     /* Allocate & initialize space for the raw data buffers */
     if ((rbuf = HDcalloc(elmt_size, (size_t)nelmts)) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
     if ((rbuf2 = HDcalloc(elmt_size, (size_t)nelmts)) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read data from the source attribute */
     if (H5Aread(aid, tid, rbuf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read data from the destination attribute */
     if (H5Aread(aid2, tid2, rbuf2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check raw data read in against data written out */
     if (wbuf) {
         if (!compare_data(aid, (hid_t)0, pid, tid, (size_t)nelmts, wbuf, rbuf, obj_owner))
-            TEST_ERROR
+            TEST_ERROR;
         if (!compare_data(aid2, (hid_t)0, pid, tid2, (size_t)nelmts, wbuf, rbuf2, obj_owner))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     /* Don't have written data, just compare data between the two attributes */
     else if (!compare_data(aid, aid2, pid, tid, (size_t)nelmts, rbuf, rbuf2, obj_owner))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen data, if necessary */
     if (H5Tdetect_class(tid, H5T_VLEN) == TRUE || H5Tdetect_class(tid, H5T_REFERENCE) == TRUE)
         if (H5Treclaim(tid, sid, H5P_DEFAULT, rbuf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if (H5Tdetect_class(tid2, H5T_VLEN) == TRUE || H5Tdetect_class(tid2, H5T_REFERENCE) == TRUE)
         if (H5Treclaim(tid2, sid2, H5P_DEFAULT, rbuf2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Release raw data buffers */
     HDfree(rbuf);
@@ -676,19 +676,19 @@ compare_attribute(hid_t aid, hid_t aid2, hid_t pid, const void *wbuf, hid_t obj_
 
     /* close the source dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataspace */
     if (H5Sclose(sid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination datatype */
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return TRUE;
 
@@ -733,23 +733,23 @@ compare_std_attributes(hid_t oid, hid_t oid2, hid_t pid)
     /* Retrieve the object copy flags from the property list, if it's non-DEFAULT */
     if (pid != H5P_DEFAULT) {
         if (H5Pget_copy_object(pid, &cpy_flags) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else
         cpy_flags = 0;
 
     /* Check the number of attributes on source dataset */
     if (H5Oget_info3(oid, &oinfo1, H5O_INFO_NUM_ATTRS) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the number of attributes on destination dataset */
     if (H5Oget_info3(oid2, &oinfo2, H5O_INFO_NUM_ATTRS) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (cpy_flags & H5O_COPY_WITHOUT_ATTR_FLAG) {
         /* Check that the destination has no attributes */
         if (oinfo2.num_attrs != 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else {
         char     attr_name[ATTR_NAME_LEN]; /* Attribute name */
@@ -757,28 +757,28 @@ compare_std_attributes(hid_t oid, hid_t oid2, hid_t pid)
 
         /* Compare the number of attributes */
         if (oinfo1.num_attrs != oinfo2.num_attrs)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check the attributes are equal */
         for (i = 0; i < (unsigned)oinfo1.num_attrs; i++) {
             if ((aid = H5Aopen_by_idx(oid, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, (hsize_t)i, H5P_DEFAULT,
                                       H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Aget_name(aid, (size_t)ATTR_NAME_LEN, attr_name) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             if ((aid2 = H5Aopen(oid2, attr_name, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check the attributes are equal */
             if (!compare_attribute(aid, aid2, pid, NULL, oid))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Close the attributes */
             if (H5Aclose(aid) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Aclose(aid2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
     }     /* end if */
 
@@ -815,7 +815,7 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
 
     /* Check size of each element */
     if ((elmt_size = H5Tget_size(tid)) == 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* If the type is a compound containing a vlen, loop over all elements for
      * each compound member.  Compounds containing reference  are not supported
@@ -832,7 +832,7 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
 
         /* Get number of members in compound */
         if ((nmembs = H5Tget_nmembers(tid)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Loop over members */
         for (memb_idx = 0; memb_idx < (unsigned)nmembs; memb_idx++) {
@@ -842,11 +842,11 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
 
             /* Get member id */
             if ((memb_id = H5Tget_member_type(tid, memb_idx)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Get member size */
             if ((memb_size = H5Tget_size(memb_id)) == 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Set up pointers to member in the first element */
             memb1 = (const uint8_t *)buf1 + memb_off;
@@ -858,7 +858,7 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
 
                 /* Get base type of vlen datatype */
                 if ((base_id = H5Tget_super(memb_id)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Iterate over all elements, recursively calling this function
                  * for each */
@@ -866,14 +866,14 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
                     /* Check vlen lengths */
                     if (((const hvl_t *)((const void *)memb1))->len !=
                         ((const hvl_t *)((const void *)memb2))->len)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check vlen data */
                     if (!compare_data(parent1, parent2, pid, base_id,
                                       ((const hvl_t *)((const void *)memb1))->len,
                                       ((const hvl_t *)((const void *)memb1))->p,
                                       ((const hvl_t *)((const void *)memb2))->p, obj_owner))
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Update member pointers */
                     memb1 += elmt_size;
@@ -888,7 +888,7 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
                 /* Iterate over all elements, calling memcmp() for each */
                 for (elmt = 0; elmt < nelmts; elmt++) {
                     if (HDmemcmp(memb1, memb2, memb_size) != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Update member pointers */
                     memb1 += elmt_size;
@@ -904,11 +904,11 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
 
         /* Check for "simple" vlen datatype */
         if (H5Tget_class(tid) != H5T_VLEN)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get base type of vlen datatype */
         if ((base_tid = H5Tget_super(tid)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Loop over elements in buffers */
         vl_buf1 = (const hvl_t *)buf1;
@@ -916,23 +916,23 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
         for (u = 0; u < nelmts; u++, vl_buf1++, vl_buf2++) {
             /* Check vlen lengths */
             if (vl_buf1->len != vl_buf2->len)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Check vlen data */
             if (!compare_data(parent1, parent2, pid, base_tid, vl_buf1->len, vl_buf1->p, vl_buf2->p,
                               obj_owner))
-                TEST_ERROR
+                TEST_ERROR;
         } /* end for */
 
         if (H5Tclose(base_tid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else if (H5Tdetect_class(tid, H5T_REFERENCE) == TRUE) {
         size_t u; /* Local index variable */
 
         /* Check for "simple" reference datatype */
         if (H5Tget_class(tid) != H5T_REFERENCE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check for object or region reference */
         if (H5Tequal(tid, H5T_STD_REF) > 0) {
@@ -947,17 +947,17 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
 
                 /* Check for types of objects handled */
                 if (H5Rget_obj_type3(ref_buf1, H5P_DEFAULT, &obj1_type) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Rget_obj_type3(ref_buf2, H5P_DEFAULT, &obj2_type) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (obj1_type != obj2_type)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Open referenced objects */
                 if ((obj1_id = H5Ropen_object(ref_buf1, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if ((obj2_id = H5Ropen_object(ref_buf2, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* break the infinite loop when the ref_object points to itself */
                 if (obj_owner > 0) {
@@ -965,16 +965,16 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
                     int         token_cmp;
 
                     if (H5Oget_info3(obj_owner, &oinfo1, H5O_INFO_BASIC) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Oget_info3(obj1_id, &oinfo2, H5O_INFO_BASIC) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Otoken_cmp(obj1_id, &oinfo1.token, &oinfo2.token, &token_cmp) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (0 == token_cmp) {
                         if (H5Oclose(obj1_id) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                         if (H5Oclose(obj2_id) < 0)
-                            TEST_ERROR
+                            TEST_ERROR;
                         return TRUE;
                     }
                 }
@@ -983,17 +983,17 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
                 switch (obj1_type) {
                     case H5O_TYPE_DATASET:
                         if (compare_datasets(obj1_id, obj2_id, pid, NULL) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
                         break;
 
                     case H5O_TYPE_GROUP:
                         if (compare_groups(obj1_id, obj2_id, pid, -1, 0) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
                         break;
 
                     case H5O_TYPE_NAMED_DATATYPE:
                         if (H5Tequal(obj1_id, obj2_id) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
                         break;
 
                     case H5O_TYPE_MAP:
@@ -1002,41 +1002,41 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
                     case H5O_TYPE_UNKNOWN:
                     case H5O_TYPE_NTYPES:
                     default:
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end switch */
 
                 /* Close objects */
                 if (H5Oclose(obj1_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Oclose(obj2_id) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 if (H5Rget_type(ref_buf1) == H5R_DATASET_REGION2) {
                     hid_t obj1_sid, obj2_sid; /* Dataspace IDs for objects referenced */
 
                     /* Get regions for referenced datasets */
                     if ((obj1_sid = H5Ropen_region(ref_buf1, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if ((obj2_sid = H5Ropen_region(ref_buf2, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Check if dataspaces are the same shape */
                     if (H5Sselect_shape_same(obj1_sid, obj2_sid) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Close dataspaces */
                     if (H5Sclose(obj1_sid) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Sclose(obj2_sid) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end if */
             }     /* end for */
         }         /* end if */
         else
-            TEST_ERROR
+            TEST_ERROR;
     } /* end else */
     else if (HDmemcmp(buf1, buf2, (elmt_size * nelmts)) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Data should be the same. :-) */
     return TRUE;
@@ -1077,81 +1077,81 @@ compare_datasets(hid_t did, hid_t did2, hid_t pid, const void *wbuf)
 
     /* Open the datatype for the source dataset */
     if ((tid = H5Dget_type(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the datatype for the destination dataset */
     if ((tid2 = H5Dget_type(did2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that both datatypes are committed/not committed */
     if ((is_committed = H5Tcommitted(tid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((is_committed2 = H5Tcommitted(tid2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (is_committed != is_committed2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compare the datatypes */
     if (H5Tequal(tid, tid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Determine the size of datatype (for later) */
     if ((elmt_size = H5Tget_size(tid)) == 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the dataspaces are equal */
 
     /* Open the dataspace for the source dataset */
     if ((sid = H5Dget_space(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the dataspace for the destination dataset */
     if ((sid2 = H5Dget_space(did2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compare the dataspaces */
     if (H5Sextent_equal(sid, sid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Determine the number of elements in dataspace (for later) */
     if ((nelmts = H5Sget_simple_extent_npoints(sid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the dataset creation property lists are equal */
 
     /* Open the dataset creation property list for the source dataset */
     if ((dcpl = H5Dget_create_plist(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the dataset creation property list for the destination dataset */
     if ((dcpl2 = H5Dget_create_plist(did2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Compare the rest of the dataset creation property lists */
     if (H5Pequal(dcpl, dcpl2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the number of filters on dataset (for later) */
     if ((nfilters = H5Pget_nfilters(dcpl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source dataset creation property list */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataset creation property list */
     if (H5Pclose(dcpl2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the allocated storage is the same */
 
     /* Check that the space allocation status is the same */
     if (H5Dget_space_status(did, &space_status) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dget_space_status(did2, &space_status2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (space_status != space_status2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the space used is the same */
     /* (Don't check if the dataset is filtered (i.e. compressed, etc.) and
@@ -1165,41 +1165,41 @@ compare_datasets(hid_t did, hid_t did2, hid_t pid, const void *wbuf)
         hsize_t storage_size2 = H5Dget_storage_size(did2); /* 2nd Dataset's raw data storage size */
 
         if (storage_size != storage_size2)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Check the raw data is equal */
 
     /* Allocate & initialize space for the raw data buffers */
     if ((rbuf = HDcalloc(elmt_size, (size_t)nelmts)) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
     if ((rbuf2 = HDcalloc(elmt_size, (size_t)nelmts)) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read data from datasets */
     if (H5Dread(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dread(did2, tid2, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check raw data read in against data written out */
     if (wbuf) {
         if (!compare_data(did, (hid_t)0, pid, tid, (size_t)nelmts, wbuf, rbuf, did))
-            TEST_ERROR
+            TEST_ERROR;
         if (!compare_data(did2, (hid_t)0, pid, tid2, (size_t)nelmts, wbuf, rbuf2, did2))
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     /* Don't have written data, just compare data between the two datasets */
     else if (!compare_data(did, did2, pid, tid, (size_t)nelmts, rbuf, rbuf2, did))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reclaim vlen data, if necessary */
     if (H5Tdetect_class(tid, H5T_VLEN) == TRUE || H5Tdetect_class(tid, H5T_REFERENCE) == TRUE)
         if (H5Treclaim(tid, sid, H5P_DEFAULT, rbuf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if (H5Tdetect_class(tid2, H5T_VLEN) == TRUE || H5Tdetect_class(tid2, H5T_REFERENCE) == TRUE)
         if (H5Treclaim(tid2, sid2, H5P_DEFAULT, rbuf2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Release raw data buffers */
     HDfree(rbuf);
@@ -1209,23 +1209,23 @@ compare_datasets(hid_t did, hid_t did2, hid_t pid, const void *wbuf)
 
     /* close the source dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination dataspace */
     if (H5Sclose(sid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the source datatype */
     if (H5Tclose(tid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the destination datatype */
     if (H5Tclose(tid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check if the attributes are equal */
     if (compare_std_attributes(did, did2, pid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Datasets should be the same. :-) */
     return TRUE;
@@ -1271,23 +1271,23 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
     /* Retrieve the object copy flags from the property list, if it's non-DEFAULT */
     if (pid != H5P_DEFAULT) {
         if (H5Pget_copy_object(pid, &cpy_flags) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else
         cpy_flags = 0;
 
     /* Check if both groups have the same # of objects */
     if (H5Gget_info(gid, &ginfo) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gget_info(gid2, &ginfo2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((cpy_flags & H5O_COPY_SHALLOW_HIERARCHY_FLAG) && depth == 0) {
         if (ginfo2.nlinks != 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else {
         if (ginfo.nlinks != ginfo2.nlinks)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Check contents of groups */
@@ -1302,20 +1302,20 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
             /* Check name of objects */
             if (H5Lget_name_by_idx(gid, ".", H5_INDEX_NAME, H5_ITER_INC, idx, objname, (size_t)NAME_BUF_SIZE,
                                    H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Lget_name_by_idx(gid2, ".", H5_INDEX_NAME, H5_ITER_INC, idx, objname2,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (HDstrcmp(objname, objname2) != 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Get link info */
             if (H5Lget_info2(gid, objname, &linfo, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Lget_info2(gid2, objname2, &linfo2, H5P_DEFAULT) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (linfo.type != linfo2.type)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Extra checks for "real" objects */
             if (linfo.type == H5L_TYPE_HARD) {
@@ -1326,20 +1326,20 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
                 /* Compare some pieces of the object info */
                 /* Get data model object info */
                 if (H5Oget_info_by_name3(gid, objname, &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Oget_info_by_name3(gid2, objname2, &oinfo2, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Get native object info */
                 if (H5Oget_native_info_by_name(gid, objname, &ninfo, H5O_NATIVE_INFO_HDR, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Oget_native_info_by_name(gid2, objname2, &ninfo2, H5O_NATIVE_INFO_HDR, H5P_DEFAULT) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 if (oinfo.type != oinfo2.type)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (oinfo.rc != oinfo2.rc)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* If NULL messages are preserved, the number of messages
                  * should be the same in the destination.
@@ -1350,7 +1350,7 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
                     if (ninfo.hdr.nmesgs != ninfo2.hdr.nmesgs)
                         ;
                     else if (ninfo.hdr.nmesgs < ninfo2.hdr.nmesgs)
-                        TEST_ERROR
+                        TEST_ERROR;
                 }
 
                 /* Check for object already having been compared */
@@ -1361,28 +1361,28 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
 
                 /* Open objects */
                 if ((oid = H5Oopen(gid, objname, H5P_DEFAULT)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if ((oid2 = H5Oopen(gid2, objname2, H5P_DEFAULT)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
 
                 /* Compare objects within group */
                 switch (oinfo.type) {
                     case H5O_TYPE_GROUP:
                         /* Compare groups */
                         if (compare_groups(oid, oid2, pid, depth - 1, copy_flags) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
                         break;
 
                     case H5O_TYPE_DATASET:
                         /* Compare datasets */
                         if (compare_datasets(oid, oid2, pid, NULL) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
                         break;
 
                     case H5O_TYPE_NAMED_DATATYPE:
                         /* Compare datatypes */
                         if (H5Tequal(oid, oid2) != TRUE)
-                            TEST_ERROR
+                            TEST_ERROR;
                         break;
 
                     case H5O_TYPE_MAP:
@@ -1397,14 +1397,14 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
 
                 /* Close objects */
                 if (H5Oclose(oid) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (H5Oclose(oid2) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 /* Check that both links are the same size */
                 if (linfo.u.val_size != linfo2.u.val_size)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 /* Compare link values */
                 if (linfo.type == H5L_TYPE_SOFT ||
@@ -1415,13 +1415,13 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
                     /* Get link values */
                     HDassert(linfo.u.val_size <= NAME_BUF_SIZE);
                     if (H5Lget_val(gid, objname, linkval, (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                     if (H5Lget_val(gid2, objname2, linkval2, (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
 
                     /* Compare link data */
                     if (HDmemcmp(linkval, linkval2, linfo.u.val_size) != 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end else-if */
                 else {
                     HDassert(0 && "Unknown type of link");
@@ -1432,7 +1432,7 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
 
     /* Check if the attributes are equal */
     if (compare_std_attributes(gid, gid2, pid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Groups should be the same. :-) */
     return TRUE;
@@ -1492,15 +1492,15 @@ test_copy_option(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fapl,
 
     /* create source file */
     if ((fid_src = H5Fcreate(src_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create group at the SRC file */
     if ((gid = H5Gcreate2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* attach attributes to the group */
     if (test_copy_attach_attributes(gid, H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set dataspace dimensions */
     dim2d[0] = DIM_SIZE_1;
@@ -1508,80 +1508,80 @@ test_copy_option(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fapl,
 
     /* create dataspace */
     if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add a dataset to the top group */
     if ((did = H5Dcreate2(gid, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create a sub-group */
     if ((gid_sub = H5Gcreate2(fid_src, NAME_GROUP_SUB, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add a dataset to the sub group */
     if ((did = H5Dcreate2(gid_sub, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create sub-sub-group */
     if ((gid_sub_sub = H5Gcreate2(gid_sub, NAME_GROUP_SUB_SUB2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* add a dataset to the sub sub group */
     if ((did = H5Dcreate2(gid_sub_sub, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataset */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close dataspace */
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gid_sub_sub) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Gclose(gid_sub) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((flag & H5O_COPY_EXPAND_SOFT_LINK_FLAG) > 0) {
         /* Create group to copy */
         if ((gid = H5Gcreate2(fid_src, NAME_GROUP_LINK, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Lcreate_soft(NAME_DATASET_SUB_SUB, fid_src, NAME_LINK_SOFT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Lcreate_soft("nowhere", fid_src, NAME_LINK_SOFT_DANGLE, H5P_DEFAULT, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Gclose(gid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create group to compare with */
         if ((gid = H5Gcreate2(fid_src, NAME_GROUP_LINK2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Lcreate_hard(fid_src, NAME_DATASET_SUB_SUB, H5L_SAME_LOC, NAME_LINK_SOFT2, H5P_DEFAULT,
                            H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Lcreate_soft("nowhere", fid_src, NAME_LINK_SOFT_DANGLE2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Gclose(gid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     if ((flag & H5O_COPY_EXPAND_EXT_LINK_FLAG) > 0) {
@@ -1591,220 +1591,220 @@ test_copy_option(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fapl,
 
         /* Create the external file and dataset */
         if ((fid_ext = H5Fcreate(ext_filename, H5F_ACC_TRUNC, fcpl_src, src_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((sid = H5Screate_simple(2, dim2d, NULL)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((did = H5Dcreate2(fid_ext, NAME_DATASET_SIMPLE, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Dclose(did) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Fclose(fid_ext) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create group to copy */
         if (!(flag & H5O_COPY_EXPAND_SOFT_LINK_FLAG)) {
             if ((gid = H5Gcreate2(fid_src, NAME_GROUP_LINK, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
         else if ((gid = H5Gopen2(fid_src, NAME_GROUP_LINK, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Lcreate_external(ext_filename, NAME_DATASET_SIMPLE, fid_src, NAME_LINK_EXTERN, H5P_DEFAULT,
                                H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Lcreate_external("no_file", "no_object", fid_src, NAME_LINK_EXTERN_DANGLE, H5P_DEFAULT,
                                H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(gid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create group to compare with */
         if (!(flag & H5O_COPY_EXPAND_SOFT_LINK_FLAG)) {
             if ((gid = H5Gcreate2(fid_src, NAME_GROUP_LINK2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
         else if ((gid = H5Gopen2(fid_src, NAME_GROUP_LINK2, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((did = H5Dcreate2(fid_src, NAME_LINK_EXTERN2, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
                               H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Lcreate_external("no_file", "no_object", fid_src, NAME_LINK_EXTERN_DANGLE2, H5P_DEFAULT,
                                H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Dclose(did) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(gid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close dataspace */
         if (H5Sclose(sid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     if ((flag & H5O_COPY_EXPAND_REFERENCE_FLAG) > 0) {
         if ((gid_ref = H5Gcreate2(fid_src, NAME_GROUP_REF, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* create an attribute of new object references */
         if (attach_ref_attr(fid_src, gid_ref) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* create an attribute of region references */
         if (attach_reg_ref_attr(fid_src, gid_ref) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* create a dataset of region references */
         if (create_reg_ref_dataset(fid_src, gid_ref) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close group holding reference objects */
         if (H5Gclose(gid_ref) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* open the source file with read-only */
     /* (except when expanding soft links */
     if ((flag & H5O_COPY_EXPAND_SOFT_LINK_FLAG) > 0) {
         if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDWR, src_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else if ((fid_src = H5Fopen(src_filename, H5F_ACC_RDONLY, src_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create destination file */
     if ((fid_dst = H5Fcreate(dst_filename, H5F_ACC_TRUNC, fcpl_dst, dst_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an uncopied object in destination file so that tokens in source and destination
        files aren't the same */
     if (H5Gclose(H5Gcreate2(fid_dst, NAME_GROUP_UNCOPIED, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create property to pass copy options */
     if ((pid = H5Pcreate(H5P_OBJECT_COPY)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set options for object copy */
     if (H5Pset_copy_object(pid, flag) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify object copy flags */
     if (H5Pget_copy_object(pid, &cpy_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (cpy_flags != flag)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* copy the group from SRC to DST */
     if (crt_intermediate_grp) {
         /* Create link creation plist to pass in intermediate group creation */
         if ((lcpl_id = H5Pcreate(H5P_LINK_CREATE)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_create_intermediate_group(lcpl_id, TRUE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_dst, "/new_g0/new_g00", pid, lcpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Pclose(lcpl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* open the group for copy */
         if ((gid = H5Gopen2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* open the destination group */
         if ((gid2 = H5Gopen2(fid_dst, "/new_g0/new_g00", H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     else if (((flag & H5O_COPY_EXPAND_SOFT_LINK_FLAG) > 0) || ((flag & H5O_COPY_EXPAND_EXT_LINK_FLAG) > 0)) {
         if (H5Ocopy(fid_src, NAME_GROUP_LINK, fid_dst, NAME_GROUP_LINK, pid, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if ((flag & H5O_COPY_EXPAND_SOFT_LINK_FLAG) > 0)
             /* Unlink dataset to copy from original location */
             /* (So group comparison works properly) */
             if (H5Ldelete(fid_src, NAME_DATASET_SUB_SUB, H5P_DEFAULT) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
         /* open the group for copy */
         if ((gid = H5Gopen2(fid_src, NAME_GROUP_LINK2, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* open the destination group */
         if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_LINK, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     else if (flag & (H5O_COPY_WITHOUT_ATTR_FLAG | H5O_COPY_PRESERVE_NULL_FLAG)) {
         if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_dst, NAME_GROUP_TOP, pid, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* open the group for copy */
         if ((gid = H5Gopen2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* open the destination group */
         if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     else if (flag & H5O_COPY_SHALLOW_HIERARCHY_FLAG) {
         if (H5Ocopy(fid_src, NAME_GROUP_TOP, fid_dst, NAME_GROUP_TOP, pid, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* open the group for copy */
         if ((gid = H5Gopen2(fid_src, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* open the destination group */
         if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_TOP, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set the copy depth */
         depth = 1;
     }
     else if ((flag & H5O_COPY_EXPAND_REFERENCE_FLAG) > 0) {
         if (H5Ocopy(fid_src, NAME_GROUP_REF, fid_dst, NAME_GROUP_REF, pid, H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* open the group for copy */
         if ((gid = H5Gopen2(fid_src, NAME_GROUP_REF, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* open the destination group */
         if ((gid2 = H5Gopen2(fid_dst, NAME_GROUP_REF, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     else {
         /* Unknown flag */
-        TEST_ERROR
+        TEST_ERROR;
     } /* end else */
 
     /* Check if the groups are equal */
     if (compare_groups(gid, gid2, pid, depth, flag) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the SRC file */
     if (H5Fclose(fid_src) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close the DST file */
     if (H5Fclose(fid_dst) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close properties */
     if (H5Pclose(pid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -1864,27 +1864,27 @@ main(void)
 
     /* Copy the file access property list */
     if ((fapl2 = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set the "use the latest version of the format" bounds for creating objects in the file */
     if (H5Pset_libver_bounds(fapl2, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an FCPL with sharing enabled */
     if ((fcpl_shared = H5Pcreate(H5P_FILE_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_shared_mesg_nindexes(fcpl_shared, 1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_shared_mesg_index(fcpl_shared, 0, H5O_SHMESG_ALL_FLAG, 10) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Obtain the default attribute storage phase change values */
     if ((ocpl = H5Pcreate(H5P_OBJECT_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_attr_phase_change(ocpl, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(ocpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test in all configurations */
     for (configuration = 0; configuration <= MAX_CONFIGURATION; configuration++) {

--- a/test/ohdr.c
+++ b/test/ohdr.c
@@ -88,9 +88,9 @@ test_cont(char *filename, hid_t fapl)
 
     /* Create the file to operate on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5AC_ignore_tags(f) < 0) {
         H5_FAILED();
         H5Eprint2(H5E_DEFAULT, stdout);
@@ -98,65 +98,65 @@ test_cont(char *filename, hid_t fapl)
     } /* end if */
 
     if (H5O_create(f, (size_t)H5O_MIN_SIZE, (size_t)0, H5P_GROUP_CREATE_DEFAULT, &oh_locA /*out*/) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5O_create(f, (size_t)H5O_MIN_SIZE, (size_t)0, H5P_GROUP_CREATE_DEFAULT, &oh_locB /*out*/) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     time_new = 11111111;
 
     if (H5O_msg_create(&oh_locA, H5O_NAME_ID, 0, 0, &long_name) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5O_msg_create(&oh_locB, H5O_MTIME_ID, 0, 0, &time_new) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5O_msg_create(&oh_locB, H5O_MTIME_ID, 0, 0, &time_new) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5O_msg_create(&oh_locB, H5O_MTIME_ID, 0, 0, &time_new) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5O_msg_create(&oh_locA, H5O_MTIME_NEW_ID, 0, 0, &time_new) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5O_msg_create(&oh_locB, H5O_MTIME_ID, 0, 0, &time_new) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5O_msg_create(&oh_locA, H5O_NAME_ID, 0, 0, &short_name) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (1 != H5O_link(&oh_locA, 1))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (1 != H5O_link(&oh_locB, 1))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5AC_prep_for_file_flush(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5AC_flush(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5AC_secure_from_file_flush(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5O__expunge_chunks_test(&oh_locA) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5O_get_hdr_info(&oh_locA, &hdr_info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     nchunks = hdr_info.nchunks;
 
     /* remove the 1st H5O_NAME_ID message */
     if (H5O_msg_remove(&oh_locA, H5O_NAME_ID, 0, FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5O_get_hdr_info(&oh_locA, &hdr_info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (hdr_info.nchunks >= nchunks)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5O_close(&oh_locA, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5O_close(&oh_locB, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -199,77 +199,77 @@ test_ohdr_cache(char *filename, hid_t fapl)
 
     /* Make a copy of the FAPL */
     if ((my_fapl = H5Pcopy(fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Tweak down the size of the metadata cache to only 64K */
     mdc_config.version = H5AC__CURR_CACHE_CONFIG_VERSION;
     if (H5Pget_mdc_config(my_fapl, &mdc_config) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     mdc_config.set_initial_size = TRUE;
     mdc_config.initial_size     = 32 * 1024;
     mdc_config.max_size         = 64 * 1024;
     mdc_config.min_size         = 8 * 1024;
     if (H5Pset_mdc_config(my_fapl, &mdc_config) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the file to operate on */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(my_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (NULL == (f = (H5F_t *)H5VL_object(file)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5AC_ignore_tags(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create object (local heap) that occupies most of cache */
     if (H5HL_create(f, (31 * 1024), &lheap_addr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Protect local heap (which actually pins it in the cache) */
     if (NULL == (lheap = H5HL_protect(f, lheap_addr, H5AC__READ_ONLY_FLAG)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create an object header */
     HDmemset(&oh_loc, 0, sizeof(oh_loc));
     if (H5O_create(f, (size_t)2048, (size_t)1, H5P_GROUP_CREATE_DEFAULT, &oh_loc /*out*/) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Query object header information */
     rc = 0;
     if (H5O__get_rc_test(&oh_loc, &rc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (0 != rc)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create object (local heap) that occupies most of cache */
     if (H5HL_create(f, (31 * 1024), &lheap_addr2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Protect local heap (which actually pins it in the cache) */
     if (NULL == (lheap2 = H5HL_protect(f, lheap_addr2, H5AC__READ_ONLY_FLAG)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Unprotect local heap (which actually unpins it from the cache) */
     if (H5HL_unprotect(lheap2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create object header message in new object header */
     time_new = 11111111;
     if (H5O_msg_create(&oh_loc, H5O_MTIME_NEW_ID, 0, 0, &time_new) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create object (local heap) that occupies most of cache */
     if (H5HL_create(f, (31 * 1024), &lheap_addr3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Protect local heap (which actually pins it in the cache) */
     if (NULL == (lheap3 = H5HL_protect(f, lheap_addr3, H5AC__READ_ONLY_FLAG)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Unprotect local heap (which actually unpins it from the cache) */
     if (H5HL_unprotect(lheap3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Query object header information */
     /* (Note that this is somewhat of a weak test, since it doesn't actually
@@ -279,24 +279,24 @@ test_ohdr_cache(char *filename, hid_t fapl)
      */
     rc = 0;
     if (H5O__get_rc_test(&oh_loc, &rc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (0 != rc)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Decrement reference count o object header */
     if (H5O_dec_rc_by_loc(&oh_loc) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close object header created */
     if (H5O_close(&oh_loc, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Unprotect local heap (which actually unpins it from the cache) */
     if (H5HL_unprotect(lheap) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -344,20 +344,20 @@ test_ohdr_swmr(hbool_t new_format)
 
     /* File access property list */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the file with/without latest format: ensure version 2 object header for SWMR */
     if (new_format) {
         /* Set to use latest library format */
         if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if ((fid = H5Fcreate(FILE_OHDR_SWMR, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
     else {
         if ((fid = H5Fcreate(FILE_OHDR_SWMR, H5F_ACC_TRUNC | H5F_ACC_SWMR_WRITE, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end else */
 
     /* Initialize data */
@@ -369,47 +369,47 @@ test_ohdr_swmr(hbool_t new_format)
     /* Create a small data space for compact dataset */
     dims[0] = (hsize_t)compact_size;
     if ((sid = H5Screate_simple(1, dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create property list for compact dataset creation */
     if ((plist = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the layout for the compact dataset */
     if (H5Pset_layout(plist, H5D_COMPACT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a compact dataset */
     if ((did = H5Dcreate2(fid, DSET_NAME, H5T_NATIVE_INT, sid, H5P_DEFAULT, plist, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write to the compact dataset */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, wbuf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file for SWMR write with/without latest format */
     if ((fid = H5Fopen(FILE_OHDR_SWMR, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the compact dataset */
     if ((did = H5Dopen2(fid, DSET_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the object information */
     if (H5Oget_native_info(did, &ninfo, H5O_NATIVE_INFO_HDR) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (new_format)
         if (ninfo.hdr.version != OBJ_VERSION_LATEST)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
     /* The size of object header should be greater than the speculative read size of H5O_SPEC_READ_SIZE */
     /* This will exercise the coding for the re-read of the object header for SWMR access */
@@ -418,27 +418,27 @@ test_ohdr_swmr(hbool_t new_format)
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataspace */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataset creation property list */
     if (H5Pclose(plist) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file access property list */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the test file */
     if (HDremove(FILE_OHDR_SWMR) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Free the buffer */
     HDfree(wbuf);
@@ -552,28 +552,28 @@ test_unknown(unsigned bogus_id, char *filename, hid_t fapl)
 
     /* Make a copy of the data file from svn. */
     if (h5_make_local_copy(FILE_BOGUS, testfile) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     TESTING("object with unknown header message and no flags set");
 
     /* Open filename */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open FILE_BOGUS */
     if ((fid_bogus = H5Fopen(testfile, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set up location ID depending on bogus_id */
     if (bogus_id == H5O_BOGUS_INVALID_ID) {
         /* Open "group" in FILE_BOGUS */
         if ((gid_bogus = H5Gopen2(fid_bogus, "group", H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         loc_bogus = gid_bogus;
 
         /* Create "group" in filename */
         if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         loc = gid;
     }
     else { /* H5O_BOGUS_VALID_ID */
@@ -583,9 +583,9 @@ test_unknown(unsigned bogus_id, char *filename, hid_t fapl)
 
     /* Open the dataset with the unknown header message, but no extra flags */
     if ((did = H5Dopen2(loc_bogus, "Dataset1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -593,9 +593,9 @@ test_unknown(unsigned bogus_id, char *filename, hid_t fapl)
 
     /* Open the dataset with the unknown header message, and "shareable" flag */
     if ((did = H5Dopen2(loc_bogus, "Dataset5", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -603,9 +603,9 @@ test_unknown(unsigned bogus_id, char *filename, hid_t fapl)
 
     /* Open the dataset with the unknown header message, and "fail if unknown and open for write" flag */
     if ((did = H5Dopen2(loc_bogus, "Dataset2", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -619,7 +619,7 @@ test_unknown(unsigned bogus_id, char *filename, hid_t fapl)
     H5E_END_TRY;
     if (did >= 0) {
         H5Dclose(did);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     PASSED();
@@ -628,24 +628,24 @@ test_unknown(unsigned bogus_id, char *filename, hid_t fapl)
 
     /* Copy object with "mark if unknown" flag on message into file (FILENAME[0]) that can be modified */
     if (H5Ocopy(loc_bogus, "Dataset4", loc, "Dataset4", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Closing: filename */
     if (bogus_id == H5O_BOGUS_INVALID_ID)
         if (H5Gclose(gid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open filename, with read-only permissions */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set up location ID depending on bogus_id */
     if (bogus_id == H5O_BOGUS_INVALID_ID) {
         /* Open "group" in filename */
         if ((gid = H5Gopen2(fid, "group", H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         loc = gid;
     }
     else
@@ -653,34 +653,34 @@ test_unknown(unsigned bogus_id, char *filename, hid_t fapl)
 
     /* Open the dataset with the "mark if unknown" message */
     if ((did = H5Dopen2(loc, "Dataset4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that the "unknown" message was _NOT_ marked */
     if (H5O__check_msg_marked_test(did, FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close "group" in filename depending on bogus_id */
     if (bogus_id == H5O_BOGUS_INVALID_ID)
         if (H5Gclose(gid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
     /* Close filename (to flush change to object header) */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open filename */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set up location ID depending on bogus_id */
     if (bogus_id == H5O_BOGUS_INVALID_ID) {
         /* Open "group" in filename */
         if ((gid = H5Gopen2(fid, "group", H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         loc = gid;
     }
     else
@@ -688,46 +688,46 @@ test_unknown(unsigned bogus_id, char *filename, hid_t fapl)
 
     /* Open the dataset with the "mark if unknown" message */
     if ((did = H5Dopen2(loc, "Dataset4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create data space */
     if ((sid = H5Screate(H5S_SCALAR)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create an attribute, to get the object header into write access */
     if ((aid = H5Acreate2(did, "Attr", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close dataspace */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close attribute */
     if (H5Aclose(aid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close "group" in filename depending on bogus_id */
     if (bogus_id == H5O_BOGUS_INVALID_ID)
         if (H5Gclose(gid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
     /* Close filename (to flush change to object header) */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open filename */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set up location ID depending on bogus_id */
     if (bogus_id == H5O_BOGUS_INVALID_ID) {
         /* Open "group" in filename */
         if ((gid = H5Gopen2(fid, "group", H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         loc = gid;
     }
     else
@@ -735,43 +735,43 @@ test_unknown(unsigned bogus_id, char *filename, hid_t fapl)
 
     /* Re-open the dataset with the "mark if unknown" message */
     if ((did = H5Dopen2(loc, "Dataset4", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that the "unknown" message was marked */
     if (H5O__check_msg_marked_test(did, TRUE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Closing: filename */
     if (bogus_id == H5O_BOGUS_INVALID_ID)
         if (H5Gclose(gid) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
     /* Closing: FILE_BOGUS */
     if (bogus_id == H5O_BOGUS_INVALID_ID)
         if (H5Gclose(gid_bogus) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     if (H5Fclose(fid_bogus) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     TESTING("object in r/w file with unknown header message & 'fail if unknown and open for write' flag set");
 
     /* Open FILE_BOGUS with RW intent this time */
     if ((fid_bogus = H5Fopen(testfile, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set up location ID */
     if (bogus_id == H5O_BOGUS_INVALID_ID) {
         /* Open "group" in FILE_BOGUS */
         if ((gid_bogus = H5Gopen2(fid_bogus, "group", H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         loc_bogus = gid_bogus;
     }
     else
@@ -786,7 +786,7 @@ test_unknown(unsigned bogus_id, char *filename, hid_t fapl)
     H5E_END_TRY;
     if (did >= 0) {
         H5Dclose(did);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     PASSED();
@@ -801,15 +801,15 @@ test_unknown(unsigned bogus_id, char *filename, hid_t fapl)
     H5E_END_TRY;
     if (did >= 0) {
         H5Dclose(did);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Closing: FILE_BOGUS */
     if (bogus_id == H5O_BOGUS_INVALID_ID)
         if (H5Gclose(gid_bogus) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     if (H5Fclose(fid_bogus) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -915,7 +915,7 @@ test_minimized_dset_ohdr_attribute_addition(hid_t fapl_id)
     int     in_val                   = 0;
     int     i;
 
-    TESTING("adding attributes to datasets created with H5Pset_dset_no_attrs_hint()")
+    TESTING("adding attributes to datasets created with H5Pset_dset_no_attrs_hint()");
 
     /* Create the test file */
     if (NULL == h5_fixname(FILENAME[1], fapl_id, filename, sizeof(filename)))
@@ -1131,124 +1131,150 @@ test_minimized_dset_ohdr_size_comparisons(hid_t fapl_id)
     for (compact = 0; compact < 2; compact++) { /* 0 or 1 */
 
         if (compact)
-            TESTING("minimized dset object headers size comparisons (compact)")
+            TESTING("minimized dset object headers size comparisons (compact)");
         else
-            TESTING("minimized dset object headers size comparisons")
+            TESTING("minimized dset object headers size comparisons");
 
         dcpl_default = H5Pcreate(H5P_DATASET_CREATE);
         if (dcpl_default < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         dcpl_minimize = H5Pcreate(H5P_DATASET_CREATE);
         if (dcpl_minimize < 0)
-            TEST_ERROR
+            TEST_ERROR;
         ret = H5Pset_dset_no_attrs_hint(dcpl_minimize, TRUE);
         if (ret < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         dcpl_dontmin = H5Pcreate(H5P_DATASET_CREATE);
         if (dcpl_dontmin < 0)
-            TEST_ERROR
+            TEST_ERROR;
         ret = H5Pset_dset_no_attrs_hint(dcpl_dontmin, FALSE);
         if (ret < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (compact) {
             ret = H5Pset_layout(dcpl_default, H5D_COMPACT);
             if (ret < 0)
-                TEST_ERROR
+                TEST_ERROR;
             ret = H5Pset_layout(dcpl_minimize, H5D_COMPACT);
             if (ret < 0)
-                TEST_ERROR
+                TEST_ERROR;
             ret = H5Pset_layout(dcpl_dontmin, H5D_COMPACT);
             if (ret < 0)
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         dspace_id = H5Screate_simple(1, array_10, NULL);
         if (dspace_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         int_type_id = H5Tcopy(H5T_NATIVE_INT);
         if (int_type_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         file_f_id = H5Fcreate(filename_a, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
         if (file_f_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         dset_f_x_id =
             H5Dcreate2(file_f_id, "default", int_type_id, dspace_id, H5P_DEFAULT, dcpl_default, H5P_DEFAULT);
         if (dset_f_x_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         dset_f_N_id =
             H5Dcreate2(file_f_id, "dsetNOT", int_type_id, dspace_id, H5P_DEFAULT, dcpl_dontmin, H5P_DEFAULT);
         if (dset_f_N_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         dset_f_Y_id =
             H5Dcreate2(file_f_id, "dsetMIN", int_type_id, dspace_id, H5P_DEFAULT, dcpl_minimize, H5P_DEFAULT);
         if (dset_f_x_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         file_F_id = H5Fcreate(filename_b, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
         if (file_F_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
         ret = H5Fset_dset_no_attrs_hint(file_F_id, TRUE);
         if (ret < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         dset_F_x_id =
             H5Dcreate2(file_F_id, "default", int_type_id, dspace_id, H5P_DEFAULT, dcpl_default, H5P_DEFAULT);
         if (dset_F_x_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         dset_F_N_id =
             H5Dcreate2(file_F_id, "dsetNOT", int_type_id, dspace_id, H5P_DEFAULT, dcpl_dontmin, H5P_DEFAULT);
         if (dset_F_N_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         dset_F_Y_id =
             H5Dcreate2(file_F_id, "dsetMIN", int_type_id, dspace_id, H5P_DEFAULT, dcpl_minimize, H5P_DEFAULT);
         if (dset_F_Y_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /*********
          * TESTS *
          *********/
 
+        /* Identity */
         if (oh_compare(dset_f_x_id, dset_f_x_id) != EQ)
-            TEST_ERROR /* identity */
+            TEST_ERROR;
 
-                if (oh_compare(dset_f_x_id, dset_f_N_id) != EQ)
-                    TEST_ERROR if (oh_compare(dset_f_x_id, dset_f_Y_id) != GT)
-                        TEST_ERROR if (oh_compare(dset_f_N_id, dset_f_Y_id) != GT) TEST_ERROR
+        if (oh_compare(dset_f_x_id, dset_f_N_id) != EQ)
+            TEST_ERROR;
+        if (oh_compare(dset_f_x_id, dset_f_Y_id) != GT)
+            TEST_ERROR;
+        if (oh_compare(dset_f_N_id, dset_f_Y_id) != GT)
+            TEST_ERROR;
 
-                if (oh_compare(dset_F_x_id, dset_F_N_id) != EQ)
-                    TEST_ERROR if (oh_compare(dset_F_x_id, dset_F_Y_id) != EQ)
-                        TEST_ERROR if (oh_compare(dset_F_N_id, dset_F_Y_id) != EQ) TEST_ERROR
+        if (oh_compare(dset_F_x_id, dset_F_N_id) != EQ)
+            TEST_ERROR;
+        if (oh_compare(dset_F_x_id, dset_F_Y_id) != EQ)
+            TEST_ERROR;
+        if (oh_compare(dset_F_N_id, dset_F_Y_id) != EQ)
+            TEST_ERROR;
 
-                if (oh_compare(dset_F_x_id, dset_f_Y_id) != EQ)
-                    TEST_ERROR if (oh_compare(dset_F_x_id, dset_f_x_id) != LT) TEST_ERROR
+        if (oh_compare(dset_F_x_id, dset_f_Y_id) != EQ)
+            TEST_ERROR;
+        if (oh_compare(dset_F_x_id, dset_f_x_id) != LT)
+            TEST_ERROR;
 
-                /************
-                 * TEARDOWN *
-                 ************/
+        /************
+         * TEARDOWN *
+         ************/
 
-                if (H5Sclose(dspace_id) < 0) TEST_ERROR if (H5Tclose(int_type_id) < 0)
-                    TEST_ERROR if (H5Pclose(dcpl_default) < 0) TEST_ERROR if (H5Pclose(dcpl_minimize) < 0)
-                        TEST_ERROR if (H5Pclose(dcpl_dontmin) < 0) TEST_ERROR
+        if (H5Sclose(dspace_id) < 0)
+            TEST_ERROR;
+        if (H5Tclose(int_type_id) < 0)
+            TEST_ERROR;
+        if (H5Pclose(dcpl_default) < 0)
+            TEST_ERROR;
+        if (H5Pclose(dcpl_minimize) < 0)
+            TEST_ERROR;
+        if (H5Pclose(dcpl_dontmin) < 0)
+            TEST_ERROR;
 
-                if (H5Fclose(file_f_id) < 0) TEST_ERROR if (H5Dclose(dset_f_x_id) < 0)
-                    TEST_ERROR if (H5Dclose(dset_f_N_id) < 0) TEST_ERROR if (H5Dclose(dset_f_Y_id) < 0)
-                        TEST_ERROR
+        if (H5Fclose(file_f_id) < 0)
+            TEST_ERROR;
+        if (H5Dclose(dset_f_x_id) < 0)
+            TEST_ERROR;
+        if (H5Dclose(dset_f_N_id) < 0)
+            TEST_ERROR;
+        if (H5Dclose(dset_f_Y_id) < 0)
+            TEST_ERROR;
 
-                if (H5Fclose(file_F_id) < 0) TEST_ERROR if (H5Dclose(dset_F_x_id) < 0)
-                    TEST_ERROR if (H5Dclose(dset_F_N_id) < 0) TEST_ERROR if (H5Dclose(dset_F_Y_id) < 0)
-                        TEST_ERROR
+        if (H5Fclose(file_F_id) < 0)
+            TEST_ERROR;
+        if (H5Dclose(dset_F_x_id) < 0)
+            TEST_ERROR;
+        if (H5Dclose(dset_F_N_id) < 0)
+            TEST_ERROR;
+        if (H5Dclose(dset_F_Y_id) < 0)
+            TEST_ERROR;
 
-                        PASSED();
+        PASSED();
 
     } /* compact and non-compact */
 
@@ -1315,102 +1341,102 @@ test_minimized_dset_ohdr_with_filter(hid_t fapl_id)
      *********/
 
     if (h5_fixname(FILENAME[1], fapl_id, filename, sizeof(filename)) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     dcpl_mx_id = H5Pcreate(H5P_DATASET_CREATE);
     if (dcpl_mx_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ret = H5Pset_dset_no_attrs_hint(dcpl_mx_id, TRUE);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dcpl_xZ_id = H5Pcreate(H5P_DATASET_CREATE);
     if (dcpl_xZ_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ret = H5Pset_chunk(dcpl_xZ_id, ndims, chunk_dim);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ret = H5Pset_filter(dcpl_xZ_id, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, 0, filter_values);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
     dcpl_mZ_id = H5Pcreate(H5P_DATASET_CREATE);
     if (dcpl_mZ_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ret = H5Pset_dset_no_attrs_hint(dcpl_mZ_id, TRUE);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ret = H5Pset_chunk(dcpl_mZ_id, ndims, chunk_dim);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ret = H5Pset_filter(dcpl_mZ_id, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, 0, filter_values);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dspace_id = H5Screate_simple(1, extents, extents);
     if (dspace_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dtype_id = H5Tcopy(H5T_NATIVE_INT);
     if (dtype_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
     if (file_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dset_xx_id = H5Dcreate2(file_id, "xx", dtype_id, dspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     if (dset_xx_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dset_mx_id = H5Dcreate2(file_id, "Mx", dtype_id, dspace_id, H5P_DEFAULT, dcpl_mx_id, H5P_DEFAULT);
     if (dset_mx_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dset_xZ_id = H5Dcreate2(file_id, "xZ", dtype_id, dspace_id, H5P_DEFAULT, dcpl_xZ_id, H5P_DEFAULT);
     if (dset_xZ_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dset_mZ_id = H5Dcreate2(file_id, "MZ", dtype_id, dspace_id, H5P_DEFAULT, dcpl_mZ_id, H5P_DEFAULT);
     if (dset_mZ_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*********
      * TESTS *
      *********/
 
     if (oh_compare(dset_mx_id, dset_xx_id) != LT)
-        TEST_ERROR
+        TEST_ERROR;
     if (oh_compare(dset_mx_id, dset_xZ_id) != LT)
-        TEST_ERROR
+        TEST_ERROR;
     if (oh_compare(dset_mZ_id, dset_mx_id) != GT)
-        TEST_ERROR
+        TEST_ERROR;
     if (oh_compare(dset_mZ_id, dset_xZ_id) != LT)
-        TEST_ERROR
+        TEST_ERROR;
 
     /************
      * TEARDOWN *
      ************/
 
     if (H5Sclose(dspace_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(dtype_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl_xZ_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl_mx_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl_mZ_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset_xx_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset_xZ_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset_mx_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset_mZ_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -1490,49 +1516,49 @@ test_minimized_dset_ohdr_modification_times(hid_t _fapl_id)
      *********/
 
     if (h5_fixname(FILENAME[1], _fapl_id, filename, sizeof(filename)) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     dcpl_mx_id = H5Pcreate(H5P_DATASET_CREATE);
     if (dcpl_mx_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ret = H5Pset_dset_no_attrs_hint(dcpl_mx_id, TRUE);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dcpl_xT_id = H5Pcreate(H5P_DATASET_CREATE);
     if (dcpl_xT_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ret = H5Pset_obj_track_times(dcpl_xT_id, TRUE);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dcpl_mT_id = H5Pcreate(H5P_DATASET_CREATE);
     if (dcpl_mT_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ret = H5Pset_dset_no_attrs_hint(dcpl_mT_id, TRUE);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ret = H5Pset_obj_track_times(dcpl_mT_id, TRUE);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dcpl_mN_id = H5Pcreate(H5P_DATASET_CREATE);
     if (dcpl_mN_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ret = H5Pset_dset_no_attrs_hint(dcpl_mN_id, TRUE);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ret = H5Pset_obj_track_times(dcpl_mN_id, FALSE);
     if (ret < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dspace_id = H5Screate_simple(1, extents, extents);
     if (dspace_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dtype_id = H5Tcopy(H5T_NATIVE_INT);
     if (dtype_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     for (i = 0; i < n_cases; i++) {
 
@@ -1542,36 +1568,36 @@ test_minimized_dset_ohdr_modification_times(hid_t _fapl_id)
 
         fapl_id = H5Pcopy(_fapl_id);
         if (fapl_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (cases[i].oh_version > 1) {
             ret = H5Pset_libver_bounds(fapl_id, H5F_LIBVER_V18, H5F_LIBVER_V110);
             if (ret < 0)
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
         if (file_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         dset_xx_id = H5Dcreate2(file_id, "xx", dtype_id, dspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         if (dset_xx_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         dset_mx_id = H5Dcreate2(file_id, "mx", dtype_id, dspace_id, H5P_DEFAULT, dcpl_mx_id, H5P_DEFAULT);
         if (dset_mx_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         dset_xT_id = H5Dcreate2(file_id, "xT", dtype_id, dspace_id, H5P_DEFAULT, dcpl_xT_id, H5P_DEFAULT);
         if (dset_xT_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
         dset_mT_id = H5Dcreate2(file_id, "mT", dtype_id, dspace_id, H5P_DEFAULT, dcpl_mT_id, H5P_DEFAULT);
         if (dset_mT_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         dset_mN_id = H5Dcreate2(file_id, "mN", dtype_id, dspace_id, H5P_DEFAULT, dcpl_mN_id, H5P_DEFAULT);
         if (dset_mN_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* ----- *
          * TESTS *
@@ -1579,38 +1605,38 @@ test_minimized_dset_ohdr_modification_times(hid_t _fapl_id)
 
         /* sanity check */
         if (oh_compare(dset_mx_id, dset_xx_id) != LT)
-            TEST_ERROR
+            TEST_ERROR;
         if (oh_compare(dset_mx_id, dset_xT_id) != LT)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (oh_compare(dset_xx_id, dset_xT_id) != EQ)
-            TEST_ERROR
+            TEST_ERROR;
         if (oh_compare(dset_mx_id, dset_mT_id) != EQ)
-            TEST_ERROR
+            TEST_ERROR;
         if (oh_compare(dset_mN_id, dset_mT_id) != LT)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (oh_compare(dset_mT_id, dset_xT_id) != LT)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* ----------------- *
          * per-case teardown *
          * ----------------- */
 
         if (H5Dclose(dset_xx_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Dclose(dset_xT_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Dclose(dset_mx_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Dclose(dset_mT_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Dclose(dset_mN_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Fclose(file_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(fapl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     } /* for each version tested */
 
@@ -1619,17 +1645,17 @@ test_minimized_dset_ohdr_modification_times(hid_t _fapl_id)
      ************/
 
     if (H5Sclose(dspace_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(dtype_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl_xT_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl_mx_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl_mT_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl_mN_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return SUCCEED;
@@ -1681,22 +1707,22 @@ test_minimized_dset_ohdr_fillvalue_backwards_compatability(hid_t _fapl_id)
 
     fapl_id = H5Pcopy(_fapl_id);
     if (fapl_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (h5_fixname(FILENAME[1], fapl_id, filename, sizeof(filename)) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     dspace_id = H5Screate_simple(1, extents, extents);
     if (dspace_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dtype_id = H5Tcopy(H5T_NATIVE_INT);
     if (dtype_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dcpl_id = H5Pcreate(H5P_DATASET_CREATE);
     if (dcpl_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     ret = H5Pset_dset_no_attrs_hint(dcpl_id, TRUE);
     if (ret == FAIL)
@@ -1712,11 +1738,11 @@ test_minimized_dset_ohdr_fillvalue_backwards_compatability(hid_t _fapl_id)
 
     file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
     if (file_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dset_0_id = H5Dcreate2(file_id, "fullrange", dtype_id, dspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
     if (dset_0_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file and re-open with different libver bounds.
      * Dataset "fullrange" must also be closed for expected reopen behavior.
@@ -1724,7 +1750,7 @@ test_minimized_dset_ohdr_fillvalue_backwards_compatability(hid_t _fapl_id)
     if (H5Fclose(file_id) < 0)
         TEST_ERROR;
     if (H5Dclose(dset_0_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     ret = H5Pset_libver_bounds(fapl_id, H5F_LIBVER_V18, H5F_LIBVER_LATEST);
     if (ret == FAIL)
@@ -1732,17 +1758,17 @@ test_minimized_dset_ohdr_fillvalue_backwards_compatability(hid_t _fapl_id)
 
     file_id = H5Fopen(filename, H5F_ACC_RDWR, fapl_id);
     if (file_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dset_1_id = H5Dcreate2(file_id, "upperrange", dtype_id, dspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
     if (dset_1_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* re-open "fullrange" dataset
      */
     dset_0_id = H5Dopen2(file_id, "fullrange", H5P_DEFAULT);
     if (dset_0_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*********
      * TESTS *
@@ -1750,24 +1776,24 @@ test_minimized_dset_ohdr_fillvalue_backwards_compatability(hid_t _fapl_id)
 
     /* dset not supporting pre-1.08 should be smaller? */
     if (oh_compare(dset_1_id, dset_0_id) != LT)
-        TEST_ERROR
+        TEST_ERROR;
 
     /************
      * TEARDOWN *
      ************/
 
     if (H5Sclose(dspace_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(dtype_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(dcpl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(fapl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset_0_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset_1_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file_id) < 0)
         TEST_ERROR;
 
@@ -1834,7 +1860,7 @@ main(void)
 
     /* Push API context */
     if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = TRUE;
 
     /* Loop through all the combinations of low/high library format bounds */
@@ -1862,13 +1888,13 @@ main(void)
 
             /* test on object continuation block */
             if (test_cont(filename, fapl) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Create the file to operate on */
             if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (NULL == (f = (H5F_t *)H5VL_object(file)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_ignore_tags(f) < 0) {
                 H5_FAILED();
                 H5Eprint2(H5E_DEFAULT, stdout);
@@ -1882,28 +1908,28 @@ main(void)
             TESTING("object header creation");
             HDmemset(&oh_loc, 0, sizeof(oh_loc));
             if (H5O_create(f, (size_t)64, (size_t)0, H5P_GROUP_CREATE_DEFAULT, &oh_loc /*out*/) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             PASSED();
 
             /* create a new message */
             TESTING("message creation");
             time_new = 11111111;
             if (H5O_msg_create(&oh_loc, H5O_MTIME_NEW_ID, 0, 0, &time_new) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (1 != H5O_link(&oh_loc, 1))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_prep_for_file_flush(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_flush(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_secure_from_file_flush(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_expunge_entry(f, H5AC_OHDR, oh_loc.addr, H5AC__NO_FLAGS_SET) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (NULL == H5O_msg_read(&oh_loc, H5O_MTIME_NEW_ID, &ro))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (ro != time_new)
-                TEST_ERROR
+                TEST_ERROR;
             PASSED();
 
             /*
@@ -1912,25 +1938,25 @@ main(void)
             TESTING("message modification");
             time_new = 33333333;
             if (H5O_msg_write(&oh_loc, H5O_MTIME_NEW_ID, 0, 0, &time_new) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_prep_for_file_flush(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_flush(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_secure_from_file_flush(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_expunge_entry(f, H5AC_OHDR, oh_loc.addr, H5AC__NO_FLAGS_SET) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (NULL == H5O_msg_read(&oh_loc, H5O_MTIME_NEW_ID, &ro))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (ro != time_new)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Make certain that chunk #0 in the object header can be encoded with a 1-byte size */
             if (H5O_get_hdr_info(&oh_loc, &hdr_info) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (hdr_info.space.total >= 256)
-                TEST_ERROR
+                TEST_ERROR;
 
             PASSED();
 
@@ -1946,22 +1972,22 @@ main(void)
             for (i = 0; i < 40; i++) {
                 time_new = (i + 1) * 1000 + 1000000;
                 if (H5O_msg_create(&oh_loc, H5O_MTIME_ID, 0, 0, &time_new) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
             } /* end for */
             if (H5AC_prep_for_file_flush(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_flush(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_secure_from_file_flush(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_expunge_entry(f, H5AC_OHDR, oh_loc.addr, H5AC__NO_FLAGS_SET) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Make certain that chunk #0 in the object header will be encoded with a 2-byte size */
             if (H5O_get_hdr_info(&oh_loc, &hdr_info) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (hdr_info.space.total < 256)
-                TEST_ERROR
+                TEST_ERROR;
 
             PASSED();
 
@@ -1972,18 +1998,18 @@ main(void)
              */
             TESTING("close & re-open object header");
             if (H5O_close(&oh_loc, NULL) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5Fclose(file) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (NULL == (f = (H5F_t *)H5VL_object(file)))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_ignore_tags(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             oh_loc.file = f;
             if (H5O_open(&oh_loc) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             PASSED();
 
             /*
@@ -1994,15 +2020,15 @@ main(void)
             for (i = 0; i < 10; i++) {
                 time_new = (i + 1) * 1000 + 10;
                 if (H5O_msg_create(&oh_loc, H5O_MTIME_NEW_ID, 0, 0, &time_new) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5AC_prep_for_file_flush(f) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5AC_flush(f) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5AC_secure_from_file_flush(f) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5AC_expunge_entry(f, H5AC_OHDR, oh_loc.addr, H5AC__NO_FLAGS_SET) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
             } /* end for */
             PASSED();
 
@@ -2011,13 +2037,13 @@ main(void)
              */
             TESTING("message deletion");
             if (H5O_msg_remove(&oh_loc, H5O_MTIME_NEW_ID, H5O_ALL, TRUE) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5O_msg_remove(&oh_loc, H5O_MTIME_ID, H5O_ALL, TRUE) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5O_msg_read(&oh_loc, H5O_MTIME_NEW_ID, &ro))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5O_msg_read(&oh_loc, H5O_MTIME_ID, &ro))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             PASSED();
 
             /*
@@ -2027,19 +2053,19 @@ main(void)
             TESTING("constant message handling");
             time_new = 22222222;
             if (H5O_msg_create(&oh_loc, H5O_MTIME_NEW_ID, H5O_MSG_FLAG_CONSTANT, 0, &time_new) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_prep_for_file_flush(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_flush(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_secure_from_file_flush(f) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (H5AC_expunge_entry(f, H5AC_OHDR, oh_loc.addr, H5AC__NO_FLAGS_SET) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (NULL == H5O_msg_read(&oh_loc, H5O_MTIME_NEW_ID, &ro))
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             if (ro != time_new)
-                TEST_ERROR
+                TEST_ERROR;
             time_new = 33333333;
             H5E_BEGIN_TRY
             {
@@ -2047,20 +2073,20 @@ main(void)
             }
             H5E_END_TRY;
             if (ret >= 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5O_msg_remove(&oh_loc, H5O_MTIME_NEW_ID, H5O_ALL, TRUE) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             PASSED();
 
             /* release resources */
             TESTING("object header closing");
             if (H5O_close(&oh_loc, NULL) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             PASSED();
 
             /* Close the file we created */
             if (H5Fclose(file) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Test reading datasets with undefined object header messages
              * and the various "fail/mark if unknown" object header message flags
@@ -2068,7 +2094,7 @@ main(void)
             HDputs("Accessing objects with unknown header messages: H5O_BOGUS_VALID_ID");
             if (single_file_vfd) {
                 if (test_unknown(H5O_BOGUS_VALID_ID, filename, fapl) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 SKIPPED();
@@ -2077,7 +2103,7 @@ main(void)
             HDputs("Accessing objects with unknown header messages: H5O_BOGUS_INVALID_ID");
             if (single_file_vfd) {
                 if (test_unknown(H5O_BOGUS_INVALID_ID, filename, fapl) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else {
                 SKIPPED();
@@ -2086,22 +2112,22 @@ main(void)
 
             /* Test object header creation metadata cache issues */
             if (test_ohdr_cache(filename, fapl) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             if (test_minimized_dset_ohdr_attribute_addition(fapl) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             if (test_minimized_dset_ohdr_size_comparisons(fapl) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             if (test_minimized_dset_ohdr_with_filter(fapl) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             if (test_minimized_dset_ohdr_modification_times(fapl) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             if (test_minimized_dset_ohdr_fillvalue_backwards_compatability(fapl) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
         } /* high */
     }     /* low */
@@ -2111,21 +2137,21 @@ main(void)
 
     /* Verify symbol table messages are cached */
     if (h5_verify_cached_stabs(FILENAME, fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5FD__supports_swmr_test(env_h5_drvr)) {
         /* A test to exercise the re-read of the object header for SWMR access */
         if (test_ohdr_swmr(TRUE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (test_ohdr_swmr(FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
         HDputs("Skipped SWMR tests for SWMR-incompatible VFD");
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = FALSE;
 
     HDputs("All object header tests passed.");

--- a/test/page_buffer.c
+++ b/test/page_buffer.c
@@ -106,7 +106,7 @@ create_file(char *filename, hid_t fcpl, hid_t fapl)
 
     num_elements = NX * NY;
     if ((data = (int *)HDcalloc((size_t)num_elements, sizeof(int))) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
     for (i = 0; i < (int)num_elements; i++)
         data[i] = i;
 
@@ -255,7 +255,7 @@ open_file(char *filename, hid_t fapl, hsize_t page_size, size_t page_buffer_size
 
     num_elements = NX * NY;
     if ((data = (int *)HDcalloc((size_t)num_elements, sizeof(int))) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     for (i = 0; i < NUM_DSETS; i++) {
 
@@ -329,7 +329,7 @@ set_multi_split(const char *env_h5_drvr, hid_t fapl, hsize_t pagesize)
 
         /* Get current split settings */
         if (H5Pget_fapl_multi(fapl, memb_map, memb_fapl_arr, memb_name, memb_addr, &relax) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (split) {
             /* Set memb_addr aligned */
@@ -345,7 +345,7 @@ set_multi_split(const char *env_h5_drvr, hid_t fapl, hsize_t pagesize)
         /* Set multi driver with new FAPLs */
         if (H5Pset_fapl_multi(fapl, memb_map, memb_fapl_arr, (const char *const *)memb_name, memb_addr,
                               relax) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free memb_name */
         for (mt = H5FD_MEM_DEFAULT; mt < H5FD_MEM_NTYPES; mt++)
@@ -397,7 +397,7 @@ test_args(hid_t orig_fapl, const char *env_h5_drvr)
     h5_fixname(FILENAME[0], orig_fapl, filename, sizeof(filename));
 
     if ((fapl = H5Pcopy(orig_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
         TEST_ERROR;
@@ -589,7 +589,7 @@ test_raw_data_handling(hid_t orig_fapl, const char *env_h5_drvr)
     h5_fixname(FILENAME[0], orig_fapl, filename, sizeof(filename));
 
     if ((fapl = H5Pcopy(orig_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (set_multi_split(env_h5_drvr, fapl, sizeof(int) * 200) != 0)
         TEST_ERROR;
@@ -869,7 +869,7 @@ test_lru_processing(hid_t orig_fapl, const char *env_h5_drvr)
     h5_fixname(FILENAME[0], orig_fapl, filename, sizeof(filename));
 
     if ((fapl = H5Pcopy(orig_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (set_multi_split(env_h5_drvr, fapl, sizeof(int) * 200) != 0)
         TEST_ERROR;
@@ -1126,7 +1126,7 @@ test_min_threshold(hid_t orig_fapl, const char *env_h5_drvr)
     h5_fixname(FILENAME[0], orig_fapl, filename, sizeof(filename));
 
     if ((fapl = H5Pcopy(orig_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (set_multi_split(env_h5_drvr, fapl, sizeof(int) * 200) != 0)
         TEST_ERROR;
@@ -1758,13 +1758,13 @@ test_stats_collection(hid_t orig_fapl, const char *env_h5_drvr)
     h5_fixname(FILENAME[0], orig_fapl, filename, sizeof(filename));
 
     if ((fapl = H5Pcopy(orig_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (set_multi_split(env_h5_drvr, fapl, sizeof(int) * 200) != 0)
         TEST_ERROR;
 
     if ((data = (int *)HDcalloc((size_t)num_elements, sizeof(int))) == NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
         TEST_ERROR;
@@ -2045,7 +2045,7 @@ verify_page_buffering_disabled(hid_t orig_fapl, const char *env_h5_drvr)
     /* first, try to create a file with page buffering enabled */
 
     if ((fapl = H5Pcopy(orig_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (set_multi_split(env_h5_drvr, fapl, 4096) != 0)
         TEST_ERROR;
@@ -2163,19 +2163,19 @@ main(void)
      */
     if ((0 == HDstrcmp(env_h5_drvr, "multi")) || (0 == HDstrcmp(env_h5_drvr, "split"))) {
 
-        SKIPPED()
+        SKIPPED();
         HDputs("Skip page buffering test because paged aggregation is disabled for multi/split drivers");
         HDexit(EXIT_SUCCESS);
     } /* end if */
 
     if ((fapl = h5_fileaccess()) < 0) {
         nerrors++;
-        PUTS_ERROR("Can't get VFD-dependent fapl")
+        PUTS_ERROR("Can't get VFD-dependent fapl");
     } /* end if */
 
     /* Push API context */
     if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = TRUE;
 
 #ifdef H5_HAVE_PARALLEL
@@ -2200,7 +2200,7 @@ main(void)
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = FALSE;
 
     HDputs("All Page Buffering tests passed.");

--- a/test/s3comms.c
+++ b/test/s3comms.c
@@ -2514,7 +2514,7 @@ test_uriencode(void)
     int             ncases       = 6;
     size_t          str_len      = 0;
 
-    TESTING("s3comms uriencode")
+    TESTING("s3comms uriencode");
 
     for (i = 0; i < ncases; i++) {
         str_len = cases[i].s_len;

--- a/test/set_extent.c
+++ b/test/set_extent.c
@@ -131,19 +131,19 @@ main(void)
 
     /* Copy the file access property list */
     if ((fapl2 = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set chunk cache so only part of the chunks can be cached on fapl */
     if (H5Pset_cache(fapl, 0, (size_t)8, 256 * sizeof(int), 0.75) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Disable chunk caching on fapl2 */
     if (H5Pset_cache(fapl2, 0, (size_t)0, (size_t)0, 0.0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set the "use the latest version of the format" bounds for creating objects in the file */
     if (H5Pset_libver_bounds(fapl2, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test with old & new format groups */
     for (new_format = FALSE; new_format <= TRUE; new_format++) {
@@ -172,13 +172,13 @@ main(void)
                 /* Set the "use the latest version of the format" bounds for
                  * creating objects in the file */
                 if (H5Pset_libver_bounds(my_fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             } /* end if */
             else
                 /* Set the "use the earliest version of the format" bounds for
                  * creating objects in the file */
                 if (H5Pset_libver_bounds(my_fapl, H5F_LIBVER_EARLIEST, H5F_LIBVER_LATEST) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Tests which use chunked datasets */
             if (!new_format || (new_format && contig_addr_vfd))
@@ -194,7 +194,7 @@ main(void)
 
     /* Close 2nd FAPL */
     if (H5Pclose(fapl2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify symbol table messages are cached */
     nerrors += (h5_verify_cached_stabs(FILENAME, fapl) < 0 ? 1 : 0);
@@ -237,15 +237,15 @@ do_ranks(hid_t fapl, hbool_t new_format)
     for (config = 0; config <= CONFIG_ALL; config++) {
         /* Create DCPL and add appropriate settings */
         if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (config & CONFIG_COMPRESS) {
 #ifdef H5_HAVE_FILTER_DEFLATE
             if (H5Pset_deflate(dcpl, 9) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 #else     /* H5_HAVE_FILTER_DEFLATE */
             if (H5Pclose(dcpl) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             continue;
 #endif    /* H5_HAVE_FILTER_DEFLATE */
         } /* end if */
@@ -253,14 +253,14 @@ do_ranks(hid_t fapl, hbool_t new_format)
         if (config & CONFIG_FILL) {
             do_fillvalue = TRUE;
             if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fillvalue) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
         else
             do_fillvalue = FALSE;
 
         if (config & CONFIG_EARLY_ALLOC)
             if (H5Pset_alloc_time(dcpl, H5D_ALLOC_TIME_EARLY) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
         if (config & CONFIG_UNFILT_EDGE)
             disable_edge_filters = TRUE;
@@ -275,10 +275,10 @@ do_ranks(hid_t fapl, hbool_t new_format)
             for (ifset = 0; ifset <= 1; ifset++) {
                 if (ifset) {
                     if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_IFSET) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 } /* end if */
                 else if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_ALLOC) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
 
                 if (test_rank1(fapl, dcpl, do_fillvalue, disable_edge_filters, FALSE) < 0) {
                     DO_RANKS_PRINT_CONFIG("Rank 1")
@@ -306,7 +306,7 @@ do_ranks(hid_t fapl, hbool_t new_format)
             /* These tests expect fill values to be written even if there is no
              * fill value defined */
             if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_ALLOC) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             if (test_rank1(fapl, dcpl, do_fillvalue, disable_edge_filters, FALSE) < 0) {
                 DO_RANKS_PRINT_CONFIG("Rank 1")
@@ -329,7 +329,7 @@ do_ranks(hid_t fapl, hbool_t new_format)
         /* The rank 4 test expects the fill value to be written only if
          * defined */
         if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_IFSET) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Iterate over different index types, but only if using the new format
          */
@@ -387,7 +387,7 @@ do_ranks(hid_t fapl, hbool_t new_format)
 
         /* Close dcpl */
         if (H5Pclose(dcpl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     PASSED();
@@ -499,34 +499,34 @@ test_rank1(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* create a file creation property list */
     if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set non-default indexed storage B-tree internal 'K' value */
     if (set_istore_k)
         if (H5Pset_istore_k(fcpl, ISTORE_IK) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* create a new file */
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close property list */
     if (H5Pclose(fcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* create the data space with unlimited dimensions. */
     if ((sid = H5Screate_simple(RANK1, dims_o, maxdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* modify dataset creation properties, i.e. enable chunking. */
     if ((my_dcpl = H5Pcopy(dcpl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(my_dcpl, RANK1, dims_c) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (disable_edge_filters)
         if (H5Pset_chunk_opts(my_dcpl, H5D_CHUNK_DONT_FILTER_PARTIAL_CHUNKS) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     /*-------------------------------------------------------------------------
      * create, write dataset
@@ -535,11 +535,11 @@ test_rank1(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* create a dataset */
     if ((did = H5Dcreate2(fid, "dset1", H5T_NATIVE_INT, sid, H5P_DEFAULT, my_dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* write */
     if (H5Dwrite(did, H5T_NATIVE_INT, sid, H5S_ALL, H5P_DEFAULT, buf_o) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #if defined(H5_SET_EXTENT_DEBUG)
     HDprintf("\n buf_o: ");
@@ -549,7 +549,7 @@ test_rank1(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 #endif
 
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*-------------------------------------------------------------------------
      * set new dimensions for the array; expand it
@@ -558,27 +558,27 @@ test_rank1(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* set new dimensions for the array. */
     if (H5Dset_extent(did, dims_e) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get dimensions */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check dimensions */
     for (i = 0; i < RANK1; i++)
         if (dims_r[i] != dims_e[i])
-            TEST_ERROR
+            TEST_ERROR;
 
     /* read */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_e) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #if defined(H5_SET_EXTENT_DEBUG)
     HDprintf("\n buf_e: ");
@@ -593,12 +593,12 @@ test_rank1(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
             if (buf_e[i] != comp_value) {
                 HDprintf("buf_e[%d] = %d\n", i, buf_e[i]);
                 HDprintf("expected = %d\n", comp_value);
-                TEST_ERROR
+                TEST_ERROR;
             } /* end if */
         }     /* end if */
         else {
             if (buf_e[i] != buf_o[i])
-                TEST_ERROR
+                TEST_ERROR;
         } /* end else */
 
     /*-------------------------------------------------------------------------
@@ -608,36 +608,36 @@ test_rank1(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* set new dimensions for the array. */
     if (H5Dset_extent(did, dims_s) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get dimensions */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check dimensions */
     for (i = 0; i < RANK1; i++)
         if (dims_r[i] != dims_s[i])
-            TEST_ERROR
+            TEST_ERROR;
 
     /* for this case we close and reopen file */
     if (set_istore_k) {
         if (H5Dclose(did) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Fclose(fid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if ((did = H5Dopen2(fid, "dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /*-------------------------------------------------------------------------
@@ -647,7 +647,7 @@ test_rank1(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* read */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_s) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #if defined(H5_SET_EXTENT_DEBUG)
     HDprintf("\n dims_r: ");
@@ -661,7 +661,7 @@ test_rank1(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
         if (buf_s[i] != buf_o[i]) {
             HDprintf("buf_s[%d] = %d\n", i, buf_s[i]);
             HDprintf("buf_o[%d] = %d\n", i, buf_o[i]);
-            TEST_ERROR
+            TEST_ERROR;
         } /* end if */
 
     /*-------------------------------------------------------------------------
@@ -671,27 +671,27 @@ test_rank1(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* set new dimensions for the array */
     if (H5Dset_extent(did, dims_o) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get dimensions. */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check dimensions */
     for (i = 0; i < RANK1; i++)
         if (dims_r[i] != dims_o[i])
-            TEST_ERROR
+            TEST_ERROR;
 
     /* read */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_r) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #if defined(H5_SET_EXTENT_DEBUG)
     HDprintf("\n dims_r: ");
@@ -706,12 +706,12 @@ test_rank1(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
             if (buf_r[i] != comp_value) {
                 HDprintf("buf_r[%d] = %d\n", i, buf_r[i]);
                 HDprintf("expected = %d\n", comp_value);
-                TEST_ERROR
+                TEST_ERROR;
             } /* end if */
         }     /* end if */
         else {
             if (buf_r[i] != buf_o[i])
-                TEST_ERROR
+                TEST_ERROR;
         } /* end else */
 
     /*-------------------------------------------------------------------------
@@ -723,22 +723,22 @@ test_rank1(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* set new dimensions for the array. */
     if (H5Dset_extent(did, dims_s) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get dimensions */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* check dimensions */
     for (i = 0; i < RANK1; i++)
         if (dims_r[i] != dims_s[i])
-            TEST_ERROR
+            TEST_ERROR;
 
     /*-------------------------------------------------------------------------
      * close dataset
@@ -746,7 +746,7 @@ test_rank1(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
      */
 
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*-------------------------------------------------------------------------
      * test a dataset with non initialized chunks
@@ -754,28 +754,28 @@ test_rank1(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
      */
 
     if ((sid = H5Screate_simple(RANK1, dims_o, maxdims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did = H5Dcreate2(fid, "dset3", H5T_NATIVE_INT, sid, H5P_DEFAULT, my_dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* set new dimensions for the array */
     dims_o[0] = 0;
     if (H5Dset_extent(did, dims_o) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*-------------------------------------------------------------------------
      * close property list
      *-------------------------------------------------------------------------
      */
     if (H5Pclose(my_dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -837,37 +837,37 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* create a file creation property list */
     if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (set_istore_k) {
         /* set non-default indexed storage B-tree internal 'K' value */
         if (H5Pset_istore_k(fcpl, ISTORE_IK) < 0) {
-            TEST_ERROR
+            TEST_ERROR;
         }
     }
 
     /* create a new file */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* create the data space with unlimited dimensions. */
     if ((sid = H5Screate_simple(RANK2, dims_o, maxdims)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* modify dataset creation properties, i.e. enable chunking. */
     if ((my_dcpl = H5Pcopy(dcpl)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
     if (H5Pset_chunk(my_dcpl, RANK2, dims_c) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
     if (disable_edge_filters)
         if (H5Pset_chunk_opts(my_dcpl, H5D_CHUNK_DONT_FILTER_PARTIAL_CHUNKS) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     /*-------------------------------------------------------------------------
      * Procedure 1
@@ -889,12 +889,12 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* create a dataset */
     if ((did = H5Dcreate2(fid, "dset1", H5T_NATIVE_INT, sid, H5P_DEFAULT, my_dcpl, H5P_DEFAULT)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* write */
     if (H5Dwrite(did, H5T_NATIVE_INT, sid, H5S_ALL, H5P_DEFAULT, buf_o) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
 #if defined(H5_SET_EXTENT_DEBUG2)
@@ -908,7 +908,7 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 #endif
 
     if (H5Sclose(sid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /*-------------------------------------------------------------------------
@@ -928,32 +928,32 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* set new dimensions for the array. */
     if (H5Dset_extent(did, dims_e) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get dimensions */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Sclose(sid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* check dimensions */
     for (i = 0; i < RANK2; i++) {
         if (dims_r[i] != dims_e[i])
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* read */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_e) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #if defined(H5_SET_EXTENT_DEBUG2)
     HDprintf("\n");
@@ -972,12 +972,12 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
                 if (buf_e[i][j] != comp_value) {
                     HDprintf("buf_e[%d][%d] = %d\n", i, j, buf_e[i][j]);
                     HDprintf("value = %d\n", comp_value);
-                    TEST_ERROR
+                    TEST_ERROR;
                 }
             }
             else {
                 if (buf_e[i][j] != buf_o[i][j])
-                    TEST_ERROR
+                    TEST_ERROR;
             }
         }
     }
@@ -1000,45 +1000,45 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* set new dimensions for the array. */
     if (H5Dset_extent(did, dims_s) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get dimensions */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Sclose(sid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* check dimensions */
     for (i = 0; i < RANK2; i++) {
         if (dims_r[i] != dims_s[i])
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* for this case we close and reopen file */
     if (set_istore_k) {
 
         if (H5Dclose(did) < 0) {
-            TEST_ERROR
+            TEST_ERROR;
         }
         if (H5Fclose(fid) < 0) {
-            TEST_ERROR
+            TEST_ERROR;
         }
 
         if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0) {
-            TEST_ERROR
+            TEST_ERROR;
         }
 
         if ((did = H5Dopen2(fid, "dset1", H5P_DEFAULT)) < 0) {
-            TEST_ERROR
+            TEST_ERROR;
         }
     }
 
@@ -1049,7 +1049,7 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* read */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_s) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
 #if defined(H5_SET_EXTENT_DEBUG2)
@@ -1068,7 +1068,7 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
             if (buf_s[i][j] != buf_o[i][j]) {
                 HDprintf("buf_s[%d][%d] = %d\n", i, j, buf_s[i][j]);
                 HDprintf("buf_o[%d][%d] = %d\n", i, j, buf_o[i][j]);
-                TEST_ERROR
+                TEST_ERROR;
             }
         }
     }
@@ -1087,27 +1087,27 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* set new dimensions for the array */
     if (H5Dset_extent(did, dims_o) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get dimensions. */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Sclose(sid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* check dimensions */
     for (i = 0; i < RANK2; i++) {
         if (dims_r[i] != dims_o[i])
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /*-------------------------------------------------------------------------
@@ -1117,7 +1117,7 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* read */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_r) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #if defined(H5_SET_EXTENT_DEBUG2)
     HDprintf("\n");
@@ -1136,12 +1136,12 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
                 if (buf_r[i][j] != comp_value) {
                     HDprintf("buf_r[%d][%d] = %d\n", i, j, buf_r[i][j]);
                     HDprintf("value = %d\n", comp_value);
-                    TEST_ERROR
+                    TEST_ERROR;
                 }
             }
             else {
                 if (buf_r[i][j] != buf_o[i][j])
-                    TEST_ERROR
+                    TEST_ERROR;
             }
         }
     }
@@ -1157,27 +1157,27 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* set new dimensions for the array. */
     if (H5Dset_extent(did, dims_s) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get dimensions */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Sclose(sid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* check dimensions */
     for (i = 0; i < RANK2; i++) {
         if (dims_r[i] != dims_s[i])
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /*-------------------------------------------------------------------------
@@ -1189,7 +1189,7 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* expand to original dimensions for the array. */
     if (H5Dset_extent(did, dims_o) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     dims_s[0] = dims_e[0];
@@ -1197,27 +1197,27 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* set new dimensions for the array. */
     if (H5Dset_extent(did, dims_s) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get dimensions */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Sclose(sid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* check dimensions */
     for (i = 0; i < RANK2; i++) {
         if (dims_r[i] != dims_s[i])
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /*-------------------------------------------------------------------------
@@ -1226,7 +1226,7 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
      */
 
     if (H5Dclose(did) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /*-------------------------------------------------------------------------
@@ -1235,23 +1235,23 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
      */
 
     if ((sid = H5Screate_simple(RANK2, dims_o, maxdims)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
     if ((did = H5Dcreate2(fid, "dset3", H5T_NATIVE_INT, sid, H5P_DEFAULT, my_dcpl, H5P_DEFAULT)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
     /* set new dimensions for the array */
     dims_o[0] = 0;
     dims_o[1] = 0;
     if (H5Dset_extent(did, dims_o) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Dclose(did) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
     if (H5Sclose(sid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /*-------------------------------------------------------------------------
@@ -1260,16 +1260,16 @@ test_rank2(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
      */
 
     if (H5Pclose(my_dcpl) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* close file creation property list */
     if (H5Pclose(fcpl) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Fclose(fid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     return 0;
@@ -1333,41 +1333,41 @@ test_rank3(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* create a file creation property list */
     if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (set_istore_k) {
         /* set non-default indexed storage B-tree internal 'K' value */
         if (H5Pset_istore_k(fcpl, ISTORE_IK) < 0) {
-            TEST_ERROR
+            TEST_ERROR;
         }
     }
     /* create a new file */
     h5_fixname(FILENAME[2], fapl, filename, sizeof filename);
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* close property list */
     if (H5Pclose(fcpl) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* create the data space with unlimited dimensions. */
     if ((sid = H5Screate_simple(RANK3, dims_o, maxdims)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* modify dataset creation properties, i.e. enable chunking. */
     if ((my_dcpl = H5Pcopy(dcpl)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
     if (H5Pset_chunk(my_dcpl, RANK3, dims_c) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
     if (disable_edge_filters)
         if (H5Pset_chunk_opts(my_dcpl, H5D_CHUNK_DONT_FILTER_PARTIAL_CHUNKS) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     /*-------------------------------------------------------------------------
      * create, write array
@@ -1376,12 +1376,12 @@ test_rank3(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* create a dataset */
     if ((did = H5Dcreate2(fid, "dset1", H5T_NATIVE_INT, sid, H5P_DEFAULT, my_dcpl, H5P_DEFAULT)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* write */
     if (H5Dwrite(did, H5T_NATIVE_INT, sid, H5S_ALL, H5P_DEFAULT, buf_o) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
 #if defined(H5_SET_EXTENT_DEBUG3)
@@ -1399,7 +1399,7 @@ test_rank3(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 #endif
 
     if (H5Sclose(sid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /*-------------------------------------------------------------------------
@@ -1410,32 +1410,32 @@ test_rank3(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* set new dimensions for the array. */
     if (H5Dset_extent(did, dims_e) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get dimensions */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Sclose(sid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* check dimensions */
     for (i = 0; i < RANK3; i++) {
         if (dims_r[i] != dims_e[i])
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* read */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_e) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #if defined(H5_SET_EXTENT_DEBUG3)
     HDprintf("\n");
@@ -1459,12 +1459,12 @@ test_rank3(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
                     if (buf_e[i][j][k] != comp_value) {
                         HDprintf("buf_e[%d][%d][%d] = %d\n", i, j, k, buf_e[i][j][k]);
                         HDprintf("value = %d\n", comp_value);
-                        TEST_ERROR
+                        TEST_ERROR;
                     }
                 }
                 else {
                     if (buf_e[i][j][k] != buf_o[i][j][k])
-                        TEST_ERROR
+                        TEST_ERROR;
                 }
             }
         }
@@ -1477,45 +1477,45 @@ test_rank3(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* set new dimensions for the array. */
     if (H5Dset_extent(did, dims_s) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get dimensions */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Sclose(sid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* check dimensions */
     for (i = 0; i < RANK3; i++) {
         if (dims_r[i] != dims_s[i])
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* for this case we close and reopen file */
     if (set_istore_k) {
 
         if (H5Dclose(did) < 0) {
-            TEST_ERROR
+            TEST_ERROR;
         }
         if (H5Fclose(fid) < 0) {
-            TEST_ERROR
+            TEST_ERROR;
         }
 
         if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0) {
-            TEST_ERROR
+            TEST_ERROR;
         }
 
         if ((did = H5Dopen2(fid, "dset1", H5P_DEFAULT)) < 0) {
-            TEST_ERROR
+            TEST_ERROR;
         }
     }
 
@@ -1526,7 +1526,7 @@ test_rank3(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* read */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_s) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
 #if defined(H5_SET_EXTENT_DEBUG3)
@@ -1550,7 +1550,7 @@ test_rank3(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
                 if (buf_s[i][j][k] != buf_o[i][j][k]) {
                     HDprintf("buf_s[%d][%d][%d] = %d\n", i, j, k, buf_s[i][j][k]);
                     HDprintf("buf_o[%d][%d][%d] = %d\n", i, j, k, buf_o[i][j][k]);
-                    TEST_ERROR
+                    TEST_ERROR;
                 }
             }
         }
@@ -1563,32 +1563,32 @@ test_rank3(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* set new dimensions for the array */
     if (H5Dset_extent(did, dims_o) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get dimensions. */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Sclose(sid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* check dimensions */
     for (i = 0; i < RANK3; i++) {
         if (dims_r[i] != dims_o[i])
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* read */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_r) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #if defined(H5_SET_EXTENT_DEBUG3)
     HDprintf("\n");
@@ -1613,12 +1613,12 @@ test_rank3(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
                     if (buf_r[i][j][k] != comp_value) {
                         HDprintf("buf_r[%d][%d][%d] = %d\n", i, j, k, buf_r[i][j][k]);
                         HDprintf("value = %d\n", comp_value);
-                        TEST_ERROR
+                        TEST_ERROR;
                     }
                 }
                 else {
                     if (buf_r[i][j][k] != buf_o[i][j][k])
-                        TEST_ERROR
+                        TEST_ERROR;
                 }
             }
         }
@@ -1636,27 +1636,27 @@ test_rank3(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
 
     /* set new dimensions for the array. */
     if (H5Dset_extent(did, dims_s) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get dimensions */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Sclose(sid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* check dimensions */
     for (i = 0; i < RANK3; i++) {
         if (dims_r[i] != dims_s[i])
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /*-------------------------------------------------------------------------
@@ -1665,7 +1665,7 @@ test_rank3(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
      */
 
     if (H5Dclose(did) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /*-------------------------------------------------------------------------
@@ -1674,24 +1674,24 @@ test_rank3(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
      */
 
     if ((sid = H5Screate_simple(RANK3, dims_o, maxdims)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
     if ((did = H5Dcreate2(fid, "dset3", H5T_NATIVE_INT, sid, H5P_DEFAULT, my_dcpl, H5P_DEFAULT)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
     /* set new dimensions for the array */
     dims_o[0] = 0;
     dims_o[1] = 0;
     dims_o[2] = 0;
     if (H5Dset_extent(did, dims_o) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Dclose(did) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
     if (H5Sclose(sid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /*-------------------------------------------------------------------------
@@ -1700,11 +1700,11 @@ test_rank3(hid_t fapl, hid_t dcpl, hbool_t do_fill_value, hbool_t disable_edge_f
      */
 
     if (H5Pclose(my_dcpl) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Fclose(fid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     return 0;
@@ -1766,27 +1766,27 @@ test_external(hid_t fapl)
     /* create a new file */
     h5_fixname(FILENAME[3], fapl, filename, sizeof filename);
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* modify dataset creation properties */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Pset_external(dcpl, EXT_FILE_NAME1, (off_t)0, size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Pset_external(dcpl, EXT_FILE_NAME2, (off_t)0, size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
-        {
+    {
 
-            char    name[256];   /*external file name        */
-            off_t   file_offset; /*external file offset        */
-            hsize_t file_size;   /*sizeof external file segment    */
+        char    name[256];   /*external file name        */
+        off_t   file_offset; /*external file offset        */
+        hsize_t file_size;   /*sizeof external file segment    */
 
-            if (H5Pget_external(dcpl, 0, sizeof(name), name, &file_offset, &file_size) < 0)
-                FAIL_STACK_ERROR
-        }
+        if (H5Pget_external(dcpl, 0, sizeof(name), name, &file_offset, &file_size) < 0)
+            FAIL_STACK_ERROR;
+    }
 
     /*-------------------------------------------------------------------------
      * Write an array AxB. These are the dimensions for creating the dataset
@@ -1803,13 +1803,13 @@ test_external(hid_t fapl)
 
     /* create the data space with unlimited dimensions. */
     if ((sid = H5Screate_simple(RANK2, dims_o, maxdims)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did = H5Dcreate2(fid, "dset1", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dwrite(did, H5T_NATIVE_INT, sid, H5S_ALL, H5P_DEFAULT, buf_o) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*-------------------------------------------------------------------------
      * read
@@ -1818,7 +1818,7 @@ test_external(hid_t fapl)
 
     /* read */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_ro) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
 #if defined(H5_SET_EXTENT_DEBUG)
     HDprintf("\n");
@@ -1852,28 +1852,28 @@ test_external(hid_t fapl)
 
     /* set new dimensions for the array. */
     if (H5Dset_extent(did, dims_e) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* get dimensions */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* check dimensions */
     for (i = 0; i < RANK2; i++) {
         if (dims_r[i] != dims_e[i])
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* read */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_e) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
 #if defined(H5_SET_EXTENT_DEBUG)
     HDprintf("\n");
@@ -1892,12 +1892,12 @@ test_external(hid_t fapl)
                 if (buf_e[i][j] != comp_value) {
                     HDprintf("buf_e[%d][%d] = %d\n", i, j, buf_e[i][j]);
                     HDprintf("value = %d\n", comp_value);
-                    TEST_ERROR
+                    TEST_ERROR;
                 }
             }
             else {
                 if (buf_e[i][j] != buf_o[i][j])
-                    TEST_ERROR
+                    TEST_ERROR;
             }
         }
     }
@@ -1915,23 +1915,23 @@ test_external(hid_t fapl)
 
     /* set new dimensions for the array. */
     if (H5Dset_extent(did, dims_s) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* get dimensions */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* check dimensions */
     for (i = 0; i < RANK2; i++) {
         if (dims_r[i] != dims_s[i])
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /*-------------------------------------------------------------------------
@@ -1941,7 +1941,7 @@ test_external(hid_t fapl)
 
     /* read */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_s) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
 #if defined(H5_SET_EXTENT_DEBUG)
     HDprintf("\n");
@@ -1959,7 +1959,7 @@ test_external(hid_t fapl)
             if (buf_s[i][j] != buf_o[i][j]) {
                 HDprintf("buf_s[%d][%d] = %d\n", i, j, buf_s[i][j]);
                 HDprintf("buf_o[%d][%d] = %d\n", i, j, buf_o[i][j]);
-                TEST_ERROR
+                TEST_ERROR;
             }
         }
     }
@@ -1977,7 +1977,7 @@ test_external(hid_t fapl)
 
         /* set new dimensions for the array. */
         if (H5Dset_extent(did, dims_e) == SUCCEED) {
-            TEST_ERROR
+            TEST_ERROR;
         }
     }
     H5E_END_TRY;
@@ -1988,13 +1988,13 @@ test_external(hid_t fapl)
      */
 
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -2044,31 +2044,31 @@ test_layouts(H5D_layout_t layout, hid_t fapl)
     /* create a new file */
     h5_fixname(FILENAME[4], fapl, filename, sizeof filename);
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* create the data space with unlimited dimensions. */
     if ((sid = H5Screate_simple(RANK2, dims_o, NULL)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* modify dataset creation properties */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Pset_layout(dcpl, layout) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* create a dataset */
     if ((did = H5Dcreate2(fid, "dset1", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* write */
     if (H5Dwrite(did, H5T_NATIVE_INT, sid, H5S_ALL, H5P_DEFAULT, buf_o) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
 #if defined(H5_SET_EXTENT_DEBUG4)
@@ -2082,7 +2082,7 @@ test_layouts(H5D_layout_t layout, hid_t fapl)
 #endif
 
     if (H5Sclose(sid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /*-------------------------------------------------------------------------
@@ -2098,31 +2098,31 @@ test_layouts(H5D_layout_t layout, hid_t fapl)
     H5E_END_TRY;
 
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get dimensions */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Sclose(sid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* check dimensions */
     for (i = 0; i < RANK2; i++) {
         if (dims_r[i] != dims_o[i])
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* read */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_r) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #if defined(H5_SET_EXTENT_DEBUG4)
     HDprintf("\n");
@@ -2147,26 +2147,26 @@ test_layouts(H5D_layout_t layout, hid_t fapl)
     H5E_END_TRY;
 
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* get the space */
     if ((sid = H5Dget_space(did)) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* get dimensions */
     if (H5Sget_simple_extent_dims(sid, dims_r, NULL) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Sclose(sid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* check dimensions */
     for (i = 0; i < RANK2; i++) {
         if (dims_r[i] != dims_o[i])
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /*-------------------------------------------------------------------------
@@ -2176,7 +2176,7 @@ test_layouts(H5D_layout_t layout, hid_t fapl)
 
     /* read */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_r) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
 #if defined(H5_SET_EXTENT_DEBUG4)
@@ -2195,15 +2195,15 @@ test_layouts(H5D_layout_t layout, hid_t fapl)
      */
 
     if (H5Dclose(did) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Pclose(dcpl) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     if (H5Fclose(fid) < 0) {
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     return 0;
@@ -2270,16 +2270,16 @@ test_random_rank4(hid_t fapl, hid_t dcpl, hbool_t do_fillvalue, hbool_t disable_
 
     /* Initialize large arrays */
     if (NULL == (rbuf = HDcalloc(1, sizeof(*rbuf))))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (wbuf = HDcalloc(1, sizeof(*wbuf))))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (dim_log = HDcalloc(1, sizeof(*dim_log))))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a new file */
     h5_fixname(FILENAME[4], fapl, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set maximum dimensions as appropriate for index type */
     if (index_type == RANK4_INDEX_BTREE)
@@ -2305,24 +2305,24 @@ test_random_rank4(hid_t fapl, hid_t dcpl, hbool_t do_fillvalue, hbool_t disable_
 
     /* Create dataset */
     if ((fspace = H5Screate_simple(4, dims, max_dims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((my_dcpl = H5Pcopy(dcpl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(my_dcpl, 4, cdims) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (disable_edge_filters)
         if (H5Pset_chunk_opts(my_dcpl, H5D_CHUNK_DONT_FILTER_PARTIAL_CHUNKS) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if ((dset = H5Dcreate2(file, "dset", H5T_NATIVE_INT, fspace, H5P_DEFAULT, my_dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(fspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create memory space, and set initial selection */
     if ((mspace = H5Screate_simple(4, mdims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sselect_hyperslab(mspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Main loop */
     for (i = 0; i < RAND4_NITER; i++) {
@@ -2407,13 +2407,13 @@ test_random_rank4(hid_t fapl, hid_t dcpl, hbool_t do_fillvalue, hbool_t disable_
 
     /* Close */
     if (H5Sclose(mspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(my_dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDfree(rbuf);
     HDfree(wbuf);
@@ -2491,11 +2491,11 @@ test_random_rank4_vl(hid_t fapl, hid_t dcpl, hbool_t do_fillvalue, hbool_t disab
 
     /* Initialize large arrays */
     if (NULL == (rbuf = HDcalloc(1, sizeof(*rbuf))))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (wbuf = HDcalloc(1, sizeof(*wbuf))))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (dim_log = HDcalloc(1, sizeof(*dim_log))))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Initialize fill value buffers so they aren't freed in case of an error */
     fill_value.len = 0;
@@ -2524,11 +2524,11 @@ test_random_rank4_vl(hid_t fapl, hid_t dcpl, hbool_t do_fillvalue, hbool_t disab
     /* create a new file */
     h5_fixname(FILENAME[4], fapl, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create VL type */
     if ((type = H5Tvlen_create(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set maximum dimensions as appropriate for index type */
     if (index_type == RANK4_INDEX_BTREE)
@@ -2554,36 +2554,37 @@ test_random_rank4_vl(hid_t fapl, hid_t dcpl, hbool_t do_fillvalue, hbool_t disab
 
     /* Make a copy of the dcpl */
     if ((my_dcpl = H5Pcopy(dcpl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create VL fill value, if requested */
     if (do_fillvalue) {
         fill_value.len = 2;
         if (NULL == (fill_value.p = HDmalloc(2 * sizeof(int))))
-            TEST_ERROR((int *)fill_value.p)[0] = 1;
+            TEST_ERROR;
+        ((int *)fill_value.p)[0] = 1;
         ((int *)fill_value.p)[1] = 2;
         if (H5Pset_fill_value(my_dcpl, type, &fill_value) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Create dataset */
     if ((fspace = H5Screate_simple(4, dims, max_dims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_chunk(my_dcpl, 4, cdims) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (disable_edge_filters)
         if (H5Pset_chunk_opts(my_dcpl, H5D_CHUNK_DONT_FILTER_PARTIAL_CHUNKS) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     if ((dset = H5Dcreate2(file, "dset", type, fspace, H5P_DEFAULT, my_dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(fspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create memory space, and set initial selection */
     if ((mspace = H5Screate_simple(4, mdims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sselect_hyperslab(mspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Main loop */
     for (i = 0; i < RAND4_VL_NITER; i++) {
@@ -2663,7 +2664,7 @@ test_random_rank4_vl(hid_t fapl, hid_t dcpl, hbool_t do_fillvalue, hbool_t disab
 
             /* Free read buffer */
             if (H5Treclaim(type, mspace, H5P_DEFAULT, rbuf) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end if */
 
         /* Handle the switch between writing and not writing */
@@ -2681,20 +2682,20 @@ test_random_rank4_vl(hid_t fapl, hid_t dcpl, hbool_t do_fillvalue, hbool_t disab
 
     /* Close */
     if (H5Sselect_all(mspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Treclaim(type, mspace, H5P_DEFAULT, wbuf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDfree(fill_value.p);
     if (H5Sclose(mspace) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(my_dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(dset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(type) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDfree(rbuf);
     HDfree(wbuf);

--- a/test/stab.c
+++ b/test/stab.c
@@ -100,52 +100,52 @@ test_misc(hid_t fcpl, hid_t fapl, hbool_t new_format)
     char  comment[64];
 
     if (new_format)
-        TESTING("miscellaneous group tests (w/new group format)")
+        TESTING("miscellaneous group tests (w/new group format)");
     else
-        TESTING("miscellaneous group tests")
+        TESTING("miscellaneous group tests");
 
     /* Create file */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create initial groups for testing, then close */
     if ((g1 = H5Gcreate2(fid, "test_1a", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((g2 = H5Gcreate2(g1, "sub_1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((g3 = H5Gcreate2(fid, "test_1b", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oset_comment(g3, "hello world") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(g1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(g2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(g3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open all groups with absolute names to check for existence */
     if ((g1 = H5Gopen2(fid, "/test_1a", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((g2 = H5Gopen2(fid, "/test_1a/sub_1", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((g3 = H5Gopen2(fid, "/test_1b", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Oget_comment_by_name(g3, "././.", comment, sizeof comment, H5P_DEFAULT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrcmp(comment, "hello world") != 0) {
         H5_FAILED();
         HDputs("    Read the wrong comment string from the group.");
         HDprintf("    got: \"%s\"\n    ans: \"hello world\"\n", comment);
-        TEST_ERROR
+        TEST_ERROR;
     }
     if (H5Gclose(g1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(g2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(g3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that creating groups with no-op names isn't allowed */
     H5E_BEGIN_TRY
@@ -154,7 +154,7 @@ test_misc(hid_t fcpl, hid_t fapl, hbool_t new_format)
     }
     H5E_END_TRY
     if (g1 >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -162,11 +162,11 @@ test_misc(hid_t fcpl, hid_t fapl, hbool_t new_format)
     }
     H5E_END_TRY
     if (g1 >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -205,14 +205,14 @@ test_long(hid_t fcpl, hid_t fapl, hbool_t new_format)
     size_t i;
 
     if (new_format)
-        TESTING("long names (w/new group format)")
+        TESTING("long names (w/new group format)");
     else
-        TESTING("long names")
+        TESTING("long names");
 
     /* Create file */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Group names */
     name1 = (char *)HDmalloc((size_t)LONG_NAME_LEN);
@@ -224,27 +224,27 @@ test_long(hid_t fcpl, hid_t fapl, hbool_t new_format)
 
     /* Create groups */
     if ((g1 = H5Gcreate2(fid, name1, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((g2 = H5Gcreate2(g1, name1, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(g1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(g2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open groups */
     if ((g1 = H5Gopen2(fid, name1, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((g2 = H5Gopen2(fid, name2, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(g1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Gclose(g2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Release name buffers */
     HDfree(name2);
@@ -291,40 +291,40 @@ test_large(hid_t fcpl, hid_t fapl, hbool_t new_format)
     int   i;
 
     if (new_format)
-        TESTING("large directories (w/new group format)")
+        TESTING("large directories (w/new group format)");
     else
-        TESTING("large directories")
+        TESTING("large directories");
 
     /* Create file */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Create a directory that has so many entries that the root
      * of the B-tree ends up splitting.
      */
     if ((cwg = H5Gcreate2(fid, "/big", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (new_format)
         if (H5G__has_stab_test(cwg) != FALSE)
-            TEST_ERROR
+            TEST_ERROR;
     for (i = 0; i < LARGE_NOBJS; i++) {
         HDsprintf(name, "%05d%05d", (HDrandom() % 100000), i);
         if ((dir = H5Gcreate2(cwg, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Gclose(dir) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     if (new_format)
         if (H5G__is_new_dense_test(cwg) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
     if (H5Gclose(cwg) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -381,236 +381,236 @@ lifecycle(hid_t fcpl, hid_t fapl2)
     /* Create file */
     h5_fixname(FILENAME[0], fapl2, filename, sizeof(filename));
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get size of file as empty */
     if ((empty_size = h5_get_file_size(filename, fapl2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set up group creation property list */
     if ((gcpl = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query default group creation property settings */
     if (H5Pget_local_heap_size_hint(gcpl, &lheap_size_hint) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (lheap_size_hint != H5G_CRT_GINFO_LHEAP_SIZE_HINT)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_link_phase_change(gcpl, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (max_compact != H5G_CRT_GINFO_MAX_COMPACT)
-        TEST_ERROR
+        TEST_ERROR;
     if (min_dense != H5G_CRT_GINFO_MIN_DENSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_est_link_info(gcpl, &est_num_entries, &est_name_len) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (est_num_entries != H5G_CRT_GINFO_EST_NUM_ENTRIES)
-        TEST_ERROR
+        TEST_ERROR;
     if (est_name_len != H5G_CRT_GINFO_EST_NAME_LEN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set GCPL parameters */
     if (H5Pset_local_heap_size_hint(gcpl, (size_t)LIFECYCLE_LOCAL_HEAP_SIZE_HINT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_link_phase_change(gcpl, LIFECYCLE_MAX_COMPACT, LIFECYCLE_MIN_DENSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_est_link_info(gcpl, LIFECYCLE_EST_NUM_ENTRIES, LIFECYCLE_EST_NAME_LEN) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group for testing lifecycle */
     if ((gid = H5Gcreate2(fid, LIFECYCLE_TOP_GROUP, H5P_DEFAULT, gcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query group creation property settings */
     if (H5Pget_local_heap_size_hint(gcpl, &lheap_size_hint) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (lheap_size_hint != LIFECYCLE_LOCAL_HEAP_SIZE_HINT)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_link_phase_change(gcpl, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (max_compact != LIFECYCLE_MAX_COMPACT)
-        TEST_ERROR
+        TEST_ERROR;
     if (min_dense != LIFECYCLE_MIN_DENSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_est_link_info(gcpl, &est_num_entries, &est_name_len) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (est_num_entries != LIFECYCLE_EST_NUM_ENTRIES)
-        TEST_ERROR
+        TEST_ERROR;
     if (est_name_len != LIFECYCLE_EST_NAME_LEN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Use internal testing routine to check that the group has no links or symbol table */
     if (H5G__is_empty_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create first "bottom" group */
     HDsprintf(objname, LIFECYCLE_BOTTOM_GROUP, (unsigned)0);
     if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on bottom group's status */
     if (H5G__is_empty_test(gid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close bottom group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on top group's status */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, &nmsgs) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (nmsgs != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create several more bottom groups, to push the top group almost to a symbol table */
     /* (Start counting at '1', since we've already created one bottom group */
     for (u = 1; u < LIFECYCLE_MAX_COMPACT; u++) {
         HDsprintf(objname, LIFECYCLE_BOTTOM_GROUP, u);
         if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check on bottom group's status */
         if (H5G__is_empty_test(gid2) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close bottom group */
         if (H5Gclose(gid2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check on top group's status */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, &nmsgs) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (nmsgs != LIFECYCLE_MAX_COMPACT)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(gid) != FALSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the object header is only one chunk and the space has been allocated correctly */
     if (H5Oget_native_info(gid, &ninfo, H5O_NATIVE_INFO_HDR) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ninfo.hdr.space.total != 151)
-        TEST_ERROR
+        TEST_ERROR;
     if (ninfo.hdr.space.free != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ninfo.hdr.nmesgs != 6)
-        TEST_ERROR
+        TEST_ERROR;
     if (ninfo.hdr.nchunks != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create one more "bottom" group, which should push top group into using a symbol table */
     HDsprintf(objname, LIFECYCLE_BOTTOM_GROUP, u);
     if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on bottom group's status */
     if (H5G__is_empty_test(gid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close bottom group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on top group's status */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the object header is still one chunk and the space has been allocated correctly */
     if (H5Oget_native_info(gid, &ninfo, H5O_NATIVE_INFO_HDR) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ninfo.hdr.space.total != 151)
-        TEST_ERROR
+        TEST_ERROR;
     if (ninfo.hdr.space.free != 92)
-        TEST_ERROR
+        TEST_ERROR;
     if (ninfo.hdr.nmesgs != 3)
-        TEST_ERROR
+        TEST_ERROR;
     if (ninfo.hdr.nchunks != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unlink objects from top group */
     while (u >= LIFECYCLE_MIN_DENSE) {
         HDsprintf(objname, LIFECYCLE_BOTTOM_GROUP, u);
 
         if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         u--;
     } /* end while */
 
     /* Check on top group's status */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unlink one more object from the group, which should transform back to using links */
     HDsprintf(objname, LIFECYCLE_BOTTOM_GROUP, u);
     if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     u--;
 
     /* Check on top group's status */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, &nmsgs) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (nmsgs != (LIFECYCLE_MIN_DENSE - 1))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unlink last two objects from top group */
     HDsprintf(objname, LIFECYCLE_BOTTOM_GROUP, u);
     if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     u--;
     HDsprintf(objname, LIFECYCLE_BOTTOM_GROUP, u);
     if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check on top group's status */
     if (H5G__is_empty_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close top group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unlink top group */
     if (H5Ldelete(fid, LIFECYCLE_TOP_GROUP, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close GCPL */
     if (H5Pclose(gcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get size of file as empty */
     if ((file_size = h5_get_file_size(filename, fapl2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -658,99 +658,99 @@ long_compact(hid_t fcpl, hid_t fapl2)
     /* Create file */
     h5_fixname(FILENAME[0], fapl2, filename, sizeof(filename));
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get size of file as empty */
     if ((empty_size = h5_get_file_size(filename, fapl2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Construct very long object name template */
     if (NULL == (objname = (char *)HDmalloc((size_t)(LONG_COMPACT_LENGTH + 1))))
-        TEST_ERROR
+        TEST_ERROR;
     HDmemset(objname, 'a', (size_t)LONG_COMPACT_LENGTH);
     objname[LONG_COMPACT_LENGTH] = '\0';
 
     /* Re-open file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create top group */
     if ((gid = H5Gcreate2(fid, "top", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Use internal testing routine to check that the group has no links or dense storage */
     if (H5G__is_empty_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create first group with "long" name */
     if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on bottom group's status */
     if (H5G__is_empty_test(gid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close bottom group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on top group's status */
     /* (Should have dense storage to hold links, since name is too long for object header message) */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create second group with "long" name */
     objname[0] = 'b';
     if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on bottom group's status */
     if (H5G__is_empty_test(gid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close bottom group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on top group's status */
     /* (Should have dense storage to hold links, since name is too long for object header message) */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unlink second object from top group */
     if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check on top group's status */
     /* (Should still be dense storage to hold links, since name is too long for object header message) */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unlink first object from top group */
     objname[0] = 'a';
     if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check on top group's status */
     /* (Should have deleted the dense storage now) */
     if (H5G__is_empty_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free object name */
     HDfree(objname);
@@ -758,23 +758,23 @@ long_compact(hid_t fcpl, hid_t fapl2)
 
     /* Close top group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unlink top group */
     if (H5Ldelete(fid, "top", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get size of file as empty */
     if ((file_size = h5_get_file_size(filename, fapl2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -821,71 +821,71 @@ read_old(void)
 
     /* Make a copy of the data file from svn. */
     if (h5_make_local_copy(FILE_OLD_GROUPS, FILE_OLD_GROUPS_COPY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open copied file */
     if ((fid = H5Fopen(FILE_OLD_GROUPS_COPY, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to open "old" group */
     if ((gid = H5Gopen2(fid, "old", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on old group's status */
     if (H5G__is_empty_test(gid) == FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a bunch of objects in the group */
     for (u = 0; u < READ_OLD_NGROUPS; u++) {
         HDsprintf(objname, "Group %u", u);
         if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check on bottom group's status */
         if (H5G__is_empty_test(gid2) != TRUE)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close bottom group */
         if (H5Gclose(gid2) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Check on old group's status */
     /* (Should stay in old "symbol table" form) */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Delete new objects from old group */
     for (u = 0; u < READ_OLD_NGROUPS; u++) {
         HDsprintf(objname, "Group %u", u);
         if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check on old group's status */
     /* (Should stay in old "symbol table" form, but have no links) */
     if (H5G__is_empty_test(gid) == FALSE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close old group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -934,97 +934,97 @@ no_compact(hid_t fcpl, hid_t fapl2)
     /* Create file */
     h5_fixname(FILENAME[0], fapl2, filename, sizeof(filename));
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get size of file as empty */
     if ((empty_size = h5_get_file_size(filename, fapl2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set up group creation property list */
     if ((gcpl = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set GCPL parameters */
     if (H5Pset_link_phase_change(gcpl, NO_COMPACT_MAX_COMPACT, NO_COMPACT_MIN_DENSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check information for default group creation */
     if (H5Pget_est_link_info(gcpl, &est_num_entries, &est_name_len) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (est_num_entries != H5G_CRT_GINFO_EST_NUM_ENTRIES)
-        TEST_ERROR
+        TEST_ERROR;
     if (est_name_len != H5G_CRT_GINFO_EST_NAME_LEN)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create group for testing no compact form */
     if ((gid = H5Gcreate2(fid, NO_COMPACT_TOP_GROUP, H5P_DEFAULT, gcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close GCPL */
     if (H5Pclose(gcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Use internal testing routine to check that the group has no links or dense storage */
     if (H5G__is_empty_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create first "bottom" group */
     HDsprintf(objname, NO_COMPACT_BOTTOM_GROUP, (unsigned)0);
     if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on bottom group's status */
     if (H5G__is_empty_test(gid2) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close bottom group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check on top group's status */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unlink object from top group */
     HDsprintf(objname, NO_COMPACT_BOTTOM_GROUP, (unsigned)0);
     if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check on top group's status */
     if (H5G__is_empty_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close top group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unlink top group */
     if (H5Ldelete(fid, NO_COMPACT_TOP_GROUP, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get size of file as empty */
     if ((file_size = h5_get_file_size(filename, fapl2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -1075,107 +1075,107 @@ gcpl_on_root(hid_t fapl2)
 
     /* Set up file creation property list */
     if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set GCPL parameters */
     if (H5Pset_link_phase_change(fcpl, GCPL_ON_ROOT_MAX_COMPACT, GCPL_ON_ROOT_MIN_DENSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties from the FCPL */
     if (H5Pget_link_phase_change(fcpl, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (max_compact != GCPL_ON_ROOT_MAX_COMPACT)
-        TEST_ERROR
+        TEST_ERROR;
     if (min_dense != GCPL_ON_ROOT_MIN_DENSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file with modified root group creation properties */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close FCPL */
     if (H5Pclose(fcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the root group */
     if ((gid = H5Gopen2(fid, "/", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties */
     if ((gcpl = H5Gget_create_plist(gid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_link_phase_change(gcpl, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (max_compact != GCPL_ON_ROOT_MAX_COMPACT)
-        TEST_ERROR
+        TEST_ERROR;
     if (min_dense != GCPL_ON_ROOT_MIN_DENSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close GCPL */
     if (H5Pclose(gcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a link creation property list, with intermediate group creation set */
     if ((lcpl = H5Pcreate(H5P_LINK_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_create_intermediate_group(lcpl, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group and intermediate groups, to check if root group settings are inherited */
     if ((gid2 = H5Gcreate2(gid, GCPL_ON_ROOT_BOTTOM_GROUP, lcpl, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close LCPL */
     if (H5Pclose(lcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties */
     if ((gcpl = H5Gget_create_plist(gid2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_link_phase_change(gcpl, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (max_compact != H5G_CRT_GINFO_MAX_COMPACT)
-        TEST_ERROR
+        TEST_ERROR;
     if (min_dense != H5G_CRT_GINFO_MIN_DENSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close GCPL */
     if (H5Pclose(gcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close bottom group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the middle group */
     if ((gid2 = H5Gopen2(fid, GCPL_ON_ROOT_MIDDLE_GROUP, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Query the group creation properties */
     if ((gcpl = H5Gget_create_plist(gid2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_link_phase_change(gcpl, &max_compact, &min_dense) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (max_compact != GCPL_ON_ROOT_MAX_COMPACT)
-        TEST_ERROR
+        TEST_ERROR;
     if (min_dense != GCPL_ON_ROOT_MIN_DENSE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close GCPL */
     if (H5Pclose(gcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close bottom group */
     if (H5Gclose(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close root group */
     if (H5Gclose(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -1226,55 +1226,55 @@ old_api(hid_t fapl)
 
     /* Create file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a group, with the old API routine and a "small" heap */
     if ((gid = H5Gcreate1(fid, OLD_API_GROUP, (size_t)0)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file with a "small" heap for group */
     if ((small_file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a group, with the old API routine and a "large" heap */
     if ((gid = H5Gcreate1(fid, OLD_API_GROUP, (size_t)10000)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open group */
     if ((gid = H5Gopen1(fid, OLD_API_GROUP)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file with a "large" heap for group */
     if ((large_file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the file with a "large" group heap is actually bigger */
     if (large_file_size <= small_file_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 #else  /* H5_NO_DEPRECATED_SYMBOLS */
@@ -1323,22 +1323,22 @@ corrupt_stab_msg(void)
 
     /* Make a copy of the data file from svn. */
     if (h5_make_local_copy(CORRUPT_STAB_FILE, CORRUPT_STAB_TMP_FILE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #ifndef H5_STRICT_FORMAT_CHECKS
     /* Open temp file through HDF5 library */
     if ((fid = H5Fopen(CORRUPT_STAB_TMP_FILE, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open dataset */
     if ((did = H5Dopen2(fid, CORRUPT_STAB_DSET, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset and file */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Now reopen with read only access.  This verifies that the issue has been
      * corrected, as the symbol table message is not patched in read only mode.
@@ -1346,22 +1346,22 @@ corrupt_stab_msg(void)
 
     /* Open file */
     if ((fid = H5Fopen(CORRUPT_STAB_TMP_FILE, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open dataset */
     if ((did = H5Dopen2(fid, CORRUPT_STAB_DSET, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close dataset and file */
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #else /* H5_STRICT_FORMAT_CHECKS */
     /* Open file */
     if ((fid = H5Fopen(CORRUPT_STAB_TMP_FILE, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify that an error is thrown when we try to access the dataset */
     H5E_BEGIN_TRY
@@ -1370,11 +1370,11 @@ corrupt_stab_msg(void)
     }
     H5E_END_TRY
     if (did >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
 #endif /* H5_STRICT_FORMAT_CHECKS */
 
@@ -1434,22 +1434,22 @@ main(void)
 
     /* Copy the file access property list */
     if ((fapl2 = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set the "use the latest version of the format" bounds for creating objects in the file */
     if (H5Pset_libver_bounds(fapl2, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set up file creation property list */
     if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fcpl2 = H5Pcopy(fcpl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set to use paged aggregation strategy and persisting free-space */
     /* Skip testing for multi/split drivers */
     if (H5Pset_file_space_strategy(fcpl2, H5F_FSPACE_STRATEGY_PAGE, 1, (hsize_t)1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop over using new group format */
     for (new_format = FALSE; new_format <= TRUE; new_format++) {

--- a/test/swmr.c
+++ b/test/swmr.c
@@ -132,20 +132,20 @@ test_metadata_read_attempts(hid_t in_fapl)
      * fapl (e.g.: split/multi), we just skip this entire test.
      */
     if ((driver_id = H5Pget_driver(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5FDdriver_query(driver_id, &driver_flags) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     compat_w_default_vfd = (driver_flags & H5FD_FEAT_DEFAULT_VFD_COMPATIBLE) ? TRUE : FALSE;
 
     if (!compat_w_default_vfd) {
-        SKIPPED()
+        SKIPPED();
         HDputs("    The current VFD is not compatible with the default VFD.");
         return 0;
     }
 
     /* Get a copy of the parameter fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -158,9 +158,9 @@ test_metadata_read_attempts(hid_t in_fapl)
      */
     /* Get # of read attempts -- should be the default: 1 */
     if (H5Pget_metadata_read_attempts(fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set the # of read attempts to 0--should fail */
     H5E_BEGIN_TRY
@@ -169,43 +169,43 @@ test_metadata_read_attempts(hid_t in_fapl)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set the # of read attempts to a # > 0--should succeed */
     if (H5Pset_metadata_read_attempts(fapl, 9) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve the # of read attempts -- should be 9 */
     if (H5Pget_metadata_read_attempts(fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != 9)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set the # of read attempts to the default for non-SWMR access: H5F_METADATA_READ_ATTEMPTS --should
      * succeed */
     if (H5Pset_metadata_read_attempts(fapl, H5F_METADATA_READ_ATTEMPTS) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve the # of read attempts -- should be H5F_METADATA_READ_ATTEMPTS */
     if (H5Pget_metadata_read_attempts(fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != H5F_METADATA_READ_ATTEMPTS)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set the # of read attempts to the default for SWMR access: H5F_SWMR_METADATA_READ_ATEMPTS --should
      * succeed */
     if (H5Pset_metadata_read_attempts(fapl, H5F_SWMR_METADATA_READ_ATTEMPTS) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve the # of read attempts -- should be H5F_SWMR_METADATA_READ_ATTEMPTS */
     if (H5Pget_metadata_read_attempts(fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != H5F_SWMR_METADATA_READ_ATTEMPTS)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the property list */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Set B:
@@ -217,173 +217,173 @@ test_metadata_read_attempts(hid_t in_fapl)
     /* Test 1 */
     /* Create a file with non-SWMR access and default fapl */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file's fapl */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from file's fapl -- should be H5F_METADATA_READ_ATTEMPTS */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != H5F_METADATA_READ_ATTEMPTS)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file's fapl */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 2 */
     /* Get a copy of the parameter fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to use latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file with SWMR access and default read attempts */
     if ((fid = H5Fopen(filename, (H5F_ACC_RDONLY | H5F_ACC_SWMR_READ), fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close fapl */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file's fapl */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from file's fapl -- should be H5F_SWMR_METADATA_READ_ATTEMPTS */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != H5F_SWMR_METADATA_READ_ATTEMPTS)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file's fapl */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 3 */
     /* Get a copy of the parameter fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to use latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the # of read attempts */
     if (H5Pset_metadata_read_attempts(fapl, 9) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file with SWMR access and fapl (non-default & set to 9) */
     if ((fid = H5Fopen(filename, (H5F_ACC_RDONLY | H5F_ACC_SWMR_READ), fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close fapl */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file's fapl */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from file's fapl -- should be 9 */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != 9)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file's fapl */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 4 */
     /* Get a copy of the parameter fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to use latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the # of read attempts */
     if (H5Pset_metadata_read_attempts(fapl, 1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file with SWMR access and fapl (non-default & set to 1) */
     if ((fid = H5Fopen(filename, (H5F_ACC_RDONLY | H5F_ACC_SWMR_READ), fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close fapl */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file's fapl */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from file fapl -- should be 1 */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file's fapl */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 5 */
     /* Get a copy of the parameter fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to use latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file with SWMR_READ and fapl (non-default read attempts but unset) */
     if ((fid = H5Fopen(filename, (H5F_ACC_RDONLY | H5F_ACC_SWMR_READ), fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close fapl */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file's fapl */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from file's fapl -- should be H5F_SWMR_METADATA_READ_ATTEMPTS */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != H5F_SWMR_METADATA_READ_ATTEMPTS)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file's fapl */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Set C:
@@ -395,241 +395,241 @@ test_metadata_read_attempts(hid_t in_fapl)
     /* Test 1 */
     /* Get a copy of the parameter fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to use latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a file with non-SWMR access and default read attempts */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC | H5F_ACC_SWMR_WRITE, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close fapl */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file's fapl */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from file's fapl -- should be H5F_SWMR_METADATA_READ_ATTEMPTS */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != H5F_SWMR_METADATA_READ_ATTEMPTS)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file's fapl */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 2 */
     /* Open the file with non-SWMR access and default fapl */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file's fapl */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from file's fapl -- should be H5F_METADATA_READ_ATTEMPTS */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != H5F_METADATA_READ_ATTEMPTS)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file's fapl */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 3 */
     /* Get a copy of the parameter fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the # of read attempts */
     if (H5Pset_metadata_read_attempts(fapl, 9) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file with non-SWMR access and fapl (non-default & set to 9) */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close fapl */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file's fapl */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from file's fapl -- should be 9 */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != 9)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file's fapl */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 4 */
     /* Get a copy of the parameter fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the # of read attempts */
     if (H5Pset_metadata_read_attempts(fapl, 1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file with non-SWMR access and fapl (non-default & set to 1) */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close fapl */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file's fapl */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from file fapl -- should be 1 */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file's fapl */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test 5 */
     /* Get a copy of the parameter fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file with non-SWMR_READ and fapl (non-default but unset) */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close fapl */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file's fapl */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from file's fapl -- should be H5F_METADATA_READ_ATTEMPTS */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != H5F_METADATA_READ_ATTEMPTS)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file's fapl */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a copy of the parameter fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to use latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the # of read attempts */
     if (H5Pset_metadata_read_attempts(fapl, 9) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC | H5F_ACC_SWMR_WRITE, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close fapl */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open file again with non-SWMR access and default fapl */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file's fapl */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from file fapl -- should be H5F_METADATA_READ_ATTEMPTS */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != H5F_METADATA_READ_ATTEMPTS)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file's fapl */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a copy of the parameter fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to use latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open file again with SWMR access and default read attempts */
     if ((fid = H5Fopen(filename, H5F_ACC_SWMR_READ, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close fapl */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file's fapl */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from file fapl -- should be H5F_SWMR_METADATA_READ_ATTEMPTS */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != H5F_SWMR_METADATA_READ_ATTEMPTS)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file's fapl */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Set D:
@@ -641,85 +641,85 @@ test_metadata_read_attempts(hid_t in_fapl)
 
     /* Create a file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a copy of the parameter fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to use latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open file again with SWMR access and default read attempts */
     if ((fid1 = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the # of read attempts */
     if (H5Pset_metadata_read_attempts(fapl, 9) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open file again with SWMR access and fapl (non-default & set to 9) */
     if ((fid2 = H5Fopen(filename, (H5F_ACC_RDONLY | H5F_ACC_SWMR_READ), fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close fapl */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open fid1 */
     if ((fid = H5Freopen(fid1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file's fapl */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from file fapl -- should be H5F_SWMR_METADATA_READ_ATTEMPTS */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != H5F_SWMR_METADATA_READ_ATTEMPTS)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file's fapl */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open fid2 */
     if ((fid = H5Freopen(fid2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file's fapl */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from file fapl -- should be H5F_SWMR_METADATA_READ_ATTEMPTS, not 9 */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != H5F_SWMR_METADATA_READ_ATTEMPTS)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file's fapl */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close all the files */
     if (H5Fclose(fid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Set E:
@@ -731,93 +731,93 @@ test_metadata_read_attempts(hid_t in_fapl)
 
     /* Get a copy of the parameter fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to use latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC | H5F_ACC_SWMR_WRITE, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close fapl */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open file again with non-SWMR access and default fapl */
     if ((fid1 = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a copy of the parameter fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the # of read attempts */
     if (H5Pset_metadata_read_attempts(fapl, 9) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open file again with non-SWMR access and fapl (non-default & set to 9) */
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close fapl */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open fid1 */
     if ((fid = H5Freopen(fid1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file's fapl */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from file fapl -- should be H5F_METADATA_READ_ATTEMPTS */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != H5F_METADATA_READ_ATTEMPTS)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file's fapl */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open fid2 */
     if ((fid = H5Freopen(fid2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get file's fapl */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from file fapl -- should be H5F_METADATA_READ_ATTEMPTS */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (attempts != H5F_METADATA_READ_ATTEMPTS)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file's fapl */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close all the files */
     if (H5Fclose(fid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -870,38 +870,38 @@ test_metadata_read_retry_info(hid_t in_fapl)
 
     /* Get a copy of the parameter in_fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
     /* Set to use latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a file without SWMR access */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a chunked dataset with 1 unlimited dimension: extensible array indexing will be used */
     if ((sid = H5Screate_simple(2, dims, max_dims_1un)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl, 2, chunk_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did1 = H5Dcreate2(fid, "DSET_1UNLIM", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a chunked dataset with 2 unlimited dimension: v2 Btree indexing will be used */
     if ((sid = H5Screate_simple(2, dims, max_dims_2un)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl, 2, chunk_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did2 = H5Dcreate2(fid, "DSET_2UNLIM", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize buffer data */
     for (i = n = 0; i < 6; i++)
@@ -910,21 +910,21 @@ test_metadata_read_retry_info(hid_t in_fapl)
 
     /* Write to the 2 datasets */
     if (H5Dwrite(did1, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dwrite(did2, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Closing */
     if (H5Dclose(did1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      *  Case 1: tests on nbins
@@ -936,41 +936,41 @@ test_metadata_read_retry_info(hid_t in_fapl)
      */
     /* Open the file without SWMR access */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset */
     if ((did1 = H5Dopen2(fid, "DSET_1UNLIM", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Dread(did1, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, chkbuf1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset */
     if ((did2 = H5Dopen2(fid, "DSET_2UNLIM", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dread(did2, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, chkbuf2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve retries information */
     if (H5Fget_metadata_read_retry_info(fid, &info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should be 0 */
     if (info.nbins != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should be all NULL */
     for (i = 0; i < H5F_NUM_METADATA_READ_RETRY_TYPES; i++)
         if (info.retries[i] != NULL)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Closing */
     if (H5Dclose(did1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Open a file with SWMR access, default # of read attempts--
@@ -979,24 +979,24 @@ test_metadata_read_retry_info(hid_t in_fapl)
      */
     /* Open the file with SWMR access */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve retries information */
     if (H5Fget_metadata_read_retry_info(fid, &info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should be 2 */
     if (info.nbins != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should be all NULL */
     for (i = 0; i < H5F_NUM_METADATA_READ_RETRY_TYPES; i++)
         if (info.retries[i] != NULL)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Closing */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Open a file with SWMR access, # of read_attempts is 10:
@@ -1004,33 +1004,33 @@ test_metadata_read_retry_info(hid_t in_fapl)
      *   info.retries should all be NULL
      */
     if ((new_fapl = H5Pcopy(fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Pset_metadata_read_attempts(new_fapl, 10) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file with SWMR access */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, new_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve retry information */
     if (H5Fget_metadata_read_retry_info(fid, &info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should be 1 */
     if (info.nbins != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should be all NULL */
     for (i = 0; i < H5F_NUM_METADATA_READ_RETRY_TYPES; i++)
         if (info.retries[i] != NULL)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Closing */
     if (H5Pclose(new_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Open a file with SWMR access, # of read attempts is 101:
@@ -1038,32 +1038,32 @@ test_metadata_read_retry_info(hid_t in_fapl)
      *   info.retries should all be NULL
      */
     if ((new_fapl = H5Pcopy(fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_metadata_read_attempts(new_fapl, 101) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file with SWMR access */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, new_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve retry information */
     if (H5Fget_metadata_read_retry_info(fid, &info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should be 3 */
     if (info.nbins != 3)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should be all NULL */
     for (i = 0; i < H5F_NUM_METADATA_READ_RETRY_TYPES; i++)
         if (info.retries[i] != NULL)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Closing */
     if (H5Pclose(new_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Open a file with SWMR access, # of read_attempts is 10000:
@@ -1071,33 +1071,33 @@ test_metadata_read_retry_info(hid_t in_fapl)
      *   info.retries should all be NULL
      */
     if ((new_fapl = H5Pcopy(fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Pset_metadata_read_attempts(new_fapl, 10000) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file with SWMR access */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, new_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve retry information */
     if (H5Fget_metadata_read_retry_info(fid, &info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should be 4 */
     if (info.nbins != 4)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should be all NULL */
     for (i = 0; i < H5F_NUM_METADATA_READ_RETRY_TYPES; i++)
         if (info.retries[i] != NULL)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Closing */
     if (H5Pclose(new_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Open a file with SWMR access, # of read_attempts is 1:
@@ -1105,33 +1105,33 @@ test_metadata_read_retry_info(hid_t in_fapl)
      *   info.retries should all be NULL
      */
     if ((new_fapl = H5Pcopy(fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Pset_metadata_read_attempts(new_fapl, 1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file with SWMR access */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, new_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve retry information */
     if (H5Fget_metadata_read_retry_info(fid, &info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should be 0 */
     if (info.nbins != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should be all NULL */
     for (i = 0; i < H5F_NUM_METADATA_READ_RETRY_TYPES; i++)
         if (info.retries[i] != NULL)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Closing */
     if (H5Pclose(new_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 2: tests on retries info
@@ -1139,40 +1139,40 @@ test_metadata_read_retry_info(hid_t in_fapl)
 
     /* Open the file with SWMR access */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset */
     if ((did1 = H5Dopen2(fid, "DSET_1UNLIM", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read data from the dataset */
     if (H5Dread(did1, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, chkbuf1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset */
     if ((did2 = H5Dopen2(fid, "DSET_2UNLIM", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Read data from the dataset */
     if (H5Dread(did2, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, chkbuf2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve retry information */
     if (H5Fget_metadata_read_retry_info(fid, &info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should be 2 */
     if (info.nbins != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should be all NULL */
     for (i = 0; i < H5F_NUM_METADATA_READ_RETRY_TYPES; i++)
         if (info.retries[i] != NULL)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Get a pointer to the internal file object */
     if ((f = (H5F_t *)H5VL_object(fid)) == NULL)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Increment 1st set of retries for metadata items:
@@ -1184,39 +1184,39 @@ test_metadata_read_retry_info(hid_t in_fapl)
     /* v2 B-tree leaf node: log retry 99 for 500 times */
     for (i = 0; i < 500; i++) {
         if (H5F_track_metadata_read_retries(f, H5AC_BT2_LEAF_ID, 99) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
 
     /* Extensive array data block: log retry 10 for 1000 times */
     for (i = 0; i < 1000; i++)
         if (H5F_track_metadata_read_retries(f, H5AC_EARRAY_DBLOCK_ID, 10) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
     /* File's superblock: log retry 1 for 1 time */
     if (H5F_track_metadata_read_retries(f, H5AC_SUPERBLOCK_ID, 1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the collection of metadata read retries */
     if (H5Fget_metadata_read_retry_info(fid, &info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify retries for v2 B-tree leaf node */
     if (info.retries[4][0] != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (info.retries[4][1] != 500)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify retries for extensive array data block */
     if (info.retries[15][0] != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (info.retries[15][1] != 1000)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify retries for file's superblock */
     if (info.retries[20][0] != 1)
-        TEST_ERROR
+        TEST_ERROR;
     if (info.retries[20][1] != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free memory for info.retries */
     for (i = 0; i < H5F_NUM_METADATA_READ_RETRY_TYPES; i++) {
@@ -1235,26 +1235,26 @@ test_metadata_read_retry_info(hid_t in_fapl)
     /* Object header: log retry 5 for 5 times */
     for (i = 0; i < 5; i++) {
         if (H5F_track_metadata_read_retries(f, H5AC_OHDR_ID, 5) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* Extensive array data block: log retry 4 for 1 time */
     if (H5F_track_metadata_read_retries(f, H5AC_EARRAY_DBLOCK_ID, 4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fixed array header : log retry 50 for 10000 times */
     for (i = 0; i < 10000; i++) {
         if (H5F_track_metadata_read_retries(f, H5AC_FARRAY_HDR_ID, 50) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* File's superblock: log retry 1 for 1 more time */
     if (H5F_track_metadata_read_retries(f, H5AC_SUPERBLOCK_ID, 1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the collection of metadata read retries */
     if (H5Fget_metadata_read_retry_info(fid, &info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Verify info has both previous + current retries information:
@@ -1263,42 +1263,42 @@ test_metadata_read_retry_info(hid_t in_fapl)
         switch (i) {
             case 0: /* Object header */
                 if (info.retries[i][0] != 5)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (info.retries[i][1] != 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 break;
 
             case 4: /* v2 B-tree leaf node */
                 if (info.retries[i][0] != 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (info.retries[i][1] != 500)
-                    TEST_ERROR
+                    TEST_ERROR;
                 break;
 
             case 15: /* Extensive array data block */
                 if (info.retries[i][0] != 1)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (info.retries[i][1] != 1000)
-                    TEST_ERROR
+                    TEST_ERROR;
                 break;
 
             case 17: /* Fixed array header */
                 if (info.retries[i][0] != 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (info.retries[i][1] != 10000)
-                    TEST_ERROR
+                    TEST_ERROR;
                 break;
 
             case 20: /* File's superblock */
                 if (info.retries[i][0] != 2)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (info.retries[i][1] != 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 break;
 
             default:
                 if (info.retries[i] != NULL)
-                    TEST_ERROR
+                    TEST_ERROR;
                 break;
         }
     }
@@ -1310,55 +1310,55 @@ test_metadata_read_retry_info(hid_t in_fapl)
 
     /* Closing */
     if (H5Dclose(did1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a copy of the file access property list */
     if ((new_fapl = H5Pcopy(fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the number of metadata read attempts to 101 */
     if (H5Pset_metadata_read_attempts(new_fapl, 101) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the file with SWMR access */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, new_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if ((f = (H5F_t *)H5VL_object(fid)) == NULL)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* File's superblock: log retry 1 for 1 time */
     if (H5F_track_metadata_read_retries(f, H5AC_SUPERBLOCK_ID, 1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the collection of metadata read retries */
     if (H5Fget_metadata_read_retry_info(fid, &info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should be 3 */
     if (info.nbins != 3)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify retries info */
     for (i = 0; i < H5F_NUM_METADATA_READ_RETRY_TYPES; i++) {
         switch (i) {
             case 20: /* File's superblock */
                 if (info.retries[i][0] != 1)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (info.retries[i][1] != 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 if (info.retries[i][2] != 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 break;
 
             default:
                 if (info.retries[i] != NULL)
-                    TEST_ERROR
+                    TEST_ERROR;
                 break;
         }
     }
@@ -1370,9 +1370,9 @@ test_metadata_read_retry_info(hid_t in_fapl)
 
     /* Closing */
     if (H5Pclose(new_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 3: Tests on retrieving the collection of retries
@@ -1388,39 +1388,39 @@ test_metadata_read_retry_info(hid_t in_fapl)
      */
     /* Open the file without SWMR access */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open fid */
     if ((fid1 = H5Freopen(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve retries information for fid */
     if (H5Fget_metadata_read_retry_info(fid, &info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve retries information for fid1*/
     if (H5Fget_metadata_read_retry_info(fid1, &info1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should be 0 */
     if (info.nbins != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (info1.nbins != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should be all NULL */
     for (i = 0; i < H5F_NUM_METADATA_READ_RETRY_TYPES; i++) {
         if (info.retries[i] != NULL)
-            TEST_ERROR
+            TEST_ERROR;
         if (info1.retries[i] != NULL)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* Closing */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Open a file with SWMR access, default # of read attempts:
@@ -1430,71 +1430,71 @@ test_metadata_read_retry_info(hid_t in_fapl)
      */
     /* Open the file with SWMR access */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object for fid */
     if ((f = (H5F_t *)H5VL_object(fid)) == NULL)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open fid */
     if ((fid1 = H5Freopen(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object for fid1 */
     if ((f1 = (H5F_t *)H5VL_object(fid1)) == NULL)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* For fid: fixed array data block page--log retry 9 for 500 times */
     for (i = 0; i < 500; i++) {
         if (H5F_track_metadata_read_retries(f, H5AC_FARRAY_DBLK_PAGE_ID, 9) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
 
     /* For fid1: free-space sections--log retry 99 for 1000 times */
     for (i = 0; i < 1000; i++) {
         if (H5F_track_metadata_read_retries(f1, H5AC_FSPACE_SINFO_ID, 99) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
 
     /* Retrieve the collection of metadata read retries for fid */
     if (H5Fget_metadata_read_retry_info(fid, &info) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the collection of metadata read retries for fid1 */
     if (H5Fget_metadata_read_retry_info(fid1, &info1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify nbins for fid & fid1: should be 2 */
     if (info.nbins != 2)
-        TEST_ERROR
+        TEST_ERROR;
     if (info1.nbins != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify retries for fid: fixed array data block page */
     if (info.retries[19][0] != 500)
-        TEST_ERROR
+        TEST_ERROR;
     if (info.retries[19][1] != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify retries for fid: free-space sections */
     /* (Since file was re-opened) */
     if (info.retries[9][0] != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (info.retries[9][1] != 1000)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify retries for fid1: free-space sections */
     if (info1.retries[9][0] != 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (info1.retries[9][1] != 1000)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify retries for fid1: fixed array data block page */
     /* (Since file was re-opened) */
     if (info1.retries[19][0] != 500)
-        TEST_ERROR
+        TEST_ERROR;
     if (info1.retries[19][1] != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free memory for info.retries and info1.retries */
     for (i = 0; i < H5F_NUM_METADATA_READ_RETRY_TYPES; i++) {
@@ -1506,12 +1506,12 @@ test_metadata_read_retry_info(hid_t in_fapl)
 
     /* Closing */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -1592,14 +1592,14 @@ test_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
     /* Get a copy of the parameter fapl (non-latest-format) */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (new_format) {
         TESTING("H5Fstart_swmr_write() when creating/opening a file with latest format");
 
         /* Set to use the latest library format */
         if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     else {
         TESTING("H5Fstart_swmr_write() when creating/opening a file without latest format");
@@ -1615,15 +1615,15 @@ test_start_swmr_write(hid_t in_fapl, hbool_t new_format)
     /* Create the file with SWMR write + non-latest-format */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC | (new_format ? 0 : H5F_ACC_SWMR_WRITE), H5P_DEFAULT,
                          fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the file's access_property list */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts from the file's fapl */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should be 100 */
     if (attempts != (unsigned int)(new_format ? H5F_METADATA_READ_ATTEMPTS : H5F_SWMR_METADATA_READ_ATTEMPTS))
@@ -1631,13 +1631,13 @@ test_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
     /* Close the property list */
     if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create "dataset1" */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl, 1, chunk_dim) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sid1 = H5Screate_simple(1, dim, max_dim)) < 0)
         FAIL_STACK_ERROR;
     if ((did1 = H5Dcreate2(fid, "dataset1", H5T_NATIVE_INT, sid1, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -1662,10 +1662,10 @@ test_start_swmr_write(hid_t in_fapl, hbool_t new_format)
     H5E_END_TRY;
     if (new_format) {
         if (ret < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read from the dataset */
     if (H5Dread(did1, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &rdata) < 0)
@@ -1673,7 +1673,7 @@ test_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
     /* Verify the data is correct */
     if (wdata != rdata)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close "dataset1", dataspace, dataset creation property list */
     if (H5Dclose(did1) < 0)
@@ -1685,11 +1685,11 @@ test_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
     /* Get the file's access_property list */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should be 100 */
     if (attempts != H5F_SWMR_METADATA_READ_ATTEMPTS)
@@ -1713,11 +1713,11 @@ test_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
     /* Get the file's access_property list */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should be 1 */
     if (attempts != H5F_METADATA_READ_ATTEMPTS)
@@ -1746,13 +1746,13 @@ test_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
     /* Create a group */
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create "dataset2" in the group, keep it open */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl, 2, chunk_dim2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sid2 = H5Screate_simple(2, dim2, max_dim2)) < 0)
         FAIL_STACK_ERROR;
     if ((did2 = H5Dcreate2(gid, "dataset2", H5T_NATIVE_INT, sid2, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -1770,11 +1770,11 @@ test_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
     /* Get the file's access_property list */
     if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the # of read attempts */
     if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should be 100 */
     if (attempts != H5F_SWMR_METADATA_READ_ATTEMPTS)
@@ -1821,9 +1821,9 @@ test_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
     /* Create "dataset3" */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl, 2, chunk_dim2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((sid3 = H5Screate_simple(2, dim2, max_dim2)) < 0)
         FAIL_STACK_ERROR;
     if ((did3 = H5Dcreate2(fid, "dataset3", H5T_NATIVE_INT, sid3, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -1952,19 +1952,19 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
     /* Create a copy of the input parameter in_fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if ((new_fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Set to use the latest library format */
     if (H5Pset_libver_bounds(new_fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (new_format) {
         TESTING("H5Fstart_swmr_write() on failure conditions for latest format");
 
         if ((fapl = H5Pcopy(new_fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     else {
         TESTING("H5Fstart_swmr_write() on failure conditions for without latest format");
@@ -1989,7 +1989,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Fclose(fid) < 0)
         FAIL_STACK_ERROR;
@@ -2000,7 +2000,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
         /* Create the file with write + latest format */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create and commit a named datatype */
         if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
@@ -2015,7 +2015,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close the datatype */
         if (H5Tclose(tid) < 0)
@@ -2033,7 +2033,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
         /* Create a file with write + non-latest-format */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Should fail to enable SWMR writing because the file's superblock version is not at least 3 */
         H5E_BEGIN_TRY
@@ -2042,7 +2042,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(fid) < 0)
             FAIL_STACK_ERROR;
@@ -2071,7 +2071,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
@@ -2090,7 +2090,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
@@ -2109,7 +2109,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
@@ -2142,7 +2142,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the datatype */
     if (H5Tclose(tid) < 0)
@@ -2155,7 +2155,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the attribute */
     if (H5Aclose(aid) < 0)
@@ -2194,7 +2194,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
     /* Should succeed in enabling SWMR writing mode */
     if (H5Fstart_swmr_write(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should fail for a second call to enable SWMR writing mode */
     H5E_BEGIN_TRY
@@ -2203,7 +2203,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
@@ -2217,7 +2217,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
     /* Should succeed in enabling SWMR writing mode */
     if (H5Fstart_swmr_write(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the same file */
     if ((fid2 = H5Freopen(fid)) < 0)
@@ -2230,7 +2230,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the files */
     if (H5Fclose(fid) < 0)
@@ -2250,7 +2250,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
 
     /* Should succeed in enabling SWMR writing for fid */
     if (H5Fstart_swmr_write(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Should fail to enable SWMR writing for fid2 */
     H5E_BEGIN_TRY
@@ -2259,7 +2259,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the files */
     if (H5Fclose(fid) < 0)
@@ -2289,7 +2289,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
         }
         H5E_END_TRY;
         if (bad_fid >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Case 2 */
 
@@ -2301,7 +2301,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
         }
         H5E_END_TRY;
         if (bad_fid >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Case 3 */
 
@@ -2316,7 +2316,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(fid) < 0)
             FAIL_STACK_ERROR;
@@ -2334,7 +2334,7 @@ test_err_start_swmr_write(hid_t in_fapl, hbool_t new_format)
         }
         H5E_END_TRY;
         if (ret >= 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (H5Fclose(fid) < 0)
             FAIL_STACK_ERROR;
@@ -2447,7 +2447,7 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
     }
 
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -2455,23 +2455,23 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
     if (new_format) {
         /* Set to use the latest library format */
         if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create the test file */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     else {
         /* Create the test file without latest format but with SWMR write */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC | H5F_ACC_SWMR_WRITE, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Create a chunked dataset with 1 extendible dimension */
     if ((sid = H5Screate_simple(1, dims, maxdims)) < 0)
         FAIL_STACK_ERROR;
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl, 1, chunk_dims) < 0)
         FAIL_STACK_ERROR;
     if ((did = H5Dcreate2(fid, "dataset", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -2479,17 +2479,17 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      *  Case (1):
@@ -2499,7 +2499,7 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         int child_notify = 0;
@@ -2533,11 +2533,11 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -2550,19 +2550,19 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* Wait for child process to complete */
     if ((tmppid = HDwaitpid(childpid, &child_status, child_wait_option)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check exit status of child process */
     if (WIFEXITED(child_status)) {
         if ((child_exit_val = WEXITSTATUS(child_status)) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else /* child process terminated abnormally */
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      *  Case (2):
@@ -2572,13 +2572,13 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* Create 2 pipes */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDpipe(in_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) {                        /* Child process */
         hid_t child_fid1 = -1, child_fid2;      /* File IDs */
@@ -2670,16 +2670,16 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Close unused write end for in_pdf */
     if (HDclose(in_pdf[1]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid1 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* open "dataset", keep it open */
     if ((did1 = H5Dopen2(fid1, "dataset", H5P_DEFAULT)) < 0)
@@ -2700,7 +2700,7 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* Enable SWMR writing mode */
     if (H5Fstart_swmr_write(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -2729,11 +2729,11 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* Close the dataset */
     if (H5Dclose(did1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the pipes */
     if (HDclose(out_pdf[1]) < 0)
@@ -2743,21 +2743,21 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* Wait for child process to complete */
     if ((tmppid = HDwaitpid(childpid, &child_status, child_wait_option)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check exit status of child process */
     if (WIFEXITED(child_status)) {
         if ((child_exit_val = WEXITSTATUS(child_status)) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else /* Child process terminated abnormally */
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      *  Case (3):
@@ -2766,11 +2766,11 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
      */
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         int child_notify = 0;
@@ -2799,15 +2799,15 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Enable SWMR writing mode */
     if (H5Fstart_swmr_write(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -2820,19 +2820,19 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* Wait for child process to complete */
     if ((tmppid = HDwaitpid(childpid, &child_status, child_wait_option)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check exit status of child process */
     if (WIFEXITED(child_status)) {
         if ((child_exit_val = WEXITSTATUS(child_status)) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else /* Child process terminated abnormally */
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      *  Case (4):
@@ -2842,11 +2842,11 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         int child_notify = 0;
@@ -2879,15 +2879,15 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Enable SWMR writing mode */
     if (H5Fstart_swmr_write(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -2896,23 +2896,23 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* Close the pipe */
     if (HDclose(out_pdf[1]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Wait for child process to complete */
     if ((tmppid = HDwaitpid(childpid, &child_status, child_wait_option)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check exit status of child process */
     if (WIFEXITED(child_status)) {
         if ((child_exit_val = WEXITSTATUS(child_status)) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else /* Child process terminated abnormally */
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      *  Case (5):
@@ -2922,11 +2922,11 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         int child_notify = 0;
@@ -2959,15 +2959,15 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Enable SWMR writing mode */
     if (H5Fstart_swmr_write(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -2980,23 +2980,23 @@ test_start_swmr_write_concur(hid_t in_fapl, hbool_t new_format)
 
     /* Wait for child process to complete */
     if ((tmppid = HDwaitpid(childpid, &child_status, child_wait_option)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check exit status of child process */
     if (WIFEXITED(child_status)) {
         if ((child_exit_val = WEXITSTATUS(child_status)) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else /* Child process terminated abnormally */
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the property list */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -3049,18 +3049,18 @@ test_start_swmr_write_stress_ohdr(hid_t in_fapl)
     HDmemset(attr_data, 0, sizeof(attr_data));
 
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
     /* Set to use the latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the test file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a chunked dataset with 2 extendible dimensions */
     if ((sid = H5Screate_simple(1, dims, maxdims)) < 0)
@@ -3070,7 +3070,7 @@ test_start_swmr_write_stress_ohdr(hid_t in_fapl)
     if (H5Tset_size(tid, 256) < 0)
         FAIL_STACK_ERROR;
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl, 1, chunk_dims) < 0)
         FAIL_STACK_ERROR;
     if (H5Pset_fill_value(dcpl, tid, &fill) < 0)
@@ -3095,7 +3095,7 @@ test_start_swmr_write_stress_ohdr(hid_t in_fapl)
     if (H5Tset_size(tid, 256) < 0)
         FAIL_STACK_ERROR;
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl, 1, chunk_dims) < 0)
         FAIL_STACK_ERROR;
     if (H5Pset_fill_value(dcpl, tid, &fill) < 0)
@@ -3105,15 +3105,15 @@ test_start_swmr_write_stress_ohdr(hid_t in_fapl)
 
     /* Close the second dataset */
     if (H5Dclose(did2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the objects for the dataset creation */
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create attribute on original dataset, to push dataspace header message out of header chunk #0 */
     if ((sid = H5Screate(H5S_SCALAR)) < 0)
@@ -3129,11 +3129,11 @@ test_start_swmr_write_stress_ohdr(hid_t in_fapl)
     if (H5Awrite(aid, tid, attr_data) < 0)
         FAIL_STACK_ERROR;
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(tid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Aclose(aid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the chunk # for the dataspace message */
     chunk_num = UINT_MAX;
@@ -3149,15 +3149,15 @@ test_start_swmr_write_stress_ohdr(hid_t in_fapl)
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the FAPL */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -3239,7 +3239,7 @@ test_object_flush_cb(hid_t in_fapl)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Case (2)
@@ -3249,14 +3249,14 @@ test_object_flush_cb(hid_t in_fapl)
 
     /* Create a copy of file access property list */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve object flush property values for the default file access property list */
     if (H5Pget_object_flush_cb(fapl, &ret_cb, &ret_ct) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     /* Should be null */
     if (ret_cb != NULL || ret_ct != NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Case (3)
@@ -3265,18 +3265,18 @@ test_object_flush_cb(hid_t in_fapl)
      */
     /* Set the object flush property */
     if (H5Pset_object_flush_cb(fapl, flush_cb, &flush_ct) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Increment the counter */
     ++flush_ct;
 
     /* Retrieve object flush property values for the non-default file access property list */
     if (H5Pget_object_flush_cb(fapl, &ret_cb, &ret_ct) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify expected values */
     if (ret_cb != flush_cb || *(unsigned *)ret_ct != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the property list */
     if (H5Pclose(fapl) < 0)
@@ -3295,18 +3295,18 @@ test_object_flush_cb(hid_t in_fapl)
 
     /* Make a copy of the input parameter in_fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to use the latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
     /* Create the test file: without setting object flush property in fapl */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the file's file access property list */
     if ((ffapl = H5Fget_access_plist(fid)) < 0)
@@ -3314,11 +3314,11 @@ test_object_flush_cb(hid_t in_fapl)
 
     /* Retrieve the object flush property values */
     if (H5Pget_object_flush_cb(ffapl, &ret_cb, &ret_ct) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify expected values */
     if (ret_cb != NULL || ret_ct != NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Pclose(ffapl) < 0)
@@ -3340,7 +3340,7 @@ test_object_flush_cb(hid_t in_fapl)
 
     /* Set the object flush property */
     if (H5Pset_object_flush_cb(fapl, flush_cb, &flush_ct) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file: with object flush property setting in fapl */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
@@ -3352,7 +3352,7 @@ test_object_flush_cb(hid_t in_fapl)
 
     /* Create a dataset */
     if ((did1 = H5Dcreate2(fid, "dataset1", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Initialize data buffer */
     for (i = 0; i < 50; i++)
@@ -3372,31 +3372,31 @@ test_object_flush_cb(hid_t in_fapl)
 
     /* Retrieve the object flush property values */
     if (H5Pget_object_flush_cb(ffapl, &ret_cb, &ret_ct) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify expected values */
     if (ret_cb != flush_cb || *(unsigned *)ret_ct != 1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a group */
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Flush the group */
     if (H5Gflush(gid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve the object flush property values */
     if (H5Pget_object_flush_cb(ffapl, &ret_cb, &ret_ct) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify expected values */
     if (ret_cb != flush_cb || *(unsigned *)ret_ct != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a dataset */
     if ((did2 = H5Dcreate2(gid, "dataset2", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Flush the dataset */
     if (H5Dflush(did2) < 0)
@@ -3404,11 +3404,11 @@ test_object_flush_cb(hid_t in_fapl)
 
     /* Retrieve the object flush property values */
     if (H5Pget_object_flush_cb(ffapl, &ret_cb, &ret_ct) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify expected values */
     if (ret_cb != flush_cb || *(unsigned *)ret_ct != 3)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Sclose(sid) < 0)
@@ -3507,17 +3507,17 @@ test_append_flush_generic(void)
 
     /* Create a copy of dataset access property list */
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the append flush property values */
     if (H5Pget_append_flush(dapl, 2, ret_boundary, &ret_cb, (void **)&ret_count) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Verify expected values */
     if (ret_boundary[0] != 0 || ret_boundary[1] != 0)
         TEST_ERROR;
     if (ret_cb != NULL || ret_count != NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the property list */
     if (H5Pclose(dapl) < 0)
@@ -3534,7 +3534,7 @@ test_append_flush_generic(void)
 
     /* Create a copy of dataset access property list */
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Invalid dataset rank: zero value */
     H5E_BEGIN_TRY
@@ -3543,7 +3543,7 @@ test_append_flush_generic(void)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Invalid dataset rank: > H5S_MAX_RANK */
     H5E_BEGIN_TRY
@@ -3552,7 +3552,7 @@ test_append_flush_generic(void)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* No boundary specified */
     H5E_BEGIN_TRY
@@ -3561,7 +3561,7 @@ test_append_flush_generic(void)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set up a valid boundary */
     boundary[0] = 1;
@@ -3574,7 +3574,7 @@ test_append_flush_generic(void)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Invalid boundary size: negative value */
     boundary[0] = (hsize_t)-1;
@@ -3585,7 +3585,7 @@ test_append_flush_generic(void)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Invalid boundary size: H5S_UNLIMITED */
     boundary[0] = 1;
@@ -3596,7 +3596,7 @@ test_append_flush_generic(void)
     }
     H5E_END_TRY;
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Case (3)
@@ -3614,16 +3614,16 @@ test_append_flush_generic(void)
 
     /* Verify expected values: with boundary rank > set boundary rank */
     if (H5Pget_append_flush(dapl, 3, ret_boundary, &ret_cb, (void **)&ret_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ret_boundary[0] != 1 || ret_boundary[1] != 1 || boundary[2] != 0)
         TEST_ERROR;
     if (ret_cb == NULL || ret_count == NULL || *ret_count != 2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify expected values: with boundary rank < set boundary rank */
     HDmemset(ret_boundary, 0, sizeof(ret_boundary));
     if (H5Pget_append_flush(dapl, 1, ret_boundary, NULL, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ret_boundary[0] != 1 || ret_boundary[1] != 0 || boundary[2] != 0)
         TEST_ERROR;
 
@@ -3697,42 +3697,42 @@ test_append_flush_dataset_chunked(hid_t in_fapl)
 
     /* Get a copy of the input parameter in_fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to use the latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
     /* Create the test file to work on */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a chunked dataset with 1 extendible dimension */
     if ((sid = H5Screate_simple(2, dims, maxdims)) < 0)
         FAIL_STACK_ERROR;
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl, 2, chunk_dims) < 0)
         FAIL_STACK_ERROR;
     if ((did1 = H5Dcreate2(fid, "dataset1", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the dataset's access property list */
     if ((ddapl = H5Dget_access_plist(did1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the append flush property values */
     if (H5Pget_append_flush(ddapl, 3, ret_boundary, &ret_cb, (void **)&ret_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify expected values */
     if (ret_boundary[0] != 0 || ret_boundary[1] != 0 || ret_boundary[2] != 0)
         TEST_ERROR;
     if (ret_cb != NULL || ret_count != NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset's access property list */
     if (H5Pclose(ddapl) < 0)
@@ -3749,12 +3749,12 @@ test_append_flush_dataset_chunked(hid_t in_fapl)
      */
     /* Create a copy of dataset access property list */
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set boundary dimension rank > the rank of dataset to be created */
     HDmemset(boundary, 0, sizeof(boundary));
     if (H5Pset_append_flush(dapl, 3, boundary, NULL, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should fail to Create the dataset */
     H5E_BEGIN_TRY
@@ -3763,12 +3763,12 @@ test_append_flush_dataset_chunked(hid_t in_fapl)
     }
     H5E_END_TRY;
     if (did2 >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set boundary for a non-extendible dimension */
     boundary[0] = boundary[1] = 1;
     if (H5Pset_append_flush(dapl, 2, boundary, NULL, NULL) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should fail to create the dataset */
     H5E_BEGIN_TRY
@@ -3777,7 +3777,7 @@ test_append_flush_dataset_chunked(hid_t in_fapl)
     }
     H5E_END_TRY;
     if (did2 >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create and close the dataset */
     if ((did2 = H5Dcreate2(fid, "dataset2", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -3792,7 +3792,7 @@ test_append_flush_dataset_chunked(hid_t in_fapl)
     }
     H5E_END_TRY;
     if (did2 >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      *  Case (3)--
@@ -3806,33 +3806,33 @@ test_append_flush_dataset_chunked(hid_t in_fapl)
     boundary[0] = 0;
     boundary[1] = 1;
     if (H5Pset_append_flush(dapl, 2, boundary, append_cb, &count) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did2 = H5Dopen2(fid, "dataset2", dapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the dataset's access property list */
     if ((ddapl = H5Dget_access_plist(did2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     HDmemset(ret_boundary, 0, sizeof(ret_boundary));
     ret_cb    = NULL;
     ret_count = NULL;
     /* Retrieve the append flush property values */
     if (H5Pget_append_flush(ddapl, 3, ret_boundary, &ret_cb, (void **)&ret_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify expected values */
     if (ret_cb != append_cb || ret_count != &count)
-        TEST_ERROR
+        TEST_ERROR;
     if (ret_boundary[0] != 0 || ret_boundary[1] != 1 || ret_boundary[2] != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDmemset(ret_boundary, 0, sizeof(ret_boundary));
     /* Retrieve the append flush property values */
     if (H5Pget_append_flush(ddapl, 1, ret_boundary, NULL, NULL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (ret_boundary[0] != 0 || ret_boundary[1] != 0 || ret_boundary[2] != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Pclose(ddapl) < 0)
@@ -3917,38 +3917,38 @@ test_append_flush_dataset_fixed(hid_t in_fapl)
 
     /* Get a copy of the input parameter in_fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to use the latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
     /* Create the test file to work on */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataset */
     if ((sid = H5Screate_simple(1, dims, dims)) < 0)
         FAIL_STACK_ERROR;
     if ((did1 = H5Dcreate2(fid, "dataset1", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the dataset's access property list */
     if ((ddapl = H5Dget_access_plist(did1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the append flush property values */
     if (H5Pget_append_flush(ddapl, 3, ret_boundary, &ret_cb, (void **)&ret_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify expected values */
     if (ret_boundary[0] != 0 || ret_boundary[1] != 0 || ret_boundary[2] != 0)
         TEST_ERROR;
     if (ret_cb != NULL || ret_count != NULL)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset's access property list */
     if (H5Pclose(ddapl) < 0)
@@ -3966,30 +3966,30 @@ test_append_flush_dataset_fixed(hid_t in_fapl)
      */
     /* Create a copy of dataset access property list */
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     boundary[0] = 1;
     boundary[1] = boundary[2] = 0;
     if (H5Pset_append_flush(dapl, 3, boundary, append_cb, &count) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Should succeed to create the dataset: append flush property has no effect */
     if ((did2 = H5Dcreate2(fid, "dataset2", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the dataset's access property list */
     if ((ddapl = H5Dget_access_plist(did2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the append flush property values */
     if (H5Pget_append_flush(ddapl, 3, ret_boundary, &ret_cb, (void **)&ret_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify expected values */
     if (ret_cb != NULL || ret_count != NULL)
-        TEST_ERROR
+        TEST_ERROR;
     if (ret_boundary[0] != 0 || ret_boundary[1] != 0 || ret_boundary[2] != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Pclose(ddapl) < 0)
@@ -3999,24 +3999,24 @@ test_append_flush_dataset_fixed(hid_t in_fapl)
 
     /* Should succeed in opening the dataset: append flush property has no effect */
     if ((did2 = H5Dopen2(fid, "dataset2", dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the dataset's access property list */
     if ((ddapl = H5Dget_access_plist(did2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the append flush property values */
     if (H5Pget_append_flush(ddapl, 3, ret_boundary, &ret_cb, (void **)&ret_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify expected values */
     if (ret_cb != NULL || ret_count != NULL)
-        TEST_ERROR
+        TEST_ERROR;
     if (ret_boundary[0] != 0 || ret_boundary[1] != 0 || ret_boundary[2] != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Dclose(did2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /*
      *  Case (3)--
      *  For a non-chunked dataset's access property list:
@@ -4027,23 +4027,23 @@ test_append_flush_dataset_fixed(hid_t in_fapl)
 
     HDmemset(boundary, 0, sizeof(boundary));
     if (H5Pset_append_flush(dapl, 1, boundary, append_cb, &count) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did2 = H5Dopen2(fid, "dataset2", dapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the dataset's access property list */
     if ((ddapl = H5Dget_access_plist(did2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the append flush property values */
     if (H5Pget_append_flush(ddapl, 1, ret_boundary, &ret_cb, (void **)&ret_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify expected values */
     if (ret_cb != NULL || ret_count != NULL)
-        TEST_ERROR
+        TEST_ERROR;
     if (ret_boundary[0] != 0 || ret_boundary[1] != 0 || ret_boundary[2] != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Pclose(ddapl) < 0)
@@ -4143,41 +4143,41 @@ test_append_flush_dataset_multiple(hid_t in_fapl)
 
     /* Create a copy of dataset access property list */
     if ((dapl1 = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dapl2 = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     boundary1[0] = 0;
     boundary1[1] = 1;
     count1       = 0;
     if (H5Pset_append_flush(dapl1, 2, boundary1, append_cb, &count1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     boundary2[0] = 1;
     boundary2[1] = 0;
     count2       = 0;
     if (H5Pset_append_flush(dapl2, 2, boundary2, append_cb2, &count2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a copy of the input parameter in_fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to use the latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
 
     /* Create the test file to work on */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a chunked dataset with 2 extendible dimensions */
     if ((sid = H5Screate_simple(2, dims, maxdims)) < 0)
         FAIL_STACK_ERROR;
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl, 2, chunk_dims) < 0)
         FAIL_STACK_ERROR;
     if ((did1 = H5Dcreate2(fid, "dataset1", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, dapl1)) < 0)
@@ -4189,17 +4189,17 @@ test_append_flush_dataset_multiple(hid_t in_fapl)
 
     /* Get the dataset's access property list for did1 */
     if ((ddapl = H5Dget_access_plist(did1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the append flush property values */
     if (H5Pget_append_flush(ddapl, 3, ret_boundary, &ret_cb, (void **)&ret_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify expected values: should be the setting in dapl1 */
     if (ret_boundary[0] != 0 || ret_boundary[1] != 1 || ret_boundary[2] != 0)
         TEST_ERROR;
     if (ret_cb != append_cb || ret_count != &count1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset's access property list */
     if (H5Pclose(ddapl) < 0)
@@ -4207,17 +4207,17 @@ test_append_flush_dataset_multiple(hid_t in_fapl)
 
     /* Get the dataset's access property list for did2 */
     if ((ddapl = H5Dget_access_plist(did2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the append flush property values */
     if (H5Pget_append_flush(ddapl, 3, ret_boundary, &ret_cb, (void **)&ret_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify expected values: should be the setting in dapl1 */
     if (ret_boundary[0] != 0 || ret_boundary[1] != 1 || ret_boundary[2] != 0)
         TEST_ERROR;
     if (ret_cb != append_cb || ret_count != &count1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset's access property list */
     if (H5Pclose(ddapl) < 0)
@@ -4251,17 +4251,17 @@ test_append_flush_dataset_multiple(hid_t in_fapl)
 
     /* Get the dataset's access property list for did1 */
     if ((ddapl = H5Dget_access_plist(did1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the append flush property values */
     if (H5Pget_append_flush(ddapl, 3, ret_boundary, &ret_cb, (void **)&ret_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify expected values: should be the setting in dapl2 */
     if (ret_boundary[0] != 1 || ret_boundary[1] != 0 || ret_boundary[2] != 0)
         TEST_ERROR;
     if (ret_cb != append_cb2 || ret_count != &count2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the access property list */
     if (H5Pclose(ddapl) < 0)
@@ -4269,17 +4269,17 @@ test_append_flush_dataset_multiple(hid_t in_fapl)
 
     /* Get the dataset's access property list for did2 */
     if ((ddapl = H5Dget_access_plist(did2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Retrieve the append flush property values */
     if (H5Pget_append_flush(ddapl, 3, ret_boundary, &ret_cb, (void **)&ret_count) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify expected values: should be the setting in dapl2 */
     if (ret_boundary[0] != 1 || ret_boundary[1] != 0 || ret_boundary[2] != 0)
         TEST_ERROR;
     if (ret_cb != append_cb2 || ret_count != &count2)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Closing */
     if (H5Pclose(ddapl) < 0)
@@ -4344,9 +4344,9 @@ test_file_lock_same(hid_t in_fapl)
 
     /* Set locking in the fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_file_locking(fapl, TRUE, TRUE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[1], fapl, filename, sizeof(filename));
@@ -4356,76 +4356,76 @@ test_file_lock_same(hid_t in_fapl)
      */
     /* Create file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get and check file intent */
     if (H5Fget_intent(fid, &intent) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (intent != H5F_ACC_RDWR)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the same file with RDWR */
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get and check the intent */
     if (H5Fget_intent(fid2, &intent) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (intent != H5F_ACC_RDWR)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 2: 1) RDWR 2) RDONLY : should succeed
      */
     /* Open file with RDWR */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get and check the intent */
     if (H5Fget_intent(fid, &intent) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (intent != H5F_ACC_RDWR)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open file with RDONLY */
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get and check the intent: should get intent from 1st open */
     if (H5Fget_intent(fid2, &intent) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (intent != H5F_ACC_RDWR)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 3: 1) RDONLY 2) RDWR : should fail
      */
     /* Open file with RDONLY */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get and check the intent */
     if (H5Fget_intent(fid, &intent) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (intent != H5F_ACC_RDONLY)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open file with RDWR should fail */
     H5E_BEGIN_TRY
@@ -4434,46 +4434,46 @@ test_file_lock_same(hid_t in_fapl)
     }
     H5E_END_TRY;
     if (fid2 >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close first file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 4: 1) RDONLY 2) RDONLY : should succeed
      */
     /* Open file with RDONLY */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get and check the intent */
     if (H5Fget_intent(fid, &intent) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (intent != H5F_ACC_RDONLY)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open file with RDONLY */
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get and check the intent */
     if (H5Fget_intent(fid2, &intent) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (intent != H5F_ACC_RDONLY)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the property list */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -4512,22 +4512,22 @@ test_file_lock_swmr_same(hid_t in_fapl)
 
     /* Set locking in the fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[1], fapl, filename, sizeof(filename));
 
     /* Set to use latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Cases a, b, c, d: H5Fopen failure cases
@@ -4542,7 +4542,7 @@ test_file_lock_swmr_same(hid_t in_fapl)
     }
     H5E_END_TRY;
     if (fid >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Case b: RDWR|SWMM_WRTE|SWMR_READ : should fail
@@ -4553,7 +4553,7 @@ test_file_lock_swmr_same(hid_t in_fapl)
     }
     H5E_END_TRY;
     if (fid >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Case c: RDONLY|SWMM_WRITE : should fail
@@ -4564,7 +4564,7 @@ test_file_lock_swmr_same(hid_t in_fapl)
     }
     H5E_END_TRY;
     if (fid >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Case d: RDONLY|SWMM_WRITE|SWMR_READ : should fail
@@ -4575,7 +4575,7 @@ test_file_lock_swmr_same(hid_t in_fapl)
     }
     H5E_END_TRY;
     if (fid >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Cases 1 - 12: combinations of different flags for 1st and 2nd opens
@@ -4585,7 +4585,7 @@ test_file_lock_swmr_same(hid_t in_fapl)
      * Case 1: 1) RDWR 2) RDWR|SWMR_WRITE : should fail
      */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -4593,95 +4593,95 @@ test_file_lock_swmr_same(hid_t in_fapl)
     }
     H5E_END_TRY;
     if (fid2 >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 2: 1) RDWR 2) RDONLY|SWMR_READ : should succeed
      */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 3: 1) RDWR|SWMR_WRITE 2)RDWR : should succeed
      */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 4: 1) RDWR|SWMR_WRITE 2) RDWR|SWMR_WRITE : should succeed
      */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 5: 1) RDWR|SWMR_WRITE 2) RDONLY|SWMR_READ : should succeed
      */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 6: 1) RDWR|SWMR_WRITE 2) RDONLY : should succeed
      */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 7: 1) RDONLY|SWMR_READ 2)RDWR : should fail
      */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -4689,17 +4689,17 @@ test_file_lock_swmr_same(hid_t in_fapl)
     }
     H5E_END_TRY;
     if (fid2 >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 8: 1) RDONLY|SWMR_READ 2) RDWR|SWMR_WRITE : should fail
      */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -4707,49 +4707,49 @@ test_file_lock_swmr_same(hid_t in_fapl)
     }
     H5E_END_TRY;
     if (fid2 >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 9: 1) RDONLY|SWMR_READ 2) RDONLY|SWMR_READ : should succeed
      */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 10: 1) RDONLY|SWMR_READ 2) RDONLY : should succeed
      */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 11: 1) RDONLY 2) RDWR|SWMR_WRITE: should fail
      */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -4757,17 +4757,17 @@ test_file_lock_swmr_same(hid_t in_fapl)
     }
     H5E_END_TRY;
     if (fid2 >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 12: 1) RDONLY 2) RDONLY|SWMR_READ : should fail
      */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     H5E_BEGIN_TRY
     {
@@ -4775,15 +4775,15 @@ test_file_lock_swmr_same(hid_t in_fapl)
     }
     H5E_END_TRY;
     if (fid2 >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the property list */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -4841,20 +4841,20 @@ test_file_lock_concur(hid_t in_fapl)
 
     /* Set locking in the fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_file_locking(fapl, TRUE, TRUE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[1], fapl, filename, sizeof(filename));
 
     /* Create the test file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 1: 1) RDWR 2) RDWR : should fail
@@ -4862,11 +4862,11 @@ test_file_lock_concur(hid_t in_fapl)
 
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         hid_t child_fid; /* File ID */
@@ -4902,11 +4902,11 @@ test_file_lock_concur(hid_t in_fapl)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -4919,31 +4919,31 @@ test_file_lock_concur(hid_t in_fapl)
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if child terminated normally */
     if (WIFEXITED(child_status)) {
         /* Check exit status of the child */
         if (WEXITSTATUS(child_status) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 2: 1) RDWR 2) RDONLY : should fail
      */
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         hid_t child_fid; /* File ID */
@@ -4979,11 +4979,11 @@ test_file_lock_concur(hid_t in_fapl)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Opens the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -4996,20 +4996,20 @@ test_file_lock_concur(hid_t in_fapl)
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if child terminated normally */
     if (WIFEXITED(child_status)) {
         /* Check exit status of the child */
         if (WEXITSTATUS(child_status) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 3: 1) RDONLY 2) RDWR : should fail
@@ -5017,11 +5017,11 @@ test_file_lock_concur(hid_t in_fapl)
 
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         hid_t child_fid; /* File ID */
@@ -5057,11 +5057,11 @@ test_file_lock_concur(hid_t in_fapl)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Opens the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -5074,20 +5074,20 @@ test_file_lock_concur(hid_t in_fapl)
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if child terminated normally */
     if (WIFEXITED(child_status)) {
         /* Check exit status of the child */
         if (WEXITSTATUS(child_status) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 4: 1) RDONLY 2) RDONLY : should succeed
@@ -5095,11 +5095,11 @@ test_file_lock_concur(hid_t in_fapl)
 
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         hid_t child_fid; /* File ID */
@@ -5140,11 +5140,11 @@ test_file_lock_concur(hid_t in_fapl)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -5157,24 +5157,24 @@ test_file_lock_concur(hid_t in_fapl)
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if child terminated normally */
     if (WIFEXITED(child_status)) {
         /* Check exit status of the child */
         if (WEXITSTATUS(child_status) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the property list */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -5234,24 +5234,24 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Set locking in the fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_file_locking(fapl, TRUE, TRUE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[2], fapl, filename, sizeof(filename));
 
     /* Set to use latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the test file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 1: 1) RDWR 2) RDWR|SWMR_WRITE : should fail
@@ -5259,11 +5259,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         hid_t child_fid; /* File ID */
@@ -5299,11 +5299,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -5316,20 +5316,20 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if child terminated normally */
     if (WIFEXITED(child_status)) {
         /* Check exit status of the child */
         if (WEXITSTATUS(child_status) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 2: 1) RDWR 2) RDONLY|SWMR_READ: should fail
@@ -5337,11 +5337,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         hid_t child_fid; /* File ID */
@@ -5377,11 +5377,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -5394,20 +5394,20 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if child terminated normally */
     if (WIFEXITED(child_status)) {
         /* Check exit status of the child */
         if (WEXITSTATUS(child_status) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 3: 1) RDWR|SWMR_WRITE 2) RDWR : should fail
@@ -5415,11 +5415,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         hid_t child_fid; /* File ID */
@@ -5455,11 +5455,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -5472,31 +5472,31 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if child terminated normally */
     if (WIFEXITED(child_status)) {
         /* Check exit status of the child */
         if (WEXITSTATUS(child_status) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 4: 1) RDWR|SWMR_WRITE 2) RDWR|SWMR_WRITE : should fail
      */
 
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         hid_t child_fid; /* File ID */
@@ -5532,11 +5532,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -5549,31 +5549,31 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if child terminated normally */
     if (WIFEXITED(child_status)) {
         /* Check exit status of the child */
         if (WEXITSTATUS(child_status) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 5: 1) RDWR|SWMR_WRITE 2) RDONLY|SWMR_READ : should succeed
      */
 
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         hid_t child_fid; /* File ID */
@@ -5599,7 +5599,7 @@ test_file_lock_swmr_concur(hid_t in_fapl)
         /* Should succeed */
         if (child_fid >= 0) {
             if (H5Fclose(child_fid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             HDexit(EXIT_SUCCESS);
         }
 
@@ -5612,11 +5612,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -5629,31 +5629,31 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if child terminated normally */
     if (WIFEXITED(child_status)) {
         /* Check exit status of the child */
         if (WEXITSTATUS(child_status) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 6: 1) RDWR|SWMR_WRITE 2) RDONLY : should fail
      */
 
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         hid_t child_fid; /* File ID */
@@ -5689,11 +5689,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -5706,20 +5706,20 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if child terminated normally */
     if (WIFEXITED(child_status)) {
         /* Check exit status of the child */
         if (WEXITSTATUS(child_status) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 7: 1) RDONLY|SWMR_READ 2) RDWR : should fail
@@ -5727,11 +5727,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         hid_t child_fid; /* File ID */
@@ -5767,11 +5767,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -5784,20 +5784,20 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if child terminated normally */
     if (WIFEXITED(child_status)) {
         /* Check exit status of the child */
         if (WEXITSTATUS(child_status) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 8: 1) RDONLY|SWMR_READ 2) RDWR|SWMR_WRITE : should fail
@@ -5805,11 +5805,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         hid_t child_fid; /* File ID */
@@ -5845,11 +5845,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -5862,20 +5862,20 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if child terminated normally */
     if (WIFEXITED(child_status)) {
         /* Check exit status of the child */
         if (WEXITSTATUS(child_status) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 9: 1) RDONLY|SWMR_READ 2) RDONLY|SWMR_READ : should succeed
@@ -5883,11 +5883,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         hid_t child_fid; /* File ID */
@@ -5913,7 +5913,7 @@ test_file_lock_swmr_concur(hid_t in_fapl)
         /* Should succeed */
         if (child_fid >= 0) {
             if (H5Fclose(child_fid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             HDexit(EXIT_SUCCESS);
         }
 
@@ -5926,11 +5926,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -5943,20 +5943,20 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if child terminated normally */
     if (WIFEXITED(child_status)) {
         /* Check exit status of the child */
         if (WEXITSTATUS(child_status) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 10: 1) RDONLY|SWMR_READ 2) RDONLY : should succeed
@@ -5964,11 +5964,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         hid_t child_fid; /* File ID */
@@ -5986,12 +5986,12 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
         /* Open the test file */
         if ((child_fid = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Should succeed */
         if (child_fid >= 0) {
             if (H5Fclose(child_fid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             HDexit(EXIT_SUCCESS);
         }
 
@@ -6004,11 +6004,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -6021,20 +6021,20 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if child terminated normally */
     if (WIFEXITED(child_status)) {
         /* Check exit status of the child */
         if (WEXITSTATUS(child_status) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 11: 1) RDONLY 2) RDWR|SWMR_WRITE : should fail
@@ -6042,11 +6042,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         hid_t child_fid; /* File ID */
@@ -6082,11 +6082,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -6099,20 +6099,20 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if child terminated normally */
     if (WIFEXITED(child_status)) {
         /* Check exit status of the child */
         if (WEXITSTATUS(child_status) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /*
      * Case 12: 1) RDONLY 2) RDONLY|SWMR_READ : should succeed
@@ -6120,11 +6120,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) { /* Child process */
         hid_t child_fid; /* File ID */
@@ -6150,7 +6150,7 @@ test_file_lock_swmr_concur(hid_t in_fapl)
         /* Should succeed */
         if (child_fid >= 0) {
             if (H5Fclose(child_fid) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
             HDexit(EXIT_SUCCESS);
         }
 
@@ -6163,11 +6163,11 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -6180,24 +6180,24 @@ test_file_lock_swmr_concur(hid_t in_fapl)
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check if child terminated normally */
     if (WIFEXITED(child_status)) {
         /* Check exit status of the child */
         if (WEXITSTATUS(child_status) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the property list */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
 
@@ -6229,13 +6229,13 @@ test_file_locking(hid_t in_fapl, hbool_t turn_locking_on, hbool_t env_var_overri
 {
 #if !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID))
     if (turn_locking_on && env_var_override)
-        TESTING("File locking: ON w/ env var override")
+        TESTING("File locking: ON w/ env var override");
     else if (turn_locking_on && !env_var_override)
-        TESTING("File locking: ON")
+        TESTING("File locking: ON");
     else if (!turn_locking_on && env_var_override)
-        TESTING("File locking: OFF w/ env var override")
+        TESTING("File locking: OFF w/ env var override");
     else
-        TESTING("File locking: OFF")
+        TESTING("File locking: OFF");
     SKIPPED();
     HDputs("    Test skipped due to fork or waitpid not defined.");
     return 0;
@@ -6252,34 +6252,34 @@ test_file_locking(hid_t in_fapl, hbool_t turn_locking_on, hbool_t env_var_overri
     herr_t ret;
 
     if (turn_locking_on && env_var_override)
-        TESTING("File locking: ON w/ env var override")
+        TESTING("File locking: ON w/ env var override");
     else if (turn_locking_on && !env_var_override)
-        TESTING("File locking: ON")
+        TESTING("File locking: ON");
     else if (!turn_locking_on && env_var_override)
-        TESTING("File locking: OFF w/ env var override")
+        TESTING("File locking: OFF w/ env var override");
     else
-        TESTING("File locking: OFF")
+        TESTING("File locking: OFF");
 
     /* Copy the incoming fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set locking in the fapl */
     if (H5Pset_file_locking(fapl, turn_locking_on ? TRUE : FALSE, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* If requested, set the environment variable */
     if (env_var_override) {
         if (HDsetenv(HDF5_USE_FILE_LOCKING, turn_locking_on ? "FALSE" : "TRUE", TRUE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5F__reparse_file_lock_variable_test() < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else {
         if (HDsetenv(HDF5_USE_FILE_LOCKING, "", TRUE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5F__reparse_file_lock_variable_test() < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* Set the filename to use for this test (dependent on fapl) */
@@ -6287,11 +6287,11 @@ test_file_locking(hid_t in_fapl, hbool_t turn_locking_on, hbool_t env_var_overri
 
     /* Create the test file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open a file for read-only and then read-write. This will fail
      * when the locking scheme is turned on.
@@ -6299,11 +6299,11 @@ test_file_locking(hid_t in_fapl, hbool_t turn_locking_on, hbool_t env_var_overri
 
     /* Create 1 pipe */
     if (HDpipe(out_pdf) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (childpid == 0) {
 
@@ -6342,11 +6342,11 @@ test_file_locking(hid_t in_fapl, hbool_t turn_locking_on, hbool_t env_var_overri
 
     /* close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Notify child process */
     notify = 1;
@@ -6359,13 +6359,13 @@ test_file_locking(hid_t in_fapl, hbool_t turn_locking_on, hbool_t env_var_overri
 
     /* Wait for child process to complete */
     if (HDwaitpid(childpid, &child_status, child_wait_option) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check exit status of the child */
     if (WIFEXITED(child_status))
         exit_status = WEXITSTATUS(child_status);
     else
-        TEST_ERROR
+        TEST_ERROR;
 
     /* The child process should have passed or failed as follows:
      *
@@ -6375,21 +6375,21 @@ test_file_locking(hid_t in_fapl, hbool_t turn_locking_on, hbool_t env_var_overri
      * locks off, env var override:         FAIL
      */
     if (turn_locking_on && !env_var_override && (0 == exit_status))
-        TEST_ERROR
+        TEST_ERROR;
     else if (!turn_locking_on && !env_var_override && (0 != exit_status))
-        TEST_ERROR
+        TEST_ERROR;
     else if (turn_locking_on && env_var_override && (0 != exit_status))
-        TEST_ERROR
+        TEST_ERROR;
     else if (!turn_locking_on && env_var_override && (0 == exit_status))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the copied property list */
     if (H5Pclose(fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -6425,30 +6425,30 @@ test_different_lock_flags(hid_t in_fapl)
     hid_t fapl_id = H5I_INVALID_HID; /* File access property list */
     char  filename[NAME_BUF_SIZE];   /* File name */
 
-    TESTING("Using different lock flags")
+    TESTING("Using different lock flags");
 
     /* Copy the incoming fapl */
     if ((fapl_id = H5Pcopy(in_fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set locking in the fapl */
     if (H5Pset_file_locking(fapl_id, TRUE, TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[1], fapl_id, filename, sizeof(filename));
 
     /* Create the test file */
     if ((fid1 = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the test file with the same flags (should pass) */
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDWR, fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unset locking in the fapl */
     if (H5Pset_file_locking(fapl_id, FALSE, FALSE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the test file with different flags (should FAIL) */
     H5E_BEGIN_TRY
@@ -6457,17 +6457,17 @@ test_different_lock_flags(hid_t in_fapl)
     }
     H5E_END_TRY;
     if (H5I_INVALID_HID != fid3)
-        FAIL_PUTS_ERROR("Should not have been able to open a file with different locking flags")
+        FAIL_PUTS_ERROR("Should not have been able to open a file with different locking flags");
 
     /* Close the files */
     if (H5Fclose(fid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the copied property list */
     if (H5Pclose(fapl_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -6503,7 +6503,7 @@ test_swmr_vfd_flag(void)
     if (H5Pset_fapl_sec2(sec2_fapl) < 0)
         FAIL_STACK_ERROR;
     if (H5Pset_libver_bounds(sec2_fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     h5_fixname(FILENAME[0], sec2_fapl, filename, sizeof(filename));
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC | H5F_ACC_SWMR_WRITE, H5P_DEFAULT, sec2_fapl)) < 0)
@@ -6518,7 +6518,7 @@ test_swmr_vfd_flag(void)
     if (H5Pset_fapl_stdio(bad_fapl) < 0)
         FAIL_STACK_ERROR;
     if (H5Pset_libver_bounds(bad_fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     fid = -1;
     h5_fixname(FILENAME[0], bad_fapl, filename, sizeof(filename));
@@ -6576,11 +6576,11 @@ test_bug_refresh(hid_t in_fapl)
 
     /* Create a copy of the input parameter in_fapl */
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to use the latest library format */
     if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -6589,11 +6589,11 @@ test_bug_refresh(hid_t in_fapl)
 
     /* Create a file with the latest format */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get a pointer to the internal file object */
     if (NULL == (f = (H5F_t *)H5VL_object(fid)))
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create groups: compact to dense storage */
     if ((gid1 = H5Gcreate2(fid, "group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -6616,26 +6616,26 @@ test_bug_refresh(hid_t in_fapl)
         FAIL_STACK_ERROR;
 
     if (H5Fflush(fid, H5F_SCOPE_GLOBAL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Grefresh(gid1) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Grefresh(gid2) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Grefresh(gid3) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Grefresh(gid4) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Grefresh(gid5) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Grefresh(gid6) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Grefresh(gid7) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Grefresh(gid8) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Grefresh(gid9) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     H5Gclose(gid1);
     H5Gclose(gid2);
@@ -6752,7 +6752,7 @@ test_refresh_concur(hid_t in_fapl, hbool_t new_format)
     } /* end if */
 
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -6760,23 +6760,23 @@ test_refresh_concur(hid_t in_fapl, hbool_t new_format)
     if (new_format) {
         /* Set to use the latest library format */
         if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create the test file */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     else {
         /* Create the test file without latest format but with SWMR write */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC | H5F_ACC_SWMR_WRITE, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Create a chunked dataset with 1 extendible dimension */
     if ((sid = H5Screate_simple(1, dims, maxdims)) < 0)
         FAIL_STACK_ERROR;
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl, 1, chunk_dims) < 0)
         FAIL_STACK_ERROR;
     if ((did = H5Dcreate2(fid, "dataset", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -6784,25 +6784,25 @@ test_refresh_concur(hid_t in_fapl, hbool_t new_format)
 
     /* Closing */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create 2 pipes */
     if (HDpipe(out_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDpipe(in_pdf) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Fork child process */
     if ((childpid = HDfork()) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (childpid == 0) {         /* Child process */
         hid_t   child_fid1 = -1; /* File ID */
@@ -6909,14 +6909,14 @@ test_refresh_concur(hid_t in_fapl, hbool_t new_format)
 
     /* Close unused read end for out_pdf */
     if (HDclose(out_pdf[0]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* Close unused write end for in_pdf */
     if (HDclose(in_pdf[1]) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the test file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset */
     if ((did = H5Dopen2(fid, "dataset", H5P_DEFAULT)) < 0)
@@ -6977,27 +6977,27 @@ test_refresh_concur(hid_t in_fapl, hbool_t new_format)
 
     /* Wait for child process to complete */
     if ((tmppid = HDwaitpid(childpid, &child_status, child_wait_option)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check exit status of child process */
     if (WIFEXITED(child_status)) {
         if ((child_exit_val = WEXITSTATUS(child_status)) != 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else /* Child process terminated abnormally */
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the property list */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -7055,7 +7055,7 @@ test_multiple_same(hid_t in_fapl, hbool_t new_format)
     } /* end if */
 
     if ((fapl = H5Pcopy(in_fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -7063,23 +7063,23 @@ test_multiple_same(hid_t in_fapl, hbool_t new_format)
     if (new_format) {
         /* Set to use the latest library format */
         if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create the test file */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     }
     else {
         /* Create the test file without latest format but with SWMR write */
         if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC | H5F_ACC_SWMR_WRITE, H5P_DEFAULT, fapl)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end if */
 
     /* Create a chunked dataset with 1 extendible dimension */
     if ((sid = H5Screate_simple(2, dims, maxdims)) < 0)
         FAIL_STACK_ERROR;
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_chunk(dcpl, 2, chunk_dims) < 0)
         FAIL_STACK_ERROR;
     if ((did = H5Dcreate2(fid, "dataset", H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -7087,33 +7087,33 @@ test_multiple_same(hid_t in_fapl, hbool_t new_format)
 
     /* Closing */
     if (H5Dclose(did) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Case 1 */
 
     /* Open the file 3 times: SWMR-write, read-write, read-only */
     if ((fid1 = H5Fopen(filename, H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fid3 = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset 3 times with fid1, fid2, fid3 */
     if ((did1 = H5Dopen2(fid1, "dataset", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did2 = H5Dopen2(fid2, "dataset", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did3 = H5Dopen2(fid3, "dataset", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write to the dataset via did1 */
     wbuf = 88;
@@ -7159,29 +7159,29 @@ test_multiple_same(hid_t in_fapl, hbool_t new_format)
 
     /* Close files */
     if (H5Fclose(fid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Case 2 */
 
     /* Open the file 3 times: read-write, read-only, read-write */
     if ((fid1 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fid3 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset 3 times with fid1, fid2, fid3 */
     if ((did1 = H5Dopen2(fid1, "dataset", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did2 = H5Dopen2(fid2, "dataset", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did3 = H5Dopen2(fid3, "dataset", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write to the dataset via did1 */
     wbuf = 88;
@@ -7241,29 +7241,29 @@ test_multiple_same(hid_t in_fapl, hbool_t new_format)
 
     /* Close files */
     if (H5Fclose(fid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid2) < 0)
         FAIL_STACK_ERROR;
     if (H5Fclose(fid3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Case 3 */
 
     /* Open the file 3 times: read-write, read-only, read-only */
     if ((fid1 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((fid3 = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the dataset 3 times with fid1, fid2, fid3 */
     if ((did1 = H5Dopen2(fid1, "dataset", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did2 = H5Dopen2(fid2, "dataset", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did3 = H5Dopen2(fid3, "dataset", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write to the dataset via did1 */
     wbuf = 88;
@@ -7287,7 +7287,7 @@ test_multiple_same(hid_t in_fapl, hbool_t new_format)
 
     /* Close file via fid2 */
     if (H5Fclose(fid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Write to dataset via did3 */
     wbuf = 99;
@@ -7300,7 +7300,7 @@ test_multiple_same(hid_t in_fapl, hbool_t new_format)
 
     /* Close file via fid3 */
     if (H5Fclose(fid3) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Enable SWMR writing */
     if (H5Fstart_swmr_write(fid1) < 0)
@@ -7319,11 +7319,11 @@ test_multiple_same(hid_t in_fapl, hbool_t new_format)
 
     /* Close file via fid1 */
     if (H5Fclose(fid1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the property list */
     if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;

--- a/test/tfile.c
+++ b/test/tfile.c
@@ -4326,7 +4326,7 @@ set_multi_split(hid_t fapl, hsize_t pagesize, hbool_t split)
 
     /* Get current split settings */
     if (H5Pget_fapl_multi(fapl, memb_map, memb_fapl_arr, memb_name, memb_addr, &relax) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (split) {
         /* Set memb_addr aligned */
@@ -4342,7 +4342,7 @@ set_multi_split(hid_t fapl, hsize_t pagesize, hbool_t split)
     /* Set multi driver with new FAPLs */
     if (H5Pset_fapl_multi(fapl, memb_map, memb_fapl_arr, (const char *const *)memb_name, memb_addr, relax) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free memb_name */
     for (mt = H5FD_MEM_DEFAULT; mt < H5FD_MEM_NTYPES; mt++)

--- a/test/tsohm.c
+++ b/test/tsohm.c
@@ -425,36 +425,36 @@ make_dtype_1(void)
 
     /* Create compound datatype. */
     if ((dtype1_id = H5Tcreate(H5T_COMPOUND, sizeof(struct dtype1_struct))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Tinsert(dtype1_id, "i1", HOFFSET(dtype1_struct, i1), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     str_id = H5Tcopy(H5T_C_S1);
     if (H5Tset_size(str_id, (size_t)10) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Tinsert(dtype1_id, "string", HOFFSET(dtype1_struct, str), str_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(dtype1_id, "i2", HOFFSET(dtype1_struct, i2), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(dtype1_id, "i3", HOFFSET(dtype1_struct, i3), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(dtype1_id, "i4", HOFFSET(dtype1_struct, i4), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(dtype1_id, "i5", HOFFSET(dtype1_struct, i5), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(dtype1_id, "i6", HOFFSET(dtype1_struct, i6), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(dtype1_id, "i7", HOFFSET(dtype1_struct, i7), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(dtype1_id, "i8", HOFFSET(dtype1_struct, i8), H5T_NATIVE_INT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tinsert(dtype1_id, "f1", HOFFSET(dtype1_struct, f1), H5T_NATIVE_FLOAT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Tclose(str_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return dtype1_id;
 
@@ -497,39 +497,39 @@ make_dtype_2(void)
 
     /* Create an int with a strange precision */
     if ((int_id = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tset_precision(int_id, (size_t)24) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create an enumeration using that int */
     if ((enum_id = H5Tenum_create(int_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     for (x = 0; x < ENUM_NUM_MEMBS; x++)
         if (H5Tenum_insert(enum_id, ENUM_NAME[x], &ENUM_VAL[x]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Create arrays of arrays of arrays of enums */
     if ((dtype2_id = H5Tarray_create2(enum_id, 3, dims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dtype2_id = H5Tarray_create2(dtype2_id, 4, dims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dtype2_id = H5Tarray_create2(dtype2_id, 2, dims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((dtype2_id = H5Tarray_create2(dtype2_id, 1, dims)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Tclose(enum_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(int_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check the datatype size.  If this is different than the #defined
      * size then the fills values will have the wrong size.
      */
     size = H5Tget_size(dtype2_id);
     if (size != DTYPE2_SIZE)
-        TEST_ERROR
+        TEST_ERROR;
 
     return dtype2_id;
 
@@ -564,10 +564,10 @@ static hid_t
 close_reopen_file(hid_t file, const char *filename, hid_t fapl_id)
 {
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     file = H5Fopen(filename, H5F_ACC_RDWR, fapl_id);
     if (file < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     return (file);
 
 error:
@@ -654,58 +654,58 @@ size1_helper(hid_t file, const char *filename, hid_t fapl_id, hbool_t test_file_
 
     dtype1_id = make_dtype_1();
     if (dtype1_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dim1[0]  = 1;
     space_id = H5Screate_simple(1, dim1, NULL);
     if (space_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     dset_id = H5Dcreate2(file, DSETNAME[0], dtype1_id, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     if (dset_id < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Test writing and reading */
     if (H5Dwrite(dset_id, dtype1_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, &wdata) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     TSOHM_S1H_VERIFY_DATA(dset_id, dtype1_id)
     if (H5Dclose(dset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (test_file_closing)
         if ((file = close_reopen_file(file, filename, fapl_id)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Create 3 more datasets with the same datatype/dataspace */
     for (x = 1; x < 4; x++) {
         dset_id = H5Dcreate2(file, DSETNAME[x], dtype1_id, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         if (0 > dset_id)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (x == 3)
             if (H5Dwrite(dset_id, dtype1_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, &wdata) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         if (H5Dclose(dset_id) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         if (test_file_closing)
             if ((file = close_reopen_file(file, filename, fapl_id)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
     }
 
     if (H5Tclose(dtype1_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make sure the data has been written successfully */
     dset_id = H5Dopen2(file, DSETNAME[0], H5P_DEFAULT);
     if (dset_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
     dtype1_id = H5Dget_type(dset_id);
     if (dtype1_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
     TSOHM_S1H_VERIFY_DATA(dset_id, dtype1_id)
 
     if (H5Dclose(dset_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create several copies of the dataset
      * this increases the amount of space saved by sharing the datatype message
@@ -714,33 +714,33 @@ size1_helper(hid_t file, const char *filename, hid_t fapl_id, hbool_t test_file_
         dset_id =
             H5Dcreate2(file, EXTRA_DSETNAME[x], dtype1_id, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         if (dset_id < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Dclose(dset_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         if (test_file_closing)
             if ((file = close_reopen_file(file, filename, fapl_id)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
     }
 
     if (H5Tclose(dtype1_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(space_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Ensure that we can still read data back from dataset 3 */
     dset_id = H5Dopen2(file, DSETNAME[3], H5P_DEFAULT);
     if (dset_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
     dtype1_id = H5Dget_type(dset_id);
     if (dtype1_id < 0)
-        TEST_ERROR
+        TEST_ERROR;
     TSOHM_S1H_VERIFY_DATA(dset_id, dtype1_id)
 
     if (H5Dclose(dset_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(dtype1_id) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return file;
 

--- a/test/unlink.c
+++ b/test/unlink.c
@@ -91,45 +91,45 @@ test_one(hid_t file)
 
     /* Create a test group */
     if ((work = H5Gcreate2(file, "/test_one", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete by absolute name */
     TESTING("unlink by absolute name");
     if ((grp = H5Gcreate2(work, "foo", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(grp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(file, "/test_one/foo", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /* Delete by local name */
     TESTING("unlink by local name");
     if ((grp = H5Gcreate2(work, "foo", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(grp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(work, "foo", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /* Delete directly - should fail */
     TESTING("unlink without a name");
     if ((grp = H5Gcreate2(work, "foo", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     H5E_BEGIN_TRY
     {
         status = H5Ldelete(grp, ".", H5P_DEFAULT);
     }
     H5E_END_TRY;
     if (status >= 0)
-        FAIL_PUTS_ERROR("    Unlinking object w/o a name should have failed.")
+        FAIL_PUTS_ERROR("    Unlinking object w/o a name should have failed.");
     if (H5Gclose(grp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Cleanup */
     if (H5Gclose(work) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -181,12 +181,12 @@ test_many(hid_t file)
     for (i = 0; i < how_many; i++) {
         HDsprintf(name, "obj_%05d", i);
         if (H5Lcreate_hard(work, "/test_many_foo", H5L_SAME_LOC, name, H5P_DEFAULT, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
     for (i = 0; i < how_many; i++) {
         HDsprintf(name, "obj_%05d", i);
         if (H5Ldelete(work, name, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
     PASSED();
 
@@ -195,12 +195,12 @@ test_many(hid_t file)
     for (i = 0; i < how_many; i++) {
         HDsprintf(name, "obj_%05d", i);
         if (H5Lcreate_hard(work, "/test_many_foo", H5L_SAME_LOC, name, H5P_DEFAULT, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
     for (i = (how_many - 1); i >= 0; --i) {
         HDsprintf(name, "obj_%05d", i);
         if (H5Ldelete(work, name, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
     PASSED();
 
@@ -209,7 +209,7 @@ test_many(hid_t file)
     for (i = 0; i < how_many; i++) {
         HDsprintf(name, "obj_%05d", i);
         if (H5Lcreate_hard(work, "/test_many_foo", H5L_SAME_LOC, name, H5P_DEFAULT, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
     for (i = 0; i < how_many; i++) {
         if (i % 2)
@@ -217,7 +217,7 @@ test_many(hid_t file)
         else
             HDsprintf(name, "obj_%05d", i / 2);
         if (H5Ldelete(work, name, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
     PASSED();
 
@@ -226,7 +226,7 @@ test_many(hid_t file)
     for (i = 0; i < how_many; i++) {
         HDsprintf(name, "obj_%05d", i);
         if (H5Lcreate_hard(work, "/test_many_foo", H5L_SAME_LOC, name, H5P_DEFAULT, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
     for (i = (how_many - 1); i >= 0; --i) {
         if (i % 2)
@@ -234,7 +234,7 @@ test_many(hid_t file)
         else
             HDsprintf(name, "obj_%05d", i / 2);
         if (H5Ldelete(work, name, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
     PASSED();
 
@@ -276,15 +276,15 @@ test_symlink(hid_t file)
 
     /* Create a test group and symlink */
     if ((work = H5Gcreate2(file, "/test_symlink", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("link_value", work, "link", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(work, "link", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Cleanup */
     if (H5Gclose(work) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -322,33 +322,33 @@ test_rename(hid_t file)
     /* Create a test group and rename something */
     TESTING("object renaming");
     if ((work = H5Gcreate2(file, "/test_rename", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((foo = H5Gcreate2(work, "foo", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lmove(work, "foo", H5L_SAME_LOC, "bar", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((inner = H5Gcreate2(foo, "inner", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(inner) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(foo) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((inner = H5Gopen2(work, "bar/inner", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(inner) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     PASSED();
 
     /* Try renaming a symlink */
     TESTING("symlink renaming");
     if (H5Lcreate_soft("link_value", work, "link_one", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lmove(work, "link_one", H5L_SAME_LOC, "link_two", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Cleanup */
     if (H5Gclose(work) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -392,24 +392,24 @@ test_new_move(hid_t fapl)
     /* Create a second file */
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
     if ((file_a = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     h5_fixname(FILENAME[2], fapl, filename, sizeof filename);
     if ((file_b = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create groups in first file */
     if ((grp_1 = H5Gcreate2(file_a, "group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((grp_2 = H5Gcreate2(file_a, "group2", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((grp_move = H5Gcreate2(grp_1, "group_move", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create hard and soft links. */
     if (H5Lcreate_hard(grp_1, "group_move", H5L_SAME_LOC, "hard", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Lcreate_soft("/group1/group_move", grp_2, "soft", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Move a group within the file.  Both of source and destination use
      * H5L_SAME_LOC.  Should fail. */
@@ -417,7 +417,7 @@ test_new_move(hid_t fapl)
     {
         if (H5Lmove(H5L_SAME_LOC, "group_move", H5L_SAME_LOC, "group_new_name", H5P_DEFAULT, H5P_DEFAULT) !=
             FAIL)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
@@ -425,30 +425,30 @@ test_new_move(hid_t fapl)
     H5E_BEGIN_TRY
     {
         if (H5Lmove(grp_1, "group_move", file_b, "group_new_name", H5P_DEFAULT, H5P_DEFAULT) != FAIL)
-            TEST_ERROR
+            TEST_ERROR;
     }
     H5E_END_TRY;
 
     /* Move a group across groups in the same file. */
     if (H5Lmove(grp_1, "group_move", grp_2, "group_new_name", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the group just moved to the new location. */
     if ((moved_grp = H5Gopen2(grp_2, "group_new_name", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     if (H5Gclose(grp_1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(grp_2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(grp_move) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(moved_grp) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file_a) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file_b) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -497,31 +497,31 @@ check_new_move(hid_t fapl)
     /* Open file */
     h5_fixname(FILENAME[1], fapl, filename, sizeof(filename));
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get hard link info */
     if (H5Oget_info_by_name3(file, "/group2/group_new_name", &oi_hard1, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Oget_info_by_name3(file, "/group1/hard", &oi_hard2, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check hard links */
     if (H5O_TYPE_GROUP != oi_hard1.type || H5O_TYPE_GROUP != oi_hard2.type)
-        FAIL_PUTS_ERROR("    Unexpected object type, should have been a group")
+        FAIL_PUTS_ERROR("    Unexpected object type, should have been a group");
     if (H5Otoken_cmp(file, &oi_hard1.token, &oi_hard2.token, &token_cmp) < 0)
-        FAIL_PUTS_ERROR("    H5Otoken_cmp failed")
+        FAIL_PUTS_ERROR("    H5Otoken_cmp failed");
     if (token_cmp)
-        FAIL_PUTS_ERROR("    Hard link test failed.  Link seems not to point to the expected file location.")
+        FAIL_PUTS_ERROR("    Hard link test failed.  Link seems not to point to the expected file location.");
 
     /* Check soft links */
     if (H5Lget_val(file, "group2/soft", linkval, sizeof(linkval), H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (HDstrcmp(linkval, "/group1/group_move") != 0)
-        FAIL_PUTS_ERROR("    Soft link test failed. Wrong link value")
+        FAIL_PUTS_ERROR("    Soft link test failed. Wrong link value");
 
     /* Cleanup */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -589,111 +589,111 @@ test_filespace(hid_t fapl)
     /* Create FAPL with raw data cache disabled */
     /* Create file access property list with raw data cache disabled */
     if ((fapl_nocache = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the cache settings */
     if (H5Pget_cache(fapl_nocache, &mdc_nelmts, &rdcc_nelmts, &rdcc_nbytes, &rdcc_w0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Disable the raw data cache */
     rdcc_nelmts = 0;
     rdcc_nbytes = 0;
     if (H5Pset_cache(fapl_nocache, mdc_nelmts, rdcc_nelmts, rdcc_nbytes, rdcc_w0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create empty file for size comparisons later */
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get the size of an empty file */
     if ((empty_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create common objects for datasets */
 
     /* Create dataset creation property list for contiguous storage */
     if ((contig_dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Make certain that space is allocated early */
     if (H5Pset_alloc_time(contig_dcpl, H5D_ALLOC_TIME_EARLY) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataset creation property list for chunked storage & early allocation */
     if ((early_chunk_dcpl = H5Pcopy(contig_dcpl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set chunk dimensions */
     if (H5Pset_chunk(early_chunk_dcpl, FILESPACE_NDIMS, chunk_dims) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataset creation property list for chunked storage & late allocation */
     if ((late_chunk_dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set chunk dimensions */
     if (H5Pset_chunk(late_chunk_dcpl, FILESPACE_NDIMS, chunk_dims) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataset creation property list for compressed, chunked storage & early allocation */
     if ((comp_dcpl = H5Pcopy(early_chunk_dcpl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Enable compression & set level */
     if (H5Pset_deflate(comp_dcpl, FILESPACE_DEFLATE_LEVEL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataset creation property list for compact storage */
     if ((compact_dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set to compact storage */
     if (H5Pset_layout(compact_dcpl, H5D_COMPACT) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspace for datasets */
     if ((space = H5Screate_simple(FILESPACE_NDIMS, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create buffer for writing dataset */
     if (NULL == (data = (int *)HDmalloc(sizeof(int) * FILESPACE_DIM0 * FILESPACE_DIM1 * FILESPACE_DIM2)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create single dataset (with contiguous storage & late allocation), remove it & verify file size */
     TESTING("    contiguous dataset with late allocation");
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a single dataset to remove */
     if ((dataset =
              H5Dcreate2(file, DATASETNAME, H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the dataset */
     if (H5Ldelete(file, DATASETNAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -702,30 +702,30 @@ test_filespace(hid_t fapl)
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a single dataset to remove */
     if ((dataset =
              H5Dcreate2(file, DATASETNAME, H5T_NATIVE_INT, space, H5P_DEFAULT, contig_dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the dataset */
     if (H5Ldelete(file, DATASETNAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -734,30 +734,30 @@ test_filespace(hid_t fapl)
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a single dataset to remove */
     if ((dataset = H5Dcreate2(file, DATASETNAME, H5T_NATIVE_INT, space, H5P_DEFAULT, late_chunk_dcpl,
                               H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the dataset */
     if (H5Ldelete(file, DATASETNAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -766,30 +766,30 @@ test_filespace(hid_t fapl)
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a single dataset to remove */
     if ((dataset = H5Dcreate2(file, DATASETNAME, H5T_NATIVE_INT, space, H5P_DEFAULT, early_chunk_dcpl,
                               H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the dataset */
     if (H5Ldelete(file, DATASETNAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -798,30 +798,30 @@ test_filespace(hid_t fapl)
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a single dataset to remove */
     if ((dataset =
              H5Dcreate2(file, DATASETNAME, H5T_NATIVE_INT, space, H5P_DEFAULT, comp_dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the dataset */
     if (H5Ldelete(file, DATASETNAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -833,12 +833,12 @@ test_filespace(hid_t fapl)
 
     /* Create file (using FAPL with disabled raw data cache) */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_nocache)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a single dataset to remove */
     if ((dataset =
              H5Dcreate2(file, DATASETNAME, H5T_NATIVE_INT, space, H5P_DEFAULT, comp_dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Alternate re-writing dataset with compressible & random data */
     for (u = 0; u < FILESPACE_REWRITE; u++) {
@@ -848,7 +848,7 @@ test_filespace(hid_t fapl)
 
         /* Write the buffer to the dataset */
         if (H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Set buffer to different random numbers each time */
         for (v = 0, tmp_data = data; v < (FILESPACE_DIM0 * FILESPACE_DIM1 * FILESPACE_DIM2); v++)
@@ -856,28 +856,28 @@ test_filespace(hid_t fapl)
 
         /* Write the buffer to the dataset */
         if (H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Close dataset */
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the dataset */
     if (H5Ldelete(file, DATASETNAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl_nocache)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -886,30 +886,30 @@ test_filespace(hid_t fapl)
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a single dataset to remove */
     if ((dataset = H5Dcreate2(file, DATASETNAME, H5T_NATIVE_INT, space, H5P_DEFAULT, compact_dcpl,
                               H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the dataset */
     if (H5Ldelete(file, DATASETNAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -921,19 +921,19 @@ test_filespace(hid_t fapl)
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create datasets to remove */
     if ((dataset =
              H5Dcreate2(file, DATASETNAME, H5T_NATIVE_INT, space, H5P_DEFAULT, contig_dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dataset2 = H5Dcreate2(file, DATASET2NAME, H5T_NATIVE_INT, space, H5P_DEFAULT, contig_dcpl,
                                H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataspace for the attributes */
     if ((attr_space = H5Screate_simple(FILESPACE_ATTR_NDIMS, attr_dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Alternate adding attributes to each one */
     for (u = 0; u < FILESPACE_NATTR; u++) {
@@ -942,56 +942,56 @@ test_filespace(hid_t fapl)
 
         /* Create an attribute on the first dataset */
         if ((attr = H5Acreate2(dataset, objname, H5T_NATIVE_INT, attr_space, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Don't worry about writing the attribute - it will have a fill value */
 
         /* Close the attribute on the first dataset */
         if (H5Aclose(attr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create an attribute on the second dataset */
         if ((attr = H5Acreate2(dataset2, objname, H5T_NATIVE_INT, attr_space, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Don't worry about writing the attribute - it will have a fill value */
 
         /* Close the attribute on the second dataset */
         if (H5Aclose(attr) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Flush the file (to fix the sizes of object header buffers, etc) */
         if (H5Fflush(file, H5F_SCOPE_GLOBAL) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Close the dataspace for the attributes */
     if (H5Sclose(attr_space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close datasets */
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the datasets */
     if (H5Ldelete(file, DATASETNAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(file, DATASET2NAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1000,33 +1000,33 @@ test_filespace(hid_t fapl)
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create datatype to commit */
     if ((type = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a single named datatype to remove */
     if (H5Tcommit2(file, TYPENAME, type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the named datatype */
     if (H5Ldelete(file, TYPENAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1035,29 +1035,29 @@ test_filespace(hid_t fapl)
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a single group to remove */
     if ((group = H5Gcreate2(file, GROUPNAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the group */
     if (H5Ldelete(file, GROUPNAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1066,15 +1066,15 @@ test_filespace(hid_t fapl)
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a many groups to remove */
     for (u = 0; u < UNLINK_NGROUPS; u++) {
         HDsprintf(objname, "%s %u", GROUPNAME, u);
         if ((group = H5Gcreate2(file, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Gclose(group) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Remove the all the groups */
@@ -1082,20 +1082,20 @@ test_filespace(hid_t fapl)
     for (u = UNLINK_NGROUPS; u > 0; u--) {
         HDsprintf(objname, "%s %u", GROUPNAME, (u - 1));
         if (H5Ldelete(file, objname, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1104,37 +1104,37 @@ test_filespace(hid_t fapl)
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a small group hierarchy to remove */
     if ((group = H5Gcreate2(file, GROUPNAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((group2 = H5Gcreate2(group, GROUP2NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the second group */
     if (H5Ldelete(file, GROUPNAME "/" GROUP2NAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the first group */
     if (H5Ldelete(file, GROUPNAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1143,21 +1143,21 @@ test_filespace(hid_t fapl)
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a complex group hierarchy to remove */
     for (u = 0; u < FILESPACE_TOP_GROUPS; u++) {
         /* Create group */
         HDsprintf(objname, "%s %u", GROUPNAME, u);
         if ((group = H5Gcreate2(file, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Create nested groups inside top groups */
         for (v = 0; v < FILESPACE_NESTED_GROUPS; v++) {
             /* Create group */
             HDsprintf(objname, "%s %u", GROUP2NAME, v);
             if ((group2 = H5Gcreate2(group, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Create datasets inside nested groups */
             for (w = 0; w < FILESPACE_NDATASETS; w++) {
@@ -1165,19 +1165,19 @@ test_filespace(hid_t fapl)
                 HDsprintf(objname, "%s %u", DATASETNAME, w);
                 if ((dataset = H5Dcreate2(group2, objname, H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT,
                                           H5P_DEFAULT)) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
                 if (H5Dclose(dataset) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
             } /* end for */
 
             /* Close nested group */
             if (H5Gclose(group2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         } /* end for */
 
         /* Close top group */
         if (H5Gclose(group) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Remove complex group hierarchy */
@@ -1186,54 +1186,54 @@ test_filespace(hid_t fapl)
         /* Open group */
         HDsprintf(objname, "%s %u", GROUPNAME, (u - 1));
         if ((group = H5Gopen2(file, objname, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Open nested groups inside top groups */
         for (v = 0; v < FILESPACE_NESTED_GROUPS; v++) {
             /* Create group */
             HDsprintf(objname, "%s %u", GROUP2NAME, v);
             if ((group2 = H5Gopen2(group, objname, H5P_DEFAULT)) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Remove datasets inside nested groups */
             for (w = 0; w < FILESPACE_NDATASETS; w++) {
                 /* Remove dataset */
                 HDsprintf(objname, "%s %u", DATASETNAME, w);
                 if (H5Ldelete(group2, objname, H5P_DEFAULT) < 0)
-                    FAIL_STACK_ERROR
+                    FAIL_STACK_ERROR;
             } /* end for */
 
             /* Close nested group */
             if (H5Gclose(group2) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
 
             /* Remove nested group */
             HDsprintf(objname, "%s %u", GROUP2NAME, v);
             if (H5Ldelete(group, objname, H5P_DEFAULT) < 0)
-                FAIL_STACK_ERROR
+                FAIL_STACK_ERROR;
         } /* end for */
 
         /* Close top group */
         if (H5Gclose(group) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
 
         /* Remove top group */
         HDsprintf(objname, "%s %u", GROUPNAME, (u - 1));
         if (H5Ldelete(file, objname, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1242,14 +1242,14 @@ test_filespace(hid_t fapl)
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a single dataset to remove */
     if ((dataset =
              H5Dcreate2(file, DATASETNAME, H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create another dataset with same name */
     H5E_BEGIN_TRY
@@ -1259,24 +1259,24 @@ test_filespace(hid_t fapl)
     H5E_END_TRY;
     if (dataset >= 0) {
         H5Dclose(dataset);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Remove the dataset */
     if (H5Ldelete(file, DATASETNAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1285,13 +1285,13 @@ test_filespace(hid_t fapl)
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a single group to remove */
     if ((group = H5Gcreate2(file, GROUPNAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Gclose(group) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create another group with same name */
     H5E_BEGIN_TRY
@@ -1301,24 +1301,24 @@ test_filespace(hid_t fapl)
     H5E_END_TRY;
     if (group >= 0) {
         H5Gclose(group);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Remove the group */
     if (H5Ldelete(file, GROUPNAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1327,21 +1327,21 @@ test_filespace(hid_t fapl)
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create datatype to commit */
     if ((type = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a single named datatype to remove */
     if (H5Tcommit2(file, TYPENAME, type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tclose(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create datatype to commit */
     if ((type = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create another named datatype with same name */
     H5E_BEGIN_TRY
@@ -1350,25 +1350,25 @@ test_filespace(hid_t fapl)
     }
     H5E_END_TRY;
     if (status >= 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Tclose(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the named datatype */
     if (H5Ldelete(file, TYPENAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1377,26 +1377,26 @@ test_filespace(hid_t fapl)
 
     /* Create file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create datasets to remove */
     if ((dataset =
              H5Dcreate2(file, DATASETNAME, H5T_NATIVE_INT, space, H5P_DEFAULT, contig_dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataspace for the attributes */
     if ((attr_space = H5Screate_simple(FILESPACE_ATTR_NDIMS, attr_dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create an attribute on the dataset */
     if ((attr = H5Acreate2(dataset, ATTRNAME, H5T_NATIVE_INT, attr_space, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Don't worry about writing the attribute - it will have a fill value */
 
     /* Close the attribute on the dataset */
     if (H5Aclose(attr) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create another attribute with same name */
     H5E_BEGIN_TRY
@@ -1406,32 +1406,32 @@ test_filespace(hid_t fapl)
     H5E_END_TRY;
     if (attr >= 0) {
         H5Aclose(attr);
-        TEST_ERROR
+        TEST_ERROR;
     } /* end if */
 
     /* Close the dataspace for the attributes */
     if (H5Sclose(attr_space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close dataset */
     if (H5Dclose(dataset) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Remove the dataset */
     if (H5Ldelete(file, DATASETNAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != empty_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
 
@@ -1442,21 +1442,21 @@ test_filespace(hid_t fapl)
 
     /* Close property lists */
     if (H5Pclose(fapl_nocache) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(contig_dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(early_chunk_dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(late_chunk_dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(comp_dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(compact_dcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close dataspace */
     if (H5Sclose(space) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Indicate success */
     /* Don't print final "PASSED", since we aren't on the correct line anymore */
@@ -1498,7 +1498,7 @@ test_create_unlink(const char *msg, hid_t fapl)
     /* Create file */
     h5_fixname(FILENAME[3], fapl, filename, sizeof filename);
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_PUTS_ERROR("    Creating file failed")
+        FAIL_PUTS_ERROR("    Creating file failed");
 
     /* Create a many groups to remove */
     for (u = 0; u < UNLINK_NGROUPS; u++) {
@@ -1527,7 +1527,7 @@ test_create_unlink(const char *msg, hid_t fapl)
 
     /* Close file */
     if (H5Fclose(file) < 0)
-        FAIL_PUTS_ERROR("Closing file failed")
+        FAIL_PUTS_ERROR("Closing file failed");
 
     PASSED();
     return 0;
@@ -1565,50 +1565,50 @@ test_link_slashes(hid_t fapl)
 
     /* Create a file */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a group in the root group */
     if ((gid = H5Gcreate2(fid, SLASHES_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a nested group in the root group */
     if ((gid2 = H5Gcreate2(gid, SLASHES_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the nested group */
     if (H5Gclose(gid2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a hard link to the nested group */
     if (H5Lcreate_hard(gid, SLASHES_GROUP_NAME, H5L_SAME_LOC, SLASHES_HARDLINK_NAME, H5P_DEFAULT,
                        H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a soft link with a relative path to the nested group */
     if (H5Lcreate_soft(SLASHES_GROUP_NAME, gid, SLASHES_SOFTLINK_NAME, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a soft link with the full path to the nested group */
     if (H5Lcreate_soft("////" SLASHES_GROUP_NAME "" SLASHES_GROUP_NAME, gid, SLASHES_SOFTLINK2_NAME,
                        H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a soft link to the root group */
     if (H5Lcreate_soft("////", gid, SLASHES_ROOTLINK_NAME, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a hard link to the existing group */
     if (H5Lcreate_hard(fid, SLASHES_GROUP_NAME, H5L_SAME_LOC, SLASHES_HARDLINK_NAME, H5P_DEFAULT,
                        H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -1646,47 +1646,47 @@ test_unlink_slashes(hid_t fapl)
 
     /* Open the file */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Open the top level group */
     if ((gid = H5Gopen2(fid, SLASHES_GROUP_NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete the root link */
     if (H5Ldelete(gid, SLASHES_ROOTLINK_NAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete the soft link with the full path */
     if (H5Ldelete(gid, SLASHES_SOFTLINK2_NAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete the soft link with the relative path */
     if (H5Ldelete(gid, SLASHES_SOFTLINK_NAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete the hard link */
     if (H5Ldelete(gid, SLASHES_HARDLINK_NAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete the group itself */
     if (H5Ldelete(gid, SLASHES_GROUP_NAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the group */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete the hard link */
     if (H5Ldelete(fid, SLASHES_HARDLINK_NAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete the group itself */
     if (H5Ldelete(fid, SLASHES_GROUP_NAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -1758,37 +1758,37 @@ test_unlink_rightleaf(hid_t fid)
 
     /* Allocate space for the group IDs */
     if (NULL == (gids = (hid_t *)HDcalloc((size_t)ngroups, sizeof(hid_t))))
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((rootid = H5Gopen2(fid, "/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create all the groups */
     for (n = 0; n < ngroups; n++) {
         HDsprintf(name, "Zone%d", n + 1);
         if ((gids[n] = H5Gcreate2(rootid, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Unlink & re-create each group */
     for (n = 0; n < ngroups; n++) {
         if (delete_node(rootid, gids[n]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         HDsprintf(name, "Zone%d", n + 1);
         if ((gids[n] = H5Gcreate2(rootid, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Close all the groups */
     for (n = 0; n < ngroups; n++) {
         if (H5Gclose(gids[n]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         gids[n] = 0;
     } /* end for */
 
     /* Close root group ID */
     if (H5Gclose(rootid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Free memory */
     HDfree(gids);
@@ -1847,40 +1847,40 @@ test_unlink_rightnode(hid_t fid)
 
     /* Allocate space for the group IDs */
     if (NULL == (gids = (hid_t *)HDcalloc((size_t)ngroups, sizeof(hid_t))))
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((rootid = H5Gopen2(fid, "/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create all the groups */
     for (n = 0; n < ngroups; n++) {
         HDsprintf(name, "ZoneB%d", n + 1);
         if ((gids[n] = H5Gcreate2(rootid, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Close all the groups */
     for (n = 0; n < ngroups; n++) {
         if (H5Gclose(gids[n]) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         gids[n] = 0;
     } /* end for */
 
     /* Unlink specific objects to trigger deletion of right leaf in non-leaf node */
     if (H5Ldelete(fid, "/ZoneB77", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneB78", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneB79", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneB8", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneB80", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close root group ID */
     if (H5Gclose(rootid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Free memory */
     HDfree(gids);
@@ -1939,326 +1939,326 @@ test_unlink_middlenode(hid_t fid)
 
     /* Allocate space for the group IDs */
     if (NULL == (gids = (hid_t *)HDcalloc((size_t)ngroups, sizeof(hid_t))))
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((rootid = H5Gopen2(fid, "/", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create all the groups */
     for (n = 0; n < ngroups; n++) {
         HDsprintf(name, "ZoneC%d", n + 1);
         if ((gids[n] = H5Gcreate2(rootid, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Close all the groups */
     for (n = 0; n < ngroups; n++) {
         if (H5Gclose(gids[n]) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         gids[n] = 0;
     } /* end for */
 
     /* Unlink specific objects to trigger deletion of all leafs in "interior" non-leaf node */
     if (H5Ldelete(fid, "/ZoneC11", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC110", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC111", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC112", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC113", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC114", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC115", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC116", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC117", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC118", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC119", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC12", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC120", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC121", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC122", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC123", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC124", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC125", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC126", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC127", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC128", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC129", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC13", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC130", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC131", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC132", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC133", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC134", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC135", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC136", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC137", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC138", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC139", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC14", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC140", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC141", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC142", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC143", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC144", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC145", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC146", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC147", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC148", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC149", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC15", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC150", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC151", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC152", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC153", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC154", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC155", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC156", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC157", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC158", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC159", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC16", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC160", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC161", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC162", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC163", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC164", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC165", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC166", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC167", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC168", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC169", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC17", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC170", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC171", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC172", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC173", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC174", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC175", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC176", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC177", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC178", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC179", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC18", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC180", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC19", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC2", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC20", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC21", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC22", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC23", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC24", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC25", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC26", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC27", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC28", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC29", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC3", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC30", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC31", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC32", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC33", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC34", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC35", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC36", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC37", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC38", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC39", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC4", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC40", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC41", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC42", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC43", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC44", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC45", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC46", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC47", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC48", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC49", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC5", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC50", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC51", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC52", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC53", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC54", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC55", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC56", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC57", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC58", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC59", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC6", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC60", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC61", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC62", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC63", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC64", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC65", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC66", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC67", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC68", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC69", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC7", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC70", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC71", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC72", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC73", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC74", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC75", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC76", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC77", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC78", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC79", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC8", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Ldelete(fid, "/ZoneC80", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close root group ID */
     if (H5Gclose(rootid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Free memory */
     HDfree(gids);
@@ -2317,47 +2317,47 @@ test_resurrect_dataset(hid_t fapl)
 
     /* Create the file */
     if ((f = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a dataset in the file */
     if ((s = H5Screate(H5S_SCALAR)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((d = H5Dcreate2(f, DATASETNAME, H5T_NATIVE_INT, s, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(s) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Unlink the dataset while it's open (will mark it for deletion when closed) */
     if (H5Ldelete(f, DATASETNAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that dataset name is NULL */
     if (H5Iget_name(d, NULL, (size_t)0) != 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-link the dataset to the group hierarchy (shouldn't get deleted now) */
     if (H5Lcreate_hard(d, ".", f, DATASET2NAME, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close things */
     if (H5Dclose(d) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((f = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Attempt to open the dataset under the new name */
     if ((d = H5Dopen2(f, DATASET2NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close things */
     if (H5Dclose(d) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(f) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -2402,45 +2402,45 @@ test_resurrect_datatype(hid_t fapl)
 
     /* Create the file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a named datatype in the file */
     if ((type = H5Tcopy(H5T_NATIVE_INT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Tcommit2(file, TYPENAME, type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Unlink the datatype while it's open (will mark it for deletion when closed) */
     if (H5Ldelete(file, TYPENAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that datatype name is NULL */
     if (H5Iget_name(type, NULL, (size_t)0) != 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-link the datatype to the group hierarchy (shouldn't get deleted now) */
     if (H5Lcreate_hard(type, ".", file, TYPE2NAME, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close things */
     if (H5Tclose(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Attempt to open the datatype under the new name */
     if ((type = H5Topen2(file, TYPE2NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close things */
     if (H5Tclose(type) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -2484,43 +2484,43 @@ test_resurrect_group(hid_t fapl)
 
     /* Create the file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create a group in the file */
     if ((group = H5Gcreate2(file, GROUPNAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Unlink the group while it's open (will mark it for deletion when closed) */
     if (H5Ldelete(file, GROUPNAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check that group's name is NULL */
     if (H5Iget_name(group, NULL, (size_t)0) != 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-link the group into the group hierarchy (shouldn't get deleted now) */
     if (H5Lcreate_hard(group, ".", file, GROUP2NAME, H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close things */
     if (H5Gclose(group) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file = H5Fopen(filename, H5F_ACC_RDONLY, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Attempt to open the datatype under the new name */
     if ((group = H5Gopen2(file, GROUP2NAME, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close things */
     if (H5Gclose(group) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(file) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -2569,56 +2569,56 @@ test_unlink_chunked_dataset(hid_t fapl)
 
     /* Create the file */
     if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dataspace */
     if ((space_id = H5Screate_simple(FILESPACE_NDIMS, dims, max_dims)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dataset creation filter */
     if ((dcpl_id = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to chunked storage */
     if (H5Pset_chunk(dcpl_id, FILESPACE_NDIMS, chunk_dims) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set to early space allocation */
     if (H5Pset_alloc_time(dcpl_id, H5D_ALLOC_TIME_EARLY) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dataset */
     if ((dset_id = H5Dcreate2(file_id, DATASETNAME, H5T_NATIVE_INT, space_id, H5P_DEFAULT, dcpl_id,
                               H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataspace */
     if (H5Sclose(space_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataset creation property list */
     if (H5Pclose(dcpl_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dataset */
     if (H5Dclose(dset_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file_id = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete the dataset */
     if (H5Ldelete(file_id, DATASETNAME, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -2668,119 +2668,119 @@ test_full_group_compact(hid_t fapl)
 
     /* Create the file */
     if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create group to link objects to */
     if ((gid = H5Gcreate2(file_id, "/keep", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create several objects to link to */
     for (u = 0; u < FULL_GROUP_NUM_KEEP; u++) {
         HDsprintf(objname, "keep %u\n", u);
         if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Gclose(gid2) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Close group with objects to keep */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file with only the objects to keep */
     if ((keep_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file_id = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create group to delete */
     if ((gid = H5Gcreate2(file_id, "/delete", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create external link (doesn't matter if it dangles) */
     if (H5Lcreate_external("foo.h5", "/dst", gid, "external", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create soft link (doesn't matter if it dangles) */
     if (H5Lcreate_soft("/foo", gid, "soft", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create hard links to objects in group to keep */
     for (u = 0; u < FULL_GROUP_NUM_KEEP; u++) {
         HDsprintf(objname, "/keep/keep %u\n", u);
         HDsprintf(objname2, "keep %u\n", u);
         if (H5Lcreate_hard(file_id, objname, gid, objname2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Create several objects to delete */
     for (u = 0; u < FULL_GROUP_NUM_DELETE_COMPACT; u++) {
         HDsprintf(objname, "delete %u\n", u);
         if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Gclose(gid2) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check on group's status */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, NULL) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_stab_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group with objects to delete */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check reference count on objects to keep */
     for (u = 0; u < FULL_GROUP_NUM_KEEP; u++) {
         HDsprintf(objname, "/keep/keep %u\n", u);
         if (H5Oget_info_by_name3(file_id, objname, &oi, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (oi.rc != 2)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file_id = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete the full group */
     if (H5Ldelete(file_id, "/delete", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check reference count on objects to keep */
     for (u = 0; u < FULL_GROUP_NUM_KEEP; u++) {
         HDsprintf(objname, "/keep/keep %u\n", u);
         if (H5Oget_info_by_name3(file_id, objname, &oi, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (oi.rc != 1)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != keep_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -2830,42 +2830,42 @@ test_full_group_dense(hid_t fapl)
 
     /* Create the file */
     if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create group to link objects to */
     if ((gid = H5Gcreate2(file_id, "/keep", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create several objects to link to */
     for (u = 0; u < FULL_GROUP_NUM_KEEP; u++) {
         HDsprintf(objname, "keep %u\n", u);
         if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Gclose(gid2) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Close group with objects to keep */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file with only the objects to keep */
     if ((keep_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Re-open the file */
     if ((file_id = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Set group creation "est. link info" closer to what will actually occur */
     if ((gcpl = H5Pcreate(H5P_GROUP_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_est_link_info(gcpl, FULL_GROUP_EST_NUM_ENTRIES, FULL_GROUP_EST_ENTRY_LEN) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create group to delete */
     /* (use non-default GCPL, in order to make certain that the group's object
@@ -2874,90 +2874,90 @@ test_full_group_dense(hid_t fapl)
      *  computation below easier/correct - QAK)
      */
     if ((gid = H5Gcreate2(file_id, "/delete", H5P_DEFAULT, gcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close GCPL */
     if (H5Pclose(gcpl) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create external link (doesn't matter if it dangles) */
     if (H5Lcreate_external("foo.h5", "/dst", gid, "external", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create soft link (doesn't matter if it dangles) */
     if (H5Lcreate_soft("/foo", gid, "soft", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create hard links to objects in group to keep */
     for (u = 0; u < FULL_GROUP_NUM_KEEP; u++) {
         HDsprintf(objname, "/keep/keep %u\n", u);
         HDsprintf(objname2, "keep %u\n", u);
         if (H5Lcreate_hard(file_id, objname, gid, objname2, H5P_DEFAULT, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Create several objects to delete */
     for (u = 0; u < FULL_GROUP_NUM_DELETE_DENSE; u++) {
         HDsprintf(objname, "delete %u\n", u);
         if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (H5Gclose(gid2) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
     } /* end for */
 
     /* Check on group's status */
     if (H5G__is_empty_test(gid) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__has_links_test(gid, NULL) == TRUE)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5G__is_new_dense_test(gid) != TRUE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close group with objects to delete */
     if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check reference count on objects to keep */
     for (u = 0; u < FULL_GROUP_NUM_KEEP; u++) {
         HDsprintf(objname, "/keep/keep %u\n", u);
         if (H5Oget_info_by_name3(file_id, objname, &oi, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (oi.rc != 2)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Re-open the file */
     if ((file_id = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Delete the full group */
     if (H5Ldelete(file_id, "/delete", H5P_DEFAULT) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check reference count on objects to keep */
     for (u = 0; u < FULL_GROUP_NUM_KEEP; u++) {
         HDsprintf(objname, "/keep/keep %u\n", u);
         if (H5Oget_info_by_name3(file_id, objname, &oi, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
-            FAIL_STACK_ERROR
+            FAIL_STACK_ERROR;
         if (oi.rc != 1)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Close the file */
     if (H5Fclose(file_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Get the size of the file */
     if ((file_size = h5_get_file_size(filename, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify the file is correct size */
     if (file_size != keep_size)
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -3009,11 +3009,11 @@ main(void)
 
     /* Copy the file access property list */
     if ((fapl2 = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set the "use the latest version of the format" bounds for creating objects in the file */
     if (H5Pset_libver_bounds(fapl2, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test with old & new format groups */
     for (new_format = FALSE; new_format <= TRUE; new_format++) {
@@ -3031,7 +3031,7 @@ main(void)
 
         h5_fixname(FILENAME[0], my_fapl, filename, sizeof filename);
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, my_fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Tests */
         nerrors += test_one(file);
@@ -3067,7 +3067,7 @@ main(void)
                                           fapl_small_mdc);
 
             if (H5Pclose(fapl_small_mdc) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         } /* end block */
 
         nerrors += test_link_slashes(my_fapl);
@@ -3098,7 +3098,7 @@ main(void)
 
         /* Close */
         if (H5Fclose(file) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end for */
 
     /* Close 2nd FAPL */

--- a/test/unregister.c
+++ b/test/unregister.c
@@ -288,7 +288,7 @@ main(void)
 
     /* Push API context */
     if (H5CX_push() < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = TRUE;
 
     /* Test unregistering filter in its own file */
@@ -302,7 +302,7 @@ main(void)
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(FALSE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     api_ctx_pushed = FALSE;
 
     HDexit(EXIT_SUCCESS);

--- a/test/vds.c
+++ b/test/vds.c
@@ -39,16 +39,25 @@ const char *FILENAME[] = {"vds_virt_0", "vds_virt_1", "vds_src_0",  "vds_src_1",
 #ifdef VDS_TEST_VERBOSE
 
 /* For verbose output just use standard error printing */
-#define TESTING_2_SUPPRESSED(WHAT) TESTING_2(WHAT)
-#define PASSED_SUPPRESSED()        PASSED()
-#define TEST_ERROR_SUPPRESSED      TEST_ERROR
+#define TESTING_2_SUPPRESSED(WHAT)                                                                           \
+    do {                                                                                                     \
+        TESTING_2(WHAT);                                                                                     \
+    } while (0)
+#define PASSED_SUPPRESSED()                                                                                  \
+    do {                                                                                                     \
+        PASSED();                                                                                            \
+    } while (0)
+#define TEST_ERROR_SUPPRESSED                                                                                \
+    do {                                                                                                     \
+        TEST_ERROR;                                                                                          \
+    } while (0)
 
 /* Print config directly to output */
 #define PRINT_CONFIG(...)                                                                                    \
-    {                                                                                                        \
+    do {                                                                                                     \
         HDprintf("Config: " __VA_ARGS__);                                                                    \
         HDputs("");                                                                                          \
-    }
+    } while (0)
 
 #else /* VDS_TEST_VERBOSE */
 
@@ -58,22 +67,28 @@ char vds_test_str_g[128]   = "";
 
 /* Replacement for TESTING_2 for non-verbose-output */
 #define TESTING_2_SUPPRESSED(WHAT)                                                                           \
-    {                                                                                                        \
+    do {                                                                                                     \
         HDsnprintf(vds_test_str_g, sizeof(vds_test_str_g), WHAT);                                            \
-    }
+    } while (0)
 
 /* Suppress output from PASSED() */
-#define PASSED_SUPPRESSED()
+#define PASSED_SUPPRESSED()                                                                                  \
+    do {                                                                                                     \
+        ;                                                                                                    \
+    } while (0)
 
 /* Replacement for TEST_ERROR for non-verbose output */
 #define TEST_ERROR_SUPPRESSED                                                                                \
-    {                                                                                                        \
-        printf("Failed config: %s\nFailed test: %s\n", vds_config_str_g, vds_test_str_g);                    \
-        TEST_ERROR                                                                                           \
-    }
+    do {                                                                                                     \
+        HDprintf("Failed config: %s\nFailed test: %s\n", vds_config_str_g, vds_test_str_g);                  \
+        TEST_ERROR;                                                                                          \
+    } while (0)
 
 /* Replacement for HDprintf for printing configuration for non-verbose output */
-#define PRINT_CONFIG(...) HDsnprintf(vds_config_str_g, sizeof(vds_config_str_g), __VA_ARGS__);
+#define PRINT_CONFIG(...)                                                                                    \
+    do {                                                                                                     \
+        HDsnprintf(vds_config_str_g, sizeof(vds_config_str_g), __VA_ARGS__);                                 \
+    } while (0)
 
 #endif /* VDS_TEST_VERBOSE */
 
@@ -113,9 +128,9 @@ vds_select_equal(hid_t space1, hid_t space2)
 
     /* Get and compare selection types */
     if ((type1 = H5Sget_select_type(space1)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((type2 = H5Sget_select_type(space2)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (type1 != type2)
         return FALSE;
 
@@ -133,32 +148,32 @@ vds_select_equal(hid_t space1, hid_t space2)
 
             /* Get and compare rank */
             if ((rank1 = H5Sget_simple_extent_ndims(space1)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if ((rank2 = H5Sget_simple_extent_ndims(space2)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (rank1 != rank2)
                 return FALSE;
 
             /* Get and compare number of points */
             if ((npoints1 = H5Sget_select_elem_npoints(space1)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if ((npoints2 = H5Sget_select_elem_npoints(space2)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (npoints1 != npoints2)
                 return FALSE;
 
             /* Allocate point lists.  Do not return directly after
              * allocating, to make sure buffers are freed. */
             if (NULL == (buf1 = (hsize_t *)HDmalloc((size_t)rank1 * (size_t)npoints1 * sizeof(hsize_t))))
-                TEST_ERROR
+                TEST_ERROR;
             if (NULL == (buf2 = (hsize_t *)HDmalloc((size_t)rank1 * (size_t)npoints1 * sizeof(hsize_t))))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Get and compare point lists */
             if (H5Sget_select_elem_pointlist(space1, (hsize_t)0, (hsize_t)npoints1, buf1) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Sget_select_elem_pointlist(space2, (hsize_t)0, (hsize_t)npoints1, buf2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             for (i = 0; i < ((size_t)rank1 * (size_t)npoints1); i++)
                 if (buf1[i] != buf2[i]) {
                     ret_value = FALSE;
@@ -182,17 +197,17 @@ vds_select_equal(hid_t space1, hid_t space2)
 
             /* Get and compare rank */
             if ((rank1 = H5Sget_simple_extent_ndims(space1)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if ((rank2 = H5Sget_simple_extent_ndims(space2)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (rank1 != rank2)
                 return FALSE;
 
             /* Get and compare number of blocks */
             if ((nblocks1 = H5Sget_select_hyper_nblocks(space1)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if ((nblocks2 = H5Sget_select_hyper_nblocks(space2)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (nblocks1 != nblocks2)
                 return FALSE;
 
@@ -200,16 +215,16 @@ vds_select_equal(hid_t space1, hid_t space2)
              * allocating, to make sure buffers are freed. */
             if (NULL ==
                 (buf1 = (hsize_t *)HDmalloc((size_t)2 * (size_t)rank1 * (size_t)nblocks1 * sizeof(*buf1))))
-                TEST_ERROR
+                TEST_ERROR;
             if (NULL ==
                 (buf2 = (hsize_t *)HDmalloc((size_t)2 * (size_t)rank1 * (size_t)nblocks1 * sizeof(*buf2))))
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Get and compare block lists */
             if (H5Sget_select_hyper_blocklist(space1, (hsize_t)0, (hsize_t)nblocks1, buf1) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Sget_select_hyper_blocklist(space2, (hsize_t)0, (hsize_t)nblocks1, buf2) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             for (i = 0; i < ((size_t)2 * (size_t)rank1 * (size_t)nblocks1); i++)
                 if (buf1[i] != buf2[i]) {
                     ret_value = FALSE;
@@ -228,7 +243,7 @@ vds_select_equal(hid_t space1, hid_t space2)
         case H5S_SEL_ERROR:
         case H5S_SEL_N:
         default:
-            TEST_ERROR
+            TEST_ERROR;
     } /* end switch */
 
     return ret_value;
@@ -270,55 +285,55 @@ vds_check_mapping(hid_t dcpl, size_t i, hid_t vspace, hid_t srcspace, const char
 
     /* Check vspace */
     if ((space_out = H5Pget_virtual_vspace(dcpl, i)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tri_ret = H5Sextent_equal(space_out, vspace)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!tri_ret)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tri_ret = vds_select_equal(space_out, vspace)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!tri_ret)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(space_out) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     space_out = -1;
 
     /* Check srcspace */
     if ((space_out = H5Pget_virtual_srcspace(dcpl, i)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((tri_ret = vds_select_equal(space_out, srcspace)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!tri_ret)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(space_out) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     space_out = -1;
 
     /* Check filename */
     if ((str_len = H5Pget_virtual_filename(dcpl, i, NULL, (size_t)0)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((size_t)str_len != HDstrlen(filename))
-        TEST_ERROR
+        TEST_ERROR;
     HDassert((size_t)str_len < sizeof(name_out));
     if ((str_len = H5Pget_virtual_filename(dcpl, i, name_out, sizeof(name_out))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((size_t)str_len != HDstrlen(filename))
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrncmp(name_out, filename, (size_t)str_len + 1) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check dsetname */
     if ((str_len = H5Pget_virtual_dsetname(dcpl, i, NULL, (size_t)0)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((size_t)str_len != HDstrlen(dsetname))
-        TEST_ERROR
+        TEST_ERROR;
     HDassert((size_t)str_len < sizeof(name_out));
     if ((str_len = H5Pget_virtual_dsetname(dcpl, i, name_out, sizeof(name_out))) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((size_t)str_len != HDstrlen(dsetname))
-        TEST_ERROR
+        TEST_ERROR;
     if (HDstrncmp(name_out, dsetname, (size_t)str_len + 1) != 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -365,105 +380,105 @@ test_api_get_ex_dcpl(test_api_config_t config, hid_t fapl, hid_t dcpl, hid_t *ex
     if (config >= TEST_API_CREATE_DSET) {
         /* Create file and dataset */
         if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((dset = H5Dcreate2(file, "vdset", H5T_NATIVE_INT, vspace, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Test H5Dget_space_status */
         if (H5Dget_space_status(dset, &space_status) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (space_status != H5D_SPACE_STATUS_ALLOCATED)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Reopen dataset if requested */
         if (config >= TEST_API_REOPEN_DSET) {
             /* Close dataset */
             if (H5Dclose(dset) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             dset = -1;
 
             /* Reopen file if requested */
             if (config == TEST_API_REOPEN_FILE) {
                 if (H5Fclose(file) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
                 file = -1;
                 if ((file = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
-                    TEST_ERROR
+                    TEST_ERROR;
             }
 
             /* Open dataset */
             if ((dset = H5Dopen2(file, "vdset", H5P_DEFAULT)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         }
 
         /* Get DCPL from dataset */
         if ((*ex_dcpl = H5Dget_create_plist(dset)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Test H5Dget_offset() (just returns HADDR_UNDEF) */
         if (HADDR_UNDEF != H5Dget_offset(dset))
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Test H5Oget_info returns correct metadata size */
         if (H5Oget_native_info(dset, &ninfo, H5O_NATIVE_INFO_META_SIZE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (ninfo.meta_size.obj.index_size != (hsize_t)0)
-            TEST_ERROR
+            TEST_ERROR;
         if (config == TEST_API_REOPEN_FILE) {
             if (ninfo.meta_size.obj.heap_size != exp_meta_size) {
                 HDprintf("VDS metadata size: %llu Expected: %llu\n",
                          (long long unsigned)ninfo.meta_size.obj.heap_size,
                          (long long unsigned)exp_meta_size);
-                TEST_ERROR
+                TEST_ERROR;
             }
         }
         else if ((ninfo.meta_size.obj.heap_size != exp_meta_size) &&
                  (ninfo.meta_size.obj.heap_size != (hsize_t)0))
-            TEST_ERROR
+            TEST_ERROR;
         if (ninfo.meta_size.attr.index_size != (hsize_t)0)
-            TEST_ERROR
+            TEST_ERROR;
         if (ninfo.meta_size.attr.index_size != (hsize_t)0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Test H5Dget_space_status */
         if (H5Dget_space_status(dset, &space_status) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (space_status != H5D_SPACE_STATUS_ALLOCATED)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close dataset */
         if (H5Dclose(dset) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         dset = -1;
 
         /* Delete dataset */
         if (H5Ldelete(file, "vdset", H5P_DEFAULT) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Close file */
         if (H5Fclose(file) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         file = -1;
     }
     else if (config == TEST_API_COPY_PLIST) {
         /* Copy property list */
         if ((*ex_dcpl = H5Pcopy(dcpl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else if (config == TEST_API_ENCDEC_PLIST) {
         size_t plist_buf_size;
 
         /* Encode property list to plist_buf */
         if (H5Pencode2(dcpl, NULL, &plist_buf_size, fapl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (NULL == (plist_buf = HDmalloc(plist_buf_size)))
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pencode2(dcpl, plist_buf, &plist_buf_size, fapl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Decode serialized property list to *ex_dcpl */
         if ((*ex_dcpl = H5Pdecode(plist_buf)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Free plist_buf */
         HDfree(plist_buf);
@@ -473,7 +488,7 @@ test_api_get_ex_dcpl(test_api_config_t config, hid_t fapl, hid_t dcpl, hid_t *ex
         /* Simply copy the id to ex_dcpl and increment the ref count so ex_dcpl
          * can be closed */
         if (H5Iinc_ref(dcpl) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         *ex_dcpl = dcpl;
     }
 
@@ -483,9 +498,9 @@ test_api_get_ex_dcpl(test_api_config_t config, hid_t fapl, hid_t dcpl, hid_t *ex
      */
     if ((*ex_dcpl != dcpl) && (config != TEST_API_REOPEN_FILE)) {
         if ((tri_ret = H5Pequal(dcpl, *ex_dcpl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (!tri_ret)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     return 0;
@@ -534,78 +549,78 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
 
     switch (config) {
         case TEST_API_BASIC:
-            TESTING_2("virtual dataset API functions")
+            TESTING_2("virtual dataset API functions");
             break;
         case TEST_API_COPY_PLIST:
-            TESTING_2("virtual dataset API functions with copied plists")
+            TESTING_2("virtual dataset API functions with copied plists");
             break;
         case TEST_API_ENCDEC_PLIST:
-            TESTING_2("virtual dataset API functions with encoded and decoded plists")
+            TESTING_2("virtual dataset API functions with encoded and decoded plists");
             break;
         case TEST_API_CREATE_DSET:
-            TESTING_2("virtual dataset create")
+            TESTING_2("virtual dataset create");
             break;
         case TEST_API_REOPEN_DSET:
-            TESTING_2("virtual dataset create with reopened dataset")
+            TESTING_2("virtual dataset create with reopened dataset");
             break;
         case TEST_API_REOPEN_FILE:
-            TESTING_2("virtual dataset create with reopened file")
+            TESTING_2("virtual dataset create with reopened file");
             break;
         case TEST_API_NTESTS:
         default:
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     h5_fixname(FILENAME[0], fapl, filename, sizeof filename);
 
     /* Create DCPL */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /*
      * Test 1: All - all selection
      */
     /* Create source dataspace */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create virtual dataspace */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select all (should not be necessary, but just to be sure) */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sselect_all(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], src_file[0], src_dset[0], srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get examination DCPL */
     if (test_api_get_ex_dcpl(config, fapl, dcpl, &ex_dcpl, vspace[0], filename, (hsize_t)69) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5Pget_virtual_count */
     if (H5Pget_virtual_count(ex_dcpl, &size_out) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (size_out != (size_t)1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the mapping in the DCPL is correct */
     if (vds_check_mapping(ex_dcpl, (size_t)0, vspace[0], srcspace[0], src_file[0], src_dset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     vspace[0] = -1;
     if (H5Pclose(ex_dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ex_dcpl = -1;
 
     /*
@@ -613,15 +628,15 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create source dataspace */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create virtual dataspace */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select regular hyperslab in source space */
     start[0]  = 2;
@@ -633,7 +648,7 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     block[0]  = 2;
     block[1]  = 4;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select composite hyperslab in virtual space */
     count[0] = 1;
@@ -641,43 +656,43 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     block[0] = 5;
     block[1] = 6;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     start[0] = 7;
     start[1] = 0;
     block[0] = 1;
     block[1] = 18;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_OR, start, NULL, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], src_file[0], src_dset[0], srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get examination DCPL */
     if (test_api_get_ex_dcpl(config, fapl, dcpl, &ex_dcpl, vspace[0], filename,
                              (low >= H5F_LIBVER_V112) ? (hsize_t)99 : (low >= H5F_LIBVER_V110 ? 174 : 213)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5Pget_virtual_count */
     if (H5Pget_virtual_count(ex_dcpl, &size_out) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (size_out != (size_t)1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the mapping in the DCPL is correct */
     if (vds_check_mapping(ex_dcpl, (size_t)0, vspace[0], srcspace[0], src_file[0], src_dset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     vspace[0] = -1;
     if (H5Pclose(ex_dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ex_dcpl = -1;
 
 #ifdef VDS_POINT_SELECTIONS /* VDS does not currently support point selections */
@@ -686,15 +701,15 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create source dataspace */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create virtual dataspace */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select points in source space */
     coord[0] = 5;
@@ -708,7 +723,7 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     coord[8] = 8;
     coord[9] = 18;
     if (H5Sselect_elements(srcspace[0], H5S_SELECT_SET, (size_t)5, coord) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select points in virtual space */
     coord[0] = 3;
@@ -722,35 +737,35 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     coord[8] = 5;
     coord[9] = 5;
     if (H5Sselect_elements(vspace[0], H5S_SELECT_SET, (size_t)5, coord) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], src_file[0], src_dset[0], srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get examination DCPL */
     if (test_api_get_ex_dcpl(config, fapl, dcpl, &ex_dcpl, vspace[0], filename, (hsize_t)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5Pget_virtual_count */
     if (H5Pget_virtual_count(ex_dcpl, &size_out) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (size_out != (size_t)1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the mapping in the DCPL is correct */
     if (vds_check_mapping(ex_dcpl, (size_t)0, vspace[0], srcspace[0], src_file[0], src_dset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     vspace[0] = -1;
     if (H5Pclose(ex_dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ex_dcpl = -1;
 
     /*
@@ -758,15 +773,15 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create source dataspace */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create virtual dataspace */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select hyperslab in source space */
     start[0] = 2;
@@ -776,7 +791,7 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     block[0] = 1;
     block[1] = 5;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, NULL, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select points in virtual space */
     coord[0] = 1;
@@ -790,35 +805,35 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     coord[8] = 7;
     coord[9] = 16;
     if (H5Sselect_elements(vspace[0], H5S_SELECT_SET, (size_t)5, coord) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], src_file[0], src_dset[0], srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get examination DCPL */
     if (test_api_get_ex_dcpl(config, fapl, dcpl, &ex_dcpl, vspace[0], filename, (hsize_t)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5Pget_virtual_count */
     if (H5Pget_virtual_count(ex_dcpl, &size_out) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (size_out != (size_t)1)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the mapping in the DCPL is correct */
     if (vds_check_mapping(ex_dcpl, (size_t)0, vspace[0], srcspace[0], src_file[0], src_dset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     vspace[0] = -1;
     if (H5Pclose(ex_dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ex_dcpl = -1;
 
     /*
@@ -826,24 +841,24 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create dataspaces */
     for (i = 0; i < 4; i++) {
         /* Create source dataspace */
         if ((srcspace[i] = H5Screate_simple(2, dims, NULL)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Create virtual dataspace */
         if ((vspace[i] = H5Screate_simple(2, dims, NULL)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* Select all (should not be necessary, but just to be sure) */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sselect_all(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select regular hyperslab in source space */
     start[0]  = 2;
@@ -855,7 +870,7 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     block[0]  = 2;
     block[1]  = 4;
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select composite hyperslab in virtual space */
     count[0] = 1;
@@ -863,13 +878,13 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     block[0] = 5;
     block[1] = 6;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     start[0] = 7;
     start[1] = 0;
     block[0] = 1;
     block[1] = 18;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_OR, start, NULL, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select points in source space */
     coord[0] = 5;
@@ -883,7 +898,7 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     coord[8] = 8;
     coord[9] = 18;
     if (H5Sselect_elements(srcspace[2], H5S_SELECT_SET, (size_t)5, coord) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select points in virtual space */
     coord[0] = 3;
@@ -897,7 +912,7 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     coord[8] = 5;
     coord[9] = 5;
     if (H5Sselect_elements(vspace[2], H5S_SELECT_SET, (size_t)5, coord) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select hyperslab in source space */
     start[0] = 2;
@@ -907,7 +922,7 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     block[0] = 1;
     block[1] = 5;
     if (H5Sselect_hyperslab(srcspace[3], H5S_SELECT_SET, start, NULL, count, block) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select points in virtual space */
     coord[0] = 1;
@@ -921,39 +936,39 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     coord[8] = 7;
     coord[9] = 16;
     if (H5Sselect_elements(vspace[3], H5S_SELECT_SET, (size_t)5, coord) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add virtual layout mappings */
     for (i = 0; i < 4; i++)
         if (H5Pset_virtual(dcpl, vspace[i], src_file[i], src_dset[i], srcspace[i]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Get examination DCPL */
     if (test_api_get_ex_dcpl(config, fapl, dcpl, &ex_dcpl, vspace[0], filename, (hsize_t)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5Pget_virtual_count */
     if (H5Pget_virtual_count(ex_dcpl, &size_out) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (size_out != (size_t)4)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check that the mappings in the DCPL are correct */
     for (i = 0; i < 4; i++)
         if (vds_check_mapping(ex_dcpl, (size_t)i, vspace[i], srcspace[i], src_file[i], src_dset[i]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     /* Close */
     for (i = 0; i < 4; i++) {
         if (H5Sclose(srcspace[i]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         srcspace[i] = -1;
         if (H5Sclose(vspace[i]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         vspace[i] = -1;
     }
     if (H5Pclose(ex_dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ex_dcpl = -1;
 
 #else  /* VDS_POINT_SELECTIONS */
@@ -963,15 +978,15 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create source dataspace */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create virtual dataspace */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select points in source space */
     coord[0] = 5;
@@ -985,7 +1000,7 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     coord[8] = 8;
     coord[9] = 18;
     if (H5Sselect_elements(srcspace[0], H5S_SELECT_SET, (size_t)5, coord) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select points in virtual space */
     coord[0] = 3;
@@ -999,7 +1014,7 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     coord[8] = 5;
     coord[9] = 5;
     if (H5Sselect_elements(vspace[0], H5S_SELECT_SET, (size_t)5, coord) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attempt to add virtual layout mapping */
     H5E_BEGIN_TRY
@@ -1008,7 +1023,7 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 #endif /* VDS_POINT_SELECTIONS */
 
     /*
@@ -1016,16 +1031,16 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create source dataspace */
     dims[0] = 1;
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select all in source space (should not be necessary, but just to be sure) */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Init virtual space extent */
     dims[0] = LIST_DOUBLE_SIZE;
@@ -1042,34 +1057,34 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     for (i = 0; i < LIST_DOUBLE_SIZE; i++) {
         /* Create virtual dataspace */
         if ((vspace[i] = H5Screate_simple(2, dims, NULL)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Select row in virtual dataspace */
         start[0] = (hsize_t)i;
         if (H5Sselect_hyperslab(vspace[i], H5S_SELECT_SET, start, NULL, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
-                /* Create file and dataset names */
-                (void) HDsnprintf(tmp_filename, sizeof(tmp_filename), "src_file%u", i);
+        /* Create file and dataset names */
+        (void)HDsnprintf(tmp_filename, sizeof(tmp_filename), "src_file%u", i);
         tmp_filename[sizeof(tmp_filename) - 1] = '\0';
         (void)HDsnprintf(tmp_dsetname, sizeof(tmp_dsetname), "src_dset%u", i);
         tmp_dsetname[sizeof(tmp_dsetname) - 1] = '\0';
 
         /* Add virtual layout mapping */
         if (H5Pset_virtual(dcpl, vspace[i], tmp_filename, tmp_dsetname, srcspace[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* Get examination DCPL */
     if (test_api_get_ex_dcpl(config, fapl, dcpl, &ex_dcpl, vspace[0], filename,
                              (low >= H5F_LIBVER_V112) ? (hsize_t)607 : (hsize_t)697) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5Pget_virtual_count */
     if (H5Pget_virtual_count(ex_dcpl, &size_out) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (size_out != (size_t)LIST_DOUBLE_SIZE)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify virtual layout */
     for (i = 0; i < LIST_DOUBLE_SIZE; i++) {
@@ -1083,20 +1098,20 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
 
         /* Check that the mapping in the DCPL is correct */
         if (vds_check_mapping(ex_dcpl, (size_t)i, vspace[i], srcspace[0], tmp_filename, tmp_dsetname) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* Close */
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     srcspace[0] = -1;
     for (i = 0; i < LIST_DOUBLE_SIZE; i++) {
         if (H5Sclose(vspace[i]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         vspace[i] = -1;
     }
     if (H5Pclose(ex_dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ex_dcpl = -1;
 
     /*
@@ -1104,37 +1119,37 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create virtual dataspace */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select all (should not be necessary, but just to be sure) */
     if (H5Sselect_all(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Get examination DCPL */
     if (test_api_get_ex_dcpl(config, fapl, dcpl, &ex_dcpl, vspace[0], filename, (hsize_t)0) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Test H5Pget_virtual_count */
     if (H5Pget_virtual_count(ex_dcpl, &size_out) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (size_out != (size_t)0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close */
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     vspace[0] = -1;
     if (H5Pclose(ex_dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     ex_dcpl = -1;
 
     /* Close */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     dcpl = -1;
 
     PASSED();
@@ -1191,7 +1206,7 @@ test_vds_prefix_first(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     int         i, j;
     char        buffer[1024]; /* buffer to read vds_prefix       */
 
-    TESTING_2_SUPPRESSED("basic virtual dataset I/O via H5Pset_vds_prefix(): all selection")
+    TESTING_2_SUPPRESSED("basic virtual dataset I/O via H5Pset_vds_prefix(): all selection");
 
     if ((srcfilename = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
         TEST_ERROR_SUPPRESSED;
@@ -1212,76 +1227,76 @@ test_vds_prefix_first(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* create tmp directory and get current working directory path */
     if (HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create DCPL */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Set fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Initialize VDS prefix items */
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     if (H5Pset_virtual_prefix(dapl, TMPDIR) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pget_virtual_prefix(dapl, buffer, sizeof(buffer)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     if (HDstrcmp(buffer, TMPDIR) != 0)
         FAIL_PUTS_ERROR("vds prefix not set correctly");
 
     /* Create source dataspace */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspace */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select all (should not be necessary, but just to be sure) */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sselect_all(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if (NULL == HDgetcwd(buffer, 1024))
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (HDchdir(TMPDIR) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (HDchdir(buffer) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create source dataset */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1290,17 +1305,17 @@ test_vds_prefix_first(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write data directly to source dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -1308,27 +1323,27 @@ test_vds_prefix_first(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++) {
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j]) {
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             }
     }
 
@@ -1339,59 +1354,59 @@ test_vds_prefix_first(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write data through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reopen srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (NULL == HDgetcwd(buffer, 1024))
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             if (HDchdir(TMPDIR) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             if (HDchdir(buffer) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read data directly from source dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdset[0] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
     if (H5Pclose(dapl) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     dapl = -1;
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     dcpl = -1;
 
     HDfree(srcfilename);
@@ -1423,7 +1438,7 @@ error:
     H5E_END_TRY;
 
     if (HDsetenv("HDF5_VDS_PREFIX", "", 1) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     HDfree(srcfilename);
     HDfree(srcfilename_map);
@@ -1478,7 +1493,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     herr_t      ret;                                        /* Generic return value */
     int         i, j, u, v;
 
-    TESTING_2_SUPPRESSED("basic virtual dataset I/O")
+    TESTING_2_SUPPRESSED("basic virtual dataset I/O");
 
     if ((srcfilename = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
         TEST_ERROR_SUPPRESSED;
@@ -1502,57 +1517,57 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Create DCPL */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Set fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /*
      * Test 1: All - all selection
      */
     /* Create source dataspace */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspace */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select all (should not be necessary, but just to be sure) */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sselect_all(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create source dataset */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1561,17 +1576,17 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write data directly to source dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -1579,27 +1594,27 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1608,46 +1623,46 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write data through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reopen srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read data directly from source dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdset[0] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
 
     /*
@@ -1656,70 +1671,70 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((vspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspace */
     dims[1] = 13;
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select all in source space (should not be necessary, but just to be sure)
      */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in virtual spaces */
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 13;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "%%src_dset1", srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset2%%", srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reset dims */
     dims[1] = 26;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "%src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2%", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1728,22 +1743,22 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write data directly to source datasets */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -1751,27 +1766,27 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1780,40 +1795,40 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write data through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[0] = H5Dopen2(srcfile[0], "%src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2%", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read data directly from source datasets */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Test H5Ocopy() to same file */
     /* Copy virtual dataset */
     if (H5Ocopy(vfile, "v_dset", vfile, "v_dset2", H5P_DEFAULT, H5P_DEFAULT) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close v_dset */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
 
     /* Adjust write buffer */
@@ -1823,22 +1838,22 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write data directly to source datasets */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -1846,36 +1861,36 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Open v_dset2 */
     if ((vdset = H5Dopen2(vfile, "v_dset2", H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through copied virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[0] = H5Dopen2(srcfile[0], "%src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2%", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Only copy to a different file if the source datasets are in a different
@@ -1883,16 +1898,16 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     if (config & TEST_IO_DIFFERENT_FILE) {
         /* Close v_dset2 */
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
 
         /* Create file to copy virtual dataset to */
         if ((vfile2 = H5Fcreate(vfilename2, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Copy virtual dataset */
         if (H5Ocopy(vfile, "v_dset", vfile2, "v_dset3", H5P_DEFAULT, H5P_DEFAULT) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Adjust write buffer */
         for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -1901,22 +1916,22 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Write data directly to source datasets */
         if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Close srcdsets and srcfile if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (H5Dclose(srcdset[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcdset[0] = -1;
             if (H5Dclose(srcdset[1]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcdset[1] = -1;
 
             if (config & TEST_IO_DIFFERENT_FILE) {
                 if (H5Fclose(srcfile[0]) < 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
                 srcfile[0] = -1;
             }
         }
@@ -1924,66 +1939,66 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         /* Reopen copied virtual file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Fclose(vfile2) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             vfile2 = -1;
             if ((vfile2 = H5Fopen(vfilename2, H5F_ACC_RDWR, vds_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
         /* Open v_dset3 */
         if ((vdset = H5Dopen2(vfile2, "v_dset3", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through copied virtual dataset */
         HDmemset(rbuf[0], 0, sizeof(rbuf));
         if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
             for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
                 if (rbuf[i][j] != buf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
 
         /* Reopen srcdsets and srcfile if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (config & TEST_IO_DIFFERENT_FILE)
                 if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             if ((srcdset[0] = H5Dopen2(srcfile[0], "%src_dset1", H5P_DEFAULT)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2%", H5P_DEFAULT)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
     }
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdset[1] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (vfile2 >= 0 && H5Fclose(vfile2) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile2 = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[1] = -1;
 
     /*
@@ -1991,71 +2006,71 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspace */
     dims[1] = 13;
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select all in source space (should not be necessary, but just to be sure)
      */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in virtual spaces */
     start[0] = 0;
     start[1] = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Add virtual layout mappings */
     offset[1] = -3;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "%%src_dset1", srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     offset[1] = 10;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset2%%", srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reset dims */
     dims[1] = 26;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "%src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2%", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2065,27 +2080,27 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Write data directly to source datasets */
     offset[1] = -3;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     offset[1] = 10;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -2093,27 +2108,27 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2122,59 +2137,59 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write data through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[0] = H5Dopen2(srcfile[0], "%src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2%", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read data directly from source datasets */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     offset[1] = -3;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     offset[1] = 10;
     if (H5Soffset_simple(vspace[0], offset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdset[1] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
 
     /*
@@ -2183,70 +2198,70 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((vspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspace */
     dims[1] = 13;
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select all in source space (should not be necessary, but just to be sure)
      */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in virtual spaces */
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 13;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilenamepct_map : ".",
                        "src_dset1", srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilenamepct_map : ".",
                        "src_dset2", srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reset dims */
     dims[1] = 26;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilenamepct, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2255,22 +2270,22 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write data directly to source datasets */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -2278,38 +2293,38 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read first source dataset through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, vspace[0], vspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != (j < (int)(sizeof(buf[0]) / sizeof(buf[0][0]) / 2) ? buf[i][j] : 0))
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Read second source dataset through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, vspace[1], vspace[1], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != (j < (int)(sizeof(buf[0]) / sizeof(buf[0][0]) / 2) ? 0 : buf[i][j]))
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2318,7 +2333,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write first source dataset through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, vspace[0], vspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2327,25 +2342,25 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write second source dataset through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, vspace[1], vspace[1], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilenamepct, H5F_ACC_RDONLY, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read data directly from source datasets */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, vspace[0], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, vspace[1], H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2353,32 +2368,32 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
             if (rbuf[i][j] != (j < (int)(sizeof(buf[0]) / sizeof(buf[0][0]) / 2)
                                    ? (buf[i][j] - (int)(sizeof(buf) / sizeof(buf[0][0])))
                                    : buf[i][j]))
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdset[1] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[1] = -1;
 
     /*
@@ -2386,19 +2401,19 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((vspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspaces */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in source space */
     start[0] = 0;
@@ -2406,10 +2421,10 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 10;
     count[1] = 13;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 13;
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in virtual spaces */
     start[0] = 0;
@@ -2417,45 +2432,45 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 5;
     count[1] = 26;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 5;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[1], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2465,7 +2480,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Write data directly to source datasets */
     /* Write first dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update evbuf */
     for (i = 0; i < 5; i++) {
@@ -2482,7 +2497,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update evbuf */
     for (i = 0; i < 5; i++) {
@@ -2495,15 +2510,15 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -2511,15 +2526,15 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read data through virtual dataset by hyperslab */
@@ -2528,7 +2543,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Read first slice */
     if (H5Dread(vdset, H5T_NATIVE_INT, vspace[0], srcspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 5; i++) {
@@ -2540,7 +2555,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Read second slice */
     if (H5Dread(vdset, H5T_NATIVE_INT, vspace[1], srcspace[1], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 5; i++) {
@@ -2554,7 +2569,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2564,7 +2579,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Write data through virtual dataset */
     /* Write first slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, vspace[0], srcspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update evbuf */
     for (i = 0; i < 5; i++) {
@@ -2581,7 +2596,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write second slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, vspace[1], srcspace[1], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update evbuf */
     for (i = 0; i < 5; i++) {
@@ -2595,11 +2610,11 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read data directly from source datasets */
@@ -2608,7 +2623,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Read first dataset */
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, srcspace[0], srcspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 5; i++) {
@@ -2620,7 +2635,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Read second dataset */
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, srcspace[1], srcspace[1], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 5; i++) {
@@ -2634,35 +2649,35 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdset[1] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[0] = -1;
     if (H5Sclose(srcspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[1] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[1] = -1;
 
     /*
@@ -2671,25 +2686,25 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create memory dataspace */
     if ((memspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     dims[1] = 52;
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((vspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspace and file space for second operation (srcspace[1])
      */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reset dims */
     dims[1] = 26;
@@ -2705,10 +2720,10 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0]  = 10;
     block[1]  = 1;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 1;
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs (checkerboard) in virtual spaces */
     start[0]  = 0;
@@ -2720,53 +2735,53 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0]  = 1;
     block[1]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 1;
     start[1] = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 0;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 1;
     start[1] = 0;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2776,7 +2791,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Write data directly to source datasets */
     /* Write first dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i += 2)
@@ -2790,7 +2805,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 1; i < 10; i += 2)
@@ -2800,15 +2815,15 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -2816,15 +2831,15 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read data through virtual dataset by hyperslab */
@@ -2833,17 +2848,17 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Read first stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Read second stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, srcspace[1], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i += 2)
@@ -2856,7 +2871,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -2866,7 +2881,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Write data through virtual dataset */
     /* Write first slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i += 2)
@@ -2880,7 +2895,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write second slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, srcspace[1], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 1; i < 10; i += 2)
@@ -2891,11 +2906,11 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read data directly from source datasets */
@@ -2904,13 +2919,13 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Read first dataset */
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i += 2)
@@ -2921,44 +2936,44 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Read second dataset */
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, memspace, srcspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdset[1] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[0] = -1;
     if (H5Sclose(srcspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[1] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[1] = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     memspace = -1;
 
     /*
@@ -2967,11 +2982,11 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create memory dataspace */
     if ((memspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     dims[0] = 3;
@@ -2979,18 +2994,18 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     dims[2] = 3;
     dims[3] = 3;
     if ((vspace[0] = H5Screate_simple(4, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((vspace[1] = H5Screate_simple(4, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspaces */
     dims[0] = 2;
     dims[1] = 4;
     dims[2] = 4;
     if ((srcspace[0] = H5Screate_simple(3, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcspace[1] = H5Screate_simple(3, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reset dims */
     dims[0] = 10;
@@ -3010,10 +3025,10 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[1]  = 1;
     block[2]  = 4;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 1;
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs (corners) in first virtual space */
     start[0]  = 0;
@@ -3033,7 +3048,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[2]  = 1;
     block[3]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs ("+" pattern) in second virtual space */
     start[0]  = 1;
@@ -3053,61 +3068,61 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[2]  = 1;
     block[3]  = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 0;
     start[2] = 1;
     count[1] = 2;
     count[2] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 0;
     start[1] = 1;
     count[0] = 2;
     count[1] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 1;
     count[0] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 0;
     start[3] = 1;
     count[1] = 2;
     count[3] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_OR, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create source dataset */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -3120,21 +3135,21 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 2;
     count[1] = 16;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Write data directly to source dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -3142,15 +3157,15 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read data through virtual dataset */
@@ -3163,7 +3178,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 9;
     count[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset by hyperslab */
     /* Reset rbuf */
@@ -3179,11 +3194,11 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[2] = 1;
     count[3] = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read first stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     HDmemset(erbuf, 0, sizeof(erbuf));
@@ -3205,7 +3220,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Reset rbuf */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
@@ -3220,7 +3235,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[2] = 1;
     count[3] = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslab in memory space */
     start[0] = 0;
@@ -3228,11 +3243,11 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 9;
     count[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read second stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 9; i++)
@@ -3256,10 +3271,10 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if ((j >= 3) && (j < 6)) {
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Reset rbuf */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
@@ -3274,7 +3289,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[2] = 1;
     count[3] = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslab in memory space */
     start[0] = 0;
@@ -3282,11 +3297,11 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 9;
     count[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read third stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 9; i++)
@@ -3308,10 +3323,10 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if ((j >= 6) && (j < 9)) {
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Now read entire VDS */
     /* Set memory space extent to 9x9, select all in order to reach part of the
@@ -3319,19 +3334,19 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     dims[0] = 9;
     dims[1] = 9;
     if (H5Sset_extent_simple(memspace, 2, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sselect_all(memspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read third stripe pattern */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf99[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(rbuf99) / sizeof(rbuf99[0])); i++)
         for (j = 0; j < (int)(sizeof(rbuf99[0]) / sizeof(rbuf99[0][0])); j++)
             if (rbuf99[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -3353,7 +3368,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[2]  = 1;
     count[3]  = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0]  = 1;
     start[1]  = 1;
     start[2]  = 0;
@@ -3367,24 +3382,24 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[2]  = 1;
     count[3]  = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_OR, start, stride, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reset extent of memspace, select hyperslab */
     dims[0] = 10;
     dims[1] = 26;
     if (H5Sset_extent_simple(memspace, 2, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 0;
     start[1] = 0;
     count[0] = 1;
     count[1] = 10;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Write data through virtual dataset by hyperslab */
     /* Write first stripe pattern */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     HDmemset(erbuf, 0, sizeof(erbuf));
@@ -3418,7 +3433,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[2]  = 1;
     count[3]  = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0]  = 1;
     start[1]  = 0;
     start[2]  = 1;
@@ -3432,7 +3447,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[2]  = 1;
     count[3]  = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_OR, start, stride, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslab in memory space */
     start[0] = 0;
@@ -3440,11 +3455,11 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 1;
     count[1] = 12;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Write second slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     erbuf[0][4]  = buf[0][0];
@@ -3479,7 +3494,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[2]  = 1;
     count[3]  = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0]  = 1;
     start[1]  = 1;
     start[2]  = 2;
@@ -3493,7 +3508,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[2]  = 1;
     count[3]  = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_OR, start, stride, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslab in memory space */
     start[0] = 0;
@@ -3501,11 +3516,11 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 1;
     count[1] = 10;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Write third slice */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     erbuf[0][2]  = buf[0][0];
@@ -3523,9 +3538,9 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read data directly from source dataset */
@@ -3535,61 +3550,61 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 2;
     count[1] = 16;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reset rbuf */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
 
     /* Read dataset */
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Now try writing to whole VDS (should fail due to unmapped elements) */
     count[0] = 9;
     count[1] = 9;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     H5E_BEGIN_TRY
     {
         ret = H5Dwrite(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]);
     }
     H5E_END_TRY
     if (ret >= 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdset[0] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[0] = -1;
     if (H5Sclose(srcspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[1] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[1] = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     memspace = -1;
 
     /*
@@ -3598,46 +3613,46 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create memory dataspace */
     if ((memspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     dims[0] = 8;
     dims[1] = 15;
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((vspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspace */
     dims[0] = 4;
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select all in source space (should not be necessary, but just to be sure)
      */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in virtual spaces */
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 4;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reset dims */
     dims[0] = 10;
@@ -3645,30 +3660,30 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reset erbuf */
     HDmemset(erbuf[0], 0, sizeof(rbuf));
@@ -3684,11 +3699,11 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 4;
     count[1] = 15;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Write data directly to first source dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     u = 0;
@@ -3706,11 +3721,11 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Select hyperslab in memory */
     start[0] = 4;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Write data directly to second source dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 4; i < 6; i++)
@@ -3726,28 +3741,28 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Select hyperslab in memory */
@@ -3760,7 +3775,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0]  = 1;
     block[1]  = 1;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslab in file */
     start[0] = 2;
@@ -3768,48 +3783,48 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 4;
     count[1] = 15;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[1] = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     memspace = -1;
 
     /*
@@ -3818,56 +3833,56 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create memory dataspace */
     dims[1] = 13;
     dims[2] = 2;
     if ((memspace = H5Screate_simple(3, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     dims[0] = 6;
     dims[1] = 10;
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((vspace[1] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((vspace[2] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspace */
     dims[0] = 2;
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select all in source space (should not be necessary, but just to be sure)
      */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in virtual spaces */
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 2;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 4;
     if (H5Sselect_hyperslab(vspace[2], H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[2], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset3",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reset dims */
     dims[0] = 10;
@@ -3875,33 +3890,33 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset3", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reset erbuf */
     HDmemset(erbuf[0], 0, sizeof(rbuf));
@@ -3919,11 +3934,11 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[1] = 5;
     count[2] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Write data directly to first source dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     u = 0;
@@ -3942,11 +3957,11 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Select hyperslab in memory */
     start[0] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Write data directly to second source dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 2; i < 4; i++)
@@ -3963,11 +3978,11 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Select hyperslab in memory */
     start[0] = 4;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Write data directly to third source dataset */
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 4; i < 6; i++)
@@ -3984,31 +3999,31 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[2] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Select hyperslab in memory */
@@ -4025,54 +4040,54 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[1]  = 3;
     block[2]  = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[2] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[1] = -1;
     if (H5Sclose(vspace[2]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[2] = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     memspace = -1;
 
     /*
@@ -4081,30 +4096,30 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create memory dataspace */
     if ((memspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     dims[0] = 10;
     dims[1] = 9;
     dims[2] = 6;
     if ((vspace[0] = H5Screate_simple(3, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((vspace[1] = H5Screate_simple(3, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspace */
     dims[1] = 12;
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select all in source space (should not be necessary, but just to be sure)
      */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in virtual spaces */
     start[0]  = 0;
@@ -4120,18 +4135,18 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[1]  = 1;
     block[2]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[2] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reset dims */
     dims[0] = 10;
@@ -4139,30 +4154,30 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Initialize erbuf */
     HDmemset(erbuf[0], 0, sizeof(rbuf));
@@ -4183,11 +4198,11 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 10;
     count[1] = 12;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Write data directly to first source dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     u = 0;
@@ -4208,11 +4223,11 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Select hyperslab in memory */
     start[1] = 8;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Write data directly to second source dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     u = 0;
@@ -4233,28 +4248,28 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Select hyperslab in memory */
@@ -4267,7 +4282,7 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0]  = 10;
     block[1]  = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslab in file */
     start[0] = 0;
@@ -4277,53 +4292,53 @@ test_basic_io(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[1] = 4;
     count[2] = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, vspace[0], H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[1] = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     memspace = -1;
 
     /* Close */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     dcpl = -1;
 
     HDfree(srcfilename);
@@ -4406,7 +4421,7 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     H5D_vds_view_t virtual_view;                   /* Virtual view property */
     int            i, j;
 
-    TESTING_2_SUPPRESSED("virtual dataset I/O with unlimited selections")
+    TESTING_2_SUPPRESSED("virtual dataset I/O with unlimited selections");
 
     h5_fixname(FILENAME[0], vds_fapl, vfilename, sizeof vfilename);
     h5_fixname(FILENAME[2], src_fapl, srcfilename, sizeof srcfilename);
@@ -4414,44 +4429,44 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Create DCPLs */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Set fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Set chunk dimensions */
     if (H5Pset_chunk(srcdcpl, 2, cdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create DAPL */
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create memory space */
     if ((memspace = H5Screate_simple(2, mdims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /*
      * Test 1: 2 Source datasets, single unlimited hyperslab virtual mappings
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspace */
     dims[0]  = 5;
     mdims[0] = 5;
     if ((srcspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     mdims[0] = 10;
 
     /* Select hyperslab in source space */
@@ -4460,49 +4475,49 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 5;
     count[1] = H5S_UNLIMITED;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in virtual spaces */
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 5;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -4519,11 +4534,11 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     start[0] = 0;
     count[1] = 10;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Write first dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -4537,7 +4552,7 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -4547,15 +4562,15 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -4563,40 +4578,40 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4605,74 +4620,74 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Select hyperslab in memory space */
     start[0] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Test H5Pget_virtual_view() */
     if (H5Pget_virtual_view(dapl, &virtual_view) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (virtual_view != H5D_VDS_LAST_AVAILABLE)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Test H5Pget_virtual_view() */
     if (H5Pget_virtual_view(dapl, &virtual_view) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (virtual_view != H5D_VDS_FIRST_MISSING)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4680,33 +4695,33 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Extend srcdset[0] */
     dims[0] = 5;
     dims[1] = 15;
     if (H5Dset_extent(srcdset[0], dims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -4716,26 +4731,26 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Write to new area of srcdset */
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((filespace = H5Dget_space(srcdset[0])) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 10;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -4743,42 +4758,42 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions.  Note that since we are using
      * H5D_VDS_FIRST_MISSING and we only extended one source dataset the
      * dimensions will not have changed. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4787,38 +4802,38 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Select hyperslab in memory space */
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf to reflect new data that is now visible due to the change to
      * H5D_VDS_LAST_AVAILABLE */
@@ -4828,27 +4843,27 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 15)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4857,37 +4872,37 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Select hyperslab in memory space */
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Extend srcdset[1] */
     dims[0] = 5;
     dims[1] = 20;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -4897,16 +4912,16 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Write to new area of srcdset */
     count[1] = 10;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((filespace = H5Dget_space(srcdset[1])) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 10;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -4916,12 +4931,12 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -4929,40 +4944,40 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -4971,17 +4986,17 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Select hyperslab in memory space */
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Now just read middle 2 rows */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
@@ -4989,9 +5004,9 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 2;
     count[1] = 20;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, memspace, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data - algorithmically check for only 2 middle rows being
      * read so we don't have to wipe out erbuf and then restore it afterwards */
@@ -4999,24 +5014,24 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         for (j = 0; j < (int)mdims[1]; j++)
             if ((i == 4) || (i == 5)) {
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Now test reopening virtual dataset without calling H5Dget_space, if
      * REOPEN_VIRT flag set */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -5026,23 +5041,23 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         start[0] = 0;
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++)
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
 
         /* Now try setting extent manually */
         /* Shrink to 18 */
         dims[1] = 18;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -5052,27 +5067,27 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         start[0] = 0;
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR_SUPPRESSED
+                        TEST_ERROR_SUPPRESSED;
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
 
         /* Shrink to 15 */
         dims[1] = 15;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -5082,63 +5097,63 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         start[0] = 0;
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR_SUPPRESSED
+                        TEST_ERROR_SUPPRESSED;
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
     }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 15)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5148,36 +5163,36 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Now test reopening virtual dataset without calling H5Dget_space, if
      * REOPEN_VIRT flag set */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -5186,28 +5201,28 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         /* Select hyperslab in memory space */
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR_SUPPRESSED
+                        TEST_ERROR_SUPPRESSED;
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
 
         /* Now try setting extent manually */
         /* Grow to 18 */
         dims[1] = 18;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -5217,27 +5232,27 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         start[0] = 0;
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR_SUPPRESSED
+                        TEST_ERROR_SUPPRESSED;
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
 
         /* Grow to 20 */
         dims[1] = 20;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -5247,50 +5262,50 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         start[0] = 0;
         start[1] = 0;
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++)
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
     }
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[1] = -1;
 
     /*
@@ -5298,21 +5313,21 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     dims[0] = 10;
     dims[1] = 10;
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspace */
     dims[1]  = 5;
     mdims[1] = 10;
     if ((srcspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     mdims[1] = 20;
 
     /* Select hyperslab in source space */
@@ -5321,7 +5336,7 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 10;
     count[1] = H5S_UNLIMITED;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in virtual spaces */
     stride[0] = 1;
@@ -5331,46 +5346,46 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0]  = 10;
     block[1]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 0;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -5387,11 +5402,11 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 10;
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Write first dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -5405,7 +5420,7 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -5415,15 +5430,15 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -5431,40 +5446,40 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5472,62 +5487,62 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5535,32 +5550,32 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Extend srcdset[0] */
     dims[1] = 7;
     if (H5Dset_extent(srcdset[0], dims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -5570,17 +5585,17 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Write to new area of srcdset */
     count[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((filespace = H5Dget_space(srcdset[0])) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 5;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 0;
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf to reflect only new data that is now visible under
      * H5D_VDS_FIRST_MISSING (first slice) */
@@ -5590,12 +5605,12 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -5603,42 +5618,42 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions.  Note that since we are using
      * H5D_VDS_FIRST_MISSING and we only extended one source dataset the
      * dimension will only have changed to add one more slice. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 11)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5646,38 +5661,38 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf to reflect new data that is now visible due to the change to
      * H5D_VDS_LAST_AVAILABLE (second new slice) */
@@ -5686,27 +5701,27 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 13)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5714,36 +5729,36 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Extend srcdset[1] */
     dims[1] = 10;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -5753,17 +5768,17 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Write to new area of srcdset */
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((filespace = H5Dget_space(srcdset[1])) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 5;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 0;
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -5773,12 +5788,12 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -5786,40 +5801,40 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5827,17 +5842,17 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Now just read middle 2 rows */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
@@ -5845,10 +5860,10 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 2;
     count[1] = 20;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 0;
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, memspace, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data - algorithmically check for only 2 middle rows being
      * read so we don't have to wipe out erbuf and then restore it afterwards */
@@ -5856,26 +5871,26 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         for (j = 0; j < (int)mdims[1]; j++)
             if ((i == 4) || (i == 5)) {
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf to reflect new data that is no longer visible due to the
      * change to H5D_VDS_FIRST_MISSING */
@@ -5885,27 +5900,27 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 14)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -5913,54 +5928,54 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[1] = -1;
 
     /*
@@ -5968,31 +5983,31 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     dims[0] = 10;
     dims[1] = 10;
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((vspace[2] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspaces */
     dims[1]  = 4;
     mdims[1] = 8;
     if ((srcspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     dims[1]  = 4;
     mdims[1] = 6;
     if ((srcspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     dims[1]  = 2;
     mdims[1] = 6;
     if ((srcspace[2] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     mdims[1] = 20;
 
     /* Select hyperslab in source spaces */
@@ -6001,11 +6016,11 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 10;
     count[1] = H5S_UNLIMITED;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sselect_hyperslab(srcspace[2], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in virtual spaces */
     stride[0] = 1;
@@ -6015,55 +6030,55 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0]  = 10;
     block[1]  = 2;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 2;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 4;
     if (H5Sselect_hyperslab(vspace[2], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 0;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[2], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset3",
                        srcspace[2]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[1], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset3", H5T_NATIVE_INT, srcspace[2], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -6080,11 +6095,11 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 10;
     count[1] = 4;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Write first dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -6100,7 +6115,7 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -6118,11 +6133,11 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 10;
     count[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Write third dataset */
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++) {
@@ -6133,18 +6148,18 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[2] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -6152,40 +6167,40 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6193,62 +6208,62 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6256,32 +6271,32 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Extend srcdset[0] */
     dims[1] = 7;
     if (H5Dset_extent(srcdset[0], dims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -6291,27 +6306,27 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Write to new area of srcdset */
     count[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((filespace = H5Dget_space(srcdset[0])) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 4;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 0;
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -6319,41 +6334,41 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions.  Note that since we are using
      * H5D_VDS_FIRST_MISSING the size will not have changed. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6361,38 +6376,38 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf to reflect new data that is now visible due to the change to
      * H5D_VDS_LAST_AVAILABLE */
@@ -6404,27 +6419,27 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 19)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6432,36 +6447,36 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcdset[2] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[2] = H5Dopen2(srcfile[0], "src_dset3", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Extend srcdset[2] */
     dims[1] = 5;
     if (H5Dset_extent(srcdset[2], dims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -6471,17 +6486,17 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Write to new area of srcdset */
     count[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((filespace = H5Dget_space(srcdset[2])) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 2;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 0;
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++) {
@@ -6493,12 +6508,12 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[2] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[2] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -6506,41 +6521,41 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions.  Note that the dimensions will not have
      * changed. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 19)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6548,62 +6563,62 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 14)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6611,36 +6626,36 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Extend srcdset[1] */
     dims[1] = 6;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -6650,17 +6665,17 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Write to new area of srcdset */
     count[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((filespace = H5Dget_space(srcdset[1])) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 4;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 0;
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++) {
@@ -6671,12 +6686,12 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -6684,40 +6699,40 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 17)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6725,58 +6740,58 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 19)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -6784,21 +6799,21 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Now just read middle 2 rows */
@@ -6807,16 +6822,16 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 2;
     count[1] = 19;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 0;
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data - algorithmically check for only 2 middle rows being
      * read */
@@ -6824,55 +6839,55 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         for (j = 0; j < (int)mdims[1]; j++)
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if ((i == 4) || (i == 5)) {
                 if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[2] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[0] = -1;
     if (H5Sclose(srcspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[1] = -1;
     if (H5Sclose(srcspace[2]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[2] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[1] = -1;
 
     /*
@@ -6880,23 +6895,23 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspaces */
     dims[0]  = 5;
     dims[1]  = 0;
     mdims[0] = 5;
     if ((srcspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     dims[1] = 5;
     if ((srcspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     mdims[0] = 10;
 
     /* Select hyperslab in source spaces */
@@ -6905,53 +6920,53 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 5;
     count[1] = H5S_UNLIMITED;
     if (H5Sselect_hyperslab(srcspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in virtual spaces */
     start[1] = 10;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 5;
     start[1] = 0;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset1",
                        srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset2",
                        srcspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace[1], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -6970,11 +6985,11 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 5;
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Write second dataset */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -6984,15 +6999,15 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -7000,40 +7015,40 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 5)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7043,62 +7058,62 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 5)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7106,33 +7121,33 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Extend srcdset[0] */
     dims[0] = 5;
     dims[1] = 5;
     if (H5Dset_extent(srcdset[0], dims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -7145,9 +7160,9 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     count[0] = 5;
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -7157,12 +7172,12 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -7170,40 +7185,40 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 5)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7213,62 +7228,62 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 15)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7278,71 +7293,71 @@ test_unlim(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[0] = -1;
     if (H5Sclose(srcspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace[1] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[1] = -1;
 
     /* Close */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     dcpl = -1;
     if (H5Pclose(srcdcpl) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     dcpl = -1;
     if (H5Pclose(dapl) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     dapl = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     memspace = -1;
 
     PASSED_SUPPRESSED();
@@ -7419,7 +7434,7 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     hsize_t     gap_size;                                               /* Gap size property */
     int         i, j;
 
-    TESTING_2_SUPPRESSED("virtual dataset I/O with printf source")
+    TESTING_2_SUPPRESSED("virtual dataset I/O with printf source");
 
     if ((srcfilename = (char *)HDcalloc(FILENAME_BUF_SIZE, sizeof(char))) == NULL)
         TEST_ERROR_SUPPRESSED;
@@ -7449,35 +7464,35 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Create DCPL */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Set fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create DAPL */
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create memory space */
     if ((memspace = H5Screate_simple(2, mdims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /*
      * Test 1: 1 Source dataset mapping, 10x5 blocks
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspace */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspace */
     dims[1] = 5;
     if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in virtual space */
     stride[0] = 1;
@@ -7487,91 +7502,91 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0]  = 10;
     block[1]  = 5;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset%b",
                        srcspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Create 2 source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -7585,9 +7600,9 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write to srcdset[0] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -7601,7 +7616,7 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write to srcdset[1] */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -7611,15 +7626,15 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -7627,40 +7642,40 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7668,32 +7683,32 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
         if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
     /* Create 3rd source dataset */
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset2", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -7702,9 +7717,9 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write to srcdset[2] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -7714,12 +7729,12 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[2] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[2] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -7727,36 +7742,36 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 15)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -7764,21 +7779,21 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Now try with different selections */
@@ -7790,25 +7805,25 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
             /* Select hyperslab in memory space */
             if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
             /* Select hyperslab in file space */
             if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
             /* Read data */
             if (H5Dread(vdset, H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, rbuf[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
             /* Verify read data */
             for (i = 0; i < (int)mdims[0]; i++)
                 for (j = 0; j < (int)mdims[1]; j++) {
                     if ((j < (int)start[1]) || (j >= (int)(start[1] + count[1]))) {
                         if (rbuf[i][j] != 0)
-                            TEST_ERROR_SUPPRESSED
+                            TEST_ERROR_SUPPRESSED;
                     }
                     else if (rbuf[i][j] != erbuf[i][j])
-                        TEST_ERROR_SUPPRESSED
+                        TEST_ERROR_SUPPRESSED;
                 }
         }
     start[1] = 0;
@@ -7816,11 +7831,11 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Now try writing through VDS */
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslab in file space */
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -7829,83 +7844,83 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write data through VDS */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reopen srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset0", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((srcdset[1] = H5Dopen2(srcfile[0], "src_dset1", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((srcdset[2] = H5Dopen2(srcfile[0], "src_dset2", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Read srcdset[0] */
     count[0] = 10;
     count[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < 10; i++)
         for (j = 0; j < 5; j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Read srcdset[1] */
     if (H5Dread(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < 10; i++)
         for (j = 0; j < 5; j++)
             if (rbuf[i][j] != buf[i][j + 5])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Read srcdset[2] */
     if (H5Dread(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < 10; i++)
         for (j = 0; j < 5; j++)
             if (rbuf[i][j] != buf[i][j + 10])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdset[0] = -1;
     if (H5Dclose(srcdset[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdset[1] = -1;
     if (H5Dclose(srcdset[2]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdset[2] = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcfile[0] = -1;
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
 
     /*
@@ -7914,16 +7929,16 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspace */
     dims[1] = 1;
     if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in virtual space */
     stride[0] = 1;
@@ -7933,104 +7948,104 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0]  = 10;
     block[1]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilenamepct_map : ".",
                        "src_dset%b", srcspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilenamepct, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilenamepct, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Create source datasets in a pattern with increasing gaps:
      * XX-X--X---X----X */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset1", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset3", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[3] = H5Dcreate2(srcfile[0], "src_dset6", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[4] = H5Dcreate2(srcfile[0], "src_dset10", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[5] = H5Dcreate2(srcfile[0], "src_dset15", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -8044,9 +8059,9 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write to srcdset[0] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -8059,7 +8074,7 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write to srcdset[1] */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -8072,7 +8087,7 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write to srcdset[2] */
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -8085,7 +8100,7 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write to srcdset[3] */
     if (H5Dwrite(srcdset[3], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -8098,7 +8113,7 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write to srcdset[4] */
     if (H5Dwrite(srcdset[4], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -8111,7 +8126,7 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write to srcdset[5] */
     if (H5Dwrite(srcdset[5], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -8121,13 +8136,13 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     if (config & TEST_IO_CLOSE_SRC) {
         for (i = 0; i < 6; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcdset[i] = -1;
         }
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -8135,40 +8150,40 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8176,74 +8191,74 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Test H5Pget_virtual_printf_gap() */
     if (H5Pget_virtual_printf_gap(dapl, &gap_size) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (gap_size != (hsize_t)0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close VDS and reopen with printf gap set to 1, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)1) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Test H5Pget_virtual_printf_gap() */
     if (H5Pget_virtual_printf_gap(dapl, &gap_size) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (gap_size != (hsize_t)1)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 4)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8251,68 +8266,68 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with printf gap set to 2, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)2) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Test H5Pget_virtual_printf_gap() */
     if (H5Pget_virtual_printf_gap(dapl, &gap_size) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (gap_size != (hsize_t)2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 7)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8320,68 +8335,68 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with printf gap set to 3, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)3) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Test H5Pget_virtual_printf_gap() */
     if (H5Pget_virtual_printf_gap(dapl, &gap_size) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (gap_size != (hsize_t)3)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 11)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8389,68 +8404,68 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with printf gap set to 4, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)4) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Test H5Pget_virtual_printf_gap() */
     if (H5Pget_virtual_printf_gap(dapl, &gap_size) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (gap_size != (hsize_t)4)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 16)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8458,62 +8473,62 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -8521,56 +8536,56 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reset dapl */
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)0) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         for (i = 0; i < 6; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcdset[i] = -1;
         }
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
 
     /* Next 2 tests are always run with a different source file, so only run if
@@ -8586,16 +8601,16 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Clear virtual layout in DCPL */
         if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Create virtual dataspaces */
         if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Create source dataspace */
         dims[1] = 5;
         if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Select hyperslabs in virtual space */
         stride[0] = 1;
@@ -8605,66 +8620,66 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         block[0]  = 10;
         block[1]  = 5;
         if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Add virtual layout mapping */
         if (H5Pset_virtual(dcpl, vspace[0], printf_srcfilename_map, "src_dset", srcspace) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Create virtual file */
         if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Create virtual dataset */
         if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             vfile = -1;
             if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (ndims != 2)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (dims[0] != 10)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (dims[1] != 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (mdims[0] != 10)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (mdims[1] != 20)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Create 2 source files, one source dataset */
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                      H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((srcfile[1] = H5Fcreate(srcfilename2, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Populate write buffer */
         for (i = 0; i < (int)mdims[0]; i++)
@@ -8678,9 +8693,9 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Write to srcdset[0] */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Update erbuf */
         for (i = 0; i < 10; i++)
@@ -8690,53 +8705,53 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         /* Close srcdset and srcfiles if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (H5Dclose(srcdset[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcdset[0] = -1;
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[1] = -1;
         }
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             vfile = -1;
             if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (ndims != 2)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (dims[0] != 10)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (dims[1] != 5)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (mdims[0] != 10)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (mdims[1] != 20)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -8744,32 +8759,32 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR_SUPPRESSED
+                        TEST_ERROR_SUPPRESSED;
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
 
         /* Reopen srcfile[1] if config option specified */
         if (config & TEST_IO_CLOSE_SRC)
             if ((srcfile[1] = H5Fopen(srcfilename2, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
         /* Create 2nd source dataset */
         if ((srcdset[1] = H5Dcreate2(srcfile[1], "src_dset", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                      H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Adjust write buffer */
         for (i = 0; i < (int)mdims[0]; i++)
@@ -8778,9 +8793,9 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Write to srcdset[1] */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Update erbuf */
         for (i = 0; i < 10; i++)
@@ -8790,50 +8805,50 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         /* Close srcdset[1] and srcfile[1] if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (H5Dclose(srcdset[1]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcdset[1] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[1] = -1;
         }
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             vfile = -1;
             if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (ndims != 2)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (dims[0] != 10)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (dims[1] != 10)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (mdims[0] != 10)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (mdims[1] != 20)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -8841,49 +8856,49 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR_SUPPRESSED
+                        TEST_ERROR_SUPPRESSED;
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
 
         /* Close */
         if (!(config & TEST_IO_CLOSE_SRC)) {
             if (H5Dclose(srcdset[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcdset[0] = -1;
             if (H5Dclose(srcdset[1]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcdset[1] = -1;
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[1] = -1;
         }
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if (H5Sclose(srcspace) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcspace = -1;
         if (H5Sclose(vspace[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vspace[0] = -1;
 
         /*
@@ -8896,16 +8911,16 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Clear virtual layout in DCPL */
         if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Create virtual dataspaces */
         if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Create source dataspace */
         dims[1] = 5;
         if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Select hyperslabs in virtual space */
         stride[0] = 1;
@@ -8915,66 +8930,66 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         block[0]  = 10;
         block[1]  = 5;
         if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Add virtual layout mapping */
         if (H5Pset_virtual(dcpl, vspace[0], printf_srcfilename_map, "%%src%%_dset%%%b", srcspace) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Create virtual file */
         if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Create virtual dataset */
         if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             vfile = -1;
             if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (ndims != 2)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (dims[0] != 10)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (dims[1] != 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (mdims[0] != 10)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (mdims[1] != 20)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Create 2 source files, one source dataset */
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((srcdset[0] = H5Dcreate2(srcfile[0], "%src%_dset%0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                      H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((srcfile[1] = H5Fcreate(srcfilename2, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Populate write buffer */
         for (i = 0; i < (int)mdims[0]; i++)
@@ -8988,9 +9003,9 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Write to srcdset[0] */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Update erbuf */
         for (i = 0; i < 10; i++)
@@ -9000,53 +9015,53 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         /* Close srcdset and srcfiles if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (H5Dclose(srcdset[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcdset[0] = -1;
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[1] = -1;
         }
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             vfile = -1;
             if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (ndims != 2)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (dims[0] != 10)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (dims[1] != 5)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (mdims[0] != 10)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (mdims[1] != 20)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -9054,32 +9069,32 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR_SUPPRESSED
+                        TEST_ERROR_SUPPRESSED;
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
 
         /* Reopen srcfile[1] if config option specified */
         if (config & TEST_IO_CLOSE_SRC)
             if ((srcfile[1] = H5Fopen(srcfilename2, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
         /* Create 2nd source dataset */
         if ((srcdset[1] = H5Dcreate2(srcfile[1], "%src%_dset%1", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                      H5P_DEFAULT, H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Adjust write buffer */
         for (i = 0; i < (int)mdims[0]; i++)
@@ -9088,9 +9103,9 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Write to srcdset[1] */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Update erbuf */
         for (i = 0; i < 10; i++)
@@ -9100,50 +9115,50 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
         /* Close srcdset[1] and srcfile[1] if config option specified */
         if (config & TEST_IO_CLOSE_SRC) {
             if (H5Dclose(srcdset[1]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcdset[1] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[1] = -1;
         }
 
         /* Reopen virtual dataset and file if config option specified */
         if (config & TEST_IO_REOPEN_VIRT) {
             if (H5Dclose(vdset) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             vdset = -1;
             if (H5Fclose(vfile) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             vfile = -1;
             if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
         /* Get VDS space */
         if ((filespace = H5Dget_space(vdset)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Get VDS space dimensions */
         if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (ndims != 2)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (dims[0] != 10)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (dims[1] != 10)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (mdims[0] != 10)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if (mdims[1] != 20)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Close filespace */
         if (H5Sclose(filespace) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -9151,49 +9166,49 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR_SUPPRESSED
+                        TEST_ERROR_SUPPRESSED;
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
 
         /* Close */
         if (!(config & TEST_IO_CLOSE_SRC)) {
             if (H5Dclose(srcdset[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcdset[0] = -1;
             if (H5Dclose(srcdset[1]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcdset[1] = -1;
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
             if (H5Fclose(srcfile[1]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[1] = -1;
         }
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if (H5Sclose(srcspace) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcspace = -1;
         if (H5Sclose(vspace[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vspace[0] = -1;
     }
 
@@ -9203,26 +9218,26 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     dims[0] = 10;
     dims[1] = 10;
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspace (2 elements wide) */
     dims[1] = 2;
     if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslab in source space */
     count[0] = 10;
     count[1] = 1;
     if (H5Sselect_hyperslab(srcspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in virtual spaces */
     stride[0] = 1;
@@ -9232,98 +9247,98 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0]  = 10;
     block[1]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 1;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[1] = 0;
 
     /* Add virtual layout mappings */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "%bsrc_dset_a%b%%", srcspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_b%b%%%%", srcspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Create 2 source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "0src_dset_a0%", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset_b0%%", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -9339,9 +9354,9 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0] = 10;
     block[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -9354,7 +9369,7 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write to srcdset[1] */
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -9363,15 +9378,15 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -9379,40 +9394,40 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9420,32 +9435,32 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
         if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
     /* Create 3rd source dataset */
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset_b1%%", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -9454,9 +9469,9 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write to srcdset[2] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -9465,12 +9480,12 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[2] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[2] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -9478,40 +9493,40 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 4)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9519,63 +9534,63 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions.  Make sure that the 4th slice is no longer
      * visible due to the change to H5D_VDS_FIRST_MISSING. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9583,32 +9598,32 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
         if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
     /* Create 4th source dataset */
     if ((srcdset[3] = H5Dcreate2(srcfile[0], "2src_dset_a2%", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -9617,9 +9632,9 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write to srcdset[3] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[3], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -9628,12 +9643,12 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[3] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[3]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[3] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -9641,40 +9656,40 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9682,63 +9697,63 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions.  Make sure that the 4th slice is now visible
      * due to the change to H5D_VDS_LAST_AVAILABLE. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 4)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9746,63 +9761,63 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with printf_gap set to 1, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)1) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions.  Make sure that the 6th slice is now visible
      * due to the change to printf_gap. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 5)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -9810,59 +9825,59 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reset dapl */
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)0) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         for (i = 0; i < 4; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcdset[i] = -1;
         }
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[1] = -1;
 
     /*
@@ -9870,25 +9885,25 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     dims[0] = 10;
     dims[1] = 10;
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspace (1 dimensional) */
     dims[0] = 50;
     if ((srcspace = H5Screate_simple(1, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslab in source space */
     count[0] = 25;
     if (H5Sselect_hyperslab(srcspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in virtual spaces */
     stride[0] = 1;
@@ -9898,103 +9913,103 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0]  = 5;
     block[1]  = 5;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0]  = 5;
     stride[1] = 10;
     block[1]  = 10;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 0;
 
     /* Add virtual layout mappings (select ALL in source space for second
      * mapping) */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_a%b", srcspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sselect_all(srcspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_b%b", srcspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Create 2 source datasets */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset_a0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdset[1] = H5Dcreate2(srcfile[0], "src_dset_b0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -10010,12 +10025,12 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0] = 5;
     block[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     count[0] = 25;
     if (H5Sselect_hyperslab(srcspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, srcspace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -10030,11 +10045,11 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Write to srcdset[1] */
     block[1] = 10;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sselect_all(srcspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, srcspace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -10044,15 +10059,15 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdsets and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -10060,40 +10075,40 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10101,63 +10116,63 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions.  Make sure that the 4th slice is no longer
      * visible due to the change to H5D_VDS_FIRST_MISSING. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 5)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10165,32 +10180,32 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
         if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
     /* Create 3rd source dataset */
     if ((srcdset[2] = H5Dcreate2(srcfile[0], "src_dset_a1", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -10200,11 +10215,11 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Write to srcdset[2] */
     block[1] = 5;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sselect_hyperslab(srcspace, H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, srcspace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -10214,12 +10229,12 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[2] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[2] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -10227,40 +10242,40 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10268,62 +10283,62 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with view set to H5D_VDS_LAST_AVAILABLE, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions.  There should be no change. */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10331,32 +10346,32 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
         if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
     /* Create 4th source dataset */
     if ((srcdset[3] = H5Dcreate2(srcfile[0], "src_dset_a2", H5T_NATIVE_INT, srcspace, H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -10365,9 +10380,9 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write to srcdset[3] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[3], H5T_NATIVE_INT, memspace, srcspace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 5; i++)
@@ -10377,12 +10392,12 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[3] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[3]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[3] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -10390,40 +10405,40 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 15)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10431,36 +10446,36 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Now test reopening virtual dataset without calling H5Dget_space, if
      * REOPEN_VIRT flag set */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -10468,28 +10483,28 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR_SUPPRESSED
+                        TEST_ERROR_SUPPRESSED;
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
 
         /* Now try setting extent manually */
         /* Shrink to 12 */
         dims[1] = 12;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -10497,27 +10512,27 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR_SUPPRESSED
+                        TEST_ERROR_SUPPRESSED;
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
 
         /* Shrink to 10 */
         dims[1] = 12;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -10525,63 +10540,63 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR_SUPPRESSED
+                        TEST_ERROR_SUPPRESSED;
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
     }
 
     /* Close VDS and reopen with view set to H5D_VDS_FIRST_MISSING, reopen file
      * as well if config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_view(dapl, H5D_VDS_FIRST_MISSING) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10589,36 +10604,36 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Now test reopening virtual dataset without calling H5Dget_space, if
      * REOPEN_VIRT flag set */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -10626,28 +10641,28 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR_SUPPRESSED
+                        TEST_ERROR_SUPPRESSED;
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
 
         /* Now try setting extent manually */
         /* Grow to 12 */
         dims[1] = 12;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -10655,27 +10670,27 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR_SUPPRESSED
+                        TEST_ERROR_SUPPRESSED;
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
 
         /* Grow to 15 */
         dims[1] = 15;
         if (H5Dset_extent(vdset, dims) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data through virtual dataset */
         /* Reset rbuf */
@@ -10683,58 +10698,58 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
         /* Select hyperslab in memory space */
         if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Read data */
         if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
         /* Verify read data */
         for (i = 0; i < (int)mdims[0]; i++)
             for (j = 0; j < (int)mdims[1]; j++) {
                 if (j >= (int)dims[1]) {
                     if (rbuf[i][j] != 0)
-                        TEST_ERROR_SUPPRESSED
+                        TEST_ERROR_SUPPRESSED;
                 }
                 else if (rbuf[i][j] != erbuf[i][j])
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
     }
 
     /* Reset dapl */
     if (H5Pset_virtual_view(dapl, H5D_VDS_LAST_AVAILABLE) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         for (i = 0; i < 4; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcdset[i] = -1;
         }
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
     if (H5Sclose(vspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[1] = -1;
 
     /*
@@ -10743,16 +10758,16 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
      */
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual dataspaces */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source dataspace */
     dims[1] = 1;
     if ((srcspace = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Select hyperslabs in virtual space */
     stride[0] = 1;
@@ -10762,88 +10777,88 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0]  = 10;
     block[1]  = 1;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilenamepct_map : ".",
                        "src_dset%b", srcspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile[0] = H5Fcreate(srcfilenamepct, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile[0] = H5Fopen(srcfilenamepct, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Create 1 source dataset */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset0", H5T_NATIVE_INT, srcspace, H5P_DEFAULT, H5P_DEFAULT,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -10857,9 +10872,9 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Write to srcdset[0] */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 10; i++)
@@ -10868,12 +10883,12 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[0] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile[0] = -1;
         }
     }
@@ -10881,40 +10896,40 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 1)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10922,62 +10937,62 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Close VDS and reopen with printf gap set to 127, reopen file as well if
      * config option specified */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)127) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 1)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 20)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -10985,63 +11000,63 @@ test_printf(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Select hyperslab in memory space */
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reset dapl */
     if (H5Pset_virtual_printf_gap(dapl, (hsize_t)0) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[0] = -1;
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile[0]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile[0] = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     if (H5Sclose(srcspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcspace = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vspace[0] = -1;
 
     /* Close */
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     dcpl = -1;
     if (H5Pclose(dapl) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     dapl = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     memspace = -1;
 
     HDfree(srcfilename);
@@ -11127,7 +11142,7 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     int     fill = -1;                          /* Fill value */
     int     i, j;
 
-    TESTING_2_SUPPRESSED("virtual dataset I/O with mixed selection types")
+    TESTING_2_SUPPRESSED("virtual dataset I/O with mixed selection types");
 
     h5_fixname(FILENAME[0], vds_fapl, vfilename, sizeof vfilename);
     h5_fixname(FILENAME[2], src_fapl, srcfilename, sizeof srcfilename);
@@ -11135,44 +11150,44 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
 
     /* Create DCPLs */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcdcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Set fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Set chunk dimensions */
     if (H5Pset_chunk(srcdcpl, 2, cdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create memory space */
     if ((memspace = H5Screate_simple(2, mdims, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Clear virtual layout in DCPL */
     if (H5Pset_layout(dcpl, H5D_VIRTUAL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create fixed mapping */
     if ((vspace[0] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 3;
     start[1] = 3;
     count[0] = 3;
     count[1] = 3;
     if (H5Sselect_hyperslab(vspace[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcspace[0] = H5Screate_simple(2, count, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_fixed", srcspace[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create unlimited mapping */
     if ((vspace[1] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 3;
     start[1] = 0;
     count[0] = 1;
@@ -11180,21 +11195,21 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0] = H5S_UNLIMITED;
     block[1] = 3;
     if (H5Sselect_hyperslab(vspace[1], H5S_SELECT_SET, start, NULL, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     dims[0] = 0;
     dims[1] = 3;
     if ((srcspace[1] = H5Screate_simple(2, dims, block)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 0;
     if (H5Sselect_hyperslab(srcspace[1], H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[1], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_unlim", srcspace[1]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create printf mapping */
     if ((vspace[2] = H5Screate_simple(2, dims, mdims)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0]  = 0;
     start[1]  = 2;
     stride[0] = 1;
@@ -11204,93 +11219,93 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0]  = 3;
     block[1]  = 2;
     if (H5Sselect_hyperslab(vspace[2], H5S_SELECT_SET, start, stride, count, block) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((srcspace[2] = H5Screate_simple(2, block, NULL)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Pset_virtual(dcpl, vspace[2], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".",
                        "src_dset_printf_%b", srcspace[2]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename, H5F_ACC_TRUNC, H5P_DEFAULT, vds_fapl)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if ((srcfile = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
     else {
         srcfile = vfile;
         if (H5Iinc_ref(srcfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile = -1;
         }
 
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 6)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 6)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Reopen srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC)
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Create fixed source dataset */
     if ((srcdset[0] = H5Dcreate2(srcfile, "src_dset_fixed", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Create unlimited source_dataset */
     if ((srcdset[1] = H5Dcreate2(srcfile, "src_dset_unlim", H5T_NATIVE_INT, srcspace[1], H5P_DEFAULT, srcdcpl,
                                  H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Populate write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -11308,9 +11323,9 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0] = 3;
     block[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 3; i++)
@@ -11321,13 +11336,13 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     if (config & TEST_IO_CLOSE_SRC) {
         for (i = 0; i < 2; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcdset[i] = -1;
         }
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile = -1;
         }
     }
@@ -11335,40 +11350,40 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 6)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 6)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -11378,37 +11393,37 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if ((i >= (int)dims[0]) || (j >= (int)dims[1])) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[1] = H5Dopen2(srcfile, "src_dset_unlim", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Extend srcdset[1] */
     dims[0] = 2;
     dims[1] = 3;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -11419,9 +11434,9 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 2; i++)
@@ -11431,11 +11446,11 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile = -1;
         }
     }
@@ -11443,40 +11458,40 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 6)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 6)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -11486,32 +11501,32 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if ((i >= (int)dims[0]) || (j >= (int)dims[1])) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
         if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
     /* Create first printf source dataset */
     if ((srcdset[2] = H5Dcreate2(srcfile, "src_dset_printf_0", H5T_NATIVE_INT, srcspace[2], H5P_DEFAULT,
                                  srcdcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -11524,9 +11539,9 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0] = 3;
     block[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[2], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 3; i++)
@@ -11536,11 +11551,11 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[2] srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[2]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[2] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile = -1;
         }
     }
@@ -11548,40 +11563,40 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 6)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 6)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -11591,37 +11606,37 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if ((i >= (int)dims[0]) || (j >= (int)dims[1])) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[1] = H5Dopen2(srcfile, "src_dset_unlim", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Extend srcdset[1] */
     dims[0] = 3;
     dims[1] = 3;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -11634,17 +11649,17 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0] = 1;
     block[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((filespace = H5Dget_space(srcdset[1])) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 2;
     start[1] = 0;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 3; i++)
@@ -11653,11 +11668,11 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile = -1;
         }
     }
@@ -11665,40 +11680,40 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 6)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 6)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -11708,32 +11723,32 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if ((i >= (int)dims[0]) || (j >= (int)dims[1])) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
         if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
     /* Create second printf source dataset, this time without using srcdcpl */
     if ((srcdset[3] = H5Dcreate2(srcfile, "src_dset_printf_1", H5T_NATIVE_INT, srcspace[2], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -11746,9 +11761,9 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0] = 3;
     block[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[3], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 3; i++)
@@ -11758,11 +11773,11 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[3] srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[3]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[3] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile = -1;
         }
     }
@@ -11770,40 +11785,40 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 6)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 7)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -11813,37 +11828,37 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if ((i >= (int)dims[0]) || (j >= (int)dims[1])) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE)
             if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         if ((srcdset[1] = H5Dopen2(srcfile, "src_dset_unlim", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Extend srcdset[1] */
     dims[0] = 7;
     dims[1] = 3;
     if (H5Dset_extent(srcdset[1], dims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -11856,17 +11871,17 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0] = 4;
     block[1] = 3;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if ((filespace = H5Dget_space(srcdset[1])) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     start[0] = 3;
     start[1] = 0;
     if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[1], H5T_NATIVE_INT, memspace, filespace, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 4; i++)
@@ -11876,11 +11891,11 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[1] and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[1]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[1] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile = -1;
         }
     }
@@ -11888,40 +11903,40 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 7)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -11931,32 +11946,32 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++) {
             if (j >= (int)dims[1]) {
                 if (rbuf[i][j] != 0)
-                    TEST_ERROR_SUPPRESSED
+                    TEST_ERROR_SUPPRESSED;
             }
             else if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
         }
 
     /* Reopen srcfile if config option specified */
     if ((config & TEST_IO_CLOSE_SRC) && (config & TEST_IO_DIFFERENT_FILE))
         if ((srcfile = H5Fopen(srcfilename, H5F_ACC_RDWR, src_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
 
     /* Create third printf source dataset */
     if ((srcdset[4] = H5Dcreate2(srcfile, "src_dset_printf_2", H5T_NATIVE_INT, srcspace[2], H5P_DEFAULT,
                                  srcdcpl, H5P_DEFAULT)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Adjust write buffer */
     for (i = 0; i < (int)mdims[0]; i++)
@@ -11969,9 +11984,9 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     block[0] = 3;
     block[1] = 2;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, block, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Dwrite(srcdset[4], H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Update erbuf */
     for (i = 0; i < 3; i++)
@@ -11981,11 +11996,11 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Close srcdset[4] srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[4]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcdset[4] = -1;
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcfile = -1;
         }
     }
@@ -11993,40 +12008,40 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename, H5F_ACC_RDWR, vds_fapl)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         if ((vdset = H5Dopen2(vfile, "v_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
     }
 
     /* Get VDS space */
     if ((filespace = H5Dget_space(vdset)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Get VDS space dimensions */
     if ((ndims = H5Sget_simple_extent_ndims(filespace)) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (ndims != 2)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (H5Sget_simple_extent_dims(filespace, dims, mdims) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (dims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[0] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     if (mdims[1] != 10)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Close filespace */
     if (H5Sclose(filespace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data through virtual dataset */
     /* Reset rbuf */
@@ -12036,58 +12051,58 @@ test_all(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     start[0] = 0;
     start[1] = 0;
     if (H5Sselect_hyperslab(memspace, H5S_SELECT_SET, start, NULL, dims, NULL) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Read data */
     if (H5Dread(vdset, H5T_NATIVE_INT, memspace, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
 
     /* Verify read data */
     for (i = 0; i < (int)mdims[0]; i++)
         for (j = 0; j < (int)mdims[1]; j++)
             if (rbuf[i][j] != erbuf[i][j])
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
 
     /* Close */
     if (!(config & TEST_IO_CLOSE_SRC)) {
         for (i = 0; i < 5; i++) {
             if (H5Dclose(srcdset[i]) < 0)
-                TEST_ERROR_SUPPRESSED
+                TEST_ERROR_SUPPRESSED;
             srcdset[i] = -1;
         }
         if (H5Fclose(srcfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile = -1;
     }
     else if (!(config & TEST_IO_DIFFERENT_FILE)) {
         if (H5Fclose(srcfile) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcfile = -1;
     }
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vdset = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     vfile = -1;
     for (i = 0; i < (int)(sizeof(srcspace) / sizeof(srcspace[0])); i++) {
         if (H5Sclose(srcspace[i]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         srcspace[i] = -1;
     }
     for (i = 0; i < (int)(sizeof(vspace) / sizeof(vspace[0])); i++) {
         if (H5Sclose(vspace[i]) < 0)
-            TEST_ERROR_SUPPRESSED
+            TEST_ERROR_SUPPRESSED;
         vspace[i] = -1;
     }
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     dcpl = -1;
     if (H5Pclose(srcdcpl) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     srcdcpl = -1;
     if (H5Sclose(memspace) < 0)
-        TEST_ERROR_SUPPRESSED
+        TEST_ERROR_SUPPRESSED;
     memspace = -1;
 
     PASSED_SUPPRESSED();
@@ -12150,29 +12165,29 @@ test_dapl_values(hid_t fapl_id)
     /* Create the file */
     h5_fixname(FILENAME[5], fapl_id, filename, sizeof(filename));
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dcpl and set up VDS mapping */
     if ((dcpl_id = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* source */
     dims = 42;
     if ((src_sid = H5Screate_simple(1, &dims, NULL)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* vds */
     dims     = 0;
     max_dims = H5S_UNLIMITED;
     if ((vds_sid = H5Screate_simple(1, &dims, &max_dims)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     start  = 0;
     stride = 42;
     count  = H5S_UNLIMITED;
     block  = 42;
     if (H5Sselect_hyperslab(vds_sid, H5S_SELECT_SET, &start, &stride, &count, &block) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* map */
     if (H5Pset_virtual(dcpl_id, vds_sid, "f-%b.h5", "/dset1", src_sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the dapls and set values
      * There are two of them. The reason for this is that the only way
@@ -12181,71 +12196,71 @@ test_dapl_values(hid_t fapl_id)
      */
     /* dapl 1 */
     if ((dapl_id1 = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_virtual_view(dapl_id1, H5D_VDS_FIRST_MISSING) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* dapl 2 */
     if ((dapl_id2 = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     /* default but we set it explicitly to be sure */
     if (H5Pset_virtual_view(dapl_id2, H5D_VDS_LAST_AVAILABLE) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pset_virtual_printf_gap(dapl_id2, 123) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Create the datasets */
     if ((did1 = H5Dcreate2(fid, "dset1", H5T_NATIVE_INT, vds_sid, H5P_DEFAULT, dcpl_id, dapl_id1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((did2 = H5Dcreate2(fid, "dset2", H5T_NATIVE_INT, vds_sid, H5P_DEFAULT, dcpl_id, dapl_id2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Close the dapls */
     if (H5Pclose(dapl_id1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     dapl_id1 = -1;
     if (H5Pclose(dapl_id2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     dapl_id2 = -1;
 
     /* Get a data access property lists from the dataset */
     if ((dapl_id1 = H5Dget_access_plist(did1)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if ((dapl_id2 = H5Dget_access_plist(did2)) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     /* Check the values from the dapls */
     /* dapl 1 */
     if (H5Pget_virtual_view(dapl_id1, &view) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5D_VDS_FIRST_MISSING != view)
-        TEST_ERROR
+        TEST_ERROR;
     /* dapl 2 */
     if (H5Pget_virtual_view(dapl_id2, &view) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5D_VDS_LAST_AVAILABLE != view)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_virtual_printf_gap(dapl_id2, &gap_size) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (gap_size != 123)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close everything */
     if (H5Sclose(vds_sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Sclose(src_sid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Dclose(did2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dapl_id1) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dapl_id2) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Pclose(dcpl_id) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR
+        FAIL_STACK_ERROR;
 
     PASSED();
     return 0;
@@ -12314,9 +12329,9 @@ main(void)
 
     /* Create FAPLs for VDS and source files */
     if ((vds_fapl = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((src_fapl = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop through all the combinations of low/high version bounds */
     for (low = H5F_LIBVER_EARLIEST; low < H5F_LIBVER_NBOUNDS; low++) {
@@ -12338,9 +12353,9 @@ main(void)
 
             /* Set the low/high version bounds */
             if (H5Pset_libver_bounds(vds_fapl, low, high) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Pset_libver_bounds(src_fapl, low, high) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Display testing info */
             low_string  = h5_get_version_string(low);
@@ -12354,7 +12369,7 @@ main(void)
                  test_api_config++)
                 nerrors += test_api((test_api_config_t)test_api_config, vds_fapl, low);
 
-            TESTING_2("Virtual dataset I/O")
+            TESTING_2("Virtual dataset I/O");
 #ifdef VDS_TEST_VERBOSE
             HDputs("");
 #else  /* VDS_TEST_VERBOSE */
@@ -12379,15 +12394,15 @@ main(void)
                 /* Set file close degree */
                 if (bit_config & TEST_IO_FCLOSE_SEMI) {
                     if (H5Pset_fclose_degree(vds_fapl, H5F_CLOSE_SEMI) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 }
                 else if (bit_config & TEST_IO_FCLOSE_STRONG) {
                     if (H5Pset_fclose_degree(vds_fapl, H5F_CLOSE_STRONG) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 }
                 else {
                     if (H5Pset_fclose_degree(vds_fapl, H5F_CLOSE_WEAK) < 0)
-                        TEST_ERROR
+                        TEST_ERROR;
                 }
 
                 /* Run tests */
@@ -12412,9 +12427,9 @@ main(void)
     }     /* end for low */
 
     if (H5Pclose(vds_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(src_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (nerrors)
         goto error;

--- a/test/vds_env.c
+++ b/test/vds_env.c
@@ -67,20 +67,20 @@ test_vds_prefix_second(unsigned config, hid_t fapl)
     int         i, j;
     char        buffer[1024]; /* buffer to read vds_prefix       */
 
-    TESTING("basic virtual dataset I/O via H5Pset_vds_prefix(): all selection with ENV prefix")
+    TESTING("basic virtual dataset I/O via H5Pset_vds_prefix(): all selection with ENV prefix");
 
     if (NULL == (srcfilename = HDmalloc(FILENAME_BUF_SIZE)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (srcfilename_map = HDmalloc(FILENAME_BUF_SIZE)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (vfilename = HDmalloc(FILENAME_BUF_SIZE)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (vfilename2 = HDmalloc(FILENAME_BUF_SIZE)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (srcfilenamepct = HDmalloc(FILENAME_BUF_SIZE)))
-        TEST_ERROR
+        TEST_ERROR;
     if (NULL == (srcfilenamepct_map = HDmalloc(FILENAME_BUF_SIZE)))
-        TEST_ERROR
+        TEST_ERROR;
 
     h5_fixname(FILENAME[0], fapl, vfilename, FILENAME_BUF_SIZE);
     h5_fixname(FILENAME[1], fapl, vfilename2, FILENAME_BUF_SIZE);
@@ -91,76 +91,76 @@ test_vds_prefix_second(unsigned config, hid_t fapl)
 
     /* create tmp directory and get current working directory path */
     if (HDmkdir(TMPDIR, (mode_t)0755) < 0 && errno != EEXIST)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create DCPL */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set fill value */
     if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Set prefix to a nonexistent directory, will be overwritten by environment variable */
     if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (H5Pset_virtual_prefix(dapl, "someprefix") < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pget_virtual_prefix(dapl, buffer, sizeof(buffer)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (HDstrcmp(buffer, "someprefix") != 0)
         FAIL_PUTS_ERROR("vds prefix not set correctly");
 
     /* Create source dataspace */
     if ((srcspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create virtual dataspace */
     if ((vspace[0] = H5Screate_simple(2, dims, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Select all (should not be necessary, but just to be sure) */
     if (H5Sselect_all(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sselect_all(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Add virtual layout mapping */
     if (H5Pset_virtual(dcpl, vspace[0], config & TEST_IO_DIFFERENT_FILE ? srcfilename_map : ".", "src_dset",
                        srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create virtual file */
     if ((vfile = H5Fcreate(vfilename2, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create source file if requested */
     if (config & TEST_IO_DIFFERENT_FILE) {
         if (NULL == HDgetcwd(buffer, 1024))
-            TEST_ERROR
+            TEST_ERROR;
         if (HDchdir(TMPDIR) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((srcfile[0] = H5Fcreate(srcfilename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (HDchdir(buffer) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
     else {
         srcfile[0] = vfile;
         if (H5Iinc_ref(srcfile[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* Create source dataset */
     if ((srcdset[0] = H5Dcreate2(srcfile[0], "src_dset", H5T_NATIVE_INT, srcspace[0], H5P_DEFAULT,
                                  H5P_DEFAULT, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create virtual dataset */
     if ((vdset = H5Dcreate2(vfile, "v_dset", H5T_NATIVE_INT, vspace[0], H5P_DEFAULT, dcpl, dapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Populate write buffer */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
@@ -169,17 +169,17 @@ test_vds_prefix_second(unsigned config, hid_t fapl)
 
     /* Write data directly to source dataset */
     if (H5Dwrite(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (H5Dclose(srcdset[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         srcdset[0] = -1;
 
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (H5Fclose(srcfile[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             srcfile[0] = -1;
         }
     }
@@ -187,27 +187,27 @@ test_vds_prefix_second(unsigned config, hid_t fapl)
     /* Reopen virtual dataset and file if config option specified */
     if (config & TEST_IO_REOPEN_VIRT) {
         if (H5Dclose(vdset) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         vdset = -1;
         if (H5Fclose(vfile) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         vfile = -1;
         if ((vfile = H5Fopen(vfilename2, H5F_ACC_RDWR, fapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((vdset = H5Dopen2(vfile, "v_dset", dapl)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* Read data through virtual dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++) {
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j]) {
-                TEST_ERROR
+                TEST_ERROR;
             }
     }
 
@@ -218,59 +218,59 @@ test_vds_prefix_second(unsigned config, hid_t fapl)
 
     /* Write data through virtual dataset */
     if (H5Dwrite(vdset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reopen srcdset and srcfile if config option specified */
     if (config & TEST_IO_CLOSE_SRC) {
         if (config & TEST_IO_DIFFERENT_FILE) {
             if (NULL == HDgetcwd(buffer, 1024))
-                TEST_ERROR
+                TEST_ERROR;
             if (HDchdir(TMPDIR) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if ((srcfile[0] = H5Fopen(srcfilename, H5F_ACC_RDONLY, fapl)) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (HDchdir(buffer) < 0)
-                TEST_ERROR
+                TEST_ERROR;
         }
         if ((srcdset[0] = H5Dopen2(srcfile[0], "src_dset", H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     /* Read data directly from source dataset */
     HDmemset(rbuf[0], 0, sizeof(rbuf));
     if (H5Dread(srcdset[0], H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify read data */
     for (i = 0; i < (int)(sizeof(buf) / sizeof(buf[0])); i++)
         for (j = 0; j < (int)(sizeof(buf[0]) / sizeof(buf[0][0])); j++)
             if (rbuf[i][j] != buf[i][j])
-                TEST_ERROR
+                TEST_ERROR;
 
     /* Close */
     if (H5Dclose(vdset) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     vdset = -1;
     if (H5Dclose(srcdset[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     srcdset[0] = -1;
     if (H5Fclose(srcfile[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     srcfile[0] = -1;
     if (H5Fclose(vfile) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     vfile = -1;
     if (H5Sclose(srcspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     srcspace[0] = -1;
     if (H5Sclose(vspace[0]) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     vspace[0] = -1;
     if (H5Pclose(dapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     dapl = -1;
     if (H5Pclose(dcpl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     dcpl = -1;
 
     HDfree(srcfilenamepct_map);
@@ -349,7 +349,7 @@ main(void)
 
     /* Set to use the latest file format */
     if ((my_fapl = H5Pcopy(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Loop through all the combinations of low/high version bounds */
     for (low = H5F_LIBVER_EARLIEST; low < H5F_LIBVER_NBOUNDS; low++) {
@@ -368,7 +368,7 @@ main(void)
 
             /* Set the low/high version bounds */
             if (H5Pset_libver_bounds(my_fapl, low, high) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Display testing info */
             low_string  = h5_get_version_string(low);
@@ -392,7 +392,7 @@ main(void)
     }     /* end for low */
 
     if (H5Pclose(my_fapl) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (nerrors)
         goto error;

--- a/test/vds_swmr_gen.c
+++ b/test/vds_swmr_gen.c
@@ -68,13 +68,13 @@ main(void)
 
     /* Create VDS dcpl */
     if ((vds_dcplid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_fill_value(vds_dcplid, VDS_DATATYPE, &VDS_FILL_VALUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create VDS dataspace */
     if ((vds_sid = H5Screate_simple(RANK, VDS_DIMS, VDS_MAX_DIMS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /************************************
      * Create source files and datasets *
@@ -87,58 +87,58 @@ main(void)
 
     /* All SWMR files need to use the latest file format */
     if ((faplid = h5_fileaccess()) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_libver_bounds(faplid, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     for (i = 0; i < N_SOURCES; i++) {
 
         /* source dataset dcpl */
         if ((src_dcplid = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_chunk(src_dcplid, RANK, PLANES[i]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pset_fill_value(src_dcplid, SOURCE_DATATYPE, &FILL_VALUES[i]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Use a mix of compressed and uncompressed datasets */
         if (0 != i % 2)
             if (H5Pset_deflate(src_dcplid, COMPRESSION_LEVEL) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
         /* Create source file, dataspace, and dataset */
         if ((fid = H5Fcreate(FILE_NAMES[i], H5F_ACC_TRUNC, H5P_DEFAULT, faplid)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((src_sid = H5Screate_simple(RANK, DIMS[i], MAX_DIMS[i])) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if ((did = H5Dcreate2(fid, SOURCE_DSET_NAME, SOURCE_DATATYPE, src_sid, H5P_DEFAULT, src_dcplid,
                               H5P_DEFAULT)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* set up hyperslabs for source and destination datasets */
         start[1] = 0;
         if (H5Sselect_hyperslab(src_sid, H5S_SELECT_SET, start, NULL, MAX_DIMS[i], NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         start[1] = (hsize_t)map_start;
         if (H5Sselect_hyperslab(vds_sid, H5S_SELECT_SET, start, NULL, MAX_DIMS[i], NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (PLANES[i][1] > INT_MAX)
-            TEST_ERROR
+            TEST_ERROR;
         map_start += (int)PLANES[i][1];
 
         /* Add VDS mapping */
         if (H5Pset_virtual(vds_dcplid, vds_sid, FILE_NAMES[i], SOURCE_DSET_PATH, src_sid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* close */
         if (H5Sclose(src_sid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Pclose(src_dcplid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Dclose(did) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Fclose(fid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     } /* end for */
 
@@ -148,24 +148,24 @@ main(void)
 
     /* file */
     if ((fid = H5Fcreate(VDS_FILE_NAME, H5F_ACC_TRUNC, H5P_DEFAULT, faplid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* dataset */
     if ((did = H5Dcreate2(fid, VDS_DSET_NAME, VDS_DATATYPE, vds_sid, H5P_DEFAULT, vds_dcplid, H5P_DEFAULT)) <
         0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* close */
     if (H5Pclose(faplid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pclose(vds_dcplid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(vds_sid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return EXIT_SUCCESS;
 

--- a/test/vds_swmr_reader.c
+++ b/test/vds_swmr_reader.c
@@ -37,60 +37,60 @@ main(void)
 
     /* Open the VDS file and dataset */
     if ((faplid = h5_fileaccess()) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid = H5Fopen(VDS_FILE_NAME, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, faplid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did = H5Dopen2(fid, VDS_DSET_NAME, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the read buffer */
     if (VDS_PLANE[1] * VDS_PLANE[2] > INT_MAX)
-        TEST_ERROR
+        TEST_ERROR;
     n_elements = (int)(VDS_PLANE[1] * VDS_PLANE[2]);
     size       = (size_t)n_elements * sizeof(int);
     if (NULL == (buffer = (int *)HDmalloc(size)))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create memory dataspace */
     if ((msid = H5Screate_simple(RANK, VDS_PLANE, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Read data until the dataset is full (via the writer) */
     do {
 
         /* Refresh metadata */
         if (H5Drefresh(did) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get the dataset dimensions */
         if ((fsid = H5Dget_space(did)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Sget_simple_extent_dims(fsid, dims, max_dims) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Check the reported size of the VDS */
         if ((n_dims = H5Sget_simple_extent_ndims(fsid)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (n_dims != RANK)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Sget_simple_extent_dims(fsid, dims, max_dims) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         /* NOTE: Don't care what dims[0] is. */
         if (dims[1] != FULL_HEIGHT)
-            TEST_ERROR
+            TEST_ERROR;
         if (dims[2] != WIDTH)
-            TEST_ERROR
+            TEST_ERROR;
         if (max_dims[0] != H5S_UNLIMITED)
-            TEST_ERROR
+            TEST_ERROR;
         if (max_dims[1] != FULL_HEIGHT)
-            TEST_ERROR
+            TEST_ERROR;
         if (max_dims[2] != WIDTH)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Continue if there's nothing to read */
         if (0 == dims[0]) {
             if (H5Sclose(fsid) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             continue;
         }
 
@@ -100,23 +100,23 @@ main(void)
         start[1] = 0;
         start[2] = 0;
         if (H5Sselect_hyperslab(fsid, H5S_SELECT_SET, start, NULL, VDS_PLANE, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Dread(did, H5T_NATIVE_INT, msid, fsid, H5P_DEFAULT, buffer) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Sclose(fsid) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     } while (dims[0] < N_PLANES_TO_WRITE);
 
     /* Close file and dataset */
     if (H5Pclose(faplid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(msid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     HDfree(buffer);
 
@@ -137,10 +137,10 @@ error:
             (void)H5Sclose(msid);
         if (fsid >= 0)
             (void)H5Sclose(fsid);
-        if (buffer != NULL)
-            HDfree(buffer);
     }
     H5E_END_TRY
+
+    HDfree(buffer);
 
     HDfprintf(stderr, "ERROR: SWMR reader exited with errors\n");
     return EXIT_FAILURE;

--- a/test/vds_swmr_writer.c
+++ b/test/vds_swmr_writer.c
@@ -50,27 +50,27 @@ main(int argc, char *argv[])
 
     file_number = HDatoi(argv[1]);
     if (file_number < 0 || file_number >= N_SOURCES)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Open the source file and dataset */
     /* All SWMR files need to use the latest file format */
     if ((faplid = h5_fileaccess()) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Pset_libver_bounds(faplid, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((fid = H5Fopen(FILE_NAMES[file_number], H5F_ACC_RDWR | H5F_ACC_SWMR_WRITE, faplid)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((did = H5Dopen2(fid, SOURCE_DSET_PATH, H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create a data buffer that represents a plane */
     n_elements = PLANES[file_number][1] * PLANES[file_number][2];
     if (NULL == (buffer = (int *)HDmalloc(n_elements * sizeof(int))))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the memory dataspace */
     if ((msid = H5Screate_simple(RANK, PLANES[file_number], NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Write planes to the dataset */
     for (i = 0; i < N_PLANES_TO_WRITE; i++) {
@@ -79,18 +79,18 @@ main(int argc, char *argv[])
 
         /* Cork the dataset's metadata in the cache */
         if (H5Odisable_mdc_flushes(did) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Set the dataset's extent. This is inefficient but that's ok here. */
         extent[0] = i + 1;
         extent[1] = PLANES[file_number][1];
         extent[2] = PLANES[file_number][2];
         if (H5Dset_extent(did, extent) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Get the file dataspace */
         if ((fsid = H5Dget_space(did)) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Each plane is filled with the plane number as a data value. */
         value = (((int)i + 1) * 10) + (int)i;
@@ -102,15 +102,15 @@ main(int argc, char *argv[])
         start[1] = 0;
         start[2] = 0;
         if (H5Sselect_hyperslab(fsid, H5S_SELECT_SET, start, NULL, PLANES[file_number], NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Write the plane to the dataset. */
         if (H5Dwrite(did, H5T_NATIVE_INT, msid, fsid, H5P_DEFAULT, buffer) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Uncork the dataset's metadata from the cache */
         if (H5Oenable_mdc_flushes(did) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Wait one second between writing planes */
         delay = HDtime(0) + (time_t)1;
@@ -119,20 +119,20 @@ main(int argc, char *argv[])
 
         /* Flush */
         if (H5Fflush(fid, H5F_SCOPE_GLOBAL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
     } /* end for */
 
     if (H5Pclose(faplid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(msid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Sclose(fsid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Dclose(did) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     HDfree(buffer);
 
     HDfprintf(stderr, "SWMR writer exited successfully\n");

--- a/test/vfd.c
+++ b/test/vfd.c
@@ -216,28 +216,28 @@ test_sec2(void)
 
     /* Check that the VFD feature flags are correct */
     if ((driver_id = H5Pget_driver(fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5FDdriver_query(driver_id, &driver_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_AGGREGATE_METADATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_ACCUMULATE_METADATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_DATA_SIEVE))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_AGGREGATE_SMALLDATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_POSIX_COMPAT_HANDLE))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_SUPPORTS_SWMR_IO))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_DEFAULT_VFD_COMPATIBLE))
-        TEST_ERROR
+        TEST_ERROR;
     /* Check for extra flags not accounted for above */
     if (driver_flags != (H5FD_FEAT_AGGREGATE_METADATA | H5FD_FEAT_ACCUMULATE_METADATA | H5FD_FEAT_DATA_SIEVE |
                          H5FD_FEAT_AGGREGATE_SMALLDATA | H5FD_FEAT_POSIX_COMPAT_HANDLE |
                          H5FD_FEAT_SUPPORTS_SWMR_IO | H5FD_FEAT_DEFAULT_VFD_COMPATIBLE))
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id)) < 0)
         TEST_ERROR;
@@ -360,26 +360,26 @@ test_core(void)
      * so backing-store related flags will not be returned here.
      */
     if ((driver_id = H5Pget_driver(fapl_id)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5FDdriver_query(driver_id, &driver_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_AGGREGATE_METADATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_ACCUMULATE_METADATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_DATA_SIEVE))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_AGGREGATE_SMALLDATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_ALLOW_FILE_IMAGE))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_CAN_USE_FILE_IMAGE_CALLBACKS))
-        TEST_ERROR
+        TEST_ERROR;
     /* Check for extra flags not accounted for above */
     if (driver_flags !=
         (H5FD_FEAT_AGGREGATE_METADATA | H5FD_FEAT_ACCUMULATE_METADATA | H5FD_FEAT_DATA_SIEVE |
          H5FD_FEAT_AGGREGATE_SMALLDATA | H5FD_FEAT_ALLOW_FILE_IMAGE | H5FD_FEAT_CAN_USE_FILE_IMAGE_CALLBACKS))
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id)) < 0)
         TEST_ERROR;
@@ -428,7 +428,7 @@ test_core(void)
      * they are correct.
      */
     if (H5Pget_fapl_core(fapl_id_out, &increment, &backing_store) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (increment != (size_t)CORE_INCREMENT)
         FAIL_PUTS_ERROR("incorrect increment from file fapl");
     if (backing_store != TRUE)
@@ -953,7 +953,7 @@ test_family_opens(char *fname, hid_t fa_pl)
     }
     H5E_END_TRY;
     if (file >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Case 2: reopen file with correct name template but default property list */
     H5E_BEGIN_TRY
@@ -962,7 +962,7 @@ test_family_opens(char *fname, hid_t fa_pl)
     }
     H5E_END_TRY;
     if (file >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Case 3: reopen file with wrong member size */
     if (H5Pset_fapl_family(fa_pl, (hsize_t)128, H5P_DEFAULT) < 0)
@@ -974,7 +974,7 @@ test_family_opens(char *fname, hid_t fa_pl)
     }
     H5E_END_TRY;
     if (file >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Case 4: reopen file with wrong name template */
     HDstrcpy(wrong_name, fname);
@@ -993,7 +993,7 @@ test_family_opens(char *fname, hid_t fa_pl)
     }
     H5E_END_TRY;
     if (file >= 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -1049,21 +1049,21 @@ test_family(void)
 
     /* Check that the VFD feature flags are correct */
     if ((driver_id = H5Pget_driver(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5FDdriver_query(driver_id, &driver_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_AGGREGATE_METADATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_ACCUMULATE_METADATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_DATA_SIEVE))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_AGGREGATE_SMALLDATA))
-        TEST_ERROR
+        TEST_ERROR;
     /* Check for extra flags not accounted for above */
     if (driver_flags != (H5FD_FEAT_AGGREGATE_METADATA | H5FD_FEAT_ACCUMULATE_METADATA | H5FD_FEAT_DATA_SIEVE |
                          H5FD_FEAT_AGGREGATE_SMALLDATA))
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
         TEST_ERROR;
@@ -1560,21 +1560,21 @@ test_multi(void)
 
     /* Check that the VFD feature flags are correct */
     if ((driver_id = H5Pget_driver(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5FDdriver_query(driver_id, &driver_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_DATA_SIEVE))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_AGGREGATE_SMALLDATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_USE_ALLOC_SIZE))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_PAGED_AGGR))
-        TEST_ERROR
+        TEST_ERROR;
     /* Check for extra flags not accounted for above */
     if (driver_flags != (H5FD_FEAT_DATA_SIEVE | H5FD_FEAT_AGGREGATE_SMALLDATA | H5FD_FEAT_USE_ALLOC_SIZE |
                          H5FD_FEAT_PAGED_AGGR))
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
         TEST_ERROR;
@@ -1661,7 +1661,7 @@ test_multi(void)
 
     /* Create and write attribute for the root group. */
     if ((root = H5Gopen2(file, "/", H5P_DEFAULT)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Attribute string. */
     if ((atype = H5Tcopy(H5T_C_S1)) < 0)
@@ -1966,28 +1966,28 @@ test_log(void)
 
     /* Check that the VFD feature flags are correct */
     if ((driver_id = H5Pget_driver(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5FDdriver_query(driver_id, &driver_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_AGGREGATE_METADATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_ACCUMULATE_METADATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_DATA_SIEVE))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_AGGREGATE_SMALLDATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_POSIX_COMPAT_HANDLE))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_SUPPORTS_SWMR_IO))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_DEFAULT_VFD_COMPATIBLE))
-        TEST_ERROR
+        TEST_ERROR;
     /* Check for extra flags not accounted for above */
     if (driver_flags != (H5FD_FEAT_AGGREGATE_METADATA | H5FD_FEAT_ACCUMULATE_METADATA | H5FD_FEAT_DATA_SIEVE |
                          H5FD_FEAT_AGGREGATE_SMALLDATA | H5FD_FEAT_POSIX_COMPAT_HANDLE |
                          H5FD_FEAT_SUPPORTS_SWMR_IO | H5FD_FEAT_DEFAULT_VFD_COMPATIBLE))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create the test file */
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
@@ -2079,23 +2079,23 @@ test_stdio(void)
 
     /* Check that the VFD feature flags are correct */
     if ((driver_id = H5Pget_driver(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5FDdriver_query(driver_id, &driver_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_AGGREGATE_METADATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_ACCUMULATE_METADATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_DATA_SIEVE))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_AGGREGATE_SMALLDATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_DEFAULT_VFD_COMPATIBLE))
-        TEST_ERROR
+        TEST_ERROR;
     /* Check for extra flags not accounted for above */
     if (driver_flags != (H5FD_FEAT_AGGREGATE_METADATA | H5FD_FEAT_ACCUMULATE_METADATA | H5FD_FEAT_DATA_SIEVE |
                          H5FD_FEAT_AGGREGATE_SMALLDATA | H5FD_FEAT_DEFAULT_VFD_COMPATIBLE))
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
         TEST_ERROR;
@@ -2197,28 +2197,28 @@ test_windows(void)
 
     /* Check that the VFD feature flags are correct */
     if ((driver_id = H5Pget_driver(fapl)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5FDdriver_query(driver_id, &driver_flags) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_AGGREGATE_METADATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_ACCUMULATE_METADATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_DATA_SIEVE))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_AGGREGATE_SMALLDATA))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_POSIX_COMPAT_HANDLE))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_SUPPORTS_SWMR_IO))
-        TEST_ERROR
+        TEST_ERROR;
     if (!(driver_flags & H5FD_FEAT_DEFAULT_VFD_COMPATIBLE))
-        TEST_ERROR
+        TEST_ERROR;
     /* Check for extra flags not accounted for above */
     if (driver_flags != (H5FD_FEAT_AGGREGATE_METADATA | H5FD_FEAT_ACCUMULATE_METADATA | H5FD_FEAT_DATA_SIEVE |
                          H5FD_FEAT_AGGREGATE_SMALLDATA | H5FD_FEAT_POSIX_COMPAT_HANDLE |
                          H5FD_FEAT_SUPPORTS_SWMR_IO | H5FD_FEAT_DEFAULT_VFD_COMPATIBLE))
-        TEST_ERROR
+        TEST_ERROR;
 
     if ((file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
         TEST_ERROR;
@@ -2351,11 +2351,11 @@ test_ros3(void)
         TEST_ERROR;
 
     if (!(driver_flags & H5FD_FEAT_DATA_SIEVE))
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Check for extra flags not accounted for above */
     if (driver_flags != (H5FD_FEAT_DATA_SIEVE))
-        TEST_ERROR
+        TEST_ERROR;
 
     PASSED();
     return 0;
@@ -2676,7 +2676,7 @@ driver_is_splitter_compatible(hid_t fapl_id)
     }
 
     if (H5Pclose(split_fapl_id) < 0) {
-        FAIL_PUTS_ERROR("Can't close contained FAPL")
+        FAIL_PUTS_ERROR("Can't close contained FAPL");
     }
     split_fapl_id = H5I_INVALID_HID;
 
@@ -3759,7 +3759,7 @@ test_ctl(void)
     if (H5Pset_driver(fapl_id, driver_id, NULL) < 0)
         PUTS_ERROR("couldn't set testing VFD on FAPL");
 
-    TESTING_2("known op code to terminal VFD (without fail on unknown flag)")
+    TESTING_2("known op code to terminal VFD (without fail on unknown flag)");
 
     op_code = H5FD_CTL__TEST_OPCODE;
     flags   = 0;
@@ -3770,7 +3770,7 @@ test_ctl(void)
 
     PASSED();
 
-    TESTING_2("known op code to terminal VFD (with fail on unknown flag)")
+    TESTING_2("known op code to terminal VFD (with fail on unknown flag)");
 
     op_code = H5FD_CTL__TEST_OPCODE;
     flags   = H5FD_CTL__FAIL_IF_UNKNOWN_FLAG;
@@ -3781,7 +3781,7 @@ test_ctl(void)
 
     PASSED();
 
-    TESTING_2("known op code to terminal VFD (without fail on unknown flag/route to terminal VFD)")
+    TESTING_2("known op code to terminal VFD (without fail on unknown flag/route to terminal VFD)");
 
     op_code = H5FD_CTL__TEST_OPCODE;
     flags   = H5FD_CTL__ROUTE_TO_TERMINAL_VFD_FLAG;
@@ -3792,7 +3792,7 @@ test_ctl(void)
 
     PASSED();
 
-    TESTING_2("known op code to terminal VFD (with fail on unknown flag/route to terminal VFD)")
+    TESTING_2("known op code to terminal VFD (with fail on unknown flag/route to terminal VFD)");
 
     op_code = H5FD_CTL__TEST_OPCODE;
     flags   = H5FD_CTL__FAIL_IF_UNKNOWN_FLAG | H5FD_CTL__ROUTE_TO_TERMINAL_VFD_FLAG;
@@ -3803,7 +3803,7 @@ test_ctl(void)
 
     PASSED();
 
-    TESTING_2("unknown op code to terminal VFD (without fail on unknown flag)")
+    TESTING_2("unknown op code to terminal VFD (without fail on unknown flag)");
 
     op_code = H5FD_CTL_OPC_RESERVED;
     flags   = 0;
@@ -3814,7 +3814,7 @@ test_ctl(void)
 
     PASSED();
 
-    TESTING_2("unknown op code to terminal VFD (with fail on unknown flag)")
+    TESTING_2("unknown op code to terminal VFD (with fail on unknown flag)");
 
     op_code = H5FD_CTL_OPC_RESERVED;
     flags   = H5FD_CTL__FAIL_IF_UNKNOWN_FLAG;
@@ -3825,7 +3825,7 @@ test_ctl(void)
 
     PASSED();
 
-    TESTING_2("unknown op code to terminal VFD (without fail on unknown flag/route to terminal VFD)")
+    TESTING_2("unknown op code to terminal VFD (without fail on unknown flag/route to terminal VFD)");
 
     op_code = H5FD_CTL_OPC_RESERVED;
     flags   = H5FD_CTL__ROUTE_TO_TERMINAL_VFD_FLAG;
@@ -3836,7 +3836,7 @@ test_ctl(void)
 
     PASSED();
 
-    TESTING_2("unknown op code to terminal VFD (with fail on unknown flag/route to terminal VFD)")
+    TESTING_2("unknown op code to terminal VFD (with fail on unknown flag/route to terminal VFD)");
 
     op_code = H5FD_CTL_OPC_RESERVED;
     flags   = H5FD_CTL__FAIL_IF_UNKNOWN_FLAG | H5FD_CTL__ROUTE_TO_TERMINAL_VFD_FLAG;
@@ -3868,7 +3868,7 @@ test_ctl(void)
         PUTS_ERROR("couldn't set splitter VFD on FAPL");
 
     TESTING_2("known op code through passthrough VFD to terminal VFD (without fail on unknown flag/no "
-              "routing flag)")
+              "routing flag)");
 
     op_code = H5FD_CTL__TEST_OPCODE;
     flags   = 0;
@@ -3884,7 +3884,7 @@ test_ctl(void)
     PASSED();
 
     TESTING_2(
-        "known op code through passthrough VFD to terminal VFD (with fail on unknown flag/no routing flag)")
+        "known op code through passthrough VFD to terminal VFD (with fail on unknown flag/no routing flag)");
 
     op_code = H5FD_CTL__TEST_OPCODE;
     flags   = H5FD_CTL__FAIL_IF_UNKNOWN_FLAG;
@@ -3901,7 +3901,7 @@ test_ctl(void)
     PASSED();
 
     TESTING_2("known op code through passthrough VFD to terminal VFD (without fail on unknown flag/route to "
-              "terminal VFD)")
+              "terminal VFD)");
 
     op_code = H5FD_CTL__TEST_OPCODE;
     flags   = H5FD_CTL__ROUTE_TO_TERMINAL_VFD_FLAG;
@@ -3917,7 +3917,7 @@ test_ctl(void)
     PASSED();
 
     TESTING_2("known op code through passthrough VFD to terminal VFD (with fail on unknown flag/route to "
-              "terminal VFD)")
+              "terminal VFD)");
 
     op_code = H5FD_CTL__TEST_OPCODE;
     flags   = H5FD_CTL__FAIL_IF_UNKNOWN_FLAG | H5FD_CTL__ROUTE_TO_TERMINAL_VFD_FLAG;
@@ -3932,7 +3932,7 @@ test_ctl(void)
 
     PASSED();
 
-    TESTING_2("unknown op code to passthrough VFD (without fail on unknown flag)")
+    TESTING_2("unknown op code to passthrough VFD (without fail on unknown flag)");
 
     op_code = H5FD_CTL_OPC_RESERVED;
     flags   = 0;
@@ -3947,7 +3947,7 @@ test_ctl(void)
 
     PASSED();
 
-    TESTING_2("unknown op code to passthrough VFD (with fail on unknown flag)")
+    TESTING_2("unknown op code to passthrough VFD (with fail on unknown flag)");
 
     op_code = H5FD_CTL_OPC_RESERVED;
     flags   = H5FD_CTL__FAIL_IF_UNKNOWN_FLAG;
@@ -3962,7 +3962,7 @@ test_ctl(void)
 
     PASSED();
 
-    TESTING_2("unknown op code to passthrough VFD (without fail on unknown flag/route to terminal VFD)")
+    TESTING_2("unknown op code to passthrough VFD (without fail on unknown flag/route to terminal VFD)");
 
     op_code = H5FD_CTL_OPC_RESERVED;
     flags   = H5FD_CTL__ROUTE_TO_TERMINAL_VFD_FLAG;
@@ -3980,7 +3980,7 @@ test_ctl(void)
 
     PASSED();
 
-    TESTING_2("unknown op code to passthrough VFD (with fail on unknown flag/route to terminal VFD)")
+    TESTING_2("unknown op code to passthrough VFD (with fail on unknown flag/route to terminal VFD)");
 
     op_code = H5FD_CTL_OPC_RESERVED;
     flags   = H5FD_CTL__FAIL_IF_UNKNOWN_FLAG | H5FD_CTL__ROUTE_TO_TERMINAL_VFD_FLAG;
@@ -3998,7 +3998,7 @@ test_ctl(void)
 
     PASSED();
 
-    TESTING_2("test cleanup")
+    TESTING_2("test cleanup");
 
     HDfree(splitter_config);
 
@@ -4631,7 +4631,7 @@ test_vector_io(const char *vfd_name)
     else {
 
         HDfprintf(stdout, "un-supported VFD\n");
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* setup the test vectors -- note that addresses are not set until
@@ -5009,7 +5009,7 @@ test_selection_io_write(H5FD_t *lf, H5FD_mem_t type, uint32_t count, hid_t mem_s
     /* Issue write call */
     if (H5FDwrite_selection(lf, type, H5P_DEFAULT, count, mem_spaces, file_spaces, offsets, element_sizes,
                             (const void **)wbufs) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     return 0;
 
@@ -5061,14 +5061,14 @@ test_selection_io_read_verify(H5FD_t *lf, H5FD_mem_t type, uint32_t count, hid_t
     /* Issue read call */
     if (H5FDread_selection(lf, type, H5P_DEFAULT, count, mem_spaces, file_spaces, offsets, element_sizes,
                            (void **)rbufs) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Verify result */
     for (i = 0; i < (int)rbufcount; i++)
         for (j = 0; j < SEL_IO_DIM0 * SEL_IO_DIM1; j++)
             if (rbufs[i][j] != erbufs[i][j]) {
-                H5_FAILED()
-                AT()
+                H5_FAILED();
+                AT();
                 HDprintf("data read from file does not match expected values at mapping array location %d\n",
                          i);
                 HDprintf("expected data: \n");
@@ -5152,26 +5152,26 @@ test_selection_io(const char *vfd_name)
     /* Set property list and file name for target driver */
 
     if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     if (HDstrcmp(vfd_name, "sec2") == 0) {
 
         if (H5Pset_fapl_sec2(fapl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         h5_fixname(FILENAME[0], fapl_id, filename, sizeof(filename));
     }
     else if (HDstrcmp(vfd_name, "stdio") == 0) {
 
         if (H5Pset_fapl_stdio(fapl_id) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         h5_fixname(FILENAME[7], fapl_id, filename, sizeof filename);
     }
     else {
 
         HDfprintf(stdout, "un-supported VFD\n");
-        TEST_ERROR
+        TEST_ERROR;
     }
 
     /* Initialize write buffers */
@@ -5183,13 +5183,13 @@ test_selection_io(const char *vfd_name)
 
     /* Create dataspaces - location 0 will be 1D and location 1 will be 2D */
     if ((mem_spaces[0] = H5Screate_simple(1, dims1, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((mem_spaces[1] = H5Screate_simple(2, dims2, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((file_spaces[0] = H5Screate_simple(1, dims1, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((file_spaces[1] = H5Screate_simple(2, dims2, NULL)) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Create file */
     flags = H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC;
@@ -5209,7 +5209,7 @@ test_selection_io(const char *vfd_name)
         /* Issue write call */
         if (test_selection_io_write(lf, type, 1, &mem_spaces[0], &file_spaces[0], &addrs[0], element_sizes,
                                     (int **)&wbufs[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Update file buf */
         for (i = 0; i < SEL_IO_DIM0 * SEL_IO_DIM1; i++)
@@ -5218,7 +5218,7 @@ test_selection_io(const char *vfd_name)
         /* Read and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[0], &file_spaces[0], &addrs[0],
                                           element_sizes, 1, (int **)&fbufs[0], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /*
          * Test 2: Simple 2D contiguous I/O
@@ -5226,7 +5226,7 @@ test_selection_io(const char *vfd_name)
         /* Issue write call */
         if (test_selection_io_write(lf, type, 1, &mem_spaces[1], &file_spaces[1], &addrs[1], element_sizes,
                                     (int **)&wbufs[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Update file buf */
         for (i = 0; i < SEL_IO_DIM0; i++)
@@ -5236,7 +5236,7 @@ test_selection_io(const char *vfd_name)
         /* Read and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[1], &file_spaces[1], &addrs[1],
                                           element_sizes, 1, (int **)&fbufs[1], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /*
          * Test 3: Strided <> Contiguous 1D I/O
@@ -5250,16 +5250,16 @@ test_selection_io(const char *vfd_name)
         count[0]  = (SEL_IO_DIM0 * SEL_IO_DIM1) / 2;
         block[0]  = 1;
         if (H5Sselect_hyperslab(mem_spaces[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Contiguous selection in file */
         if (H5Sselect_hyperslab(file_spaces[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Issue write call */
         if (test_selection_io_write(lf, type, 1, &mem_spaces[0], &file_spaces[0], &addrs[0], element_sizes,
                                     (int **)&wbufs[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Update file buf */
         for (i = 0; i < (SEL_IO_DIM0 * SEL_IO_DIM1) / 2; i++)
@@ -5274,18 +5274,18 @@ test_selection_io(const char *vfd_name)
         /* Read and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[0], &file_spaces[0], &addrs[0],
                                           element_sizes, 1, (int **)&erbufs[0], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Reset selections */
         if (H5Sselect_all(mem_spaces[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Sselect_all(file_spaces[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read entire file buffer and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[0], &file_spaces[0], &addrs[0],
                                           element_sizes, 1, (int **)&fbufs[0], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /*
          * Test 4: Contiguous <> Strided 1D I/O
@@ -5297,18 +5297,18 @@ test_selection_io(const char *vfd_name)
         start[0]  = 1;
         stride[0] = 2;
         if (H5Sselect_hyperslab(mem_spaces[0], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Strided selection in file */
         count[0] = (SEL_IO_DIM0 * SEL_IO_DIM1) / 2;
         block[0] = 1;
         if (H5Sselect_hyperslab(file_spaces[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Issue write call */
         if (test_selection_io_write(lf, type, 1, &mem_spaces[0], &file_spaces[0], &addrs[0], element_sizes,
                                     (int **)&wbufs[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Update file buf */
         for (i = 0; i < (SEL_IO_DIM0 * SEL_IO_DIM1) / 2; i++)
@@ -5323,18 +5323,18 @@ test_selection_io(const char *vfd_name)
         /* Read and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[0], &file_spaces[0], &addrs[0],
                                           element_sizes, 1, (int **)&erbufs[0], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Reset selections */
         if (H5Sselect_all(mem_spaces[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Sselect_all(file_spaces[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read entire file buffer and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[0], &file_spaces[0], &addrs[0],
                                           element_sizes, 1, (int **)&fbufs[0], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /*
          * Test 5: Strided <> Strided 1D I/O
@@ -5348,17 +5348,17 @@ test_selection_io(const char *vfd_name)
         count[0]  = (SEL_IO_DIM0 * SEL_IO_DIM1) / 2;
         block[0]  = 1;
         if (H5Sselect_hyperslab(mem_spaces[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Strided selection in file */
         start[0] = 0;
         if (H5Sselect_hyperslab(file_spaces[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Issue write call */
         if (test_selection_io_write(lf, type, 1, &mem_spaces[0], &file_spaces[0], &addrs[0], element_sizes,
                                     (int **)&wbufs[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Update file buf */
         for (i = 0; i < (SEL_IO_DIM0 * SEL_IO_DIM1) / 2; i++)
@@ -5373,18 +5373,18 @@ test_selection_io(const char *vfd_name)
         /* Read and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[0], &file_spaces[0], &addrs[0],
                                           element_sizes, 1, (int **)&erbufs[0], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Reset selections */
         if (H5Sselect_all(mem_spaces[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Sselect_all(file_spaces[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read entire file buffer and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[0], &file_spaces[0], &addrs[0],
                                           element_sizes, 1, (int **)&fbufs[0], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /*
          * Test 6: Strided <> Contiguous 2D I/O
@@ -5399,16 +5399,16 @@ test_selection_io(const char *vfd_name)
         block[0]  = 1;
         block[1]  = 1;
         if (H5Sselect_hyperslab(mem_spaces[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Contiguous selection in file */
         if (H5Sselect_hyperslab(file_spaces[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Issue write call */
         if (test_selection_io_write(lf, type, 1, &mem_spaces[1], &file_spaces[1], &addrs[1], element_sizes,
                                     (int **)&wbufs[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Update file buf */
         for (i = 0; i < SEL_IO_DIM0 / 2; i++)
@@ -5426,18 +5426,18 @@ test_selection_io(const char *vfd_name)
         /* Read and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[1], &file_spaces[1], &addrs[1],
                                           element_sizes, 1, (int **)&erbufs[1], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Reset selections */
         if (H5Sselect_all(mem_spaces[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Sselect_all(file_spaces[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read entire file buffer and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[1], &file_spaces[1], &addrs[1],
                                           element_sizes, 1, (int **)&fbufs[1], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /*
          * Test 7: Contiguous <> Strided 2D I/O
@@ -5448,7 +5448,7 @@ test_selection_io(const char *vfd_name)
         count[0] = SEL_IO_DIM0;
         count[1] = SEL_IO_DIM1 / 2;
         if (H5Sselect_hyperslab(mem_spaces[1], H5S_SELECT_SET, start, NULL, count, NULL) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Strided selection in file */
         stride[0] = 1;
@@ -5456,12 +5456,12 @@ test_selection_io(const char *vfd_name)
         block[0]  = 1;
         block[1]  = 1;
         if (H5Sselect_hyperslab(file_spaces[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Issue write call */
         if (test_selection_io_write(lf, type, 1, &mem_spaces[1], &file_spaces[1], &addrs[1], element_sizes,
                                     (int **)&wbufs[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Update file buf */
         for (i = 0; i < SEL_IO_DIM0; i++)
@@ -5479,18 +5479,18 @@ test_selection_io(const char *vfd_name)
         /* Read and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[1], &file_spaces[1], &addrs[1],
                                           element_sizes, 1, (int **)&erbufs[1], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Reset selections */
         if (H5Sselect_all(mem_spaces[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Sselect_all(file_spaces[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read entire file buffer and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[1], &file_spaces[1], &addrs[1],
                                           element_sizes, 1, (int **)&fbufs[1], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /*
          * Test 8: Strided <> Strided 2D I/O
@@ -5509,7 +5509,7 @@ test_selection_io(const char *vfd_name)
         block[0]  = 1;
         block[1]  = 1;
         if (H5Sselect_hyperslab(mem_spaces[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Strided selection (across dim 0) in file */
         start[0]  = 1;
@@ -5521,12 +5521,12 @@ test_selection_io(const char *vfd_name)
         block[0]  = 1;
         block[1]  = 1;
         if (H5Sselect_hyperslab(file_spaces[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Issue write call */
         if (test_selection_io_write(lf, type, 1, &mem_spaces[1], &file_spaces[1], &addrs[1], element_sizes,
                                     (int **)&wbufs[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Update file buf */
         for (i = 0, i2 = 1, j2 = 0; i < SEL_IO_DIM0; i++)
@@ -5550,18 +5550,18 @@ test_selection_io(const char *vfd_name)
         /* Read and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[1], &file_spaces[1], &addrs[1],
                                           element_sizes, 1, (int **)&erbufs[1], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Reset selections */
         if (H5Sselect_all(mem_spaces[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Sselect_all(file_spaces[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read entire file buffer and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[1], &file_spaces[1], &addrs[1],
                                           element_sizes, 1, (int **)&fbufs[1], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /*
          * Test 9: Strided 1D <> Strided 2D I/O
@@ -5572,7 +5572,7 @@ test_selection_io(const char *vfd_name)
         count[0]  = (SEL_IO_DIM0 * SEL_IO_DIM1) / 2;
         block[0]  = 1;
         if (H5Sselect_hyperslab(mem_spaces[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Strided selection (across dim 1) in file */
         start[0]  = 0;
@@ -5584,12 +5584,12 @@ test_selection_io(const char *vfd_name)
         block[0]  = 1;
         block[1]  = 1;
         if (H5Sselect_hyperslab(file_spaces[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Issue write call */
         if (test_selection_io_write(lf, type, 1, &mem_spaces[0], &file_spaces[1], &addrs[1], element_sizes,
                                     (int **)&wbufs[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Update file buf */
         for (i = 1, i2 = 0, j2 = 1; i < (SEL_IO_DIM0 * SEL_IO_DIM1); i += 2) {
@@ -5611,18 +5611,18 @@ test_selection_io(const char *vfd_name)
         /* Read and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[0], &file_spaces[1], &addrs[1],
                                           element_sizes, 1, (int **)&erbufs[0], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Reset selections */
         if (H5Sselect_all(mem_spaces[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Sselect_all(file_spaces[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read entire file buffer and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[0], &file_spaces[1], &addrs[1],
                                           element_sizes, 1, (int **)&fbufs[1], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /*
          * Test 10: Strided 2D <> Strided 1D I/O
@@ -5637,7 +5637,7 @@ test_selection_io(const char *vfd_name)
         block[0]  = 1;
         block[1]  = 1;
         if (H5Sselect_hyperslab(mem_spaces[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Strided selection in file */
         start[0]  = 0;
@@ -5645,12 +5645,12 @@ test_selection_io(const char *vfd_name)
         count[0]  = (SEL_IO_DIM0 * SEL_IO_DIM1) / 2;
         block[0]  = 1;
         if (H5Sselect_hyperslab(file_spaces[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Issue write call */
         if (test_selection_io_write(lf, type, 1, &mem_spaces[1], &file_spaces[0], &addrs[0], element_sizes,
                                     (int **)&wbufs[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Update file buf */
         for (i = 0, i2 = 0; i < SEL_IO_DIM0; i += 2)
@@ -5671,18 +5671,18 @@ test_selection_io(const char *vfd_name)
         /* Read and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[1], &file_spaces[0], &addrs[0],
                                           element_sizes, 1, (int **)&erbufs[1], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Reset selections */
         if (H5Sselect_all(mem_spaces[1]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Sselect_all(file_spaces[0]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Read entire file buffer and verify */
         if (test_selection_io_read_verify(lf, type, 1, &mem_spaces[1], &file_spaces[0], &addrs[0],
                                           element_sizes, 1, (int **)&fbufs[0], FALSE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
 
         /* Run tests with full and partial element sizes array */
         for (shorten_element_sizes = 0; shorten_element_sizes <= 1; shorten_element_sizes++) {
@@ -5698,12 +5698,12 @@ test_selection_io(const char *vfd_name)
             count[0]  = (SEL_IO_DIM0 * SEL_IO_DIM1) / 2;
             block[0]  = 1;
             if (H5Sselect_hyperslab(mem_spaces[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Strided selection in file (1D) */
             start[0] = 1;
             if (H5Sselect_hyperslab(file_spaces[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Strided selection (across dim 0) in memory (2D) */
             start[0]  = 1;
@@ -5715,7 +5715,7 @@ test_selection_io(const char *vfd_name)
             block[0]  = 1;
             block[1]  = 1;
             if (H5Sselect_hyperslab(mem_spaces[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Strided selection (across dim 1) in file (2D) */
             start[0]  = 0;
@@ -5727,12 +5727,12 @@ test_selection_io(const char *vfd_name)
             block[0]  = 1;
             block[1]  = 1;
             if (H5Sselect_hyperslab(file_spaces[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Issue write call */
             if (test_selection_io_write(lf, type, 2, mem_spaces, file_spaces, addrs, element_sizes,
                                         (int **)wbufs) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Update file bufs */
             for (i = 0; i < (SEL_IO_DIM0 * SEL_IO_DIM1) / 2; i++)
@@ -5763,31 +5763,31 @@ test_selection_io(const char *vfd_name)
             /* Read and verify */
             if (test_selection_io_read_verify(lf, type, 2, mem_spaces, file_spaces, addrs, element_sizes, 2,
                                               (int **)erbufs, FALSE) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Reset selections */
             if (H5Sselect_all(mem_spaces[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Sselect_all(file_spaces[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Sselect_all(mem_spaces[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Sselect_all(file_spaces[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Read entire file buffer and verify */
             if (test_selection_io_read_verify(lf, type, 2, mem_spaces, file_spaces, addrs, element_sizes, 2,
                                               (int **)fbufs, FALSE) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /*
              * Test 12: Strided <> Strided 2D I/O, 2 different selections in the same memory buffer
              */
             /* Switch mem and file spaces to both be 2D */
             if (H5Sset_extent_simple(mem_spaces[0], 2, dims2, NULL) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Sset_extent_simple(file_spaces[0], 2, dims2, NULL) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Strided selection in memory (1st) */
             start[0]  = 0;
@@ -5799,12 +5799,12 @@ test_selection_io(const char *vfd_name)
             block[0]  = 1;
             block[1]  = 1;
             if (H5Sselect_hyperslab(mem_spaces[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Strided selection (across dim 0) in memory (2nd) */
             start[0] = 1;
             if (H5Sselect_hyperslab(mem_spaces[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Strided selection in file (1st) */
             start[0]  = 0;
@@ -5816,7 +5816,7 @@ test_selection_io(const char *vfd_name)
             block[0]  = 1;
             block[1]  = 1;
             if (H5Sselect_hyperslab(file_spaces[0], H5S_SELECT_SET, start, stride, count, block) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Strided selection (across dim 1) in file (2nd) */
             start[0]  = 0;
@@ -5828,7 +5828,7 @@ test_selection_io(const char *vfd_name)
             block[0]  = 1;
             block[1]  = 1;
             if (H5Sselect_hyperslab(file_spaces[1], H5S_SELECT_SET, start, stride, count, block) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Use the same memory buffer for both selections */
             wbufs[0] = wbuf2[0];
@@ -5842,7 +5842,7 @@ test_selection_io(const char *vfd_name)
             /* Issue write call */
             if (test_selection_io_write(lf, type, 2, mem_spaces, file_spaces, addrs, element_sizes,
                                         (int **)wbufs) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Update file bufs - need to reuse 1D array so data stays consistent, so use math to
              * find 1D index into 2D array */
@@ -5881,28 +5881,28 @@ test_selection_io(const char *vfd_name)
             /* Read and verify */
             if (test_selection_io_read_verify(lf, type, 2, mem_spaces, file_spaces, addrs, element_sizes, 1,
                                               (int **)&erbufs[1], shorten_element_sizes ? TRUE : FALSE) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Reset selections */
             if (H5Sselect_all(mem_spaces[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Sselect_all(file_spaces[0]) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Sselect_all(mem_spaces[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Sselect_all(file_spaces[1]) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Read entire file buffer and verify */
             if (test_selection_io_read_verify(lf, type, 2, mem_spaces, file_spaces, addrs, element_sizes, 2,
                                               (int **)fbufs, FALSE) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Reset first spaces to 1D */
             if (H5Sset_extent_simple(mem_spaces[0], 1, dims1, NULL) < 0)
-                TEST_ERROR
+                TEST_ERROR;
             if (H5Sset_extent_simple(file_spaces[0], 1, dims1, NULL) < 0)
-                TEST_ERROR
+                TEST_ERROR;
 
             /* Reset write buffer array */
             wbufs[0] = wbuf1;
@@ -5932,9 +5932,9 @@ test_selection_io(const char *vfd_name)
     /* Close dataspaces */
     for (i = 0; i < 2; i++) {
         if (H5Sclose(mem_spaces[i]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5Sclose(file_spaces[i]) < 0)
-            TEST_ERROR
+            TEST_ERROR;
     }
 
     PASSED();

--- a/test/vol.c
+++ b/test/vol.c
@@ -794,7 +794,7 @@ test_basic_file_operation(const char *env_h5_drvr)
     if (H5Pset_fclose_degree(fapl_id, H5F_CLOSE_SEMI) < 0)
         TEST_ERROR;
     if (H5Pset_metadata_read_attempts(fapl_id, 9) < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* H5Fcreate */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id)) < 0)
@@ -1987,11 +1987,11 @@ test_async_vol_props(void)
     conn_env_str = HDgetenv(HDF5_VOL_CONNECTOR);
     if (conn_env_str) {
         if (NULL == (conn_env_str = HDstrdup(conn_env_str)))
-            TEST_ERROR
+            TEST_ERROR;
         if (HDunsetenv(HDF5_VOL_CONNECTOR) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         if (H5VL__reparse_def_vol_conn_variable_test() < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     /* Test query w/default VOL, which should indicate no async, since native connector
@@ -2000,9 +2000,9 @@ test_async_vol_props(void)
     if (H5Pget_vol_cap_flags(fapl_id, &cap_flags) < 0)
         FAIL_STACK_ERROR;
     if ((cap_flags & H5VL_CAP_FLAG_ASYNC) > 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((cap_flags & H5VL_CAP_FLAG_NATIVE_FILES) == 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close FAPL */
     if (H5Pclose(fapl_id) < 0)
@@ -2014,9 +2014,9 @@ test_async_vol_props(void)
 
     /* Set environment variable to use 'fake async' connector & re-init default connector */
     if (HDsetenv(HDF5_VOL_CONNECTOR, "fake_async", TRUE) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5VL__reparse_def_vol_conn_variable_test() < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Retrieve the file access property again */
     fapl_id = h5_fileaccess();
@@ -2026,15 +2026,15 @@ test_async_vol_props(void)
     if (H5Pget_vol_cap_flags(fapl_id, &cap_flags) < 0)
         FAIL_STACK_ERROR;
     if ((cap_flags & H5VL_CAP_FLAG_ASYNC) == 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((cap_flags & H5VL_CAP_FLAG_NATIVE_FILES) > 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Reset environment variable & re-init default connector */
     if (HDunsetenv(HDF5_VOL_CONNECTOR) < 0)
-        TEST_ERROR
+        TEST_ERROR;
     if (H5VL__reparse_def_vol_conn_variable_test() < 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Close FAPL */
     if (H5Pclose(fapl_id) < 0)
@@ -2052,9 +2052,9 @@ test_async_vol_props(void)
     if (H5Pget_vol_cap_flags(fapl_id, &cap_flags) < 0)
         FAIL_STACK_ERROR;
     if ((cap_flags & H5VL_CAP_FLAG_ASYNC) == 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((cap_flags & H5VL_CAP_FLAG_NATIVE_FILES) > 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Stack the [internal] passthrough VOL connector on top of the fake async connector */
     passthru_info.under_vol_id   = vol_id;
@@ -2067,9 +2067,9 @@ test_async_vol_props(void)
     if (H5Pget_vol_cap_flags(fapl_id, &cap_flags) < 0)
         FAIL_STACK_ERROR;
     if ((cap_flags & H5VL_CAP_FLAG_ASYNC) == 0)
-        TEST_ERROR
+        TEST_ERROR;
     if ((cap_flags & H5VL_CAP_FLAG_NATIVE_FILES) > 0)
-        TEST_ERROR
+        TEST_ERROR;
 
     /* Unregister the fake async VOL ID */
     if (H5VLunregister_connector(vol_id) < 0)
@@ -2082,11 +2082,11 @@ test_async_vol_props(void)
     /* Restore environment variable, if there was one */
     if (conn_env_str) {
         if (HDsetenv(HDF5_VOL_CONNECTOR, conn_env_str, TRUE) < 0)
-            TEST_ERROR
+            TEST_ERROR;
         HDfree(conn_env_str);
 
         if (H5VL__reparse_def_vol_conn_variable_test() < 0)
-            TEST_ERROR
+            TEST_ERROR;
     } /* end if */
 
     PASSED();

--- a/testpar/t_init_term.c
+++ b/testpar/t_init_term.c
@@ -64,7 +64,7 @@ main(int argc, char **argv)
         if (0 == nerrors)
             PASSED();
         else
-            H5_FAILED()
+            H5_FAILED();
     }
 
     return (nerrors != 0);

--- a/testpar/t_pflush2.c
+++ b/testpar/t_pflush2.c
@@ -187,7 +187,7 @@ main(int argc, char *argv[])
     /* Check the case where the file was flushed */
     h5_fixname(FILENAME[0], fapl_id1, name, sizeof(name));
     if (check_test_file(name, sizeof(name), fapl_id1)) {
-        H5_FAILED()
+        H5_FAILED();
         goto error;
     }
     else if (mpi_rank == 0) {
@@ -208,7 +208,7 @@ main(int argc, char *argv[])
             PASSED();
     }
     else {
-        H5_FAILED()
+        H5_FAILED();
         goto error;
     }
 

--- a/testpar/t_prestart.c
+++ b/testpar/t_prestart.c
@@ -125,7 +125,7 @@ main(int argc, char **argv)
         if (0 == nerrors)
             PASSED();
         else
-            H5_FAILED()
+            H5_FAILED();
     }
 
     return (nerrors != 0);

--- a/testpar/t_pshutdown.c
+++ b/testpar/t_pshutdown.c
@@ -114,7 +114,7 @@ main(int argc, char **argv)
         if (0 == nerrors)
             PASSED();
         else
-            H5_FAILED()
+            H5_FAILED();
     }
 
     return (nerrors != 0);


### PR DESCRIPTION
The main testing macros in h5test.h (TEST_ERROR, etc.) are now enclosed in do..while loops and will need a semicolon at the end.

Apologies for the size. The changes are easily propagated to new code with a regular expression or even find-n-replace.