### PR TITLE
Suppress the "obsolete" category of Autoconf warnings

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -236,7 +236,10 @@ ${automake_cmd} || exit 1
 echo
 
 # AUTOCONF
-autoconf_cmd="${HDF5_AUTOCONF} --force"
+# The "obsolete" warnings category flags our Java macros as obsolete.
+# Since there is no clear way to upgrade them (Java support in the Autotools
+# is not great) and they work well enough for now, we suppress those warnings.
+autoconf_cmd="${HDF5_AUTOCONF} --force --warnings=no-obsolete"
 echo "${autoconf_cmd}"
 if [ "$verbose" = true ] ; then
     ${HDF5_AUTOCONF} --version


### PR DESCRIPTION
Very new versions of Autoconf complain about our Java macros. Since they
work well enough and there is no obvious upgrade path, we're suppressing
the category for now.