### PR TITLE
Check that copy of type when inserting inside cmpd is valid

### DIFF
--- a/src/H5Tcompound.c
+++ b/src/H5Tcompound.c
@@ -473,7 +473,12 @@ H5T__insert(H5T_t *parent, const char *name, size_t offset, const H5T_t *member)
     parent->shared->u.compnd.memb[idx].name   = H5MM_xstrdup(name);
     parent->shared->u.compnd.memb[idx].offset = offset;
     parent->shared->u.compnd.memb[idx].size   = total_size;
-    parent->shared->u.compnd.memb[idx].type   = H5T_copy(member, H5T_COPY_ALL);
+    {
+        H5T_t* t = H5T_copy(member, H5T_COPY_ALL);
+        if (!t)
+            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL, "member type cannot be copied")
+        parent->shared->u.compnd.memb[idx].type   = t;
+    }
 
     parent->shared->u.compnd.sorted = H5T_SORT_NONE;
     parent->shared->u.compnd.nmembs++;

--- a/test/cmpd_dset.c
+++ b/test/cmpd_dset.c
@@ -2210,6 +2210,46 @@ error:
     return 1;
 } /* test_ooo_order */
 
+static unsigned
+test_compound_error_member()
+{
+    hid_t tenum = -1;
+    hid_t tcmp  = -1;
+    TESTING("that error on compound member type fail early");
+
+    if ((tenum = H5Tenum_create(H5Tcopy(H5T_NATIVE_INT))) < 0)
+        TEST_ERROR;
+
+    if ((tcmp = H5Tcreate(H5T_COMPOUND, 2 * H5Tget_size(H5T_NATIVE_LONG))) < 0)
+        TEST_ERROR;
+
+    if ((H5Tinsert(tcmp, "long", 0, H5T_NATIVE_LONG)) < 0)
+        TEST_ERROR;
+
+    if ((H5Tinsert(tcmp, "enum", H5Tget_size(H5T_NATIVE_LONG), tenum)) < 0)
+        TEST_ERROR;
+
+    /* Close */
+    if (H5Tclose(tcmp))
+        TEST_ERROR;
+    if (H5Tclose(tenum))
+        TEST_ERROR;
+
+    PASSED();
+    return 0;
+
+error:
+    H5E_BEGIN_TRY
+    {
+        H5Tclose(tenum);
+        H5Tclose(tcmp);
+    }
+    H5E_END_TRY
+    HDputs("*** DATASET TESTS FAILED ***");
+    return 1;
+}
+
+
 /*-------------------------------------------------------------------------
  * Function:    main
  *
@@ -2266,6 +2306,9 @@ main(int argc, char *argv[])
 
     HDputs("Testing compound member ordering:");
     nerrors += test_ooo_order(fname, fapl_id);
+
+    HDputs("Testing invalid insert:");
+    nerrors += test_compound_error_member();
 
     /* Verify symbol table messages are cached */
     nerrors += (h5_verify_cached_stabs(FILENAME, fapl_id) < 0 ? 1 : 0);


### PR DESCRIPTION
Here is a fix for the problem encountered here: https://forum.hdfgroup.org/t/bug-h5tcopy-of-empty-enum/9634/2

Today, the error is arriving when using the compound type for example in H5Tclose in the test.

I add the test a bit randomly, and it is not finish, i was not able to understand really where it should go and how I need to write it.
