### PR TITLE
Set a constant in H5SM to UINT_MAX instead of -1U

### DIFF
--- a/src/H5SM.c
+++ b/src/H5SM.c
@@ -1076,7 +1076,7 @@ H5SM_try_share(H5F_t *f, H5O_t *open_oh, unsigned defer_flags, unsigned type_id,
     ssize_t               index_num;
     htri_t                tri_ret;
 #ifndef NDEBUG
-    unsigned deferred_type = -1U;
+    unsigned deferred_type = UINT_MAX;
 #endif
     htri_t ret_value = TRUE;
 


### PR DESCRIPTION
MSVC complains about using 80s tricks instead of the appropriate integer constant

`30>C:\Users\Dana Robinson\Desktop\hdf5\hdf5\src\H5SM.c(1079,30): warning C4146: unary minus operator applied to unsigned type, result still unsigned`