### PR TITLE
Quiets const warnings

### DIFF
--- a/src/H5B2int.c
+++ b/src/H5B2int.c
@@ -1776,8 +1776,8 @@ H5B2__delete_node(H5B2_hdr_t *hdr, uint16_t depth, H5B2_node_ptr_t *curr_node, v
         H5B2_leaf_t *leaf; /* Pointer to leaf node */
 
         /* Lock the current B-tree node */
-        if (NULL == (leaf = H5B2__protect_leaf(hdr, parent, (H5B2_node_ptr_t *)curr_node, FALSE,
-                                               H5AC__NO_FLAGS_SET)))
+        if (NULL ==
+            (leaf = H5B2__protect_leaf(hdr, parent, (H5B2_node_ptr_t *)curr_node, FALSE, H5AC__NO_FLAGS_SET)))
             HGOTO_ERROR(H5E_BTREE, H5E_CANTPROTECT, FAIL, "unable to protect B-tree leaf node")
 
         /* Set up information about current node */
@@ -1956,9 +1956,8 @@ H5B2__update_flush_depend(H5B2_hdr_t *hdr, unsigned depth, H5B2_node_ptr_t *node
             H5B2_leaf_t *child_leaf;
 
             /* Protect child */
-            if (NULL ==
-                (child_leaf = H5B2__protect_leaf(hdr, new_parent, (H5B2_node_ptr_t *)node_ptr, FALSE,
-                                                 H5AC__NO_FLAGS_SET)))
+            if (NULL == (child_leaf = H5B2__protect_leaf(hdr, new_parent, (H5B2_node_ptr_t *)node_ptr, FALSE,
+                                                         H5AC__NO_FLAGS_SET)))
                 HGOTO_ERROR(H5E_BTREE, H5E_CANTPROTECT, FAIL, "unable to protect B-tree leaf node")
             child_class = H5AC_BT2_LEAF;
             child       = child_leaf;

--- a/src/H5B2int.c
+++ b/src/H5B2int.c
@@ -1664,7 +1664,7 @@ H5B2__iterate_node(H5B2_hdr_t *hdr, uint16_t depth, H5B2_node_ptr_t *curr_node, 
 
         /* Lock the current B-tree node */
         if (NULL == (leaf = H5B2__protect_leaf(hdr, parent, (H5B2_node_ptr_t *)curr_node, FALSE,
-                                               H5AC__READ_ONLY_FLAG))) /* Casting away const OK -QAK */
+                                               H5AC__READ_ONLY_FLAG)))
             HGOTO_ERROR(H5E_BTREE, H5E_CANTPROTECT, FAIL, "unable to protect B-tree leaf node")
 
         /* Set up information about current node */
@@ -1777,7 +1777,7 @@ H5B2__delete_node(H5B2_hdr_t *hdr, uint16_t depth, H5B2_node_ptr_t *curr_node, v
 
         /* Lock the current B-tree node */
         if (NULL == (leaf = H5B2__protect_leaf(hdr, parent, (H5B2_node_ptr_t *)curr_node, FALSE,
-                                               H5AC__NO_FLAGS_SET))) /* Casting away const OK -QAK */
+                                               H5AC__NO_FLAGS_SET)))
             HGOTO_ERROR(H5E_BTREE, H5E_CANTPROTECT, FAIL, "unable to protect B-tree leaf node")
 
         /* Set up information about current node */
@@ -1958,7 +1958,7 @@ H5B2__update_flush_depend(H5B2_hdr_t *hdr, unsigned depth, H5B2_node_ptr_t *node
             /* Protect child */
             if (NULL ==
                 (child_leaf = H5B2__protect_leaf(hdr, new_parent, (H5B2_node_ptr_t *)node_ptr, FALSE,
-                                                 H5AC__NO_FLAGS_SET))) /* Casting away const OK -QAK */
+                                                 H5AC__NO_FLAGS_SET)))
                 HGOTO_ERROR(H5E_BTREE, H5E_CANTPROTECT, FAIL, "unable to protect B-tree leaf node")
             child_class = H5AC_BT2_LEAF;
             child       = child_leaf;

--- a/src/H5Dint.c
+++ b/src/H5Dint.c
@@ -1564,7 +1564,7 @@ done:
     vds_prefix     = (char *)H5MM_xfree(vds_prefix);
 
     if (ret_value == NULL) {
-        /* Free the location--casting away const*/
+        /* Free the location */
         if (dataset) {
             if (shared_fo == NULL && dataset->shared) { /* Need to free shared fo */
                 dataset->shared->extfile_prefix = (char *)H5MM_xfree(dataset->shared->extfile_prefix);
@@ -3502,7 +3502,7 @@ H5D_flush_all(H5F_t *f)
     HDassert(f);
 
     /* Iterate over all the open datasets */
-    if (H5I_iterate(H5I_DATASET, H5D__flush_all_cb, f, FALSE) < 0) /* Casting away const OK -QAK */
+    if (H5I_iterate(H5I_DATASET, H5D__flush_all_cb, f, FALSE) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_BADITER, FAIL, "unable to flush cached dataset info")
 
 done:

--- a/src/H5Dvirtual.c
+++ b/src/H5Dvirtual.c
@@ -528,7 +528,7 @@ H5D__virtual_store_layout(H5F_t *f, H5O_layout_t *layout)
 
         /* Insert block into global heap */
         if (H5HG_insert(f, block_size, heap_block, &(virt->serial_list_hobjid)) <
-            0) /* Casting away const OK  --NAF */
+            0)
             HGOTO_ERROR(H5E_OHDR, H5E_CANTINSERT, FAIL, "unable to insert virtual dataset heap block")
     } /* end if */
 

--- a/src/H5Dvirtual.c
+++ b/src/H5Dvirtual.c
@@ -527,8 +527,7 @@ H5D__virtual_store_layout(H5F_t *f, H5O_layout_t *layout)
         UINT32ENCODE(heap_block_p, chksum)
 
         /* Insert block into global heap */
-        if (H5HG_insert(f, block_size, heap_block, &(virt->serial_list_hobjid)) <
-            0)
+        if (H5HG_insert(f, block_size, heap_block, &(virt->serial_list_hobjid)) < 0)
             HGOTO_ERROR(H5E_OHDR, H5E_CANTINSERT, FAIL, "unable to insert virtual dataset heap block")
     } /* end if */
 

--- a/src/H5EAcache.c
+++ b/src/H5EAcache.c
@@ -638,7 +638,7 @@ H5EA__cache_iblock_get_initial_load_size(void *_udata, size_t *image_len)
 
     /* Set up fake index block for computing size on disk */
     HDmemset(&iblock, 0, sizeof(iblock));
-    iblock.hdr         = (H5EA_hdr_t *)hdr; /* Casting away 'const' OK - QAK */
+    iblock.hdr         = (H5EA_hdr_t *)hdr;
     iblock.nsblks      = H5EA_SBLK_FIRST_IDX(hdr->cparam.sup_blk_min_data_ptrs);
     iblock.ndblk_addrs = 2 * ((size_t)hdr->cparam.sup_blk_min_data_ptrs - 1);
     iblock.nsblk_addrs = hdr->nsblks - iblock.nsblks;

--- a/src/H5Gname.c
+++ b/src/H5Gname.c
@@ -446,9 +446,10 @@ H5G_name_copy(H5G_name_t *dst, const H5G_name_t *src, H5_copy_depth_t depth)
         dst->user_path_r = H5RS_dup(src->user_path_r);
     }
     else {
-        /* Discarding 'const' qualifier OK - QAK */
+H5_GCC_CLANG_DIAG_OFF("cast-qual")
         H5G_name_reset((H5G_name_t *)src);
-    } /* end if */
+H5_GCC_CLANG_DIAG_ON("cast-qual")
+    }
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5G_name_copy() */

--- a/src/H5Gname.c
+++ b/src/H5Gname.c
@@ -446,9 +446,9 @@ H5G_name_copy(H5G_name_t *dst, const H5G_name_t *src, H5_copy_depth_t depth)
         dst->user_path_r = H5RS_dup(src->user_path_r);
     }
     else {
-H5_GCC_CLANG_DIAG_OFF("cast-qual")
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
         H5G_name_reset((H5G_name_t *)src);
-H5_GCC_CLANG_DIAG_ON("cast-qual")
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
     }
 
     FUNC_LEAVE_NOAPI(SUCCEED)

--- a/src/H5Gnode.c
+++ b/src/H5Gnode.c
@@ -1228,9 +1228,9 @@ H5G__node_copy(H5F_t *f, const void H5_ATTR_UNUSED *_lt_key, haddr_t addr, const
             /* Set up group location for soft link to start in */
             H5G_name_reset(&grp_path);
             grp_loc.path = &grp_path;
-H5_GCC_CLANG_DIAG_OFF("cast-qual")
+            H5_GCC_CLANG_DIAG_OFF("cast-qual")
             grp_loc.oloc = (H5O_loc_t *)src_oloc;
-H5_GCC_CLANG_DIAG_ON("cast-qual")
+            H5_GCC_CLANG_DIAG_ON("cast-qual")
 
             /* Get pointer to link value in local heap */
             if ((link_name = (char *)H5HL_offset_into(heap, tmp_src_ent.cache.slink.lval_offset)) == NULL)

--- a/src/H5Gnode.c
+++ b/src/H5Gnode.c
@@ -1228,7 +1228,9 @@ H5G__node_copy(H5F_t *f, const void H5_ATTR_UNUSED *_lt_key, haddr_t addr, const
             /* Set up group location for soft link to start in */
             H5G_name_reset(&grp_path);
             grp_loc.path = &grp_path;
+H5_GCC_CLANG_DIAG_OFF("cast-qual")
             grp_loc.oloc = (H5O_loc_t *)src_oloc;
+H5_GCC_CLANG_DIAG_ON("cast-qual")
 
             /* Get pointer to link value in local heap */
             if ((link_name = (char *)H5HL_offset_into(heap, tmp_src_ent.cache.slink.lval_offset)) == NULL)

--- a/src/H5Gobj.c
+++ b/src/H5Gobj.c
@@ -242,21 +242,20 @@ H5G__obj_create_real(H5F_t *f, const H5O_ginfo_t *ginfo, const H5O_linfo_t *linf
 
     /* Check for format of group to create */
     if (use_at_least_v18) {
+H5_GCC_CLANG_DIAG_OFF("cast-qual")
         /* Insert link info message */
-        /* (Casting away const OK - QAK) */
         if (H5O_msg_create(oloc, H5O_LINFO_ID, 0, H5O_UPDATE_TIME, (void *)linfo) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_CANTINIT, FAIL, "can't create message")
 
         /* Insert group info message */
-        /* (Casting away const OK - QAK) */
         if (H5O_msg_create(oloc, H5O_GINFO_ID, H5O_MSG_FLAG_CONSTANT, 0, (void *)ginfo) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_CANTINIT, FAIL, "can't create message")
 
         /* Insert pipeline message */
         if (pline && pline->nused)
-            /* (Casting away const OK - QAK) */
             if (H5O_msg_create(oloc, H5O_PLINE_ID, H5O_MSG_FLAG_CONSTANT, 0, (void *)pline) < 0)
                 HGOTO_ERROR(H5E_SYM, H5E_CANTINIT, FAIL, "can't create message")
+H5_GCC_CLANG_DIAG_ON("cast-qual")
     } /* end if */
     else {
         H5O_stab_t stab; /* Symbol table message	*/
@@ -398,9 +397,10 @@ H5G__obj_stab_to_new_cb(const H5O_link_t *lnk, void *_udata)
     HDassert(udata);
 
     /* Insert link into group */
-    /* (Casting away const OK - QAK) */
+H5_GCC_CLANG_DIAG_OFF("cast-qual")
     if (H5G_obj_insert(udata->grp_oloc, lnk->name, (H5O_link_t *)lnk, FALSE, H5O_TYPE_UNKNOWN, NULL) < 0)
         HGOTO_ERROR(H5E_SYM, H5E_CANTINSERT, H5_ITER_ERROR, "can't insert link into group")
+H5_GCC_CLANG_DIAG_ON("cast-qual")
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Gobj.c
+++ b/src/H5Gobj.c
@@ -242,7 +242,7 @@ H5G__obj_create_real(H5F_t *f, const H5O_ginfo_t *ginfo, const H5O_linfo_t *linf
 
     /* Check for format of group to create */
     if (use_at_least_v18) {
-H5_GCC_CLANG_DIAG_OFF("cast-qual")
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
         /* Insert link info message */
         if (H5O_msg_create(oloc, H5O_LINFO_ID, 0, H5O_UPDATE_TIME, (void *)linfo) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_CANTINIT, FAIL, "can't create message")
@@ -255,7 +255,7 @@ H5_GCC_CLANG_DIAG_OFF("cast-qual")
         if (pline && pline->nused)
             if (H5O_msg_create(oloc, H5O_PLINE_ID, H5O_MSG_FLAG_CONSTANT, 0, (void *)pline) < 0)
                 HGOTO_ERROR(H5E_SYM, H5E_CANTINIT, FAIL, "can't create message")
-H5_GCC_CLANG_DIAG_ON("cast-qual")
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
     } /* end if */
     else {
         H5O_stab_t stab; /* Symbol table message	*/
@@ -397,10 +397,10 @@ H5G__obj_stab_to_new_cb(const H5O_link_t *lnk, void *_udata)
     HDassert(udata);
 
     /* Insert link into group */
-H5_GCC_CLANG_DIAG_OFF("cast-qual")
+    H5_GCC_CLANG_DIAG_OFF("cast-qual")
     if (H5G_obj_insert(udata->grp_oloc, lnk->name, (H5O_link_t *)lnk, FALSE, H5O_TYPE_UNKNOWN, NULL) < 0)
         HGOTO_ERROR(H5E_SYM, H5E_CANTINSERT, H5_ITER_ERROR, "can't insert link into group")
-H5_GCC_CLANG_DIAG_ON("cast-qual")
+    H5_GCC_CLANG_DIAG_ON("cast-qual")
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Gtraverse.c
+++ b/src/H5Gtraverse.c
@@ -713,18 +713,17 @@ H5G__traverse_real(const H5G_loc_t *_loc, const char *name, unsigned target, H5G
                         HGOTO_ERROR(H5E_SYM, H5E_CANTOPENOBJ, FAIL, "unable to hold file open")
 
                 /* Reset any non-default object header messages */
+H5_GCC_CLANG_DIAG_OFF("cast-qual")
                 if (ginfo != &def_ginfo)
-                    /* (Casting away const OK - QAK) */
                     if (H5O_msg_reset(H5O_GINFO_ID, (void *)ginfo) < 0)
                         HGOTO_ERROR(H5E_SYM, H5E_CANTRELEASE, FAIL, "unable to reset group info message")
                 if (linfo != &def_linfo)
-                    /* (Casting away const OK - QAK) */
                     if (H5O_msg_reset(H5O_LINFO_ID, (void *)linfo) < 0)
                         HGOTO_ERROR(H5E_SYM, H5E_CANTRELEASE, FAIL, "unable to reset link info message")
                 if (pline != &def_pline)
-                    /* (Casting away const OK - QAK) */
                     if (H5O_msg_reset(H5O_PLINE_ID, (void *)pline) < 0)
                         HGOTO_ERROR(H5E_SYM, H5E_CANTRELEASE, FAIL, "unable to reset I/O pipeline message")
+H5_GCC_CLANG_DIAG_ON("cast-qual")
             } /* end if */
             else
                 HGOTO_ERROR(H5E_SYM, H5E_NOTFOUND, FAIL, "component not found")

--- a/src/H5Gtraverse.c
+++ b/src/H5Gtraverse.c
@@ -713,7 +713,7 @@ H5G__traverse_real(const H5G_loc_t *_loc, const char *name, unsigned target, H5G
                         HGOTO_ERROR(H5E_SYM, H5E_CANTOPENOBJ, FAIL, "unable to hold file open")
 
                 /* Reset any non-default object header messages */
-H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                H5_GCC_CLANG_DIAG_OFF("cast-qual")
                 if (ginfo != &def_ginfo)
                     if (H5O_msg_reset(H5O_GINFO_ID, (void *)ginfo) < 0)
                         HGOTO_ERROR(H5E_SYM, H5E_CANTRELEASE, FAIL, "unable to reset group info message")
@@ -723,7 +723,7 @@ H5_GCC_CLANG_DIAG_OFF("cast-qual")
                 if (pline != &def_pline)
                     if (H5O_msg_reset(H5O_PLINE_ID, (void *)pline) < 0)
                         HGOTO_ERROR(H5E_SYM, H5E_CANTRELEASE, FAIL, "unable to reset I/O pipeline message")
-H5_GCC_CLANG_DIAG_ON("cast-qual")
+                H5_GCC_CLANG_DIAG_ON("cast-qual")
             } /* end if */
             else
                 HGOTO_ERROR(H5E_SYM, H5E_NOTFOUND, FAIL, "component not found")

--- a/src/H5HFcache.c
+++ b/src/H5HFcache.c
@@ -742,9 +742,9 @@ H5HF__cache_hdr_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG_UN
     HDassert(len == hdr->heap_size);
 
     /* Set the shared heap header's file context for this operation */
-H5_GCC_CLANG_DIAG_OFF("discarded-qualifiers")
+    H5_GCC_CLANG_DIAG_OFF("discarded-qualifiers")
     hdr->f = f;
-H5_GCC_CLANG_DIAG_ON("discarded-qualifiers")
+    H5_GCC_CLANG_DIAG_ON("discarded-qualifiers")
 
     /* Magic number */
     H5MM_memcpy(image, H5HF_HDR_MAGIC, (size_t)H5_SIZEOF_MAGIC);
@@ -1330,9 +1330,9 @@ H5HF__cache_iblock_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG
     hdr = iblock->hdr;
 
     /* Set the shared heap header's file context for this operation */
-H5_GCC_CLANG_DIAG_OFF("discarded-qualifiers")
+    H5_GCC_CLANG_DIAG_OFF("discarded-qualifiers")
     hdr->f = f;
-H5_GCC_CLANG_DIAG_ON("discarded-qualifiers")
+    H5_GCC_CLANG_DIAG_ON("discarded-qualifiers")
 
     /* Magic number */
     H5MM_memcpy(image, H5HF_IBLOCK_MAGIC, (size_t)H5_SIZEOF_MAGIC);

--- a/src/H5HFcache.c
+++ b/src/H5HFcache.c
@@ -742,7 +742,9 @@ H5HF__cache_hdr_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG_UN
     HDassert(len == hdr->heap_size);
 
     /* Set the shared heap header's file context for this operation */
+H5_GCC_CLANG_DIAG_OFF("discarded-qualifiers")
     hdr->f = f;
+H5_GCC_CLANG_DIAG_ON("discarded-qualifiers")
 
     /* Magic number */
     H5MM_memcpy(image, H5HF_HDR_MAGIC, (size_t)H5_SIZEOF_MAGIC);
@@ -1328,7 +1330,9 @@ H5HF__cache_iblock_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG
     hdr = iblock->hdr;
 
     /* Set the shared heap header's file context for this operation */
+H5_GCC_CLANG_DIAG_OFF("discarded-qualifiers")
     hdr->f = f;
+H5_GCC_CLANG_DIAG_ON("discarded-qualifiers")
 
     /* Magic number */
     H5MM_memcpy(image, H5HF_IBLOCK_MAGIC, (size_t)H5_SIZEOF_MAGIC);
@@ -1675,7 +1679,6 @@ H5HF__cache_dblock_verify_chksum(const void *_image, size_t len, void *_udata)
     chk_p -= H5HF_SIZEOF_CHKSUM;
 
     /* Reset checksum field, for computing the checksum */
-    /* (Casting away const OK - QAK) */
     HDmemset(chk_p, 0, (size_t)H5HF_SIZEOF_CHKSUM);
 
     /* Compute checksum on entire direct block */

--- a/src/H5Idbg.c
+++ b/src/H5Idbg.c
@@ -111,7 +111,7 @@ H5I__id_dump_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
             const H5T_t *dt = (const H5T_t *)info->object;
 
             H5_GCC_CLANG_DIAG_OFF("cast-qual")
-            object = (void *)H5T_get_actual_type((H5T_t *)dt); /* Casting away const OK - QAK */
+            object = (void *)H5T_get_actual_type((H5T_t *)dt);
             H5_GCC_CLANG_DIAG_ON("cast-qual")
 
             path = H5T_nameof(object);

--- a/src/H5Iint.c
+++ b/src/H5Iint.c
@@ -697,7 +697,7 @@ H5I_subst(hid_t id, const void *new_object)
 
     /* Get the old object pointer to return */
     H5_GCC_CLANG_DIAG_OFF("cast-qual")
-    ret_value = (void *)info->object; /* (Casting away const OK -QAK) */
+    ret_value = (void *)info->object;
     H5_GCC_CLANG_DIAG_ON("cast-qual")
 
     /* Set the new object pointer for the ID */
@@ -731,7 +731,7 @@ H5I_object(hid_t id)
     if (NULL != (info = H5I__find_id(id))) {
         /* Get the object pointer to return */
         H5_GCC_CLANG_DIAG_OFF("cast-qual")
-        ret_value = (void *)info->object; /* (Casting away const OK -QAK) */
+        ret_value = (void *)info->object;
         H5_GCC_CLANG_DIAG_ON("cast-qual")
     }
 
@@ -767,7 +767,7 @@ H5I_object_verify(hid_t id, H5I_type_t type)
     if (type == H5I_TYPE(id) && NULL != (info = H5I__find_id(id))) {
         /* Get the object pointer to return */
         H5_GCC_CLANG_DIAG_OFF("cast-qual")
-        ret_value = (void *)info->object; /* (Casting away const OK -QAK) */
+        ret_value = (void *)info->object;
         H5_GCC_CLANG_DIAG_ON("cast-qual")
     }
 
@@ -930,7 +930,7 @@ H5I__remove_common(H5I_type_info_t *type_info, hid_t id)
         type_info->last_id_info = NULL;
 
     H5_GCC_CLANG_DIAG_OFF("cast-qual")
-    ret_value = (void *)info->object; /* (Casting away const OK -QAK) */
+    ret_value = (void *)info->object;
     H5_GCC_CLANG_DIAG_ON("cast-qual")
 
     if (!H5I_marking_g)
@@ -1032,7 +1032,6 @@ H5I__dec_ref(hid_t id, void **request)
         type_info = H5I_type_info_array_g[H5I_TYPE(id)];
 
         H5_GCC_CLANG_DIAG_OFF("cast-qual")
-        /* (Casting away const OK -QAK) */
         if (!type_info->cls->free_func || (type_info->cls->free_func)((void *)info->object, request) >= 0) {
             /* Remove the node from the type */
             if (NULL == H5I__remove_common(type_info, id))
@@ -1521,7 +1520,7 @@ H5I__iterate_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
          * case we'll need to get the wrapped object struct (H5F_t *, etc.).
          */
         H5_GCC_CLANG_DIAG_OFF("cast-qual")
-        object = H5I__unwrap((void *)info->object, type); /* Casting away const OK */
+        object = H5I__unwrap((void *)info->object, type);
         H5_GCC_CLANG_DIAG_ON("cast-qual")
 
         /* Invoke callback function */
@@ -1713,7 +1712,7 @@ H5I__find_id_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
 
     /* Get a pointer to the VOL connector's data */
     H5_GCC_CLANG_DIAG_OFF("cast-qual")
-    object = H5I__unwrap((void *)info->object, type); /* Casting away const OK */
+    object = H5I__unwrap((void *)info->object, type);
     H5_GCC_CLANG_DIAG_ON("cast-qual")
 
     /* Check for a match */

--- a/src/H5Lint.c
+++ b/src/H5Lint.c
@@ -595,8 +595,9 @@ H5L__link_cb(H5G_loc_t *grp_loc /*in*/, const char *name, const H5O_link_t H5_AT
         udata->lnk->cset = H5F_DEFAULT_CSET; /* Default character encoding for link */
 
     /* Set the link's name correctly */
-    /* Casting away const OK -QAK */
+H5_GCC_CLANG_DIAG_OFF("cast-qual")
     udata->lnk->name = (char *)name;
+H5_GCC_CLANG_DIAG_ON("cast-qual")
 
     /* Insert link into group */
     if (H5G_obj_insert(grp_loc->oloc, name, udata->lnk, TRUE,
@@ -1374,9 +1375,10 @@ H5L__move_dest_cb(H5G_loc_t *grp_loc /*in*/, const char *name, const H5O_link_t 
             HGOTO_ERROR(H5E_LINK, H5E_CANTINIT, FAIL, "moving a link across files is not allowed")
 
     /* Give the object its new name */
-    /* Casting away const okay -JML */
     HDassert(udata->lnk->name == NULL);
+H5_GCC_CLANG_DIAG_OFF("cast-qual")
     udata->lnk->name = (char *)name;
+H5_GCC_CLANG_DIAG_ON("cast-qual")
 
     /* Insert the link into the group */
     if (H5G_obj_insert(grp_loc->oloc, name, udata->lnk, TRUE, H5O_TYPE_UNKNOWN, NULL) < 0)
@@ -2123,7 +2125,9 @@ H5L__link_copy_file(H5F_t *dst_file, const H5O_link_t *_src_lnk, const H5O_loc_t
         /* Set up group location for link */
         H5G_name_reset(&lnk_grp_path);
         lnk_grp_loc.path = &lnk_grp_path;
-        lnk_grp_loc.oloc = (H5O_loc_t *)src_oloc; /* Casting away const OK -QAK */
+H5_GCC_CLANG_DIAG_OFF("cast-qual")
+        lnk_grp_loc.oloc = (H5O_loc_t *)src_oloc;
+H5_GCC_CLANG_DIAG_ON("cast-qual")
 
         /* Check if the target object exists */
         if (H5G_loc_exists(&lnk_grp_loc, src_lnk->name, &tar_exists) < 0)

--- a/src/H5Lint.c
+++ b/src/H5Lint.c
@@ -595,9 +595,9 @@ H5L__link_cb(H5G_loc_t *grp_loc /*in*/, const char *name, const H5O_link_t H5_AT
         udata->lnk->cset = H5F_DEFAULT_CSET; /* Default character encoding for link */
 
     /* Set the link's name correctly */
-H5_GCC_CLANG_DIAG_OFF("cast-qual")
+    H5_GCC_CLANG_DIAG_OFF("cast-qual")
     udata->lnk->name = (char *)name;
-H5_GCC_CLANG_DIAG_ON("cast-qual")
+    H5_GCC_CLANG_DIAG_ON("cast-qual")
 
     /* Insert link into group */
     if (H5G_obj_insert(grp_loc->oloc, name, udata->lnk, TRUE,
@@ -1376,9 +1376,9 @@ H5L__move_dest_cb(H5G_loc_t *grp_loc /*in*/, const char *name, const H5O_link_t 
 
     /* Give the object its new name */
     HDassert(udata->lnk->name == NULL);
-H5_GCC_CLANG_DIAG_OFF("cast-qual")
+    H5_GCC_CLANG_DIAG_OFF("cast-qual")
     udata->lnk->name = (char *)name;
-H5_GCC_CLANG_DIAG_ON("cast-qual")
+    H5_GCC_CLANG_DIAG_ON("cast-qual")
 
     /* Insert the link into the group */
     if (H5G_obj_insert(grp_loc->oloc, name, udata->lnk, TRUE, H5O_TYPE_UNKNOWN, NULL) < 0)
@@ -2125,9 +2125,9 @@ H5L__link_copy_file(H5F_t *dst_file, const H5O_link_t *_src_lnk, const H5O_loc_t
         /* Set up group location for link */
         H5G_name_reset(&lnk_grp_path);
         lnk_grp_loc.path = &lnk_grp_path;
-H5_GCC_CLANG_DIAG_OFF("cast-qual")
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
         lnk_grp_loc.oloc = (H5O_loc_t *)src_oloc;
-H5_GCC_CLANG_DIAG_ON("cast-qual")
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
 
         /* Check if the target object exists */
         if (H5G_loc_exists(&lnk_grp_loc, src_lnk->name, &tar_exists) < 0)

--- a/src/H5Ocache.c
+++ b/src/H5Ocache.c
@@ -1430,13 +1430,13 @@ H5O__chunk_deserialize(H5O_t *oh, haddr_t addr, size_t chunk_size, const uint8_t
             oh->nmesgs++;
 
             /* Initialize information about message */
-            mesg->dirty    = FALSE;
-            mesg->flags    = flags;
-            mesg->crt_idx  = crt_idx;
-            mesg->native   = NULL;
-H5_GCC_CLANG_DIAG_OFF("cast-qual")
-            mesg->raw      = (uint8_t *)chunk_image;
-H5_GCC_CLANG_DIAG_ON("cast-qual")
+            mesg->dirty   = FALSE;
+            mesg->flags   = flags;
+            mesg->crt_idx = crt_idx;
+            mesg->native  = NULL;
+            H5_GCC_CLANG_DIAG_OFF("cast-qual")
+            mesg->raw = (uint8_t *)chunk_image;
+            H5_GCC_CLANG_DIAG_ON("cast-qual")
             mesg->raw_size = mesg_size;
             mesg->chunkno  = chunkno;
 
@@ -1640,10 +1640,10 @@ H5O__chunk_serialize(const H5F_t *f, H5O_t *oh, unsigned chunkno)
     /* Encode any dirty messages in this chunk */
     for (u = 0, curr_msg = &oh->mesg[0]; u < oh->nmesgs; u++, curr_msg++)
         if (curr_msg->dirty && curr_msg->chunkno == chunkno)
-H5_GCC_CLANG_DIAG_OFF("cast-qual")
-            if (H5O_msg_flush((H5F_t *)f, oh, curr_msg) < 0)
-                HGOTO_ERROR(H5E_OHDR, H5E_CANTENCODE, FAIL, "unable to encode object header message")
-H5_GCC_CLANG_DIAG_ON("cast-qual")
+            H5_GCC_CLANG_DIAG_OFF("cast-qual")
+    if (H5O_msg_flush((H5F_t *)f, oh, curr_msg) < 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTENCODE, FAIL, "unable to encode object header message")
+    H5_GCC_CLANG_DIAG_ON("cast-qual")
 
     /* Sanity checks */
     if (oh->version > H5O_VERSION_1)

--- a/src/H5Ocache.c
+++ b/src/H5Ocache.c
@@ -1434,7 +1434,9 @@ H5O__chunk_deserialize(H5O_t *oh, haddr_t addr, size_t chunk_size, const uint8_t
             mesg->flags    = flags;
             mesg->crt_idx  = crt_idx;
             mesg->native   = NULL;
-            mesg->raw      = (uint8_t *)chunk_image; /* Casting away const OK - QAK */
+H5_GCC_CLANG_DIAG_OFF("cast-qual")
+            mesg->raw      = (uint8_t *)chunk_image;
+H5_GCC_CLANG_DIAG_ON("cast-qual")
             mesg->raw_size = mesg_size;
             mesg->chunkno  = chunkno;
 
@@ -1638,9 +1640,10 @@ H5O__chunk_serialize(const H5F_t *f, H5O_t *oh, unsigned chunkno)
     /* Encode any dirty messages in this chunk */
     for (u = 0, curr_msg = &oh->mesg[0]; u < oh->nmesgs; u++, curr_msg++)
         if (curr_msg->dirty && curr_msg->chunkno == chunkno)
-            /* Casting away const OK -QAK */
+H5_GCC_CLANG_DIAG_OFF("cast-qual")
             if (H5O_msg_flush((H5F_t *)f, oh, curr_msg) < 0)
                 HGOTO_ERROR(H5E_OHDR, H5E_CANTENCODE, FAIL, "unable to encode object header message")
+H5_GCC_CLANG_DIAG_ON("cast-qual")
 
     /* Sanity checks */
     if (oh->version > H5O_VERSION_1)

--- a/src/H5Ocache.c
+++ b/src/H5Ocache.c
@@ -1639,11 +1639,12 @@ H5O__chunk_serialize(const H5F_t *f, H5O_t *oh, unsigned chunkno)
 
     /* Encode any dirty messages in this chunk */
     for (u = 0, curr_msg = &oh->mesg[0]; u < oh->nmesgs; u++, curr_msg++)
-        if (curr_msg->dirty && curr_msg->chunkno == chunkno)
+        if (curr_msg->dirty && curr_msg->chunkno == chunkno) {
             H5_GCC_CLANG_DIAG_OFF("cast-qual")
-    if (H5O_msg_flush((H5F_t *)f, oh, curr_msg) < 0)
-        HGOTO_ERROR(H5E_OHDR, H5E_CANTENCODE, FAIL, "unable to encode object header message")
-    H5_GCC_CLANG_DIAG_ON("cast-qual")
+            if (H5O_msg_flush((H5F_t *)f, oh, curr_msg) < 0)
+                HGOTO_ERROR(H5E_OHDR, H5E_CANTENCODE, FAIL, "unable to encode object header message")
+            H5_GCC_CLANG_DIAG_ON("cast-qual")
+        }
 
     /* Sanity checks */
     if (oh->version > H5O_VERSION_1)

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -11544,7 +11544,7 @@ H5S__hyper_proj_int_iterate(H5S_hyper_span_info_t *ss_span_info, const H5S_hyper
         H5S_HYPER_PROJ_INT_ADD_SKIP(
             udata,
             H5S__hyper_spans_nelem_helper((H5S_hyper_span_info_t *)ss_span_info, 0, udata->op_gen) * count,
-            FAIL); /* Casting away const OK -NAF */
+            FAIL);
 
     /* Clean up if we are done */
     if (depth == 0) {

--- a/test/objcopy_ref.c
+++ b/test/objcopy_ref.c
@@ -939,10 +939,10 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
             H5R_ref_t *ref_buf1, *ref_buf2; /* Aliases for buffers to compare */
 
             /* Loop over elements in buffers */
-H5_GCC_CLANG_DIAG_OFF("cast-qual")
+            H5_GCC_CLANG_DIAG_OFF("cast-qual")
             ref_buf1 = (H5R_ref_t *)buf1;
             ref_buf2 = (H5R_ref_t *)buf2;
-H5_GCC_CLANG_DIAG_ON("cast-qual")
+            H5_GCC_CLANG_DIAG_ON("cast-qual")
             for (u = 0; u < nelmts; u++, ref_buf1++, ref_buf2++) {
                 hid_t      obj1_id, obj2_id;     /* IDs for objects referenced */
                 H5O_type_t obj1_type, obj2_type; /* Types of objects referenced */

--- a/test/objcopy_ref.c
+++ b/test/objcopy_ref.c
@@ -939,8 +939,10 @@ compare_data(hid_t parent1, hid_t parent2, hid_t pid, hid_t tid, size_t nelmts, 
             H5R_ref_t *ref_buf1, *ref_buf2; /* Aliases for buffers to compare */
 
             /* Loop over elements in buffers */
+H5_GCC_CLANG_DIAG_OFF("cast-qual")
             ref_buf1 = (H5R_ref_t *)buf1;
             ref_buf2 = (H5R_ref_t *)buf2;
+H5_GCC_CLANG_DIAG_ON("cast-qual")
             for (u = 0; u < nelmts; u++, ref_buf1++, ref_buf2++) {
                 hid_t      obj1_id, obj2_id;     /* IDs for objects referenced */
                 H5O_type_t obj1_type, obj2_type; /* Types of objects referenced */


### PR DESCRIPTION
Quiets long-standing, difficult-to-remove warnings about const issues.

With this change, serial Autotools builds w/ gcc are warning-free so we can start testing one config w/ -Werror, which will help ensure that warnings won't sneak back into the library.