### PR TITLE
Fix Doxygen warnings and cosmetics

### DIFF
--- a/doxygen/dox/ReferenceManual.dox
+++ b/doxygen/dox/ReferenceManual.dox
@@ -50,7 +50,7 @@ The functions provided by the HDF5 C-API are grouped into the following
 </td></tr>
 <tr>
 <td><a href="./deprecated.html">Deprecated functions</a></td>
-<td>Functions with \ref ASYNC "asynchronous variants"</td>
+<td>Functions with \ref ASYNC</td>
 <td>\ref api-compat-macros</td>
 </tr>
 </table>

--- a/doxygen/dox/ReferenceManual.dox
+++ b/doxygen/dox/ReferenceManual.dox
@@ -9,7 +9,7 @@ The functions provided by the HDF5 C-API are grouped into the following
 <td>
 
 <table>
-<tr><td style="border: none;">
+<tr valign="top"><td style="border: none;">
 \li \ref H5A "Attributes (H5A)"
 \li \ref H5D "Datasets (H5D)"
 \li \ref H5S "Dataspaces (H5S)"
@@ -29,10 +29,7 @@ The functions provided by the HDF5 C-API are grouped into the following
 \li \ref H5PL "Dynamically-loaded Plugins (H5PL)"
 \li \ref H5R "References (H5R)"
 \li \ref H5VL "Virtual Object Layer (H5VL)"
-</td><td style="border: none;vertical-align: top;">
-\li Functions with \ref ASYNC "asynchronous variants"
-\li \ref api-compat-macros
-\li <a href="./deprecated.html">Deprecated functions</a>
+</td><td style="border: none;">
 \li \ref high_level
     <ul>
     <li>\ref H5LT "Lite (H5LT, H5LD)"
@@ -48,11 +45,14 @@ The functions provided by the HDF5 C-API are grouped into the following
 \a Core \a library: \ref H5 \ref H5A \ref H5D \ref H5E \ref H5ES \ref H5F \ref H5G \ref H5I \ref H5L
 \ref H5M \ref H5O \ref H5P \ref H5PL \ref H5R \ref H5S \ref H5T \ref H5VL \ref H5Z
 </td></tr>
-
 <tr><td colspan="3" style="border: none;">
 \a High-level \a library: \ref H5LT \ref H5IM \ref H5TB \ref H5PT \ref H5DS \ref H5DO \ref H5LR
 </td></tr>
-
+<tr>
+<td><a href="./deprecated.html">Deprecated functions</a></td>
+<td>Functions with \ref ASYNC "asynchronous variants"</td>
+<td>\ref api-compat-macros</td>
+</tr>
 </table>
 
 </td></tr>

--- a/hl/src/H5LDpublic.h
+++ b/hl/src/H5LDpublic.h
@@ -38,7 +38,6 @@ extern "C" {
  *       - H5LDget_dset_dims()
  *       - H5LDget_dset_elmts()
  *       - H5LDget_dset_type_size()
- *       .
  *
  * \par Example:
  * See the example code in H5LDget_dset_elmts() for usage of this routine.
@@ -76,7 +75,6 @@ H5_HLDLL herr_t H5LDget_dset_dims(hid_t did, hsize_t *cur_dims);
  *       - H5LDget_dset_dims()
  *       - H5LDget_dset_elmts()
  *       - H5LDget_dset_type_size()
- *       .
  *
  * \par Example:
  * See the example code in H5LDget_dset_elmts() for usage of this routine.
@@ -129,7 +127,6 @@ H5_HLDLL size_t H5LDget_dset_type_size(hid_t did, const char *fields);
  *       - H5LDget_dset_dims()
  *       - H5LDget_dset_elmts()
  *       - H5LDget_dset_type_size()
- *       .
  *
  * \par Examples:
  *

--- a/hl/src/H5LTpublic.h
+++ b/hl/src/H5LTpublic.h
@@ -55,94 +55,92 @@ extern "C" {
  * \note This line includes the H5LT module in Fortran applications:
  *       \code use h5lt \endcode
  *
+ * <table>
+ * <tr valign="top"><td style="border: none;">
  * - Dataset Functions
  *   - Make dataset functions
- *      - \ref H5LTmake_dataset
- *      - \ref H5LTmake_dataset_char
- *      - \ref H5LTmake_dataset_short
- *      - \ref H5LTmake_dataset_int
- *      - \ref H5LTmake_dataset_long
- *      - \ref H5LTmake_dataset_float
- *      - \ref H5LTmake_dataset_double
- *      - \ref H5LTmake_dataset_string
- *      .
+ *     - \ref H5LTmake_dataset
+ *     - \ref H5LTmake_dataset_char
+ *     - \ref H5LTmake_dataset_short
+ *     - \ref H5LTmake_dataset_int
+ *     - \ref H5LTmake_dataset_long
+ *     - \ref H5LTmake_dataset_float
+ *     - \ref H5LTmake_dataset_double
+ *     - \ref H5LTmake_dataset_string
+ *
  *   - Read dataset functions
- *      - \ref H5LTread_dataset
- *      - \ref H5LTread_dataset_char
- *      - \ref H5LTread_dataset_short
- *      - \ref H5LTread_dataset_int
- *      - \ref H5LTread_dataset_long
- *      - \ref H5LTread_dataset_float
- *      - \ref H5LTread_dataset_double
- *      - \ref H5LTread_dataset_string
- *      .
+ *     - \ref H5LTread_dataset
+ *     - \ref H5LTread_dataset_char
+ *     - \ref H5LTread_dataset_short
+ *     - \ref H5LTread_dataset_int
+ *     - \ref H5LTread_dataset_long
+ *     - \ref H5LTread_dataset_float
+ *     - \ref H5LTread_dataset_double
+ *     - \ref H5LTread_dataset_string
+ *
  *   - Query dataset functions
- *      - \ref H5LTfind_dataset
- *      - \ref H5LTget_dataset_ndims
- *      - \ref H5LTget_dataset_info
- *      .
+ *     - \ref H5LTfind_dataset
+ *     - \ref H5LTget_dataset_ndims
+ *     - \ref H5LTget_dataset_info
+ *
  *   - Dataset watch functions
- *      - \ref H5LDget_dset_dims
- *      - \ref H5LDget_dset_elmts
- *      - \ref H5LDget_dset_type_size
- *      .
- *   .
+ *     - \ref H5LDget_dset_dims
+ *     - \ref H5LDget_dset_elmts
+ *     - \ref H5LDget_dset_type_size
+ * </td><td style="border: none;">
  * - Attribute Functions
  *   - Set attribute functions
- *      - \ref H5LTset_attribute_string
- *      - \ref H5LTset_attribute_char
- *      - \ref H5LTset_attribute_uchar
- *      - \ref H5LTset_attribute_short
- *      - \ref H5LTset_attribute_ushort
- *      - \ref H5LTset_attribute_int
- *      - \ref H5LTset_attribute_uint
- *      - \ref H5LTset_attribute_long
- *      - \ref H5LTset_attribute_long_long
- *      - \ref H5LTset_attribute_ulong
- *      - \ref H5LTset_attribute_ullong
- *      - \ref H5LTset_attribute_float
- *      - \ref H5LTset_attribute_double
- *      - \ref H5LTset_attribute_f (fortran ONLY)
- *      .
+ *     - \ref H5LTset_attribute_string
+ *     - \ref H5LTset_attribute_char
+ *     - \ref H5LTset_attribute_uchar
+ *     - \ref H5LTset_attribute_short
+ *     - \ref H5LTset_attribute_ushort
+ *     - \ref H5LTset_attribute_int
+ *     - \ref H5LTset_attribute_uint
+ *     - \ref H5LTset_attribute_long
+ *     - \ref H5LTset_attribute_long_long
+ *     - \ref H5LTset_attribute_ulong
+ *     - \ref H5LTset_attribute_ullong
+ *     - \ref H5LTset_attribute_float
+ *     - \ref H5LTset_attribute_double
+ *     - <code>H5LTset_attribute_f</code> (fortran ONLY)
+ *
  *   - Get attribute functions
- *      - \ref H5LTget_attribute
- *      - \ref H5LTget_attribute_string
- *      - \ref H5LTget_attribute_char
- *      - \ref H5LTget_attribute_uchar
- *      - \ref H5LTget_attribute_short
- *      - \ref H5LTget_attribute_ushort
- *      - \ref H5LTget_attribute_int
- *      - \ref H5LTget_attribute_uint
- *      - \ref H5LTget_attribute_long
- *      - \ref H5LTget_attribute_long_long
- *      - \ref H5LTget_attribute_ulong
- *      - \ref H5LTget_attribute_ullong
- *      - \ref H5LTget_attribute_float
- *      - \ref H5LTget_attribute_double
- *      .
+ *     - \ref H5LTget_attribute
+ *     - \ref H5LTget_attribute_string
+ *     - \ref H5LTget_attribute_char
+ *     - \ref H5LTget_attribute_uchar
+ *     - \ref H5LTget_attribute_short
+ *     - \ref H5LTget_attribute_ushort
+ *     - \ref H5LTget_attribute_int
+ *     - \ref H5LTget_attribute_uint
+ *     - \ref H5LTget_attribute_long
+ *     - \ref H5LTget_attribute_long_long
+ *     - \ref H5LTget_attribute_ulong
+ *     - \ref H5LTget_attribute_ullong
+ *     - \ref H5LTget_attribute_float
+ *     - \ref H5LTget_attribute_double
+ *
  *   - Query attribute functions
- *      - \ref H5LTfind_attribute
- *      - \ref H5LTget_attribute_info
- *      - \ref H5LTget_attribute_ndims
- *      .
- *   .
+ *     - \ref H5LTfind_attribute
+ *     - \ref H5LTget_attribute_info
+ *     - \ref H5LTget_attribute_ndims
+ * </td><td style="border: none;">
  * - Datatype Functions
  *   - Datatype translation functions
- *      - \ref H5LTtext_to_dtype
- *      - \ref H5LTdtype_to_text
- *      .
- *   .
+ *     - \ref H5LTtext_to_dtype
+ *     - \ref H5LTdtype_to_text
+ *
  * - File image function
  *   - Open file image function
- *      - \ref H5LTopen_file_image
- *      .
- *   .
+ *     - \ref H5LTopen_file_image
+ *
  * - Path and object function
  *   - Query path and object function
- *      - \ref H5LTpath_valid
- *      .
- *   .
- * .
+ *     - \ref H5LTpath_valid
+ * </td></tr>
+ * </table>
+ *
  */
 
 /*-------------------------------------------------------------------------
@@ -1609,8 +1607,6 @@ H5_HLDLL htri_t H5LTpath_valid(hid_t loc_id, const char *path, hbool_t check_obj
  *              release the file image buffer after the file image is
  *              closed.  This flag is valid only when used with
  *              #H5LT_FILE_IMAGE_DONT_COPY.
- *            .
- *          .
  *
  * \note      **Motivation:**
  * \note      H5LTopen_file_image() and other elements of HDF5

--- a/hl/src/H5TBpublic.h
+++ b/hl/src/H5TBpublic.h
@@ -49,7 +49,7 @@ extern "C" {
  *   - \ref H5TBwrite_records (No Fortran)
  *   - \ref H5TBwrite_fields_name
  *   - \ref H5TBwrite_fields_index
- *   .
+ *
  * - Modification
  *   - \ref H5TBdelete_record (No Fortran)
  *   - \ref H5TBinsert_record (No Fortran)
@@ -57,22 +57,20 @@ extern "C" {
  *   - \ref H5TBcombine_tables (No Fortran)
  *   - \ref H5TBinsert_field
  *   - \ref H5TBdelete_field
- *   .
+ *
  * - Retrieval
  *   - \ref H5TBread_table
  *   - \ref H5TBread_records (No Fortran)
  *   - \ref H5TBread_fields_name
  *   - \ref H5TBread_fields_index
- *   .
+ *
  * - Query
  *   - \ref H5TBget_table_info
  *   - \ref H5TBget_field_info
- *   .
+ *
  * - Query Table Attributes
  *   - \ref H5TBAget_fill
  *   - \ref H5TBAget_title
- *   .
- * .
  *
  */
 


### PR DESCRIPTION
There are still three undefined `h5watch` references, but that'll fix itself once we add tooling docs.