### PR TITLE
Cleanup and shellcheck fixes in the SWMR test script

### DIFF
--- a/test/test_swmr.sh.in
+++ b/test/test_swmr.sh.in
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 #
 # Copyright by The HDF Group.
 # Copyright by the Board of Trustees of the University of Illinois.
@@ -11,12 +11,10 @@
 # If you do not have access to either file, you may request a copy from
 # help@hdfgroup.org.
 #
-# Tests for the swmr feature.
+# Acceptance tests for the SWMR feature
 #
-# Created:
-#   Albert Cheng, 2009/07/22
+###############################################################################
 
-srcdir=@srcdir@
 utils_testdir=@abs_top_builddir@/@H5_UTILS_TEST_BUILDDIR@
 testdir=@abs_top_builddir@/@H5_TEST_BUILDDIR@
 
@@ -43,7 +41,7 @@ MESSAGE_TIMEOUT=300                     # Message timeout length in secs
                                         # This should be the same as the define in "test/h5test.h"
 
 ###############################################################################
-## short hands and function definitions
+## Aliases and function definitions
 ###############################################################################
 DPRINT=:                # Set to "echo Debug:" for debugging printing,
                         # else ":" for noop.
@@ -62,16 +60,16 @@ TESTING() {
 # This performs similar function as the routine h5_wait_message() in test/h5test.c
 WAIT_MESSAGE() {
     message=$1                                  # Get the name of the message file to wait for
-    t0=`date +%s`                               # Get current time in seconds
+    t0=$(date +%s)                              # Get current time in seconds
     difft=0                                     # Initialize the time difference
     mexist=0                                    # Indicate whether the message file is found
     while [ $difft -lt $MESSAGE_TIMEOUT ] ;     # Loop till message times out
     do
-        t1=`date +%s`                           # Get current time in seconds
-        difft=`expr $t1 - $t0`                  # Calculate the time difference
-        if [ -e $message ]; then                # If message file is found:
+        t1=$(date +%s)                          # Get current time in seconds
+        difft=$(("$t1" - "$t0"))                # Calculate the time difference
+        if [ -e "$message" ]; then              # If message file is found:
             mexist=1                            #       indicate the message file is found
-            rm $message                         #       remove the message file
+            rm "$message"                       #       remove the message file
             break                               #       get out of the while loop
         fi
     done;
@@ -130,7 +128,7 @@ for FILE in swmr*; do
         *.o) continue ;;    ## don't copy the .o files
     esac
     if test -f "$FILE" ; then
-        cp $FILE swmr_test
+        cp "$FILE" swmr_test
     fi
 done
 
@@ -145,12 +143,12 @@ if [ -f .libs/swmr ]; then
             *.o) continue ;;    ## don't copy the .o files
         esac
         if test -f "$FILE" ; then
-            cp $FILE swmr_test/.libs
+            cp "$FILE" swmr_test/.libs
         fi
     done
 fi
 
-cd swmr_test
+cd swmr_test || exit 1
 
 
 # Loop over index types
@@ -173,7 +171,7 @@ do
         $testdir/swmr_generator -q $compress $index_type
         if test $? -ne 0; then
             echo generator had error
-            nerrors=`expr $nerrors + 1`
+            nerrors=$((nerrors + 1))
         fi
 
         # Launch the Generator with SWMR_WRITE
@@ -181,7 +179,7 @@ do
         $testdir/swmr_generator -q -s $compress $index_type
         if test $? -ne 0; then
             echo generator had error
-            nerrors=`expr $nerrors + 1`
+            nerrors=$((nerrors + 1))
         fi
 
         # Check for error and exit if one occurred
@@ -209,7 +207,6 @@ do
         # Wait for message from writer process before starting reader(s)
         WAIT_MESSAGE $WRITER_MESSAGE
 
-        #
         # Launch the Readers
         #declare -a seeds=(<seed1> <seed2> <seed3> ... )
         echo launch $Nreaders swmr_readers
@@ -220,19 +217,19 @@ do
             seed=""
             $testdir/swmr_reader -q $Nsecs_add $seed 2>&1 |tee swmr_reader.out.$n &
             pid_readers="$pid_readers $!"
-            n=`expr $n + 1`
+            n=$((n + 1))
         done
-        $DPRINT pid_readers=$pid_readers
+        $DPRINT pid_readers="$pid_readers"
         $IFDEBUG ps
 
-        # Collect exit code of the readers first because they usually finish
+        # Collect exit codes of the readers first because they usually finish
         # before the writer.
         for xpid in $pid_readers; do
-            $DPRINT checked reader $xpid
-            wait $xpid
+            $DPRINT checked reader "$xpid"
+            wait "$xpid"
             if test $? -ne 0; then
                 echo reader had error
-                nerrors=`expr $nerrors + 1`
+                nerrors=$((nerrors + 1))
             fi
         done
 
@@ -241,7 +238,7 @@ do
         wait $pid_writer
         if test $? -ne 0; then
             echo writer had error
-            nerrors=`expr $nerrors + 1`
+            nerrors=$((nerrors + 1))
         fi
 
         # Check for error and exit if one occurred
@@ -266,7 +263,7 @@ do
         $testdir/swmr_generator -q -s $compress $index_type
         if test $? -ne 0; then
             echo generator had error
-            nerrors=`expr $nerrors + 1`
+            nerrors=$((nerrors + 1))
         fi
 
         # Remove any possible writer message file before launching writer
@@ -281,7 +278,7 @@ do
 
         # Wait for message from writer process before starting reader(s)
         WAIT_MESSAGE $WRITER_MESSAGE
-        #
+
         # Launch the Readers
         #declare -a seeds=(<seed1> <seed2> <seed3> ... )
         echo launch $Nreaders swmr_readers
@@ -292,19 +289,19 @@ do
             seed=""
             $testdir/swmr_reader -q $Nsecs_add $seed 2>&1 |tee swmr_reader.out.$n &
             pid_readers="$pid_readers $!"
-            n=`expr $n + 1`
+            n=$((n + 1))
         done
-        $DPRINT pid_readers=$pid_readers
+        $DPRINT pid_readers="$pid_readers"
         $IFDEBUG ps
 
         # Collect exit code of the readers first because they usually finish
         # before the writer.
         for xpid in $pid_readers; do
-            $DPRINT checked reader $xpid
-            wait $xpid
+            $DPRINT checked reader "$xpid"
+            wait "$xpid"
             if test $? -ne 0; then
                 echo reader had error
-                nerrors=`expr $nerrors + 1`
+                nerrors=$((nerrors + 1))
             fi
         done
 
@@ -313,7 +310,7 @@ do
         wait $pid_writer
         if test $? -ne 0; then
             echo writer had error
-            nerrors=`expr $nerrors + 1`
+            nerrors=$((nerrors + 1))
         fi
 
         # Check for error and exit if one occurred
@@ -344,7 +341,7 @@ do
 
         # Wait for message from writer process before starting reader(s)
         WAIT_MESSAGE $WRITER_MESSAGE
-        #
+
         # Launch the Remove Readers
         #declare -a seeds=(<seed1> <seed2> <seed3> ... )
         n=0
@@ -355,19 +352,19 @@ do
             seed=""
             $testdir/swmr_remove_reader -q $Nsecs_rem $seed 2>&1 |tee swmr_reader.out.$n &
             pid_readers="$pid_readers $!"
-            n=`expr $n + 1`
+            n=$((n + 1))
         done
-        $DPRINT pid_readers=$pid_readers
+        $DPRINT pid_readers="$pid_readers"
         $IFDEBUG ps
 
         # Collect exit code of the readers first because they usually finish
         # before the writer.
         for xpid in $pid_readers; do
-            $DPRINT checked reader $xpid
-            wait $xpid
+            $DPRINT checked reader "$xpid"
+            wait "$xpid"
             if test $? -ne 0; then
                 echo reader had error
-                nerrors=`expr $nerrors + 1`
+                nerrors=$((nerrors + 1))
             fi
         done
 
@@ -376,7 +373,7 @@ do
         wait $pid_writer
         if test $? -ne 0; then
             echo writer had error
-            nerrors=`expr $nerrors + 1`
+            nerrors=$((nerrors + 1))
         fi
 
         # Check for error and exit if one occurred
@@ -401,7 +398,7 @@ do
         $testdir/swmr_generator -q $compress $index_type
         if test $? -ne 0; then
             echo generator had error
-            nerrors=`expr $nerrors + 1`
+            nerrors=$((nerrors + 1))
         fi
 
         # Launch the Writer (not in parallel - just to rebuild the datasets)
@@ -410,7 +407,7 @@ do
         $testdir/swmr_writer -q $Nrecords $seed
         if test $? -ne 0; then
             echo writer had error
-            nerrors=`expr $nerrors + 1`
+            nerrors=$((nerrors + 1))
         fi
 
         # Remove any possible writer message file before launching writer
@@ -436,19 +433,19 @@ do
             seed=""
             $testdir/swmr_remove_reader -q $Nsecs_addrem $seed 2>&1 |tee swmr_reader.out.$n &
             pid_readers="$pid_readers $!"
-            n=`expr $n + 1`
+            n=$((n + 1))
         done
-        $DPRINT pid_readers=$pid_readers
+        $DPRINT pid_readers="$pid_readers"
         $IFDEBUG ps
 
         # Collect exit code of the readers first because they usually finish
         # before the writer.
         for xpid in $pid_readers; do
-            $DPRINT checked reader $xpid
-            wait $xpid
+            $DPRINT checked reader "$xpid"
+            wait "$xpid"
             if test $? -ne 0; then
                 echo reader had error
-                nerrors=`expr $nerrors + 1`
+                nerrors=$((nerrors + 1))
             fi
         done
 
@@ -457,7 +454,7 @@ do
         wait $pid_writer
         if test $? -ne 0; then
             echo writer had error
-            nerrors=`expr $nerrors + 1`
+            nerrors=$((nerrors + 1))
         fi
 
         # Check for error and exit if one occurred
@@ -485,7 +482,7 @@ do
         $testdir/swmr_generator -q $compress $index_type $seed
         if test $? -ne 0; then
             echo generator had error
-            nerrors=`expr $nerrors + 1`
+            nerrors=$((nerrors + 1))
         fi
 
         # Remove any possible writer message file before launching writer
@@ -507,26 +504,26 @@ do
             # The sparse reader spits out a LOT of data so it's set to 'quiet'
             $testdir/swmr_sparse_reader -q $Nrecs_spa 2>&1 |tee swmr_reader.out.$n &
             pid_readers="$pid_readers $!"
-            n=`expr $n + 1`
+            n=$((n + 1))
         done
-        $DPRINT pid_readers=$pid_readers
+        $DPRINT pid_readers="$pid_readers"
         $IFDEBUG ps
 
         # Collect exit code of the writer
-        $DPRINT checked writer $pid_writer
-        wait $pid_writer
+        $DPRINT checked writer "$pid_writer"
+        wait "$pid_writer"
         if test $? -ne 0; then
             echo writer had error
-            nerrors=`expr $nerrors + 1`
+            nerrors=$((nerrors + 1))
         fi
 
         # Collect exit code of the readers
         for xpid in $pid_readers; do
-            $DPRINT checked reader $xpid
-            wait $xpid
+            $DPRINT checked reader "$xpid"
+            wait "$xpid"
             if test $? -ne 0; then
                 echo reader had error
-                nerrors=`expr $nerrors + 1`
+                nerrors=$((nerrors + 1))
             fi
         done
 


### PR DESCRIPTION
Interestingly, quoting $compression, etc. as suggested by shellcheck causes hangs.