### PR TITLE
Adds the malloc attribute to appropriate functions (gcc only)

### DIFF
--- a/src/H5FLprivate.h
+++ b/src/H5FLprivate.h
@@ -399,33 +399,33 @@ typedef struct H5FL_fac_head_t {
  * Library prototypes.
  */
 /* Block free lists */
-H5_DLL void * H5FL_blk_malloc(H5FL_blk_head_t *head, size_t size H5FL_TRACK_PARAMS);
-H5_DLL void * H5FL_blk_calloc(H5FL_blk_head_t *head, size_t size H5FL_TRACK_PARAMS);
+H5_DLL void * H5FL_blk_malloc(H5FL_blk_head_t *head, size_t size H5FL_TRACK_PARAMS) H5_ATTR_MALLOC;
+H5_DLL void * H5FL_blk_calloc(H5FL_blk_head_t *head, size_t size H5FL_TRACK_PARAMS) H5_ATTR_MALLOC;
 H5_DLL void * H5FL_blk_free(H5FL_blk_head_t *head, void *block);
 H5_DLL void * H5FL_blk_realloc(H5FL_blk_head_t *head, void *block, size_t new_size H5FL_TRACK_PARAMS);
 H5_DLL htri_t H5FL_blk_free_block_avail(H5FL_blk_head_t *head, size_t size);
 
 /* Regular free lists */
-H5_DLL void *H5FL_reg_malloc(H5FL_reg_head_t *head H5FL_TRACK_PARAMS);
-H5_DLL void *H5FL_reg_calloc(H5FL_reg_head_t *head H5FL_TRACK_PARAMS);
+H5_DLL void *H5FL_reg_malloc(H5FL_reg_head_t *head H5FL_TRACK_PARAMS) H5_ATTR_MALLOC;
+H5_DLL void *H5FL_reg_calloc(H5FL_reg_head_t *head H5FL_TRACK_PARAMS) H5_ATTR_MALLOC;
 H5_DLL void *H5FL_reg_free(H5FL_reg_head_t *head, void *obj);
 
 /* Array free lists */
-H5_DLL void *H5FL_arr_malloc(H5FL_arr_head_t *head, size_t elem H5FL_TRACK_PARAMS);
-H5_DLL void *H5FL_arr_calloc(H5FL_arr_head_t *head, size_t elem H5FL_TRACK_PARAMS);
+H5_DLL void *H5FL_arr_malloc(H5FL_arr_head_t *head, size_t elem H5FL_TRACK_PARAMS) H5_ATTR_MALLOC;
+H5_DLL void *H5FL_arr_calloc(H5FL_arr_head_t *head, size_t elem H5FL_TRACK_PARAMS) H5_ATTR_MALLOC;
 H5_DLL void *H5FL_arr_free(H5FL_arr_head_t *head, void *obj);
 H5_DLL void *H5FL_arr_realloc(H5FL_arr_head_t *head, void *obj, size_t new_elem H5FL_TRACK_PARAMS);
 
 /* Sequence free lists */
-H5_DLL void *H5FL_seq_malloc(H5FL_seq_head_t *head, size_t elem H5FL_TRACK_PARAMS);
-H5_DLL void *H5FL_seq_calloc(H5FL_seq_head_t *head, size_t elem H5FL_TRACK_PARAMS);
+H5_DLL void *H5FL_seq_malloc(H5FL_seq_head_t *head, size_t elem H5FL_TRACK_PARAMS) H5_ATTR_MALLOC;
+H5_DLL void *H5FL_seq_calloc(H5FL_seq_head_t *head, size_t elem H5FL_TRACK_PARAMS) H5_ATTR_MALLOC;
 H5_DLL void *H5FL_seq_free(H5FL_seq_head_t *head, void *obj);
 H5_DLL void *H5FL_seq_realloc(H5FL_seq_head_t *head, void *obj, size_t new_elem H5FL_TRACK_PARAMS);
 
 /* Factory free lists */
 H5_DLL H5FL_fac_head_t *H5FL_fac_init(size_t size);
-H5_DLL void *           H5FL_fac_malloc(H5FL_fac_head_t *head H5FL_TRACK_PARAMS);
-H5_DLL void *           H5FL_fac_calloc(H5FL_fac_head_t *head H5FL_TRACK_PARAMS);
+H5_DLL void *           H5FL_fac_malloc(H5FL_fac_head_t *head H5FL_TRACK_PARAMS) H5_ATTR_MALLOC;
+H5_DLL void *           H5FL_fac_calloc(H5FL_fac_head_t *head H5FL_TRACK_PARAMS) H5_ATTR_MALLOC;
 H5_DLL void *           H5FL_fac_free(H5FL_fac_head_t *head, void *obj);
 H5_DLL herr_t           H5FL_fac_term(H5FL_fac_head_t *head);
 

--- a/src/H5MMprivate.h
+++ b/src/H5MMprivate.h
@@ -39,8 +39,8 @@
 /*
  * Library prototypes...
  */
-H5_DLL void * H5MM_malloc(size_t size);
-H5_DLL void * H5MM_calloc(size_t size);
+H5_DLL void * H5MM_malloc(size_t size) H5_ATTR_MALLOC;
+H5_DLL void * H5MM_calloc(size_t size) H5_ATTR_MALLOC;
 H5_DLL void * H5MM_realloc(void *mem, size_t size);
 H5_DLL char * H5MM_xstrdup(const char *s);
 H5_DLL char * H5MM_strdup(const char *s);

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -232,52 +232,68 @@
  * gcc warnings (it has to use the public API and can't include this
  * file). Be sure to update that file if the #ifdefs change here.
  */
+/* clang-format off */
 #if defined(H5_HAVE_ATTRIBUTE) && !defined(__SUNPRO_C)
-#define H5_ATTR_FORMAT(X, Y, Z) __attribute__((format(X, Y, Z)))
-#define H5_ATTR_UNUSED          __attribute__((unused))
-#ifdef H5_HAVE_PARALLEL
-#define H5_ATTR_PARALLEL_UNUSED __attribute__((unused))
-#define H5_ATTR_PARALLEL_USED   /*void*/
+#   define H5_ATTR_FORMAT(X, Y, Z) __attribute__((format(X, Y, Z)))
+#   define H5_ATTR_UNUSED          __attribute__((unused))
+
+#   ifdef H5_HAVE_PARALLEL
+#       define H5_ATTR_PARALLEL_UNUSED __attribute__((unused))
+#       define H5_ATTR_PARALLEL_USED   /*void*/
+#   else
+#       define H5_ATTR_PARALLEL_UNUSED /*void*/
+#       define H5_ATTR_PARALLEL_USED   __attribute__((unused))
+#   endif
+
+#   ifdef H5_NO_DEPRECATED_SYMBOLS
+#       define H5_ATTR_DEPRECATED_USED H5_ATTR_UNUSED
+#   else
+#       define H5_ATTR_DEPRECATED_USED /*void*/
+#   endif
+
+#   ifdef H5_DEBUG_API
+#       define H5_ATTR_DEBUG_API_USED /*void*/
+#   else
+#       define H5_ATTR_DEBUG_API_USED H5_ATTR_UNUSED
+#   endif /* H5_DEBUG_API */
+
+#   ifndef NDEBUG
+#       define H5_ATTR_NDEBUG_UNUSED /*void*/
+#   else
+#       define H5_ATTR_NDEBUG_UNUSED H5_ATTR_UNUSED
+#   endif
+
+#   define H5_ATTR_NORETURN __attribute__((noreturn))
+#   define H5_ATTR_CONST    __attribute__((const))
+#   define H5_ATTR_PURE     __attribute__((pure))
+
+#   if defined(__clang__) || defined(__GNUC__) && __GNUC__ >= 7 && !defined(__INTEL_COMPILER)
+#       define H5_ATTR_FALLTHROUGH __attribute__((fallthrough));
+#   else
+#       define H5_ATTR_FALLTHROUGH /* FALLTHROUGH */
+#   endif
+
+#  if defined(__GNUC__) && !defined(__INTEL_COMPILER)
+#       define H5_ATTR_MALLOC __attribute__((malloc))
+#  else
+#       define H5_ATTR_MALLOC /*void*/
+#  endif
+
 #else
-#define H5_ATTR_PARALLEL_UNUSED /*void*/
-#define H5_ATTR_PARALLEL_USED   __attribute__((unused))
+#   define H5_ATTR_FORMAT(X, Y, Z) /*void*/
+#   define H5_ATTR_UNUSED          /*void*/
+#   define H5_ATTR_NDEBUG_UNUSED   /*void*/
+#   define H5_ATTR_DEBUG_API_USED  /*void*/
+#   define H5_ATTR_DEPRECATED_USED /*void*/
+#   define H5_ATTR_PARALLEL_UNUSED /*void*/
+#   define H5_ATTR_PARALLEL_USED   /*void*/
+#   define H5_ATTR_NORETURN        /*void*/
+#   define H5_ATTR_CONST           /*void*/
+#   define H5_ATTR_PURE            /*void*/
+#   define H5_ATTR_FALLTHROUGH     /*void*/
+#   define H5_ATTR_MALLOC          /*void*/
 #endif
-#ifdef H5_NO_DEPRECATED_SYMBOLS
-#define H5_ATTR_DEPRECATED_USED H5_ATTR_UNUSED
-#else                           /* H5_NO_DEPRECATED_SYMBOLS */
-#define H5_ATTR_DEPRECATED_USED /*void*/
-#endif                          /* H5_NO_DEPRECATED_SYMBOLS */
-#ifdef H5_DEBUG_API
-#define H5_ATTR_DEBUG_API_USED /*void*/
-#else                          /* H5_DEBUG_API */
-#define H5_ATTR_DEBUG_API_USED H5_ATTR_UNUSED
-#endif /* H5_DEBUG_API */
-#ifndef NDEBUG
-#define H5_ATTR_NDEBUG_UNUSED /*void*/
-#else                         /* NDEBUG */
-#define H5_ATTR_NDEBUG_UNUSED H5_ATTR_UNUSED
-#endif /* NDEBUG */
-#define H5_ATTR_NORETURN __attribute__((noreturn))
-#define H5_ATTR_CONST    __attribute__((const))
-#define H5_ATTR_PURE     __attribute__((pure))
-#if defined(__clang__) || defined(__GNUC__) && __GNUC__ >= 7 && !defined(__INTEL_COMPILER)
-#define H5_ATTR_FALLTHROUGH __attribute__((fallthrough));
-#else
-#define H5_ATTR_FALLTHROUGH /* FALLTHROUGH */
-#endif
-#else
-#define H5_ATTR_FORMAT(X, Y, Z) /*void*/
-#define H5_ATTR_UNUSED          /*void*/
-#define H5_ATTR_NDEBUG_UNUSED   /*void*/
-#define H5_ATTR_DEBUG_API_USED  /*void*/
-#define H5_ATTR_DEPRECATED_USED /*void*/
-#define H5_ATTR_PARALLEL_UNUSED /*void*/
-#define H5_ATTR_PARALLEL_USED   /*void*/
-#define H5_ATTR_NORETURN        /*void*/
-#define H5_ATTR_CONST           /*void*/
-#define H5_ATTR_PURE            /*void*/
-#define H5_ATTR_FALLTHROUGH     /*void*/
-#endif
+/* clang-format on */
 
 /*
  * Networking headers used by the mirror VFD and related tests and utilities.


### PR DESCRIPTION
This adds the `malloc` attribute on to malloc-like internal HDF5 library calls (e.g. `H5MM_malloc()`). In theory, this can help the optimizer to emit better code. The `malloc` attribute has been in use for a long time (I originally spotted it in gcc 3.2 docs), so I don't check the gcc version. There is an improved version that takes a corresponding free function that can be used to detect mismatches and I might add that later.

I also reformatted the attributes defines to make them easier to read.

malloc attribute docs here:

https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes