### PR TITLE
Onion VFD: Cleans up warnings related to onion VFD stuff in tools code

### DIFF
--- a/tools/lib/h5tools.c
+++ b/tools/lib/h5tools.c
@@ -575,7 +575,7 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
                 /* Onion driver */
                 if (!vfd_info->info)
                     H5TOOLS_GOTO_ERROR(FAIL, "Onion VFD info is invalid");
-                if (H5Pset_fapl_onion(fapl_id, (H5FD_onion_fapl_info_t *)vfd_info->info) < 0)
+                if (H5Pset_fapl_onion(fapl_id, (const H5FD_onion_fapl_info_t *)vfd_info->info) < 0)
                     H5TOOLS_GOTO_ERROR(FAIL, "H5Pset_fapl_onion() failed");
             }
             else {

--- a/tools/src/h5diff/h5diff_common.c
+++ b/tools/src/h5diff/h5diff_common.c
@@ -497,7 +497,7 @@ parse_command_line(int argc, const char *const *argv, const char **fname1, const
     /* If file 1 uses the onion VFD, get the revision number */
     if (opts->vfd_info[0].u.name && !HDstrcmp(opts->vfd_info[0].u.name, "onion")) {
         if (opts->vfd_info[0].info) {
-            errno = 0;
+            errno                     = 0;
             onion_fa_g_1.revision_num = HDstrtoull(opts->vfd_info[0].info, NULL, 10);
             if (errno == ERANGE) {
                 HDprintf("Invalid onion revision specified for file 1\n");
@@ -514,7 +514,7 @@ parse_command_line(int argc, const char *const *argv, const char **fname1, const
     /* If file 2 uses the onion VFD, get the revision number */
     if (opts->vfd_info[1].u.name && !HDstrcmp(opts->vfd_info[1].u.name, "onion")) {
         if (opts->vfd_info[1].info) {
-            errno = 0;
+            errno                     = 0;
             onion_fa_g_2.revision_num = HDstrtoull(opts->vfd_info[1].info, NULL, 10);
             if (errno == ERANGE) {
                 HDprintf("Invalid onion revision specified for file 2\n");

--- a/tools/src/h5diff/h5diff_common.c
+++ b/tools/src/h5diff/h5diff_common.c
@@ -494,32 +494,39 @@ parse_command_line(int argc, const char *const *argv, const char **fname1, const
         }
     }
 
-    /* Copy the VFD driver info for both the files if it's the onion file */
-    if (opts->vfd_info[0].u.name) {
-        if (!HDstrcmp(opts->vfd_info[0].u.name, "onion")) {
-            if (opts->vfd_info[0].info)
-                onion_fa_g_1.revision_num = HDatoi((char *)(opts->vfd_info[0].info));
-            else
-                onion_fa_g_1.revision_num = 0;
-
-            /* Need to free this memory */
-            opts->vfd_info[0].info = HDmalloc(sizeof(H5FD_onion_fapl_info_t));
-            HDmemcpy(opts->vfd_info[0].info, &onion_fa_g_1, sizeof(H5FD_onion_fapl_info_t));
+    /* If file 1 uses the onion VFD, get the revision number */
+    if (opts->vfd_info[0].u.name && !HDstrcmp(opts->vfd_info[0].u.name, "onion")) {
+        if (opts->vfd_info[0].info) {
+            errno = 0;
+            onion_fa_g_1.revision_num = HDstrtoull(opts->vfd_info[0].info, NULL, 10);
+            if (errno == ERANGE) {
+                HDprintf("Invalid onion revision specified for file 1\n");
+                usage();
+                h5diff_exit(EXIT_FAILURE);
+            }
         }
-    } /* driver name defined */
+        else
+            onion_fa_g_1.revision_num = 0;
 
-    if (opts->vfd_info[1].u.name) {
-        if (!HDstrcmp(opts->vfd_info[1].u.name, "onion")) {
-            if (opts->vfd_info[1].info)
-                onion_fa_g_2.revision_num = HDatoi((char *)(opts->vfd_info[1].info));
-            else
-                onion_fa_g_2.revision_num = 0;
+        opts->vfd_info[0].info = &onion_fa_g_1;
+    }
 
-            /* Need to free this memory */
-            opts->vfd_info[1].info = HDmalloc(sizeof(H5FD_onion_fapl_info_t));
-            HDmemcpy(opts->vfd_info[1].info, &onion_fa_g_2, sizeof(H5FD_onion_fapl_info_t));
+    /* If file 2 uses the onion VFD, get the revision number */
+    if (opts->vfd_info[1].u.name && !HDstrcmp(opts->vfd_info[1].u.name, "onion")) {
+        if (opts->vfd_info[1].info) {
+            errno = 0;
+            onion_fa_g_2.revision_num = HDstrtoull(opts->vfd_info[1].info, NULL, 10);
+            if (errno == ERANGE) {
+                HDprintf("Invalid onion revision specified for file 2\n");
+                usage();
+                h5diff_exit(EXIT_FAILURE);
+            }
         }
-    } /* driver name defined */
+        else
+            onion_fa_g_2.revision_num = 0;
+
+        opts->vfd_info[1].info = &onion_fa_g_2;
+    }
 
     /* check options */
     check_options(opts);

--- a/tools/src/h5diff/h5diff_main.c
+++ b/tools/src/h5diff/h5diff_main.c
@@ -127,10 +127,6 @@ main(int argc, char *argv[])
                 HDfree(opts.sset[i]->count.data);
             if (opts.sset[i]->block.data)
                 HDfree(opts.sset[i]->block.data);
-            if (opts.vfd_info[0].info)
-                HDfree(opts.vfd_info[1].info);
-            if (opts.vfd_info[1].info)
-                HDfree(opts.vfd_info[1].info);
 
             HDfree(opts.sset[i]);
             opts.sset[i] = NULL;

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -1314,23 +1314,28 @@ end_collect:
         }
     }
 
-    /* Copy the VFD driver info for the input file if it's the onion file */
-    if (vfd_info_g.u.name) {
-        if (!HDstrcmp(vfd_info_g.u.name, "onion")) {
+    /* If the file uses the onion VFD, get the revision number */
+    if (vfd_info_g.u.name && !HDstrcmp(vfd_info_g.u.name, "onion")) {
+
+        if (vfd_info_g.info) {
+            if (!HDstrcmp(vfd_info_g.info, "revision_count"))
+                get_onion_revision_count = TRUE;
+            else {
+                errno = 0;
+                onion_fa_g.revision_num = HDstrtoull(vfd_info_g.info, NULL, 10);
+                if (errno == ERANGE) {
+                    HDprintf("Invalid onion revision specified\n");
+                    goto error;
+                }
+
+                HDprintf("Using revision %" PRIu64 "\n", onion_fa_g.revision_num);
+            }
+        }
+        else
             onion_fa_g.revision_num = 0;
 
-            if (vfd_info_g.info) {
-                if (!HDstrcmp(vfd_info_g.info, "revision_count"))
-                    get_onion_revision_count = TRUE;
-                else {
-                    onion_fa_g.revision_num = HDstrtoull((const char *)(vfd_info_g.info), NULL, 0);
-                    HDprintf("Using revision %" PRIu64 "\n", onion_fa_g.revision_num);
-                }
-            }
-
-            vfd_info_g.info = &onion_fa_g;
-        }
-    } /* driver name defined */
+        vfd_info_g.info = &onion_fa_g;
+    }
 
 parse_end:
     /* check for file name to be processed */

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -1321,7 +1321,7 @@ end_collect:
             if (!HDstrcmp(vfd_info_g.info, "revision_count"))
                 get_onion_revision_count = TRUE;
             else {
-                errno = 0;
+                errno                   = 0;
                 onion_fa_g.revision_num = HDstrtoull(vfd_info_g.info, NULL, 10);
                 if (errno == ERANGE) {
                     HDprintf("Invalid onion revision specified\n");

--- a/tools/test/h5dump/testh5dump.sh.in
+++ b/tools/test/h5dump/testh5dump.sh.in
@@ -381,7 +381,7 @@ $SRC_H5DUMP_TESTFILES/err_attr_dspace.ddl
 $SRC_H5DUMP_TESTFILES/tst_onion_objs.ddl
 $SRC_H5DUMP_TESTFILES/tst_onion_dset_ext.ddl
 $SRC_H5DUMP_TESTFILES/tst_onion_dset_1d.ddl
-$SRC_H5DUMP_TESTFILES/tst_onion_revision_count.ddl
+#$SRC_H5DUMP_TESTFILES/tst_onion_revision_count.ddl
 "
 
 LIST_ERROR_TEST_FILES="
@@ -1500,7 +1500,7 @@ TOOLTEST_FAIL tCVE_2018_11206_fill_new.h5
 TOOLTEST tst_onion_objs.ddl --enable-error-stack --vfd-name onion --vfd-info 3 tst_onion_objs.h5
 TOOLTEST tst_onion_dset_ext.ddl --enable-error-stack --vfd-name onion --vfd-info 1 tst_onion_dset_ext.h5
 TOOLTEST tst_onion_dset_1d.ddl --enable-error-stack --vfd-name onion --vfd-info 1 tst_onion_dset_1d.h5
-TOOLTEST tst_onion_revision_count.ddl --enable-error-stack --vfd-name onion --vfd-info revision_count tst_onion_objs.h5
+#TOOLTEST tst_onion_revision_count.ddl --enable-error-stack --vfd-name onion --vfd-info revision_count tst_onion_objs.h5
 
 # Clean up temporary files/directories
 CLEAN_TESTFILES_AND_TESTDIR


### PR DESCRIPTION
Also disables an h5dump test that has a missing file.

Does not require review.