### PR TITLE
Removes workaround for platforms that lack C99 stuct initializers

### DIFF
--- a/config/cmake/H5pubconf.h.in
+++ b/config/cmake/H5pubconf.h.in
@@ -98,10 +98,6 @@
 /* Define if the __attribute__(()) extension is present */
 #cmakedefine H5_HAVE_ATTRIBUTE @H5_HAVE_ATTRIBUTE@
 
-/* Define if the compiler understands C99 designated initialization of structs
-   and unions */
-#cmakedefine H5_HAVE_C99_DESIGNATED_INITIALIZER @H5_HAVE_C99_DESIGNATED_INITIALIZER@
-
 /* Define to 1 if you have the `clock_gettime' function. */
 #cmakedefine H5_HAVE_CLOCK_GETTIME @H5_HAVE_CLOCK_GETTIME@
 

--- a/config/cmake_ext_mod/ConfigureChecks.cmake
+++ b/config/cmake_ext_mod/ConfigureChecks.cmake
@@ -493,7 +493,6 @@ endif ()
 if (MINGW OR NOT WINDOWS)
   foreach (other_test
       HAVE_ATTRIBUTE
-      HAVE_C99_DESIGNATED_INITIALIZER
       SYSTEM_SCOPE_THREADS
       HAVE_SOCKLEN_T
   )

--- a/config/cmake_ext_mod/HDFTests.c
+++ b/config/cmake_ext_mod/HDFTests.c
@@ -11,38 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #define SIMPLE_TEST(x) int main(){ x; return 0; }
 
-#ifdef HAVE_C99_DESIGNATED_INITIALIZER
-
-#ifdef FC_DUMMY_MAIN
-#ifndef FC_DUMMY_MAIN_EQ_F77
-#  ifdef __cplusplus
-extern "C"
-#  endif
-int FC_DUMMY_MAIN()
-{ return 1;}
-#endif
-#endif
-int
-main ()
-{
-
-  typedef struct
-  {
-    int x;
-    union
-    {
-      int i;
-      double d;
-    }u;
-  }di_struct_t;
-  di_struct_t x =
-  { 0,
-    { .d = 0.0}};
-  ;
-  return 0;
-}
-
-#endif
 
 #ifdef HAVE_ATTRIBUTE
 

--- a/configure.ac
+++ b/configure.ac
@@ -2130,21 +2130,6 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]],[[int __attribute__((unused)) x]])],
                  AC_MSG_RESULT([yes])],
                [AC_MSG_RESULT([no])])
 
-AC_MSG_CHECKING([for C99 designated initialization support])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
-                typedef struct {
-                    int x;
-                    union {
-                        int i;
-                        double d;
-                    } u;
-                } di_struct_t;
-                di_struct_t x = {0, { .d = 0.0}}; ]])],
-               [AC_DEFINE([HAVE_C99_DESIGNATED_INITIALIZER], [1],
-                         [Define if the compiler understands C99 designated initialization of structs and unions])
-                 AC_MSG_RESULT([yes])],
-               [AC_MSG_RESULT([no])])
-
 ## ----------------------------------------------------------------------
 ## Remove old ways of determining debug/production build.
 ## These were used in 1.8.x and earlier. We should probably keep these checks


### PR DESCRIPTION
MSVC supports this now, so this work-around can go.

This PR can be pushed to anyplace we require C99.