### PR TITLE
Enabling h5repack to support onion VFD

### DIFF
--- a/tools/src/h5repack/h5repack_main.c
+++ b/tools/src/h5repack/h5repack_main.c
@@ -82,9 +82,9 @@ static H5FD_onion_fapl_info_t onion_fa_in_g = {
     32,                            /* page_size                      */
     H5FD_ONION_STORE_TARGET_ONION, /* store_target                   */
     H5FD_ONION_FAPL_INFO_REVISION_ID_LATEST,
-    0,                  /* force_write_open               */
-    0,                  /* creation_flags                 */
-    "input file",       /* comment                        */
+    0,            /* force_write_open               */
+    0,            /* creation_flags                 */
+    "input file", /* comment                        */
 };
 
 /*-------------------------------------------------------------------------
@@ -889,7 +889,7 @@ parse_command_line(int argc, const char *const *argv, pack_opt_t *options)
     /* If the input file uses the onion VFD, get the revision number */
     if (in_vfd_info.u.name && !HDstrcmp(in_vfd_info.u.name, "onion")) {
         if (in_vfd_info.info) {
-            errno                     = 0;
+            errno                      = 0;
             onion_fa_in_g.revision_num = HDstrtoull(in_vfd_info.info, NULL, 10);
             if (errno == ERANGE) {
                 HDprintf("Invalid onion revision specified for the input file\n");

--- a/tools/src/h5repack/h5repack_main.c
+++ b/tools/src/h5repack/h5repack_main.c
@@ -76,6 +76,17 @@ static struct h5_long_options l_opts[] = {{"alignment", require_arg, 'a'},
                                           {"dst-vfd-info", require_arg, 'Z'},
                                           {NULL, 0, '\0'}};
 
+static H5FD_onion_fapl_info_t onion_fa_in_g = {
+    H5FD_ONION_FAPL_INFO_VERSION_CURR,
+    H5P_DEFAULT,                   /* backing_fapl_id                */
+    32,                            /* page_size                      */
+    H5FD_ONION_STORE_TARGET_ONION, /* store_target                   */
+    H5FD_ONION_FAPL_INFO_REVISION_ID_LATEST,
+    0,                  /* force_write_open               */
+    0,                  /* creation_flags                 */
+    "input file",       /* comment                        */
+};
+
 /*-------------------------------------------------------------------------
  * Function: usage
  *
@@ -873,6 +884,23 @@ parse_command_line(int argc, const char *const *argv, pack_opt_t *options)
         usage(h5tools_getprogname());
         h5tools_setstatus(EXIT_FAILURE);
         ret_value = -1;
+    }
+
+    /* If the input file uses the onion VFD, get the revision number */
+    if (in_vfd_info.u.name && !HDstrcmp(in_vfd_info.u.name, "onion")) {
+        if (in_vfd_info.info) {
+            errno                     = 0;
+            onion_fa_in_g.revision_num = HDstrtoull(in_vfd_info.info, NULL, 10);
+            if (errno == ERANGE) {
+                HDprintf("Invalid onion revision specified for the input file\n");
+                usage(h5tools_getprogname());
+                exit(EXIT_FAILURE);
+            }
+        }
+        else
+            onion_fa_in_g.revision_num = 0;
+
+        in_vfd_info.info = &onion_fa_in_g;
     }
 
     /* Setup FAPL for input and output file accesses */

--- a/tools/test/h5repack/h5repack.sh.in
+++ b/tools/test/h5repack/h5repack.sh.in
@@ -177,6 +177,13 @@ $SRC_TOOLS_TESTFILES/vds/5_a.h5
 $SRC_TOOLS_TESTFILES/vds/5_b.h5
 $SRC_TOOLS_TESTFILES/vds/5_c.h5
 $SRC_TOOLS_TESTFILES/vds/5_vds.h5
+########tools/testfiles########
+$SRC_TOOLS_TESTFILES/tst_onion_dset_1d.h5
+$SRC_TOOLS_TESTFILES/tst_onion_dset_1d.h5.onion
+$SRC_TOOLS_TESTFILES/tst_onion_dset_ext.h5
+$SRC_TOOLS_TESTFILES/tst_onion_dset_ext.h5.onion
+$SRC_TOOLS_TESTFILES/tst_onion_objs.h5
+$SRC_TOOLS_TESTFILES/tst_onion_objs.h5.onion
 "
 
 LIST_OTHER_TEST_FILES="
@@ -251,6 +258,10 @@ $SRC_H5REPACK_TESTFILES/textlinksrc-merge.textlinksrc.h5.tst
 $SRC_H5REPACK_TESTFILES/textlinktar-merge.textlinktar.h5.tst
 $SRC_H5REPACK_TESTFILES/textlink-merge.textlink.h5.tst
 $SRC_H5REPACK_TESTFILES/h5copy_extlinks_src-merge.h5copy_extlinks_src.h5.tst
+########onion#files########
+$SRC_H5REPACK_TESTFILES/onion.tst_onion_dset_1d.h5.ddl
+$SRC_H5REPACK_TESTFILES/onion.tst_onion_dset_ext.h5.ddl
+$SRC_H5REPACK_TESTFILES/onion.tst_onion_objs.h5.ddl
 "
 
 #
@@ -1130,6 +1141,56 @@ TOOLTEST_DUMP()
    rm -f $outfile
 }
 
+# This is same as TOOLTEST_DUMP() with comparing h5dump output
+# without any option
+#
+TOOLTEST_DUMP_NO_OPT()
+{
+    infile=$2
+    outfile=out-$1.$2
+    expect="$TESTDIR/$1.$2.ddl"
+    actual="$TESTDIR/out-$1.$2.out"
+    actual_err="$TESTDIR/out-$1.$2.err"
+
+    shift
+    shift
+
+    # Run test.
+    TESTING $H5REPACK $@
+    (
+        cd $TESTDIR
+        $RUNSERIAL $H5REPACK_BIN "$@" $infile $outfile
+    ) >$actual 2>$actual_err
+    RET=$?
+    if [ $RET != 0 ] ; then
+    echo "*FAILED*"
+    nerrors="`expr $nerrors + 1`"
+    else
+     echo " PASSED"
+     VERIFY h5dump output $@
+     (
+        cd $TESTDIR
+        $RUNSERIAL $H5DUMP_BIN $outfile
+     ) >$actual 2>$actual_err
+     cat $actual_err >> $actual
+
+     RET=$?
+
+    fi
+
+    if cmp -s $expect $actual; then
+     echo " PASSED"
+    else
+     echo "*FAILED*"
+     echo "    Expected result (*.ddl) differs from actual result (*.out)"
+     nerrors="`expr $nerrors + 1`"
+     test yes = "$verbose" && diff -c $expect $actual |sed 's/^/    /'
+    fi
+
+   rm -f $actual $actual_err
+   rm -f $outfile
+}
+
 # This is similar to TOOLTEST_DUMP().
 # Test h5repack with options added for paged aggregation.
 # h5stat is used on the repacked file and the expected output
@@ -1830,6 +1891,9 @@ TOOLTEST_DUMP textlink-mergeprune textlink.h5 --merge --prune --enable-error-sta
 #TOOLTEST_DUMP textlinksrc-mergeprune textlinksrc.h5 --merge --prune --enable-error-stack
 ### HDFFV-11128 needs fixed to enable the following test
 #TOOLTEST_DUMP textlinktar-mergeprune textlinktar.h5 --merge --prune --enable-error-stack
+TOOLTEST_DUMP_NO_OPT onion tst_onion_dset_1d.h5 --src-vfd-name onion --src-vfd-info 1
+TOOLTEST_DUMP_NO_OPT onion tst_onion_dset_ext.h5 --src-vfd-name onion --src-vfd-info 1
+TOOLTEST_DUMP_NO_OPT onion tst_onion_objs.h5 --src-vfd-name onion --src-vfd-info 1
 
 # Clean up temporary files/directories
 CLEAN_TESTFILES_AND_TESTDIR

--- a/tools/test/h5repack/testfiles/onion.tst_onion_dset_1d.h5.ddl
+++ b/tools/test/h5repack/testfiles/onion.tst_onion_dset_1d.h5.ddl
@@ -1,0 +1,11 @@
+HDF5 "out-onion.tst_onion_dset_1d.h5" {
+GROUP "/" {
+   DATASET "DS1" {
+      DATATYPE  H5T_STD_I32LE
+      DATASPACE  SIMPLE { ( 1, 16 ) / ( 1, 16 ) }
+      DATA {
+      (0,0): 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+      }
+   }
+}
+}

--- a/tools/test/h5repack/testfiles/onion.tst_onion_dset_ext.h5.ddl
+++ b/tools/test/h5repack/testfiles/onion.tst_onion_dset_ext.h5.ddl
@@ -1,0 +1,18 @@
+HDF5 "out-onion.tst_onion_dset_ext.h5" {
+GROUP "/" {
+   DATASET "DS1" {
+      DATATYPE  H5T_STD_I32LE
+      DATASPACE  SIMPLE { ( 8, 4 ) / ( H5S_UNLIMITED, H5S_UNLIMITED ) }
+      DATA {
+      (0,0): 0, 1, 2, 3,
+      (1,0): 1, 2, 3, 4,
+      (2,0): 2, 3, 4, 5,
+      (3,0): 3, 4, 5, 6,
+      (4,0): 0, 1, 2, 3,
+      (5,0): 1, 2, 3, 4,
+      (6,0): 2, 3, 4, 5,
+      (7,0): 3, 4, 5, 6
+      }
+   }
+}
+}

--- a/tools/test/h5repack/testfiles/onion.tst_onion_objs.h5.ddl
+++ b/tools/test/h5repack/testfiles/onion.tst_onion_objs.h5.ddl
@@ -1,0 +1,24 @@
+HDF5 "out-onion.tst_onion_objs.h5" {
+GROUP "/" {
+   DATASET "DS1" {
+      DATATYPE  H5T_STD_I32LE
+      DATASPACE  SIMPLE { ( 4, 4 ) / ( H5S_UNLIMITED, H5S_UNLIMITED ) }
+      DATA {
+      (0,0): 0, 1, 2, 3,
+      (1,0): 1, 2, 3, 4,
+      (2,0): 2, 3, 4, 5,
+      (3,0): 3, 4, 5, 6
+      }
+   }
+   DATASET "DS2" {
+      DATATYPE  H5T_STD_I32LE
+      DATASPACE  SIMPLE { ( 4, 4 ) / ( H5S_UNLIMITED, H5S_UNLIMITED ) }
+      DATA {
+      (0,0): 0, 1, 2, 3,
+      (1,0): 1, 2, 3, 4,
+      (2,0): 2, 3, 4, 5,
+      (3,0): 3, 4, 5, 6
+      }
+   }
+}
+}


### PR DESCRIPTION
The input file can take options (`--src-vfd-name` and `--src-vfd-info`) for the Onion VFD.  But output file doesn't allow using the Onion VFD because h5repack copies the objects from the input file to the output file and may mess up with the versioning.  Below is an example of enabling the Onion VFD:

```
h5repack input_file output_file --src-vfd-name onion --src-vfd-info 1
```
or 
```
h5repack --src-vfd-name onion --src-vfd-info 1 input_file output_file
```

The Fluor people made the request to finalize a file with certain revision.  They can use h5repack to do it just like Git merge.