### PR TITLE
[1.12 Merge] Fixes a bug where t_cache fails due to a string size being too small …

### DIFF
--- a/testpar/t_cache.c
+++ b/testpar/t_cache.c
@@ -1116,6 +1116,8 @@ setup_derived_types(void)
     MPI_Aint      displs[9];
     struct mssg_t sample; /* used to compute displacements */
 
+    HDmemset(&sample, 0, sizeof(struct mssg_t));
+
     /* setup the displacements array */
     if ((MPI_SUCCESS != MPI_Get_address(&sample.req, &displs[0])) ||
         (MPI_SUCCESS != MPI_Get_address(&sample.src, &displs[1])) ||
@@ -6949,7 +6951,7 @@ main(int argc, char **argv)
 
     /* fix the file names */
     for (u = 0; u < sizeof(FILENAME) / sizeof(FILENAME[0]) - 1; ++u) {
-        if (h5_fixname(FILENAME[u], fapl, filenames[u], sizeof(filenames[u])) == NULL) {
+        if (h5_fixname(FILENAME[u], fapl, filenames[u], PATH_MAX) == NULL) {
             nerrors++;
             if (verbose)
                 HDfprintf(stdout, "%d:%s: h5_fixname() failed.\n", world_mpi_rank, FUNC);
@@ -7043,8 +7045,8 @@ finish:
     MPI_Barrier(MPI_COMM_WORLD);
     if (MAINPROCESS) { /* only process 0 reports */
         HDprintf("===================================\n");
-        if (failures) {
-            HDprintf("***metadata cache tests detected %d failures***\n", failures);
+        if (nerrors || failures) {
+            HDprintf("***metadata cache tests detected %d failures***\n", nerrors + failures);
         }
         else {
             HDprintf("metadata cache tests finished with no failures\n");
@@ -7061,5 +7063,5 @@ finish:
     MPI_Finalize();
 
     /* cannot just return (failures) because exit code is limited to 1byte */
-    return (failures != 0);
+    return (nerrors != 0 || failures != 0);
 }


### PR DESCRIPTION
…(#1720)

* Fixes a bug where t_cache fails due to a string size being too small

Recent warning reductions led to an incorrect string size being passed
to h5_fileaccess, causing the test to silently fail. In addition to
fixing the bug, the test will now fail noisily on setup failures.

* Updates the t_cache test to fail noisily on setup errors