### PR TITLE
Added the standard output file and enable the test case in the h5dump test suite

### DIFF
--- a/tools/test/h5dump/testh5dump.sh.in
+++ b/tools/test/h5dump/testh5dump.sh.in
@@ -381,7 +381,7 @@ $SRC_H5DUMP_TESTFILES/err_attr_dspace.ddl
 $SRC_H5DUMP_TESTFILES/tst_onion_objs.ddl
 $SRC_H5DUMP_TESTFILES/tst_onion_dset_ext.ddl
 $SRC_H5DUMP_TESTFILES/tst_onion_dset_1d.ddl
-#$SRC_H5DUMP_TESTFILES/tst_onion_revision_count.ddl
+$SRC_H5DUMP_TESTFILES/tst_onion_revision_count.ddl
 "
 
 LIST_ERROR_TEST_FILES="
@@ -1500,7 +1500,7 @@ TOOLTEST_FAIL tCVE_2018_11206_fill_new.h5
 TOOLTEST tst_onion_objs.ddl --enable-error-stack --vfd-name onion --vfd-info 3 tst_onion_objs.h5
 TOOLTEST tst_onion_dset_ext.ddl --enable-error-stack --vfd-name onion --vfd-info 1 tst_onion_dset_ext.h5
 TOOLTEST tst_onion_dset_1d.ddl --enable-error-stack --vfd-name onion --vfd-info 1 tst_onion_dset_1d.h5
-#TOOLTEST tst_onion_revision_count.ddl --enable-error-stack --vfd-name onion --vfd-info revision_count tst_onion_objs.h5
+TOOLTEST tst_onion_revision_count.ddl --enable-error-stack --vfd-name onion --vfd-info revision_count tst_onion_objs.h5
 
 # Clean up temporary files/directories
 CLEAN_TESTFILES_AND_TESTDIR

--- a/tools/testfiles/tst_onion_revision_count.ddl
+++ b/tools/testfiles/tst_onion_revision_count.ddl
@@ -1,0 +1,1 @@
+The number of revisions for the onion file is 6


### PR DESCRIPTION
(tools/testfiles/tst_onion_revision_count.ddl) was left out in the previous checkin.