### PR TITLE
Converts testhdf5 macros to h5test macros in chunk_info.c

### DIFF
--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -179,11 +179,18 @@ verify_get_chunk_info(hid_t dset, hid_t dspace, hsize_t chk_index, hsize_t exp_c
 
     if (H5Dget_chunk_info(dset, dspace, chk_index, out_offset, &read_flt_msk, &addr, &size) < 0)
         TEST_ERROR;
-    CHECK(addr, HADDR_UNDEF, "H5Dget_chunk_info");
-    VERIFY(size, exp_chk_size, "H5Dget_chunk_info, chunk size");
-    VERIFY(read_flt_msk, exp_flt_msk, "H5Dget_chunk_info, filter mask");
-    VERIFY(out_offset[0], exp_offset[0], "H5Dget_chunk_info, offset[0]");
-    VERIFY(out_offset[1], exp_offset[1], "H5Dget_chunk_info, offset[1]");
+
+    if (HADDR_UNDEF == addr)
+        FAIL_PUTS_ERROR("address cannot be HADDR_UNDEF");
+    if (size != exp_chk_size)
+        FAIL_PUTS_ERROR("unexpected chunk size");
+    if (read_flt_msk != exp_flt_msk)
+        FAIL_PUTS_ERROR("unexpected filter mask");
+    if (out_offset[0] != exp_offset[0])
+        FAIL_PUTS_ERROR("unexpected offset[0]");
+    if (out_offset[1] != exp_offset[1])
+        FAIL_PUTS_ERROR("unexpected offset[1]");
+
     return SUCCEED;
 
 error:
@@ -213,9 +220,14 @@ verify_get_chunk_info_by_coord(hid_t dset, hsize_t *offset, hsize_t exp_chk_size
     /* Get info of the chunk at logical coordinates specified by offset */
     if (H5Dget_chunk_info_by_coord(dset, offset, &read_flt_msk, &addr, &size) < 0)
         TEST_ERROR;
-    CHECK(addr, HADDR_UNDEF, "H5Dget_chunk_info_by_coord");
-    VERIFY(size, exp_chk_size, "H5Dget_chunk_info_by_coord, chunk size");
-    VERIFY(read_flt_msk, exp_flt_msk, "H5Dget_chunk_info_by_coord, filter mask");
+
+    if (HADDR_UNDEF == addr)
+        FAIL_PUTS_ERROR("address cannot be HADDR_UNDEF");
+    if (size != exp_chk_size)
+        FAIL_PUTS_ERROR("unexpected chunk size");
+    if (read_flt_msk != exp_flt_msk)
+        FAIL_PUTS_ERROR("unexpected filter mask");
+
     return SUCCEED;
 
 error:
@@ -245,8 +257,12 @@ verify_empty_chunk_info(hid_t dset, hsize_t *offset)
     /* Get info of the chunk at logical coordinates specified by offset */
     if (H5Dget_chunk_info_by_coord(dset, offset, &read_flt_msk, &addr, &size) < 0)
         TEST_ERROR;
-    VERIFY(addr, HADDR_UNDEF, "H5Dget_chunk_info_by_coord, chunk address");
-    VERIFY(size, EMPTY_CHK_SIZE, "H5Dget_chunk_info_by_coord, chunk size");
+
+    if (HADDR_UNDEF != addr)
+        FAIL_PUTS_ERROR("address was not HADDR_UNDEF");
+    if (EMPTY_CHK_SIZE != size)
+        FAIL_PUTS_ERROR("size was not EMPTY_CHK_SIZE");
+
     return SUCCEED;
 
 error:
@@ -428,12 +444,14 @@ verify_idx_nchunks(hid_t dset, hid_t dspace, H5D_chunk_index_t exp_idx_type, hsi
     /* Get and verify the number of chunks */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, exp_num_chunks, "H5Dget_num_chunks, number of chunks");
+    if (nchunks != exp_num_chunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify the number of chunks again, passing in H5S_ALL */
     if (H5Dget_num_chunks(dset, H5S_ALL, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, exp_num_chunks, "H5Dget_num_chunks, number of chunks");
+    if (nchunks != exp_num_chunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     return SUCCEED;
 
@@ -603,7 +621,8 @@ test_get_chunk_info_highest_v18(hid_t fapl)
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, NUM_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (NUM_CHUNKS_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of the last written chunk again, passing in H5S_ALL
        this time */
@@ -666,7 +685,8 @@ test_get_chunk_info_highest_v18(hid_t fapl)
     /* Verify that the number of chunks is 0 */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, NO_CHUNK_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (NO_CHUNK_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Attempt to get info of a chunk from an empty dataset, should fail */
     chk_index = OUTOFRANGE_CHK_INDEX;
@@ -1128,7 +1148,8 @@ test_chunk_info_fixed_array(const char *filename, hid_t fapl)
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, NUM_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (NUM_CHUNKS_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of each written chunk */
     chk_index = 0;
@@ -1271,7 +1292,8 @@ test_chunk_info_extensible_array(const char *filename, hid_t fapl)
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, NUM_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (NUM_CHUNKS_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of each written chunk */
     chk_index = 0;
@@ -1419,7 +1441,8 @@ test_chunk_info_version2_btrees(const char *filename, hid_t fapl)
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, NUM_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (NUM_CHUNKS_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Go through all written chunks, get their info and verify the values */
     chk_index = 0;
@@ -1602,7 +1625,8 @@ test_basic_query(hid_t fapl)
     /* Get the number of chunks and verify that no chunk has been written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, NO_CHUNK_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (NO_CHUNK_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Initialize the array of chunk data for the single chunk */
     for (ii = 0; ii < CHUNK_NX; ii++)
@@ -1618,7 +1642,8 @@ test_basic_query(hid_t fapl)
     /* Get and verify that one chunk had been written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, ONE_CHUNK_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (ONE_CHUNK_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of the first and only chunk */
     if (verify_get_chunk_info(dset, H5S_ALL, 0, CHK_SIZE, offset, flt_msk) == FAIL)
@@ -1649,7 +1674,8 @@ test_basic_query(hid_t fapl)
     /* Get and verify that two chunks had been written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, TWO_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (TWO_CHUNKS_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of the first written chunk in the dataset, its
        offset should be (0,0) */
@@ -1685,20 +1711,28 @@ test_basic_query(hid_t fapl)
     if (H5Dchunk_iter(dset, H5P_DEFAULT, &iter_cb, &udata) < 0)
         TEST_ERROR;
 
-    VERIFY(udata.last_index, 1, "Iterator did not iterate all chunks");
-    VERIFY(chunk_infos[0].offset[0], 0, "Offset mismatch");
-    VERIFY(chunk_infos[0].offset[1], 0, "Offset mismatch");
-    VERIFY(chunk_infos[0].filter_mask, 0, "Filter mismatch");
-    VERIFY(chunk_infos[0].nbytes, 96, "Size mismatch");
+    if (udata.last_index != 1)
+        FAIL_PUTS_ERROR("Iterator did not iterate over all chunks");
+    if (chunk_infos[0].offset[0] != 0)
+        FAIL_PUTS_ERROR("offset[0] mismatch");
+    if (chunk_infos[0].offset[1] != 0)
+        FAIL_PUTS_ERROR("offset[1] mismatch");
+    if (chunk_infos[0].filter_mask != 0)
+        FAIL_PUTS_ERROR("filter mask mismatch");
+    if (chunk_infos[0].nbytes != 96)
+        FAIL_PUTS_ERROR("size mismatch");
 
-    VERIFY(chunk_infos[1].offset[0], 1, "Offset mismatch");
-    VERIFY(chunk_infos[1].offset[1], 1, "Offset mismatch");
+    if (chunk_infos[1].offset[0] != 1)
+        FAIL_PUTS_ERROR("offset[0] mismatch");
+    if (chunk_infos[1].offset[1] != 1)
+        FAIL_PUTS_ERROR("offset[1] mismatch");
 
     /* Iterate and stop after one iteration */
     cptr = &(chunk_infos[0]);
     if (H5Dchunk_iter(dset, H5P_DEFAULT, &iter_cb_stop, &cptr) < 0)
         TEST_ERROR;
-    VERIFY(cptr, &(chunk_infos[1]), "Verification of halted iterator failed\n");
+    if (cptr != &(chunk_infos[1]))
+        FAIL_PUTS_ERROR("Verification of halted iterator failed");
 
     /* Iterate and fail after one iteration */
     cptr = &(chunk_infos[0]);
@@ -1709,7 +1743,8 @@ test_basic_query(hid_t fapl)
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR;
-    VERIFY(cptr, &(chunk_infos[1]), "Verification of halted iterator failed\n");
+    if (cptr != &(chunk_infos[1]))
+        FAIL_PUTS_ERROR("Verification of halted iterator failed");
 
     /* Release resourse */
     if (H5Dclose(dset) < 0)
@@ -2102,7 +2137,8 @@ test_flt_msk_with_skip_compress(hid_t fapl)
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, H5S_ALL, &nchunks) < 0)
         TEST_ERROR;
-    VERIFY(nchunks, ONE_CHUNK_WRITTEN, "H5Dget_num_chunks, number of chunks");
+    if (ONE_CHUNK_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of the first and only chunk */
     chk_index = 0;


### PR DESCRIPTION
The two macro schemes were not designed to work together. Also
quiets some MSVC warnings about comparing pointers and integers.

```
220>C:\Users\Dana Robinson\Desktop\hdf5\hdf5\test\chunk_info.c(1701,5): warning C4311: 'type cast': pointer truncation from 'chunk_iter_info_t *' to 'long'
220>C:\Users\Dana Robinson\Desktop\hdf5\hdf5\test\chunk_info.c(1712,5): warning C4311: 'type cast': pointer truncation from 'chunk_iter_info_t *' to 'long'
```