### PR TITLE
Converts __int64 to LONGLONG in LARGE_INTEGER union members on Windows

### DIFF
--- a/src/H5FDcore.c
+++ b/src/H5FDcore.c
@@ -1607,7 +1607,7 @@ H5FD__core_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t closing
                 BOOL  bError;           /* Boolean error flag */
 
                 /* Windows uses this odd QuadPart union for 32/64-bit portability */
-                li.QuadPart = (__int64)file->eoa;
+                li.QuadPart = (LONGLONG)file->eoa;
 
                 /* Extend the file to make sure it's large enough.
                  *

--- a/src/H5FDlog.c
+++ b/src/H5FDlog.c
@@ -1626,7 +1626,7 @@ H5FD__log_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t H5_ATTR_
                                      */
 
             /* Windows uses this odd QuadPart union for 32/64-bit portability */
-            li.QuadPart = (__int64)file->eoa;
+            li.QuadPart = (LONGLONG)file->eoa;
 
             /* Extend the file to make sure it's large enough.
              *

--- a/src/H5FDsec2.c
+++ b/src/H5FDsec2.c
@@ -915,7 +915,7 @@ H5FD__sec2_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t H5_ATTR
         BOOL  bError;           /* Boolean error flag */
 
         /* Windows uses this odd QuadPart union for 32/64-bit portability */
-        li.QuadPart = (__int64)file->eoa;
+        li.QuadPart = (LONGLONG)file->eoa;
 
         /* Extend the file to make sure it's large enough.
          *

--- a/src/H5FDstdio.c
+++ b/src/H5FDstdio.c
@@ -1066,7 +1066,7 @@ H5FD_stdio_truncate(H5FD_t *_file, hid_t /*UNUSED*/ dxpl_id, hbool_t /*UNUSED*/ 
             rewind(file->fp);
 
             /* Windows uses this odd QuadPart union for 32/64-bit portability */
-            li.QuadPart = (__int64)file->eoa;
+            li.QuadPart = (LONGLONG)file->eoa;
 
             /* Extend the file to make sure it's large enough.
              *


### PR DESCRIPTION
The current Win32 API uses LONGLONG instead of __int64 for these, now that MSVC supports (most of) C99.

https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-large_integer-r1