### PR TITLE
Removes VERIFY/CHECK macros from the chunk_info test

### DIFF
--- a/hl/src/H5LTanalyze.c
+++ b/hl/src/H5LTanalyze.c
@@ -28,9 +28,14 @@
 #elif defined _MSC_VER                                            
 #pragma warning(push, 1)                                          
 #endif                                                            
-#line 1 "hl/src/H5LTanalyze.c"
+#line 2 "./hl/src/H5LTanalyze.c"
+/* Quiet warnings about integer type macro redifinitions on Visual Studio
+ * (MSVC doesn't define STDC_VERSION, but has inttypes.h). This is an
+ * issue that is apparently fixed in flex 2.6.5.
+ */
+#include <stdint.h>
 
-#line 3 "hl/src/H5LTanalyze.c"
+#line 9 "./hl/src/H5LTanalyze.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -888,7 +893,7 @@ int yy_flex_debug = 0;
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
 char *yytext;
-#line 1 "hl/src/H5LTanalyze.l"
+#line 1 "./hl/src/H5LTanalyze.l"
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  * Copyright by The HDF Group.                                               *
  * Copyright by the Board of Trustees of the University of Illinois.         *
@@ -906,7 +911,8 @@ char *yytext;
  * If you make any changes to H5LTanalyze.l, please run bin/genparser to
  * recreate the output files.
  */
-#line 21 "hl/src/H5LTanalyze.l"
+
+#line 29 "./hl/src/H5LTanalyze.l"
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
@@ -930,8 +936,8 @@ static int my_yyinput(char *, int);
 extern char *myinput;
 extern size_t input_len;
 
-#line 903 "hl/src/H5LTanalyze.c"
-#line 904 "hl/src/H5LTanalyze.c"
+#line 910 "./hl/src/H5LTanalyze.c"
+#line 911 "./hl/src/H5LTanalyze.c"
 
 #define INITIAL 0
 
@@ -1140,10 +1146,10 @@ YY_DECL
 		}
 
 	{
-#line 46 "hl/src/H5LTanalyze.l"
+#line 54 "./hl/src/H5LTanalyze.l"
 
 
-#line 1116 "hl/src/H5LTanalyze.c"
+#line 1123 "./hl/src/H5LTanalyze.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1202,277 +1208,277 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 48 "hl/src/H5LTanalyze.l"
+#line 56 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_STD_I8BE_TOKEN);}
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 49 "hl/src/H5LTanalyze.l"
+#line 57 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_STD_I8LE_TOKEN);}
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 50 "hl/src/H5LTanalyze.l"
+#line 58 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_STD_I16BE_TOKEN);}
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 51 "hl/src/H5LTanalyze.l"
+#line 59 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_STD_I16LE_TOKEN);}
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 52 "hl/src/H5LTanalyze.l"
+#line 60 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_STD_I32BE_TOKEN);}
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 53 "hl/src/H5LTanalyze.l"
+#line 61 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_STD_I32LE_TOKEN);}
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 54 "hl/src/H5LTanalyze.l"
+#line 62 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_STD_I64BE_TOKEN);}
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 55 "hl/src/H5LTanalyze.l"
+#line 63 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_STD_I64LE_TOKEN);}
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 57 "hl/src/H5LTanalyze.l"
+#line 65 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_STD_U8BE_TOKEN);}
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 58 "hl/src/H5LTanalyze.l"
+#line 66 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_STD_U8LE_TOKEN);}
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 59 "hl/src/H5LTanalyze.l"
+#line 67 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_STD_U16BE_TOKEN);}
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 60 "hl/src/H5LTanalyze.l"
+#line 68 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_STD_U16LE_TOKEN);}
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 61 "hl/src/H5LTanalyze.l"
+#line 69 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_STD_U32BE_TOKEN);}
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 62 "hl/src/H5LTanalyze.l"
+#line 70 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_STD_U32LE_TOKEN);}
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 63 "hl/src/H5LTanalyze.l"
+#line 71 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_STD_U64BE_TOKEN);}
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 64 "hl/src/H5LTanalyze.l"
+#line 72 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_STD_U64LE_TOKEN);}
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 66 "hl/src/H5LTanalyze.l"
+#line 74 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_NATIVE_CHAR_TOKEN);}
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 67 "hl/src/H5LTanalyze.l"
+#line 75 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_NATIVE_SCHAR_TOKEN);}
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 68 "hl/src/H5LTanalyze.l"
+#line 76 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_NATIVE_UCHAR_TOKEN);}
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 69 "hl/src/H5LTanalyze.l"
+#line 77 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_NATIVE_SHORT_TOKEN);}
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 70 "hl/src/H5LTanalyze.l"
+#line 78 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_NATIVE_USHORT_TOKEN);}
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 71 "hl/src/H5LTanalyze.l"
+#line 79 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_NATIVE_INT_TOKEN);}
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 72 "hl/src/H5LTanalyze.l"
+#line 80 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_NATIVE_UINT_TOKEN);}
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 73 "hl/src/H5LTanalyze.l"
+#line 81 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_NATIVE_LONG_TOKEN);}
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 74 "hl/src/H5LTanalyze.l"
+#line 82 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_NATIVE_ULONG_TOKEN);}
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 75 "hl/src/H5LTanalyze.l"
+#line 83 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_NATIVE_LLONG_TOKEN);}
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 76 "hl/src/H5LTanalyze.l"
+#line 84 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_NATIVE_ULLONG_TOKEN);}
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 78 "hl/src/H5LTanalyze.l"
+#line 86 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_IEEE_F32BE_TOKEN);}
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 79 "hl/src/H5LTanalyze.l"
+#line 87 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_IEEE_F32LE_TOKEN);}
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 80 "hl/src/H5LTanalyze.l"
+#line 88 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_IEEE_F64BE_TOKEN);}
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 81 "hl/src/H5LTanalyze.l"
+#line 89 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_IEEE_F64LE_TOKEN);}
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 82 "hl/src/H5LTanalyze.l"
+#line 90 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_NATIVE_FLOAT_TOKEN);}
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 83 "hl/src/H5LTanalyze.l"
+#line 91 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_NATIVE_DOUBLE_TOKEN);}
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 84 "hl/src/H5LTanalyze.l"
+#line 92 "./hl/src/H5LTanalyze.l"
 {return hid(H5T_NATIVE_LDOUBLE_TOKEN);}
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 86 "hl/src/H5LTanalyze.l"
+#line 94 "./hl/src/H5LTanalyze.l"
 {return token(H5T_STRING_TOKEN);}
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 87 "hl/src/H5LTanalyze.l"
+#line 95 "./hl/src/H5LTanalyze.l"
 {return token(STRSIZE_TOKEN);}
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 88 "hl/src/H5LTanalyze.l"
+#line 96 "./hl/src/H5LTanalyze.l"
 {return token(STRPAD_TOKEN);}
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 89 "hl/src/H5LTanalyze.l"
+#line 97 "./hl/src/H5LTanalyze.l"
 {return token(CSET_TOKEN);}
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 90 "hl/src/H5LTanalyze.l"
+#line 98 "./hl/src/H5LTanalyze.l"
 {return token(CTYPE_TOKEN);}
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 91 "hl/src/H5LTanalyze.l"
+#line 99 "./hl/src/H5LTanalyze.l"
 {return token(H5T_STR_NULLTERM_TOKEN);}
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 92 "hl/src/H5LTanalyze.l"
+#line 100 "./hl/src/H5LTanalyze.l"
 {return token(H5T_STR_NULLPAD_TOKEN);}
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 93 "hl/src/H5LTanalyze.l"
+#line 101 "./hl/src/H5LTanalyze.l"
 {return token(H5T_STR_SPACEPAD_TOKEN);}
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 94 "hl/src/H5LTanalyze.l"
+#line 102 "./hl/src/H5LTanalyze.l"
 {return token(H5T_CSET_ASCII_TOKEN);}
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 95 "hl/src/H5LTanalyze.l"
+#line 103 "./hl/src/H5LTanalyze.l"
 {return token(H5T_CSET_UTF8_TOKEN);}
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 96 "hl/src/H5LTanalyze.l"
+#line 104 "./hl/src/H5LTanalyze.l"
 {return token(H5T_C_S1_TOKEN);}
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 97 "hl/src/H5LTanalyze.l"
+#line 105 "./hl/src/H5LTanalyze.l"
 {return token(H5T_FORTRAN_S1_TOKEN);}
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 98 "hl/src/H5LTanalyze.l"
+#line 106 "./hl/src/H5LTanalyze.l"
 {return token(H5T_VARIABLE_TOKEN);}
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
-#line 100 "hl/src/H5LTanalyze.l"
+#line 108 "./hl/src/H5LTanalyze.l"
 {return token(H5T_COMPOUND_TOKEN);}
 	YY_BREAK
 case 49:
 YY_RULE_SETUP
-#line 101 "hl/src/H5LTanalyze.l"
+#line 109 "./hl/src/H5LTanalyze.l"
 {return token(H5T_ENUM_TOKEN);}
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 102 "hl/src/H5LTanalyze.l"
+#line 110 "./hl/src/H5LTanalyze.l"
 {return token(H5T_ARRAY_TOKEN);}
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 103 "hl/src/H5LTanalyze.l"
+#line 111 "./hl/src/H5LTanalyze.l"
 {return token(H5T_VLEN_TOKEN);}
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 105 "hl/src/H5LTanalyze.l"
+#line 113 "./hl/src/H5LTanalyze.l"
 {return token(H5T_OPAQUE_TOKEN);}
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 106 "hl/src/H5LTanalyze.l"
+#line 114 "./hl/src/H5LTanalyze.l"
 {return token(OPQ_SIZE_TOKEN);}
 	YY_BREAK
 case 54:
 YY_RULE_SETUP
-#line 107 "hl/src/H5LTanalyze.l"
+#line 115 "./hl/src/H5LTanalyze.l"
 {return token(OPQ_TAG_TOKEN);}
 	YY_BREAK
 case 55:
 YY_RULE_SETUP
-#line 109 "hl/src/H5LTanalyze.l"
+#line 117 "./hl/src/H5LTanalyze.l"
 {
                         H5LTyylval.ival = HDatoi(yytext);
                         return NUMBER;
@@ -1481,7 +1487,7 @@ YY_RULE_SETUP
 case 56:
 /* rule 56 can match eol */
 YY_RULE_SETUP
-#line 114 "hl/src/H5LTanalyze.l"
+#line 122 "./hl/src/H5LTanalyze.l"
 {
                     H5LTyylval.sval = trim_quotes(yytext);
                     return STRING;
@@ -1489,46 +1495,46 @@ YY_RULE_SETUP
 	YY_BREAK
 case 57:
 YY_RULE_SETUP
-#line 119 "hl/src/H5LTanalyze.l"
+#line 127 "./hl/src/H5LTanalyze.l"
 {return token('{');}
 	YY_BREAK
 case 58:
 YY_RULE_SETUP
-#line 120 "hl/src/H5LTanalyze.l"
+#line 128 "./hl/src/H5LTanalyze.l"
 {return token('}');}
 	YY_BREAK
 case 59:
 YY_RULE_SETUP
-#line 121 "hl/src/H5LTanalyze.l"
+#line 129 "./hl/src/H5LTanalyze.l"
 {return token('[');}
 	YY_BREAK
 case 60:
 YY_RULE_SETUP
-#line 122 "hl/src/H5LTanalyze.l"
+#line 130 "./hl/src/H5LTanalyze.l"
 {return token(']');}
 	YY_BREAK
 case 61:
 YY_RULE_SETUP
-#line 123 "hl/src/H5LTanalyze.l"
+#line 131 "./hl/src/H5LTanalyze.l"
 {return token(':');}
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 124 "hl/src/H5LTanalyze.l"
+#line 132 "./hl/src/H5LTanalyze.l"
 {return token(';');}
 	YY_BREAK
 case 63:
 /* rule 63 can match eol */
 YY_RULE_SETUP
-#line 125 "hl/src/H5LTanalyze.l"
+#line 133 "./hl/src/H5LTanalyze.l"
 ;
 	YY_BREAK
 case 64:
 YY_RULE_SETUP
-#line 127 "hl/src/H5LTanalyze.l"
+#line 135 "./hl/src/H5LTanalyze.l"
 ECHO;
 	YY_BREAK
-#line 1501 "hl/src/H5LTanalyze.c"
+#line 1508 "./hl/src/H5LTanalyze.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2533,7 +2539,7 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 127 "hl/src/H5LTanalyze.l"
+#line 135 "./hl/src/H5LTanalyze.l"
 
 
 /* Allocate a copy of `quoted` with the double quote character at

--- a/hl/src/H5LTanalyze.l
+++ b/hl/src/H5LTanalyze.l
@@ -17,6 +17,14 @@
  * recreate the output files.
  */
 
+%top{
+/* Quiet warnings about integer type macro redifinitions on Visual Studio
+ * (MSVC doesn't define STDC_VERSION, but has inttypes.h). This is an
+ * issue that is apparently fixed in flex 2.6.5.
+ */
+#include <stdint.h>
+}
+
 %{
 #include <assert.h>
 #include <stdlib.h>

--- a/hl/src/H5LTparse.c
+++ b/hl/src/H5LTparse.c
@@ -28,11 +28,12 @@
 #elif defined _MSC_VER                                            
 #pragma warning(push, 1)                                          
 #endif                                                            
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.5.1.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2020 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -70,11 +71,14 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
+/* Undocumented macros, especially those whose name start with YY_,
+   are private implementation details.  Do not rely on them.  */
+
 /* Identify Bison output.  */
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.0.4"
+#define YYBISON_VERSION "3.5.1"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -95,12 +99,11 @@
 #define yyerror         H5LTyyerror
 #define yydebug         H5LTyydebug
 #define yynerrs         H5LTyynerrs
-
 #define yylval          H5LTyylval
 #define yychar          H5LTyychar
 
-/* Copy the first part of user declarations.  */
-#line 20 "hl/src/H5LTparse.y" /* yacc.c:339  */
+/* First part of user prologue.  */
+#line 20 "./hl/src/H5LTparse.y"
 
 #include <stdio.h>
 #include <string.h>
@@ -150,13 +153,26 @@ static hbool_t     is_enum_memb = 0;       /*flag to lexer for enum member*/
 static char*       enum_memb_symbol;       /*enum member symbol string*/
 
 
-#line 124 "hl/src/H5LTparse.c" /* yacc.c:339  */
+#line 127 "./hl/src/H5LTparse.c"
 
-# ifndef YY_NULLPTR
-#  if defined __cplusplus && 201103L <= __cplusplus
-#   define YY_NULLPTR nullptr
+# ifndef YY_CAST
+#  ifdef __cplusplus
+#   define YY_CAST(Type, Val) static_cast<Type> (Val)
+#   define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
 #  else
-#   define YY_NULLPTR 0
+#   define YY_CAST(Type, Val) ((Type) (Val))
+#   define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
+#  endif
+# endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
+#  else
+#   define YY_NULLPTR ((void*)0)
 #  endif
 # endif
 
@@ -168,8 +184,8 @@ static char*       enum_memb_symbol;       /*enum member symbol string*/
 # define YYERROR_VERBOSE 0
 #endif
 
-/* In a future release of Bison, this section will be replaced
-   by #include "H5LTparse.h".  */
+/* Use api.header.include to #include this header
+   instead of duplicating it here.  */
 #ifndef YY_H5LTYY_HL_SRC_H5LTPARSE_H_INCLUDED
 # define YY_H5LTYY_HL_SRC_H5LTPARSE_H_INCLUDED
 /* Debug traces.  */
@@ -246,18 +262,17 @@ extern int H5LTyydebug;
 
 /* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-
 union YYSTYPE
 {
-#line 69 "hl/src/H5LTparse.y" /* yacc.c:355  */
+#line 69 "./hl/src/H5LTparse.y"
 
     int     ival;         /*for integer token*/
     char    *sval;        /*for name string*/
     hid_t   hid;          /*for hid_t token*/
 
-#line 229 "hl/src/H5LTparse.c" /* yacc.c:355  */
-};
+#line 244 "./hl/src/H5LTparse.c"
 
+};
 typedef union YYSTYPE YYSTYPE;
 # define YYSTYPE_IS_TRIVIAL 1
 # define YYSTYPE_IS_DECLARED 1
@@ -270,36 +285,81 @@ hid_t H5LTyyparse (void);
 
 #endif /* !YY_H5LTYY_HL_SRC_H5LTPARSE_H_INCLUDED  */
 
-/* Copy the second part of user declarations.  */
 
-#line 246 "hl/src/H5LTparse.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
 #endif
 
-#ifdef YYTYPE_UINT8
-typedef YYTYPE_UINT8 yytype_uint8;
-#else
-typedef unsigned char yytype_uint8;
+/* On compilers that do not define __PTRDIFF_MAX__ etc., make sure
+   <limits.h> and (if available) <stdint.h> are included
+   so that the code can choose integer types of a good width.  */
+
+#ifndef __PTRDIFF_MAX__
+# include <limits.h> /* INFRINGES ON USER NAME SPACE */
+# if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stdint.h> /* INFRINGES ON USER NAME SPACE */
+#  define YY_STDINT_H
+# endif
 #endif
 
-#ifdef YYTYPE_INT8
-typedef YYTYPE_INT8 yytype_int8;
+/* Narrow types that promote to a signed type and that can represent a
+   signed or unsigned integer of at least N bits.  In tables they can
+   save space and decrease cache pressure.  Promoting to a signed type
+   helps avoid bugs in integer arithmetic.  */
+
+#ifdef __INT_LEAST8_MAX__
+typedef __INT_LEAST8_TYPE__ yytype_int8;
+#elif defined YY_STDINT_H
+typedef int_least8_t yytype_int8;
 #else
 typedef signed char yytype_int8;
 #endif
 
-#ifdef YYTYPE_UINT16
-typedef YYTYPE_UINT16 yytype_uint16;
+#ifdef __INT_LEAST16_MAX__
+typedef __INT_LEAST16_TYPE__ yytype_int16;
+#elif defined YY_STDINT_H
+typedef int_least16_t yytype_int16;
 #else
-typedef unsigned short int yytype_uint16;
+typedef short yytype_int16;
 #endif
 
-#ifdef YYTYPE_INT16
-typedef YYTYPE_INT16 yytype_int16;
+#if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST8_TYPE__ yytype_uint8;
+#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST8_MAX <= INT_MAX)
+typedef uint_least8_t yytype_uint8;
+#elif !defined __UINT_LEAST8_MAX__ && UCHAR_MAX <= INT_MAX
+typedef unsigned char yytype_uint8;
 #else
-typedef short int yytype_int16;
+typedef short yytype_uint8;
+#endif
+
+#if defined __UINT_LEAST16_MAX__ && __UINT_LEAST16_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST16_TYPE__ yytype_uint16;
+#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST16_MAX <= INT_MAX)
+typedef uint_least16_t yytype_uint16;
+#elif !defined __UINT_LEAST16_MAX__ && USHRT_MAX <= INT_MAX
+typedef unsigned short yytype_uint16;
+#else
+typedef int yytype_uint16;
+#endif
+
+#ifndef YYPTRDIFF_T
+# if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
+#  define YYPTRDIFF_T __PTRDIFF_TYPE__
+#  define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
+# elif defined PTRDIFF_MAX
+#  ifndef ptrdiff_t
+#   include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  endif
+#  define YYPTRDIFF_T ptrdiff_t
+#  define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
+# else
+#  define YYPTRDIFF_T long
+#  define YYPTRDIFF_MAXIMUM LONG_MAX
+# endif
 #endif
 
 #ifndef YYSIZE_T
@@ -307,15 +367,27 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T
+# elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
-#  define YYSIZE_T unsigned int
+#  define YYSIZE_T unsigned
 # endif
 #endif
 
-#define YYSIZE_MAXIMUM ((YYSIZE_T) -1)
+#define YYSIZE_MAXIMUM                                  \
+  YY_CAST (YYPTRDIFF_T,                                 \
+           (YYPTRDIFF_MAXIMUM < YY_CAST (YYSIZE_T, -1)  \
+            ? YYPTRDIFF_MAXIMUM                         \
+            : YY_CAST (YYSIZE_T, -1)))
+
+#define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
+
+/* Stored state numbers (used for stacks). */
+typedef yytype_uint8 yy_state_t;
+
+/* State numbers in computations.  */
+typedef int yy_state_fast_t;
 
 #ifndef YY_
 # if defined YYENABLE_NLS && YYENABLE_NLS
@@ -329,30 +401,19 @@ typedef short int yytype_int16;
 # endif
 #endif
 
-#ifndef YY_ATTRIBUTE
-# if (defined __GNUC__                                               \
-      && (2 < __GNUC__ || (__GNUC__ == 2 && 96 <= __GNUC_MINOR__)))  \
-     || defined __SUNPRO_C && 0x5110 <= __SUNPRO_C
-#  define YY_ATTRIBUTE(Spec) __attribute__(Spec)
+#ifndef YY_ATTRIBUTE_PURE
+# if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_PURE __attribute__ ((__pure__))
 # else
-#  define YY_ATTRIBUTE(Spec) /* empty */
+#  define YY_ATTRIBUTE_PURE
 # endif
 #endif
 
-#ifndef YY_ATTRIBUTE_PURE
-# define YY_ATTRIBUTE_PURE   YY_ATTRIBUTE ((__pure__))
-#endif
-
 #ifndef YY_ATTRIBUTE_UNUSED
-# define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
-#endif
-
-#if !defined _Noreturn \
-     && (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112)
-# if defined _MSC_VER && 1200 <= _MSC_VER
-#  define _Noreturn __declspec (noreturn)
+# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
 # else
-#  define _Noreturn YY_ATTRIBUTE ((__noreturn__))
+#  define YY_ATTRIBUTE_UNUSED
 # endif
 #endif
 
@@ -363,13 +424,13 @@ typedef short int yytype_int16;
 # define YYUSE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
+#if defined __GNUC__ && ! defined __ICC && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
-    _Pragma ("GCC diagnostic push") \
-    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")\
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                            \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
     _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
-# define YY_IGNORE_MAYBE_UNINITIALIZED_END \
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
     _Pragma ("GCC diagnostic pop")
 #else
 # define YY_INITIAL_VALUE(Value) Value
@@ -382,6 +443,20 @@ typedef short int yytype_int16;
 # define YY_INITIAL_VALUE(Value) /* Nothing. */
 #endif
 
+#if defined __cplusplus && defined __GNUC__ && ! defined __ICC && 6 <= __GNUC__
+# define YY_IGNORE_USELESS_CAST_BEGIN                          \
+    _Pragma ("GCC diagnostic push")                            \
+    _Pragma ("GCC diagnostic ignored \"-Wuseless-cast\"")
+# define YY_IGNORE_USELESS_CAST_END            \
+    _Pragma ("GCC diagnostic pop")
+#endif
+#ifndef YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_END
+#endif
+
+
+#define YY_ASSERT(E) ((void) (0 && (E)))
 
 #if ! defined yyoverflow || YYERROR_VERBOSE
 
@@ -458,17 +533,17 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
 {
-  yytype_int16 yyss_alloc;
+  yy_state_t yyss_alloc;
   YYSTYPE yyvs_alloc;
 };
 
 /* The size of the maximum gap between one aligned stack and the next.  */
-# define YYSTACK_GAP_MAXIMUM (sizeof (union yyalloc) - 1)
+# define YYSTACK_GAP_MAXIMUM (YYSIZEOF (union yyalloc) - 1)
 
 /* The size of an array large to enough to hold all stacks, each with
    N elements.  */
 # define YYSTACK_BYTES(N) \
-     ((N) * (sizeof (yytype_int16) + sizeof (YYSTYPE)) \
+     ((N) * (YYSIZEOF (yy_state_t) + YYSIZEOF (YYSTYPE)) \
       + YYSTACK_GAP_MAXIMUM)
 
 # define YYCOPY_NEEDED 1
@@ -481,11 +556,11 @@ union yyalloc
 # define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
     do                                                                  \
       {                                                                 \
-        YYSIZE_T yynewbytes;                                            \
+        YYPTRDIFF_T yynewbytes;                                         \
         YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
         Stack = &yyptr->Stack_alloc;                                    \
-        yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-        yyptr += yynewbytes / sizeof (*yyptr);                          \
+        yynewbytes = yystacksize * YYSIZEOF (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / YYSIZEOF (*yyptr);                        \
       }                                                                 \
     while (0)
 
@@ -497,12 +572,12 @@ union yyalloc
 # ifndef YYCOPY
 #  if defined __GNUC__ && 1 < __GNUC__
 #   define YYCOPY(Dst, Src, Count) \
-      __builtin_memcpy (Dst, Src, (Count) * sizeof (*(Src)))
+      __builtin_memcpy (Dst, Src, YY_CAST (YYSIZE_T, (Count)) * sizeof (*(Src)))
 #  else
 #   define YYCOPY(Dst, Src, Count)              \
       do                                        \
         {                                       \
-          YYSIZE_T yyi;                         \
+          YYPTRDIFF_T yyi;                      \
           for (yyi = 0; yyi < (Count); yyi++)   \
             (Dst)[yyi] = (Src)[yyi];            \
         }                                       \
@@ -525,17 +600,18 @@ union yyalloc
 /* YYNSTATES -- Number of states.  */
 #define YYNSTATES  134
 
-/* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
-   by yylex, with out-of-bounds checking.  */
 #define YYUNDEFTOK  2
 #define YYMAXUTOK   313
 
+
+/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, with out-of-bounds checking.  */
 #define YYTRANSLATE(YYX)                                                \
-  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
-   as returned by yylex, without out-of-bounds checking.  */
-static const yytype_uint8 yytranslate[] =
+   as returned by yylex.  */
+static const yytype_int8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -573,7 +649,7 @@ static const yytype_uint8 yytranslate[] =
 
 #if YYDEBUG
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
-static const yytype_uint16 yyrline[] =
+static const yytype_int16 yyrline[] =
 {
        0,   102,   102,   103,   105,   106,   107,   108,   110,   111,
      112,   113,   114,   117,   118,   119,   120,   121,   122,   123,
@@ -628,7 +704,7 @@ static const char *const yytname[] =
 # ifdef YYPRINT
 /* YYTOKNUM[NUM] -- (External) token number corresponding to the
    (internal) symbol number NUM (which must be that of a token).  */
-static const yytype_uint16 yytoknum[] =
+static const yytype_int16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
      265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
@@ -640,14 +716,14 @@ static const yytype_uint16 yytoknum[] =
 };
 # endif
 
-#define YYPACT_NINF -25
+#define YYPACT_NINF (-25)
 
-#define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-25)))
+#define yypact_value_is_default(Yyn) \
+  ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF -1
+#define YYTABLE_NINF (-1)
 
-#define yytable_value_is_error(Yytable_value) \
+#define yytable_value_is_error(Yyn) \
   0
 
   /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
@@ -673,7 +749,7 @@ static const yytype_int16 yypact[] =
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
      Performed when YYTABLE does not specify something else to do.  Zero
      means the default is an error.  */
-static const yytype_uint8 yydefact[] =
+static const yytype_int8 yydefact[] =
 {
        2,    13,    14,    15,    16,    17,    18,    19,    20,    21,
       22,    23,    24,    25,    26,    27,    28,    29,    30,    31,
@@ -738,7 +814,7 @@ static const yytype_uint8 yytable[] =
       20,    21,    22,    23,    24,    25,    26,    27
 };
 
-static const yytype_uint8 yycheck[] =
+static const yytype_int8 yycheck[] =
 {
        3,     4,     5,     6,     7,     8,     9,    10,    11,    12,
       13,    14,    15,    16,    17,    18,    19,    20,    21,    22,
@@ -764,7 +840,7 @@ static const yytype_uint8 yycheck[] =
 
   /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
      symbol of state STATE-NUM.  */
-static const yytype_uint8 yystos[] =
+static const yytype_int8 yystos[] =
 {
        0,     3,     4,     5,     6,     7,     8,     9,    10,    11,
       12,    13,    14,    15,    16,    17,    18,    19,    20,    21,
@@ -783,7 +859,7 @@ static const yytype_uint8 yystos[] =
 };
 
   /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_uint8 yyr1[] =
+static const yytype_int8 yyr1[] =
 {
        0,    65,    66,    66,    67,    67,    67,    67,    68,    68,
       68,    68,    68,    69,    69,    69,    69,    69,    69,    69,
@@ -798,7 +874,7 @@ static const yytype_uint8 yyr1[] =
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
+static const yytype_int8 yyr2[] =
 {
        0,     2,     0,     1,     1,     1,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
@@ -825,22 +901,22 @@ static const yytype_uint8 yyr2[] =
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)                                  \
-do                                                              \
-  if (yychar == YYEMPTY)                                        \
-    {                                                           \
-      yychar = (Token);                                         \
-      yylval = (Value);                                         \
-      YYPOPSTACK (yylen);                                       \
-      yystate = *yyssp;                                         \
-      goto yybackup;                                            \
-    }                                                           \
-  else                                                          \
-    {                                                           \
-      yyerror (YY_("syntax error: cannot back up")); \
-      YYERROR;                                                  \
-    }                                                           \
-while (0)
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == YYEMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
 
 /* Error token number */
 #define YYTERROR        1
@@ -880,37 +956,39 @@ do {                                                                      \
 } while (0)
 
 
-/*----------------------------------------.
-| Print this symbol's value on YYOUTPUT.  |
-`----------------------------------------*/
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
+yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep)
 {
-  FILE *yyo = yyoutput;
-  YYUSE (yyo);
+  FILE *yyoutput = yyo;
+  YYUSE (yyoutput);
   if (!yyvaluep)
     return;
 # ifdef YYPRINT
   if (yytype < YYNTOKENS)
-    YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
+    YYPRINT (yyo, yytoknum[yytype], *yyvaluep);
 # endif
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   YYUSE (yytype);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
+yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep)
 {
-  YYFPRINTF (yyoutput, "%s %s (",
+  YYFPRINTF (yyo, "%s %s (",
              yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
 
-  yy_symbol_value_print (yyoutput, yytype, yyvaluep);
-  YYFPRINTF (yyoutput, ")");
+  yy_symbol_value_print (yyo, yytype, yyvaluep);
+  YYFPRINTF (yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -919,7 +997,7 @@ yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
 `------------------------------------------------------------------*/
 
 static void
-yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
+yy_stack_print (yy_state_t *yybottom, yy_state_t *yytop)
 {
   YYFPRINTF (stderr, "Stack now");
   for (; yybottom <= yytop; yybottom++)
@@ -942,20 +1020,20 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule)
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, int yyrule)
 {
-  unsigned long int yylno = yyrline[yyrule];
+  int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
+  YYFPRINTF (stderr, "Reducing stack by rule %d (line %d):\n",
              yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
-                       yystos[yyssp[yyi + 1 - yynrhs]],
-                       &(yyvsp[(yyi + 1) - (yynrhs)])
+                       yystos[+yyssp[yyi + 1 - yynrhs]],
+                       &yyvsp[(yyi + 1) - (yynrhs)]
                                               );
       YYFPRINTF (stderr, "\n");
     }
@@ -999,13 +1077,13 @@ int yydebug;
 
 # ifndef yystrlen
 #  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen strlen
+#   define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
 #  else
 /* Return the length of YYSTR.  */
-static YYSIZE_T
+static YYPTRDIFF_T
 yystrlen (const char *yystr)
 {
-  YYSIZE_T yylen;
+  YYPTRDIFF_T yylen;
   for (yylen = 0; yystr[yylen]; yylen++)
     continue;
   return yylen;
@@ -1041,12 +1119,12 @@ yystpcpy (char *yydest, const char *yysrc)
    backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
    null, do not copy; instead, return the length of what the result
    would have been.  */
-static YYSIZE_T
+static YYPTRDIFF_T
 yytnamerr (char *yyres, const char *yystr)
 {
   if (*yystr == '"')
     {
-      YYSIZE_T yyn = 0;
+      YYPTRDIFF_T yyn = 0;
       char const *yyp = yystr;
 
       for (;;)
@@ -1059,7 +1137,10 @@ yytnamerr (char *yyres, const char *yystr)
           case '\\':
             if (*++yyp != '\\')
               goto do_not_strip_quotes;
-            /* Fall through.  */
+            else
+              goto append;
+
+          append:
           default:
             if (yyres)
               yyres[yyn] = *yyp;
@@ -1074,10 +1155,10 @@ yytnamerr (char *yyres, const char *yystr)
     do_not_strip_quotes: ;
     }
 
-  if (! yyres)
+  if (yyres)
+    return yystpcpy (yyres, yystr) - yyres;
+  else
     return yystrlen (yystr);
-
-  return yystpcpy (yyres, yystr) - yyres;
 }
 # endif
 
@@ -1090,19 +1171,19 @@ yytnamerr (char *yyres, const char *yystr)
    *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
    required number of bytes is too large to store.  */
 static int
-yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
-                yytype_int16 *yyssp, int yytoken)
+yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
+                yy_state_t *yyssp, int yytoken)
 {
-  YYSIZE_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
-  YYSIZE_T yysize = yysize0;
   enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
   /* Internationalized format string. */
   const char *yyformat = YY_NULLPTR;
-  /* Arguments of yyformat. */
+  /* Arguments of yyformat: reported tokens (one for the "unexpected",
+     one per "expected"). */
   char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  /* Number of reported tokens (one for the "unexpected", one per
-     "expected"). */
+  /* Actual size of YYARG. */
   int yycount = 0;
+  /* Cumulated lengths of YYARG.  */
+  YYPTRDIFF_T yysize = 0;
 
   /* There are many possibilities here to consider:
      - If this state is a consistent state with a default action, then
@@ -1129,7 +1210,9 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
   */
   if (yytoken != YYEMPTY)
     {
-      int yyn = yypact[*yyssp];
+      int yyn = yypact[+*yyssp];
+      YYPTRDIFF_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
+      yysize = yysize0;
       yyarg[yycount++] = yytname[yytoken];
       if (!yypact_value_is_default (yyn))
         {
@@ -1154,11 +1237,12 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
                   }
                 yyarg[yycount++] = yytname[yyx];
                 {
-                  YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (! (yysize <= yysize1
-                         && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
+                  YYPTRDIFF_T yysize1
+                    = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
+                  if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+                    yysize = yysize1;
+                  else
                     return 2;
-                  yysize = yysize1;
                 }
               }
         }
@@ -1170,6 +1254,7 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
       case N:                               \
         yyformat = S;                       \
       break
+    default: /* Avoid compiler warnings. */
       YYCASE_(0, YY_("syntax error"));
       YYCASE_(1, YY_("syntax error, unexpected %s"));
       YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
@@ -1180,10 +1265,13 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
     }
 
   {
-    YYSIZE_T yysize1 = yysize + yystrlen (yyformat);
-    if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
+    /* Don't count the "%s"s in the final size, but reserve room for
+       the terminator.  */
+    YYPTRDIFF_T yysize1 = yysize + (yystrlen (yyformat) - 2 * yycount) + 1;
+    if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+      yysize = yysize1;
+    else
       return 2;
-    yysize = yysize1;
   }
 
   if (*yymsg_alloc < yysize)
@@ -1209,8 +1297,8 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
         }
       else
         {
-          yyp++;
-          yyformat++;
+          ++yyp;
+          ++yyformat;
         }
   }
   return 0;
@@ -1253,7 +1341,7 @@ int yynerrs;
 hid_t
 yyparse (void)
 {
-    int yystate;
+    yy_state_fast_t yystate;
     /* Number of tokens to shift before error messages enabled.  */
     int yyerrstatus;
 
@@ -1265,16 +1353,16 @@ yyparse (void)
        to reallocate them elsewhere.  */
 
     /* The state stack.  */
-    yytype_int16 yyssa[YYINITDEPTH];
-    yytype_int16 *yyss;
-    yytype_int16 *yyssp;
+    yy_state_t yyssa[YYINITDEPTH];
+    yy_state_t *yyss;
+    yy_state_t *yyssp;
 
     /* The semantic value stack.  */
     YYSTYPE yyvsa[YYINITDEPTH];
     YYSTYPE *yyvs;
     YYSTYPE *yyvsp;
 
-    YYSIZE_T yystacksize;
+    YYPTRDIFF_T yystacksize;
 
   int yyn;
   int yyresult;
@@ -1288,7 +1376,7 @@ yyparse (void)
   /* Buffer for error messages, and its allocated size.  */
   char yymsgbuf[128];
   char *yymsg = yymsgbuf;
-  YYSIZE_T yymsg_alloc = sizeof yymsgbuf;
+  YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
 #endif
 
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
@@ -1309,46 +1397,54 @@ yyparse (void)
   yychar = YYEMPTY; /* Cause a token to be read.  */
   goto yysetstate;
 
+
 /*------------------------------------------------------------.
-| yynewstate -- Push a new state, which is found in yystate.  |
+| yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
- yynewstate:
+yynewstate:
   /* In all cases, when you get here, the value and location stacks
      have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
- yysetstate:
-  *yyssp = yystate;
+
+/*--------------------------------------------------------------------.
+| yysetstate -- set current state (the top of the stack) to yystate.  |
+`--------------------------------------------------------------------*/
+yysetstate:
+  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
+  YY_IGNORE_USELESS_CAST_BEGIN
+  *yyssp = YY_CAST (yy_state_t, yystate);
+  YY_IGNORE_USELESS_CAST_END
 
   if (yyss + yystacksize - 1 <= yyssp)
+#if !defined yyoverflow && !defined YYSTACK_RELOCATE
+    goto yyexhaustedlab;
+#else
     {
       /* Get the current used size of the three stacks, in elements.  */
-      YYSIZE_T yysize = yyssp - yyss + 1;
+      YYPTRDIFF_T yysize = yyssp - yyss + 1;
 
-#ifdef yyoverflow
+# if defined yyoverflow
       {
         /* Give user a chance to reallocate the stack.  Use copies of
            these so that the &'s don't force the real ones into
            memory.  */
+        yy_state_t *yyss1 = yyss;
         YYSTYPE *yyvs1 = yyvs;
-        yytype_int16 *yyss1 = yyss;
 
         /* Each stack pointer address is followed by the size of the
            data in use in that stack, in bytes.  This used to be a
            conditional around just the two extra args, but that might
            be undefined if yyoverflow is a macro.  */
         yyoverflow (YY_("memory exhausted"),
-                    &yyss1, yysize * sizeof (*yyssp),
-                    &yyvs1, yysize * sizeof (*yyvsp),
+                    &yyss1, yysize * YYSIZEOF (*yyssp),
+                    &yyvs1, yysize * YYSIZEOF (*yyvsp),
                     &yystacksize);
-
         yyss = yyss1;
         yyvs = yyvs1;
       }
-#else /* no yyoverflow */
-# ifndef YYSTACK_RELOCATE
-      goto yyexhaustedlab;
-# else
+# else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
         goto yyexhaustedlab;
@@ -1357,42 +1453,43 @@ yyparse (void)
         yystacksize = YYMAXDEPTH;
 
       {
-        yytype_int16 *yyss1 = yyss;
+        yy_state_t *yyss1 = yyss;
         union yyalloc *yyptr =
-          (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
+          YY_CAST (union yyalloc *,
+                   YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
         if (! yyptr)
           goto yyexhaustedlab;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
-#  undef YYSTACK_RELOCATE
+# undef YYSTACK_RELOCATE
         if (yyss1 != yyssa)
           YYSTACK_FREE (yyss1);
       }
 # endif
-#endif /* no yyoverflow */
 
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
 
-      YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-                  (unsigned long int) yystacksize));
+      YY_IGNORE_USELESS_CAST_BEGIN
+      YYDPRINTF ((stderr, "Stack size increased to %ld\n",
+                  YY_CAST (long, yystacksize)));
+      YY_IGNORE_USELESS_CAST_END
 
       if (yyss + yystacksize - 1 <= yyssp)
         YYABORT;
     }
-
-  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
   if (yystate == YYFINAL)
     YYACCEPT;
 
   goto yybackup;
 
+
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-
   /* Do appropriate processing given the current state.  Read a
      lookahead token if we need one and don't already have one.  */
 
@@ -1442,15 +1539,13 @@ yybackup:
 
   /* Shift the lookahead token.  */
   YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
-
-  /* Discard the shifted token.  */
-  yychar = YYEMPTY;
-
   yystate = yyn;
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 
+  /* Discard the shifted token.  */
+  yychar = YYEMPTY;
   goto yynewstate;
 
 
@@ -1465,7 +1560,7 @@ yydefault:
 
 
 /*-----------------------------.
-| yyreduce -- Do a reduction.  |
+| yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
   /* yyn is the number of a rule to reduce with.  */
@@ -1485,247 +1580,247 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-        case 2:
-#line 102 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { memset(arr_stack, 0, STACK_SIZE*sizeof(struct arr_info)); /*initialize here?*/ }
-#line 1462 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+  case 2:
+#line 102 "./hl/src/H5LTparse.y"
+                { memset(arr_stack, 0, STACK_SIZE*sizeof(struct arr_info)); /*initialize here?*/ }
+#line 1557 "./hl/src/H5LTparse.c"
     break;
 
   case 3:
-#line 103 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { return (yyval.hid);}
-#line 1468 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 103 "./hl/src/H5LTparse.y"
+                          { return (yyval.hid);}
+#line 1563 "./hl/src/H5LTparse.c"
     break;
 
   case 13:
-#line 117 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_STD_I8BE); }
-#line 1474 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 117 "./hl/src/H5LTparse.y"
+                                            { (yyval.hid) = H5Tcopy(H5T_STD_I8BE); }
+#line 1569 "./hl/src/H5LTparse.c"
     break;
 
   case 14:
-#line 118 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_STD_I8LE); }
-#line 1480 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 118 "./hl/src/H5LTparse.y"
+                                            { (yyval.hid) = H5Tcopy(H5T_STD_I8LE); }
+#line 1575 "./hl/src/H5LTparse.c"
     break;
 
   case 15:
-#line 119 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_STD_I16BE); }
-#line 1486 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 119 "./hl/src/H5LTparse.y"
+                                            { (yyval.hid) = H5Tcopy(H5T_STD_I16BE); }
+#line 1581 "./hl/src/H5LTparse.c"
     break;
 
   case 16:
-#line 120 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_STD_I16LE); }
-#line 1492 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 120 "./hl/src/H5LTparse.y"
+                                            { (yyval.hid) = H5Tcopy(H5T_STD_I16LE); }
+#line 1587 "./hl/src/H5LTparse.c"
     break;
 
   case 17:
-#line 121 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_STD_I32BE); }
-#line 1498 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 121 "./hl/src/H5LTparse.y"
+                                            { (yyval.hid) = H5Tcopy(H5T_STD_I32BE); }
+#line 1593 "./hl/src/H5LTparse.c"
     break;
 
   case 18:
-#line 122 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_STD_I32LE); }
-#line 1504 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 122 "./hl/src/H5LTparse.y"
+                                            { (yyval.hid) = H5Tcopy(H5T_STD_I32LE); }
+#line 1599 "./hl/src/H5LTparse.c"
     break;
 
   case 19:
-#line 123 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_STD_I64BE); }
-#line 1510 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 123 "./hl/src/H5LTparse.y"
+                                            { (yyval.hid) = H5Tcopy(H5T_STD_I64BE); }
+#line 1605 "./hl/src/H5LTparse.c"
     break;
 
   case 20:
-#line 124 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_STD_I64LE); }
-#line 1516 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 124 "./hl/src/H5LTparse.y"
+                                            { (yyval.hid) = H5Tcopy(H5T_STD_I64LE); }
+#line 1611 "./hl/src/H5LTparse.c"
     break;
 
   case 21:
-#line 125 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_STD_U8BE); }
-#line 1522 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 125 "./hl/src/H5LTparse.y"
+                                            { (yyval.hid) = H5Tcopy(H5T_STD_U8BE); }
+#line 1617 "./hl/src/H5LTparse.c"
     break;
 
   case 22:
-#line 126 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_STD_U8LE); }
-#line 1528 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 126 "./hl/src/H5LTparse.y"
+                                            { (yyval.hid) = H5Tcopy(H5T_STD_U8LE); }
+#line 1623 "./hl/src/H5LTparse.c"
     break;
 
   case 23:
-#line 127 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_STD_U16BE); }
-#line 1534 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 127 "./hl/src/H5LTparse.y"
+                                            { (yyval.hid) = H5Tcopy(H5T_STD_U16BE); }
+#line 1629 "./hl/src/H5LTparse.c"
     break;
 
   case 24:
-#line 128 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_STD_U16LE); }
-#line 1540 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 128 "./hl/src/H5LTparse.y"
+                                            { (yyval.hid) = H5Tcopy(H5T_STD_U16LE); }
+#line 1635 "./hl/src/H5LTparse.c"
     break;
 
   case 25:
-#line 129 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_STD_U32BE); }
-#line 1546 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 129 "./hl/src/H5LTparse.y"
+                                            { (yyval.hid) = H5Tcopy(H5T_STD_U32BE); }
+#line 1641 "./hl/src/H5LTparse.c"
     break;
 
   case 26:
-#line 130 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_STD_U32LE); }
-#line 1552 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 130 "./hl/src/H5LTparse.y"
+                                            { (yyval.hid) = H5Tcopy(H5T_STD_U32LE); }
+#line 1647 "./hl/src/H5LTparse.c"
     break;
 
   case 27:
-#line 131 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_STD_U64BE); }
-#line 1558 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 131 "./hl/src/H5LTparse.y"
+                                            { (yyval.hid) = H5Tcopy(H5T_STD_U64BE); }
+#line 1653 "./hl/src/H5LTparse.c"
     break;
 
   case 28:
-#line 132 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_STD_U64LE); }
-#line 1564 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 132 "./hl/src/H5LTparse.y"
+                                            { (yyval.hid) = H5Tcopy(H5T_STD_U64LE); }
+#line 1659 "./hl/src/H5LTparse.c"
     break;
 
   case 29:
-#line 133 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_NATIVE_CHAR); }
-#line 1570 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 133 "./hl/src/H5LTparse.y"
+                                                { (yyval.hid) = H5Tcopy(H5T_NATIVE_CHAR); }
+#line 1665 "./hl/src/H5LTparse.c"
     break;
 
   case 30:
-#line 134 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_NATIVE_SCHAR); }
-#line 1576 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 134 "./hl/src/H5LTparse.y"
+                                                { (yyval.hid) = H5Tcopy(H5T_NATIVE_SCHAR); }
+#line 1671 "./hl/src/H5LTparse.c"
     break;
 
   case 31:
-#line 135 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_NATIVE_UCHAR); }
-#line 1582 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 135 "./hl/src/H5LTparse.y"
+                                                { (yyval.hid) = H5Tcopy(H5T_NATIVE_UCHAR); }
+#line 1677 "./hl/src/H5LTparse.c"
     break;
 
   case 32:
-#line 136 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_NATIVE_SHORT); }
-#line 1588 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 136 "./hl/src/H5LTparse.y"
+                                                { (yyval.hid) = H5Tcopy(H5T_NATIVE_SHORT); }
+#line 1683 "./hl/src/H5LTparse.c"
     break;
 
   case 33:
-#line 137 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_NATIVE_USHORT); }
-#line 1594 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 137 "./hl/src/H5LTparse.y"
+                                                { (yyval.hid) = H5Tcopy(H5T_NATIVE_USHORT); }
+#line 1689 "./hl/src/H5LTparse.c"
     break;
 
   case 34:
-#line 138 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_NATIVE_INT); }
-#line 1600 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 138 "./hl/src/H5LTparse.y"
+                                                { (yyval.hid) = H5Tcopy(H5T_NATIVE_INT); }
+#line 1695 "./hl/src/H5LTparse.c"
     break;
 
   case 35:
-#line 139 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_NATIVE_UINT); }
-#line 1606 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 139 "./hl/src/H5LTparse.y"
+                                                { (yyval.hid) = H5Tcopy(H5T_NATIVE_UINT); }
+#line 1701 "./hl/src/H5LTparse.c"
     break;
 
   case 36:
-#line 140 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_NATIVE_LONG); }
-#line 1612 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 140 "./hl/src/H5LTparse.y"
+                                                { (yyval.hid) = H5Tcopy(H5T_NATIVE_LONG); }
+#line 1707 "./hl/src/H5LTparse.c"
     break;
 
   case 37:
-#line 141 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_NATIVE_ULONG); }
-#line 1618 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 141 "./hl/src/H5LTparse.y"
+                                                { (yyval.hid) = H5Tcopy(H5T_NATIVE_ULONG); }
+#line 1713 "./hl/src/H5LTparse.c"
     break;
 
   case 38:
-#line 142 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_NATIVE_LLONG); }
-#line 1624 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 142 "./hl/src/H5LTparse.y"
+                                                { (yyval.hid) = H5Tcopy(H5T_NATIVE_LLONG); }
+#line 1719 "./hl/src/H5LTparse.c"
     break;
 
   case 39:
-#line 143 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_NATIVE_ULLONG); }
-#line 1630 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 143 "./hl/src/H5LTparse.y"
+                                                { (yyval.hid) = H5Tcopy(H5T_NATIVE_ULLONG); }
+#line 1725 "./hl/src/H5LTparse.c"
     break;
 
   case 40:
-#line 146 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_IEEE_F32BE); }
-#line 1636 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 146 "./hl/src/H5LTparse.y"
+                                             { (yyval.hid) = H5Tcopy(H5T_IEEE_F32BE); }
+#line 1731 "./hl/src/H5LTparse.c"
     break;
 
   case 41:
-#line 147 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_IEEE_F32LE); }
-#line 1642 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 147 "./hl/src/H5LTparse.y"
+                                             { (yyval.hid) = H5Tcopy(H5T_IEEE_F32LE); }
+#line 1737 "./hl/src/H5LTparse.c"
     break;
 
   case 42:
-#line 148 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_IEEE_F64BE); }
-#line 1648 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 148 "./hl/src/H5LTparse.y"
+                                             { (yyval.hid) = H5Tcopy(H5T_IEEE_F64BE); }
+#line 1743 "./hl/src/H5LTparse.c"
     break;
 
   case 43:
-#line 149 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_IEEE_F64LE); }
-#line 1654 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 149 "./hl/src/H5LTparse.y"
+                                             { (yyval.hid) = H5Tcopy(H5T_IEEE_F64LE); }
+#line 1749 "./hl/src/H5LTparse.c"
     break;
 
   case 44:
-#line 150 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_NATIVE_FLOAT); }
-#line 1660 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 150 "./hl/src/H5LTparse.y"
+                                                  { (yyval.hid) = H5Tcopy(H5T_NATIVE_FLOAT); }
+#line 1755 "./hl/src/H5LTparse.c"
     break;
 
   case 45:
-#line 151 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_NATIVE_DOUBLE); }
-#line 1666 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 151 "./hl/src/H5LTparse.y"
+                                                  { (yyval.hid) = H5Tcopy(H5T_NATIVE_DOUBLE); }
+#line 1761 "./hl/src/H5LTparse.c"
     break;
 
   case 46:
-#line 152 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tcopy(H5T_NATIVE_LDOUBLE); }
-#line 1672 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 152 "./hl/src/H5LTparse.y"
+                                                  { (yyval.hid) = H5Tcopy(H5T_NATIVE_LDOUBLE); }
+#line 1767 "./hl/src/H5LTparse.c"
     break;
 
   case 47:
-#line 156 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { csindex++; cmpd_stack[csindex].id = H5Tcreate(H5T_COMPOUND, 1); /*temporarily set size to 1*/ }
-#line 1678 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 156 "./hl/src/H5LTparse.y"
+                            { csindex++; cmpd_stack[csindex].id = H5Tcreate(H5T_COMPOUND, 1); /*temporarily set size to 1*/ }
+#line 1773 "./hl/src/H5LTparse.c"
     break;
 
   case 48:
-#line 158 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = cmpd_stack[csindex].id; 
+#line 158 "./hl/src/H5LTparse.y"
+                            { (yyval.hid) = cmpd_stack[csindex].id; 
                               cmpd_stack[csindex].id = 0;
                               cmpd_stack[csindex].first_memb = 1; 
                               csindex--;
                             }
-#line 1688 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 1783 "./hl/src/H5LTparse.c"
     break;
 
   case 51:
-#line 167 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { cmpd_stack[csindex].is_field = 1; /*notify lexer a compound member is parsed*/ }
-#line 1694 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 167 "./hl/src/H5LTparse.y"
+                                 { cmpd_stack[csindex].is_field = 1; /*notify lexer a compound member is parsed*/ }
+#line 1789 "./hl/src/H5LTparse.c"
     break;
 
   case 52:
-#line 169 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {   
+#line 169 "./hl/src/H5LTparse.y"
+                        {   
                             size_t origin_size, new_size;
                             hid_t dtype_id = cmpd_stack[csindex].id;
 
@@ -1759,109 +1854,109 @@ yyreduce:
                              
                             new_size = H5Tget_size(dtype_id);
                         }
-#line 1733 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 1828 "./hl/src/H5LTparse.c"
     break;
 
   case 53:
-#line 205 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {
+#line 205 "./hl/src/H5LTparse.y"
+                        {
                             (yyval.sval) = HDstrdup(yylval.sval);
                             HDfree(yylval.sval);
                             yylval.sval = NULL;
                         }
-#line 1743 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 1838 "./hl/src/H5LTparse.c"
     break;
 
   case 54:
-#line 212 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.ival) = 0; }
-#line 1749 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 212 "./hl/src/H5LTparse.y"
+                        { (yyval.ival) = 0; }
+#line 1844 "./hl/src/H5LTparse.c"
     break;
 
   case 55:
-#line 214 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.ival) = yylval.ival; }
-#line 1755 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 214 "./hl/src/H5LTparse.y"
+                        { (yyval.ival) = yylval.ival; }
+#line 1850 "./hl/src/H5LTparse.c"
     break;
 
   case 57:
-#line 218 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { asindex++; /*pushd onto the stack*/ }
-#line 1761 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 218 "./hl/src/H5LTparse.y"
+                                        { asindex++; /*pushd onto the stack*/ }
+#line 1856 "./hl/src/H5LTparse.c"
     break;
 
   case 58:
-#line 220 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { 
+#line 220 "./hl/src/H5LTparse.y"
+                        { 
                           (yyval.hid) = H5Tarray_create2((yyvsp[-1].hid), arr_stack[asindex].ndims, arr_stack[asindex].dims);
                           arr_stack[asindex].ndims = 0;
                           asindex--;
                           H5Tclose((yyvsp[-1].hid));
                         }
-#line 1772 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 1867 "./hl/src/H5LTparse.c"
     break;
 
   case 61:
-#line 230 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { arr_stack[asindex].is_dim = 1; /*notice lexer of dimension size*/ }
-#line 1778 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 230 "./hl/src/H5LTparse.y"
+                            { arr_stack[asindex].is_dim = 1; /*notice lexer of dimension size*/ }
+#line 1873 "./hl/src/H5LTparse.c"
     break;
 
   case 62:
-#line 231 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { unsigned ndims = arr_stack[asindex].ndims;
+#line 231 "./hl/src/H5LTparse.y"
+                                { unsigned ndims = arr_stack[asindex].ndims;
                                   arr_stack[asindex].dims[ndims] = (hsize_t)yylval.ival; 
                                   arr_stack[asindex].ndims++;
                                   arr_stack[asindex].is_dim = 0; 
                                 }
-#line 1788 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 1883 "./hl/src/H5LTparse.c"
     break;
 
   case 65:
-#line 242 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = H5Tvlen_create((yyvsp[-1].hid)); H5Tclose((yyvsp[-1].hid)); }
-#line 1794 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 242 "./hl/src/H5LTparse.y"
+                            { (yyval.hid) = H5Tvlen_create((yyvsp[-1].hid)); H5Tclose((yyvsp[-1].hid)); }
+#line 1889 "./hl/src/H5LTparse.c"
     break;
 
   case 66:
-#line 248 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {   
+#line 248 "./hl/src/H5LTparse.y"
+                            {   
                                 size_t size = (size_t)yylval.ival;
                                 (yyval.hid) = H5Tcreate(H5T_OPAQUE, size);
                             }
-#line 1803 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 1898 "./hl/src/H5LTparse.c"
     break;
 
   case 67:
-#line 253 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {  
+#line 253 "./hl/src/H5LTparse.y"
+                            {  
                                 H5Tset_tag((yyvsp[-3].hid), yylval.sval);
                                 HDfree(yylval.sval);
                                 yylval.sval = NULL;
                             }
-#line 1813 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 1908 "./hl/src/H5LTparse.c"
     break;
 
   case 68:
-#line 258 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { (yyval.hid) = (yyvsp[-5].hid); }
-#line 1819 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 258 "./hl/src/H5LTparse.y"
+                            { (yyval.hid) = (yyvsp[-5].hid); }
+#line 1914 "./hl/src/H5LTparse.c"
     break;
 
   case 71:
-#line 267 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {  
+#line 267 "./hl/src/H5LTparse.y"
+                            {  
                                 if((yyvsp[-1].ival) == H5T_VARIABLE_TOKEN)
                                     is_variable = 1;
                                 else 
                                     str_size = yylval.ival;
                             }
-#line 1830 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 1925 "./hl/src/H5LTparse.c"
     break;
 
   case 72:
-#line 274 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {
+#line 274 "./hl/src/H5LTparse.y"
+                            {
                                 if((yyvsp[-1].ival) == H5T_STR_NULLTERM_TOKEN)
                                     str_pad = H5T_STR_NULLTERM;
                                 else if((yyvsp[-1].ival) == H5T_STR_NULLPAD_TOKEN)
@@ -1869,34 +1964,34 @@ yyreduce:
                                 else if((yyvsp[-1].ival) == H5T_STR_SPACEPAD_TOKEN)
                                     str_pad = H5T_STR_SPACEPAD;
                             }
-#line 1843 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 1938 "./hl/src/H5LTparse.c"
     break;
 
   case 73:
-#line 283 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {  
+#line 283 "./hl/src/H5LTparse.y"
+                            {  
                                 if((yyvsp[-1].ival) == H5T_CSET_ASCII_TOKEN)
                                     str_cset = H5T_CSET_ASCII;
                                 else if((yyvsp[-1].ival) == H5T_CSET_UTF8_TOKEN)
                                     str_cset = H5T_CSET_UTF8;
                             }
-#line 1854 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 1949 "./hl/src/H5LTparse.c"
     break;
 
   case 74:
-#line 290 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {
+#line 290 "./hl/src/H5LTparse.y"
+                            {
                                 if((yyvsp[-1].hid) == H5T_C_S1_TOKEN)
                                     (yyval.hid) = H5Tcopy(H5T_C_S1);
                                 else if((yyvsp[-1].hid) == H5T_FORTRAN_S1_TOKEN)
                                     (yyval.hid) = H5Tcopy(H5T_FORTRAN_S1);
                             }
-#line 1865 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 1960 "./hl/src/H5LTparse.c"
     break;
 
   case 75:
-#line 297 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {   
+#line 297 "./hl/src/H5LTparse.y"
+                            {   
                                 hid_t str_id = (yyvsp[-1].hid);
 
                                 /*set string size*/
@@ -1912,83 +2007,83 @@ yyreduce:
 
                                 (yyval.hid) = str_id; 
                             }
-#line 1886 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 1981 "./hl/src/H5LTparse.c"
     break;
 
   case 76:
-#line 314 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {(yyval.ival) = H5T_VARIABLE_TOKEN;}
-#line 1892 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 314 "./hl/src/H5LTparse.y"
+                                               {(yyval.ival) = H5T_VARIABLE_TOKEN;}
+#line 1987 "./hl/src/H5LTparse.c"
     break;
 
   case 78:
-#line 317 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {(yyval.ival) = H5T_STR_NULLTERM_TOKEN;}
-#line 1898 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 317 "./hl/src/H5LTparse.y"
+                                               {(yyval.ival) = H5T_STR_NULLTERM_TOKEN;}
+#line 1993 "./hl/src/H5LTparse.c"
     break;
 
   case 79:
-#line 318 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {(yyval.ival) = H5T_STR_NULLPAD_TOKEN;}
-#line 1904 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 318 "./hl/src/H5LTparse.y"
+                                               {(yyval.ival) = H5T_STR_NULLPAD_TOKEN;}
+#line 1999 "./hl/src/H5LTparse.c"
     break;
 
   case 80:
-#line 319 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {(yyval.ival) = H5T_STR_SPACEPAD_TOKEN;}
-#line 1910 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 319 "./hl/src/H5LTparse.y"
+                                               {(yyval.ival) = H5T_STR_SPACEPAD_TOKEN;}
+#line 2005 "./hl/src/H5LTparse.c"
     break;
 
   case 81:
-#line 321 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {(yyval.ival) = H5T_CSET_ASCII_TOKEN;}
-#line 1916 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 321 "./hl/src/H5LTparse.y"
+                                             {(yyval.ival) = H5T_CSET_ASCII_TOKEN;}
+#line 2011 "./hl/src/H5LTparse.c"
     break;
 
   case 82:
-#line 322 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {(yyval.ival) = H5T_CSET_UTF8_TOKEN;}
-#line 1922 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 322 "./hl/src/H5LTparse.y"
+                                            {(yyval.ival) = H5T_CSET_UTF8_TOKEN;}
+#line 2017 "./hl/src/H5LTparse.c"
     break;
 
   case 83:
-#line 324 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {(yyval.hid) = H5T_C_S1_TOKEN;}
-#line 1928 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 324 "./hl/src/H5LTparse.y"
+                                               {(yyval.hid) = H5T_C_S1_TOKEN;}
+#line 2023 "./hl/src/H5LTparse.c"
     break;
 
   case 84:
-#line 325 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {(yyval.hid) = H5T_FORTRAN_S1_TOKEN;}
-#line 1934 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 325 "./hl/src/H5LTparse.y"
+                                               {(yyval.hid) = H5T_FORTRAN_S1_TOKEN;}
+#line 2029 "./hl/src/H5LTparse.c"
     break;
 
   case 85:
-#line 329 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { is_enum = 1; enum_id = H5Tenum_create((yyvsp[-1].hid)); H5Tclose((yyvsp[-1].hid)); }
-#line 1940 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 329 "./hl/src/H5LTparse.y"
+                            { is_enum = 1; enum_id = H5Tenum_create((yyvsp[-1].hid)); H5Tclose((yyvsp[-1].hid)); }
+#line 2035 "./hl/src/H5LTparse.c"
     break;
 
   case 86:
-#line 331 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    { is_enum = 0; /*reset*/ (yyval.hid) = enum_id; }
-#line 1946 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 331 "./hl/src/H5LTparse.y"
+                            { is_enum = 0; /*reset*/ (yyval.hid) = enum_id; }
+#line 2041 "./hl/src/H5LTparse.c"
     break;
 
   case 89:
-#line 336 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {
+#line 336 "./hl/src/H5LTparse.y"
+                                            {
                                                 is_enum_memb = 1; /*indicate member of enum*/
                                                 enum_memb_symbol = HDstrdup(yylval.sval); 
                                                 HDfree(yylval.sval);
                                                 yylval.sval = NULL;
                                             }
-#line 1957 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 2052 "./hl/src/H5LTparse.c"
     break;
 
   case 90:
-#line 343 "hl/src/H5LTparse.y" /* yacc.c:1646  */
-    {
+#line 343 "./hl/src/H5LTparse.y"
+                            {
                                 char char_val=(char)yylval.ival;
                                 short short_val=(short)yylval.ival;
                                 int int_val=(int)yylval.ival;
@@ -2030,11 +2125,12 @@ yyreduce:
                                 H5Tclose(super);
                                 H5Tclose(native);
                             }
-#line 2004 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 2099 "./hl/src/H5LTparse.c"
     break;
 
 
-#line 2008 "hl/src/H5LTparse.c" /* yacc.c:1646  */
+#line 2103 "./hl/src/H5LTparse.c"
+
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -2059,14 +2155,13 @@ yyreduce:
   /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-
-  yyn = yyr1[yyn];
-
-  yystate = yypgoto[yyn - YYNTOKENS] + *yyssp;
-  if (0 <= yystate && yystate <= YYLAST && yycheck[yystate] == *yyssp)
-    yystate = yytable[yystate];
-  else
-    yystate = yydefgoto[yyn - YYNTOKENS];
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
 
   goto yynewstate;
 
@@ -2098,7 +2193,7 @@ yyerrlab:
           {
             if (yymsg != yymsgbuf)
               YYSTACK_FREE (yymsg);
-            yymsg = (char *) YYSTACK_ALLOC (yymsg_alloc);
+            yymsg = YY_CAST (char *, YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
             if (!yymsg)
               {
                 yymsg = yymsgbuf;
@@ -2149,12 +2244,10 @@ yyerrlab:
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
-
-  /* Pacify compilers like GCC when the user code never invokes
-     YYERROR and the label yyerrorlab therefore never appears in user
-     code.  */
-  if (/*CONSTCOND*/ 0)
-     goto yyerrorlab;
+  /* Pacify compilers when the user code never invokes YYERROR and the
+     label yyerrorlab therefore never appears in user code.  */
+  if (0)
+    YYERROR;
 
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
@@ -2216,12 +2309,14 @@ yyacceptlab:
   yyresult = 0;
   goto yyreturn;
 
+
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
   goto yyreturn;
+
 
 #if !defined yyoverflow || YYERROR_VERBOSE
 /*-------------------------------------------------.
@@ -2233,6 +2328,10 @@ yyexhaustedlab:
   /* Fall through.  */
 #endif
 
+
+/*-----------------------------------------------------.
+| yyreturn -- parsing is finished, return the result.  |
+`-----------------------------------------------------*/
 yyreturn:
   if (yychar != YYEMPTY)
     {
@@ -2249,7 +2348,7 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[*yyssp], yyvsp);
+                  yystos[+*yyssp], yyvsp);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow

--- a/hl/src/H5LTparse.h
+++ b/hl/src/H5LTparse.h
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.5.1.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2020 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -29,6 +30,9 @@
 
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
+
+/* Undocumented macros, especially those whose name start with YY_,
+   are private implementation details.  Do not rely on them.  */
 
 #ifndef YY_H5LTYY_HL_SRC_H5LTPARSE_H_INCLUDED
 # define YY_H5LTYY_HL_SRC_H5LTPARSE_H_INCLUDED
@@ -106,18 +110,17 @@ extern int H5LTyydebug;
 
 /* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-
 union YYSTYPE
 {
-#line 69 "hl/src/H5LTparse.y" /* yacc.c:1909  */
+#line 69 "./hl/src/H5LTparse.y"
 
     int     ival;         /*for integer token*/
     char    *sval;        /*for name string*/
     hid_t   hid;          /*for hid_t token*/
 
-#line 119 "hl/src/H5LTparse.h" /* yacc.c:1909  */
-};
+#line 122 "./hl/src/H5LTparse.h"
 
+};
 typedef union YYSTYPE YYSTYPE;
 # define YYSTYPE_IS_TRIVIAL 1
 # define YYSTYPE_IS_DECLARED 1

--- a/src/H5Pdcpl.c
+++ b/src/H5Pdcpl.c
@@ -2995,6 +2995,15 @@ H5Pget_external(hid_t plist_id, unsigned idx, size_t name_size, char *name /*out
     /* Return values */
     if (name_size > 0 && name)
         HDstrncpy(name, efl.slot[idx].name, name_size);
+    /* XXX: Badness!
+     *
+     * The offset parameter is of type off_t and the offset field of H5O_efl_entry_t
+     * is HDoff_t which is a different type on Windows (off_t is a 32-bit long,
+     * HDoff_t is __int64, a 64-bit type).
+     *
+     * In a future API reboot, we'll either want to make this parameter a haddr_t
+     * or define a 64-bit HDF5-specific offset type that is platform-independent.
+     */
     if (offset)
         *offset = efl.slot[idx].offset;
     if (size)

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -5781,6 +5781,9 @@ H5_DLL herr_t H5Pget_dset_no_attrs_hint(hid_t dcpl_id, hbool_t *minimize);
  *          are null pointers then the corresponding information is not
  *          returned.
  *
+ * \note On Windows, off_t is typically a 32-bit signed long value, which
+ *       limits the valid offset that can be returned to 2 GiB.
+ *
  * \version 1.6.4 \p idx parameter type changed to unsigned.
  * \since 1.0.0
  *

--- a/src/H5SM.c
+++ b/src/H5SM.c
@@ -1076,7 +1076,7 @@ H5SM_try_share(H5F_t *f, H5O_t *open_oh, unsigned defer_flags, unsigned type_id,
     ssize_t               index_num;
     htri_t                tri_ret;
 #ifndef NDEBUG
-    unsigned deferred_type = -1U;
+    unsigned deferred_type = UINT_MAX;
 #endif
     htri_t ret_value = TRUE;
 

--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -179,11 +179,18 @@ verify_get_chunk_info(hid_t dset, hid_t dspace, hsize_t chk_index, hsize_t exp_c
 
     if (H5Dget_chunk_info(dset, dspace, chk_index, out_offset, &read_flt_msk, &addr, &size) < 0)
         TEST_ERROR;
-    CHECK(addr, HADDR_UNDEF, "H5Dget_chunk_info");
-    VERIFY(size, exp_chk_size, "H5Dget_chunk_info, chunk size");
-    VERIFY(read_flt_msk, exp_flt_msk, "H5Dget_chunk_info, filter mask");
-    VERIFY(out_offset[0], exp_offset[0], "H5Dget_chunk_info, offset[0]");
-    VERIFY(out_offset[1], exp_offset[1], "H5Dget_chunk_info, offset[1]");
+
+    if (HADDR_UNDEF == addr)
+        FAIL_PUTS_ERROR("address cannot be HADDR_UNDEF");
+    if (size != exp_chk_size)
+        FAIL_PUTS_ERROR("unexpected chunk size");
+    if (read_flt_msk != exp_flt_msk)
+        FAIL_PUTS_ERROR("unexpected filter mask");
+    if (out_offset[0] != exp_offset[0])
+        FAIL_PUTS_ERROR("unexpected offset[0]");
+    if (out_offset[1] != exp_offset[1])
+        FAIL_PUTS_ERROR("unexpected offset[1]");
+
     return SUCCEED;
 
 error:
@@ -213,9 +220,14 @@ verify_get_chunk_info_by_coord(hid_t dset, hsize_t *offset, hsize_t exp_chk_size
     /* Get info of the chunk at logical coordinates specified by offset */
     if (H5Dget_chunk_info_by_coord(dset, offset, &read_flt_msk, &addr, &size) < 0)
         TEST_ERROR;
-    CHECK(addr, HADDR_UNDEF, "H5Dget_chunk_info_by_coord");
-    VERIFY(size, exp_chk_size, "H5Dget_chunk_info_by_coord, chunk size");
-    VERIFY(read_flt_msk, exp_flt_msk, "H5Dget_chunk_info_by_coord, filter mask");
+
+    if (HADDR_UNDEF == addr)
+        FAIL_PUTS_ERROR("address cannot be HADDR_UNDEF");
+    if (size != exp_chk_size)
+        FAIL_PUTS_ERROR("unexpected chunk size");
+    if (read_flt_msk != exp_flt_msk)
+        FAIL_PUTS_ERROR("unexpected filter mask");
+
     return SUCCEED;
 
 error:
@@ -245,8 +257,12 @@ verify_empty_chunk_info(hid_t dset, hsize_t *offset)
     /* Get info of the chunk at logical coordinates specified by offset */
     if (H5Dget_chunk_info_by_coord(dset, offset, &read_flt_msk, &addr, &size) < 0)
         TEST_ERROR;
-    VERIFY(addr, HADDR_UNDEF, "H5Dget_chunk_info_by_coord, chunk address");
-    VERIFY(size, EMPTY_CHK_SIZE, "H5Dget_chunk_info_by_coord, chunk size");
+
+    if (HADDR_UNDEF != addr)
+        FAIL_PUTS_ERROR("address was not HADDR_UNDEF");
+    if (EMPTY_CHK_SIZE != size)
+        FAIL_PUTS_ERROR("size was not EMPTY_CHK_SIZE");
+
     return SUCCEED;
 
 error:
@@ -428,12 +444,14 @@ verify_idx_nchunks(hid_t dset, hid_t dspace, H5D_chunk_index_t exp_idx_type, hsi
     /* Get and verify the number of chunks */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, exp_num_chunks, "H5Dget_num_chunks, number of chunks");
+    if (nchunks != exp_num_chunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify the number of chunks again, passing in H5S_ALL */
     if (H5Dget_num_chunks(dset, H5S_ALL, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, exp_num_chunks, "H5Dget_num_chunks, number of chunks");
+    if (nchunks != exp_num_chunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     return SUCCEED;
 
@@ -603,7 +621,8 @@ test_get_chunk_info_highest_v18(hid_t fapl)
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, NUM_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (NUM_CHUNKS_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of the last written chunk again, passing in H5S_ALL
        this time */
@@ -666,7 +685,8 @@ test_get_chunk_info_highest_v18(hid_t fapl)
     /* Verify that the number of chunks is 0 */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, NO_CHUNK_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (NO_CHUNK_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Attempt to get info of a chunk from an empty dataset, should fail */
     chk_index = OUTOFRANGE_CHK_INDEX;
@@ -1128,7 +1148,8 @@ test_chunk_info_fixed_array(const char *filename, hid_t fapl)
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, NUM_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (NUM_CHUNKS_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of each written chunk */
     chk_index = 0;
@@ -1271,7 +1292,8 @@ test_chunk_info_extensible_array(const char *filename, hid_t fapl)
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, NUM_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (NUM_CHUNKS_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of each written chunk */
     chk_index = 0;
@@ -1419,7 +1441,8 @@ test_chunk_info_version2_btrees(const char *filename, hid_t fapl)
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, NUM_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (NUM_CHUNKS_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Go through all written chunks, get their info and verify the values */
     chk_index = 0;
@@ -1602,7 +1625,8 @@ test_basic_query(hid_t fapl)
     /* Get the number of chunks and verify that no chunk has been written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, NO_CHUNK_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (NO_CHUNK_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Initialize the array of chunk data for the single chunk */
     for (ii = 0; ii < CHUNK_NX; ii++)
@@ -1618,7 +1642,8 @@ test_basic_query(hid_t fapl)
     /* Get and verify that one chunk had been written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, ONE_CHUNK_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (ONE_CHUNK_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of the first and only chunk */
     if (verify_get_chunk_info(dset, H5S_ALL, 0, CHK_SIZE, offset, flt_msk) == FAIL)
@@ -1649,7 +1674,8 @@ test_basic_query(hid_t fapl)
     /* Get and verify that two chunks had been written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, TWO_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (TWO_CHUNKS_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of the first written chunk in the dataset, its
        offset should be (0,0) */
@@ -1685,20 +1711,28 @@ test_basic_query(hid_t fapl)
     if (H5Dchunk_iter(dset, H5P_DEFAULT, &iter_cb, &udata) < 0)
         TEST_ERROR;
 
-    VERIFY(udata.last_index, 1, "Iterator did not iterate all chunks");
-    VERIFY(chunk_infos[0].offset[0], 0, "Offset mismatch");
-    VERIFY(chunk_infos[0].offset[1], 0, "Offset mismatch");
-    VERIFY(chunk_infos[0].filter_mask, 0, "Filter mismatch");
-    VERIFY(chunk_infos[0].nbytes, 96, "Size mismatch");
+    if (udata.last_index != 1)
+        FAIL_PUTS_ERROR("Iterator did not iterate over all chunks");
+    if (chunk_infos[0].offset[0] != 0)
+        FAIL_PUTS_ERROR("offset[0] mismatch");
+    if (chunk_infos[0].offset[1] != 0)
+        FAIL_PUTS_ERROR("offset[1] mismatch");
+    if (chunk_infos[0].filter_mask != 0)
+        FAIL_PUTS_ERROR("filter mask mismatch");
+    if (chunk_infos[0].nbytes != 96)
+        FAIL_PUTS_ERROR("size mismatch");
 
-    VERIFY(chunk_infos[1].offset[0], 1, "Offset mismatch");
-    VERIFY(chunk_infos[1].offset[1], 1, "Offset mismatch");
+    if (chunk_infos[1].offset[0] != 1)
+        FAIL_PUTS_ERROR("offset[0] mismatch");
+    if (chunk_infos[1].offset[1] != 1)
+        FAIL_PUTS_ERROR("offset[1] mismatch");
 
     /* Iterate and stop after one iteration */
     cptr = &(chunk_infos[0]);
     if (H5Dchunk_iter(dset, H5P_DEFAULT, &iter_cb_stop, &cptr) < 0)
         TEST_ERROR;
-    VERIFY(cptr, &(chunk_infos[1]), "Verification of halted iterator failed\n");
+    if (cptr != &(chunk_infos[1]))
+        FAIL_PUTS_ERROR("Verification of halted iterator failed");
 
     /* Iterate and fail after one iteration */
     cptr = &(chunk_infos[0]);
@@ -1709,7 +1743,8 @@ test_basic_query(hid_t fapl)
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR;
-    VERIFY(cptr, &(chunk_infos[1]), "Verification of halted iterator failed\n");
+    if (cptr != &(chunk_infos[1]))
+        FAIL_PUTS_ERROR("Verification of halted iterator failed");
 
     /* Release resourse */
     if (H5Dclose(dset) < 0)
@@ -2102,7 +2137,8 @@ test_flt_msk_with_skip_compress(hid_t fapl)
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, H5S_ALL, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, ONE_CHUNK_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (ONE_CHUNK_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of the first and only chunk */
     chk_index = 0;


### PR DESCRIPTION
Mixing testhdf5 and h5test macros is a bad idea. Also quiets a couple
of MSVC warnings.