### PR TITLE
Fixes a bug in h5perf that causes file open failures

### DIFF
--- a/tools/src/h5perf/pio_engine.c
+++ b/tools/src/h5perf/pio_engine.c
@@ -286,7 +286,7 @@ do_pio(parameters param)
         char base_name[256];
 
         HDsnprintf(base_name, sizeof(base_name), "#pio_tmp_%lu", nf);
-        pio_create_filename(iot, base_name, fname, sizeof(fname));
+        pio_create_filename(iot, base_name, fname, FILENAME_MAX);
         if (pio_debug_level > 0)
             HDfprintf(output, "rank %d: data filename=%s\n", pio_mpi_rank_g, fname);
 

--- a/tools/src/h5perf/sio_engine.c
+++ b/tools/src/h5perf/sio_engine.c
@@ -203,7 +203,7 @@ do_sio(parameters param, results *res)
     /* Open file for write */
 
     HDstrcpy(base_name, "#sio_tmp");
-    sio_create_filename(iot, base_name, fname, sizeof(fname), &param);
+    sio_create_filename(iot, base_name, fname, FILENAME_MAX, &param);
 
     if (sio_debug_level > 0)
         HDfprintf(output, "data filename=%s\n", fname);


### PR DESCRIPTION
When the filename was flipped from being a static array to being
dynamically allocated, the sizeof(filename) call wasn't updated.
This always returns the size of the pointer, truncating the
filename.