### PR TITLE
Updates the MinGW configure.ac check for the Winsock library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1352,7 +1352,8 @@ esac
 ## Windows
 case "`uname`" in
   MINGW*)
-    AC_HAVE_LIBRARY([ws2_32])
+    # The Winsock library
+    AC_CHECK_LIB([ws2_32], [GetUserName])
     ;;
 esac
 


### PR DESCRIPTION
Newer versions of the Autotools complain about AC_HAVE_LIBRARY being obsolete