### PR TITLE
Misc clang warning fixes

### DIFF
--- a/bin/genparser
+++ b/bin/genparser
@@ -236,6 +236,7 @@ do
     echo '#pragma GCC diagnostic ignored "-Wsign-conversion"                ' >> tmp.out
     echo '#pragma GCC diagnostic ignored "-Wstrict-overflow"                ' >> tmp.out
     echo '#pragma GCC diagnostic ignored "-Wstrict-prototypes"              ' >> tmp.out
+    echo '#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"           ' >> tmp.out
     echo '#if !defined (__clang__)                                          ' >> tmp.out
     echo '#pragma GCC diagnostic ignored "-Wlarger-than="                   ' >> tmp.out
     echo '#pragma GCC diagnostic ignored "-Wsuggest-attribute=const"        ' >> tmp.out

--- a/hl/src/H5LTanalyze.c
+++ b/hl/src/H5LTanalyze.c
@@ -10,6 +10,7 @@
 #pragma GCC diagnostic ignored "-Wsign-conversion"                
 #pragma GCC diagnostic ignored "-Wstrict-overflow"                
 #pragma GCC diagnostic ignored "-Wstrict-prototypes"              
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #if !defined (__clang__)                                          
 #pragma GCC diagnostic ignored "-Wlarger-than="                   
 #pragma GCC diagnostic ignored "-Wsuggest-attribute=const"        
@@ -28,14 +29,14 @@
 #elif defined _MSC_VER                                            
 #pragma warning(push, 1)                                          
 #endif                                                            
-#line 2 "./hl/src/H5LTanalyze.c"
+#line 2 "hl/src//H5LTanalyze.c"
 /* Quiet warnings about integer type macro redifinitions on Visual Studio
  * (MSVC doesn't define STDC_VERSION, but has inttypes.h). This is an
  * issue that is apparently fixed in flex 2.6.5.
  */
 #include <stdint.h>
 
-#line 9 "./hl/src/H5LTanalyze.c"
+#line 9 "hl/src//H5LTanalyze.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -893,7 +894,7 @@ int yy_flex_debug = 0;
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
 char *yytext;
-#line 1 "./hl/src/H5LTanalyze.l"
+#line 1 "hl/src//H5LTanalyze.l"
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  * Copyright by The HDF Group.                                               *
  * Copyright by the Board of Trustees of the University of Illinois.         *
@@ -912,7 +913,7 @@ char *yytext;
  * recreate the output files.
  */
 
-#line 29 "./hl/src/H5LTanalyze.l"
+#line 29 "hl/src//H5LTanalyze.l"
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
@@ -936,8 +937,8 @@ static int my_yyinput(char *, int);
 extern char *myinput;
 extern size_t input_len;
 
-#line 910 "./hl/src/H5LTanalyze.c"
-#line 911 "./hl/src/H5LTanalyze.c"
+#line 910 "hl/src//H5LTanalyze.c"
+#line 911 "hl/src//H5LTanalyze.c"
 
 #define INITIAL 0
 
@@ -1146,10 +1147,10 @@ YY_DECL
 		}
 
 	{
-#line 54 "./hl/src/H5LTanalyze.l"
+#line 54 "hl/src//H5LTanalyze.l"
 
 
-#line 1123 "./hl/src/H5LTanalyze.c"
+#line 1123 "hl/src//H5LTanalyze.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1208,277 +1209,277 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 56 "./hl/src/H5LTanalyze.l"
+#line 56 "hl/src//H5LTanalyze.l"
 {return hid(H5T_STD_I8BE_TOKEN);}
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 57 "./hl/src/H5LTanalyze.l"
+#line 57 "hl/src//H5LTanalyze.l"
 {return hid(H5T_STD_I8LE_TOKEN);}
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 58 "./hl/src/H5LTanalyze.l"
+#line 58 "hl/src//H5LTanalyze.l"
 {return hid(H5T_STD_I16BE_TOKEN);}
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 59 "./hl/src/H5LTanalyze.l"
+#line 59 "hl/src//H5LTanalyze.l"
 {return hid(H5T_STD_I16LE_TOKEN);}
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 60 "./hl/src/H5LTanalyze.l"
+#line 60 "hl/src//H5LTanalyze.l"
 {return hid(H5T_STD_I32BE_TOKEN);}
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 61 "./hl/src/H5LTanalyze.l"
+#line 61 "hl/src//H5LTanalyze.l"
 {return hid(H5T_STD_I32LE_TOKEN);}
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 62 "./hl/src/H5LTanalyze.l"
+#line 62 "hl/src//H5LTanalyze.l"
 {return hid(H5T_STD_I64BE_TOKEN);}
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 63 "./hl/src/H5LTanalyze.l"
+#line 63 "hl/src//H5LTanalyze.l"
 {return hid(H5T_STD_I64LE_TOKEN);}
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 65 "./hl/src/H5LTanalyze.l"
+#line 65 "hl/src//H5LTanalyze.l"
 {return hid(H5T_STD_U8BE_TOKEN);}
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 66 "./hl/src/H5LTanalyze.l"
+#line 66 "hl/src//H5LTanalyze.l"
 {return hid(H5T_STD_U8LE_TOKEN);}
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 67 "./hl/src/H5LTanalyze.l"
+#line 67 "hl/src//H5LTanalyze.l"
 {return hid(H5T_STD_U16BE_TOKEN);}
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 68 "./hl/src/H5LTanalyze.l"
+#line 68 "hl/src//H5LTanalyze.l"
 {return hid(H5T_STD_U16LE_TOKEN);}
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 69 "./hl/src/H5LTanalyze.l"
+#line 69 "hl/src//H5LTanalyze.l"
 {return hid(H5T_STD_U32BE_TOKEN);}
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 70 "./hl/src/H5LTanalyze.l"
+#line 70 "hl/src//H5LTanalyze.l"
 {return hid(H5T_STD_U32LE_TOKEN);}
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 71 "./hl/src/H5LTanalyze.l"
+#line 71 "hl/src//H5LTanalyze.l"
 {return hid(H5T_STD_U64BE_TOKEN);}
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 72 "./hl/src/H5LTanalyze.l"
+#line 72 "hl/src//H5LTanalyze.l"
 {return hid(H5T_STD_U64LE_TOKEN);}
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 74 "./hl/src/H5LTanalyze.l"
+#line 74 "hl/src//H5LTanalyze.l"
 {return hid(H5T_NATIVE_CHAR_TOKEN);}
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 75 "./hl/src/H5LTanalyze.l"
+#line 75 "hl/src//H5LTanalyze.l"
 {return hid(H5T_NATIVE_SCHAR_TOKEN);}
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 76 "./hl/src/H5LTanalyze.l"
+#line 76 "hl/src//H5LTanalyze.l"
 {return hid(H5T_NATIVE_UCHAR_TOKEN);}
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 77 "./hl/src/H5LTanalyze.l"
+#line 77 "hl/src//H5LTanalyze.l"
 {return hid(H5T_NATIVE_SHORT_TOKEN);}
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 78 "./hl/src/H5LTanalyze.l"
+#line 78 "hl/src//H5LTanalyze.l"
 {return hid(H5T_NATIVE_USHORT_TOKEN);}
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 79 "./hl/src/H5LTanalyze.l"
+#line 79 "hl/src//H5LTanalyze.l"
 {return hid(H5T_NATIVE_INT_TOKEN);}
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 80 "./hl/src/H5LTanalyze.l"
+#line 80 "hl/src//H5LTanalyze.l"
 {return hid(H5T_NATIVE_UINT_TOKEN);}
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 81 "./hl/src/H5LTanalyze.l"
+#line 81 "hl/src//H5LTanalyze.l"
 {return hid(H5T_NATIVE_LONG_TOKEN);}
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 82 "./hl/src/H5LTanalyze.l"
+#line 82 "hl/src//H5LTanalyze.l"
 {return hid(H5T_NATIVE_ULONG_TOKEN);}
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 83 "./hl/src/H5LTanalyze.l"
+#line 83 "hl/src//H5LTanalyze.l"
 {return hid(H5T_NATIVE_LLONG_TOKEN);}
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 84 "./hl/src/H5LTanalyze.l"
+#line 84 "hl/src//H5LTanalyze.l"
 {return hid(H5T_NATIVE_ULLONG_TOKEN);}
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 86 "./hl/src/H5LTanalyze.l"
+#line 86 "hl/src//H5LTanalyze.l"
 {return hid(H5T_IEEE_F32BE_TOKEN);}
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 87 "./hl/src/H5LTanalyze.l"
+#line 87 "hl/src//H5LTanalyze.l"
 {return hid(H5T_IEEE_F32LE_TOKEN);}
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 88 "./hl/src/H5LTanalyze.l"
+#line 88 "hl/src//H5LTanalyze.l"
 {return hid(H5T_IEEE_F64BE_TOKEN);}
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 89 "./hl/src/H5LTanalyze.l"
+#line 89 "hl/src//H5LTanalyze.l"
 {return hid(H5T_IEEE_F64LE_TOKEN);}
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 90 "./hl/src/H5LTanalyze.l"
+#line 90 "hl/src//H5LTanalyze.l"
 {return hid(H5T_NATIVE_FLOAT_TOKEN);}
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 91 "./hl/src/H5LTanalyze.l"
+#line 91 "hl/src//H5LTanalyze.l"
 {return hid(H5T_NATIVE_DOUBLE_TOKEN);}
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 92 "./hl/src/H5LTanalyze.l"
+#line 92 "hl/src//H5LTanalyze.l"
 {return hid(H5T_NATIVE_LDOUBLE_TOKEN);}
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 94 "./hl/src/H5LTanalyze.l"
+#line 94 "hl/src//H5LTanalyze.l"
 {return token(H5T_STRING_TOKEN);}
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 95 "./hl/src/H5LTanalyze.l"
+#line 95 "hl/src//H5LTanalyze.l"
 {return token(STRSIZE_TOKEN);}
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 96 "./hl/src/H5LTanalyze.l"
+#line 96 "hl/src//H5LTanalyze.l"
 {return token(STRPAD_TOKEN);}
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 97 "./hl/src/H5LTanalyze.l"
+#line 97 "hl/src//H5LTanalyze.l"
 {return token(CSET_TOKEN);}
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 98 "./hl/src/H5LTanalyze.l"
+#line 98 "hl/src//H5LTanalyze.l"
 {return token(CTYPE_TOKEN);}
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 99 "./hl/src/H5LTanalyze.l"
+#line 99 "hl/src//H5LTanalyze.l"
 {return token(H5T_STR_NULLTERM_TOKEN);}
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 100 "./hl/src/H5LTanalyze.l"
+#line 100 "hl/src//H5LTanalyze.l"
 {return token(H5T_STR_NULLPAD_TOKEN);}
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 101 "./hl/src/H5LTanalyze.l"
+#line 101 "hl/src//H5LTanalyze.l"
 {return token(H5T_STR_SPACEPAD_TOKEN);}
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 102 "./hl/src/H5LTanalyze.l"
+#line 102 "hl/src//H5LTanalyze.l"
 {return token(H5T_CSET_ASCII_TOKEN);}
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 103 "./hl/src/H5LTanalyze.l"
+#line 103 "hl/src//H5LTanalyze.l"
 {return token(H5T_CSET_UTF8_TOKEN);}
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 104 "./hl/src/H5LTanalyze.l"
+#line 104 "hl/src//H5LTanalyze.l"
 {return token(H5T_C_S1_TOKEN);}
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 105 "./hl/src/H5LTanalyze.l"
+#line 105 "hl/src//H5LTanalyze.l"
 {return token(H5T_FORTRAN_S1_TOKEN);}
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 106 "./hl/src/H5LTanalyze.l"
+#line 106 "hl/src//H5LTanalyze.l"
 {return token(H5T_VARIABLE_TOKEN);}
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
-#line 108 "./hl/src/H5LTanalyze.l"
+#line 108 "hl/src//H5LTanalyze.l"
 {return token(H5T_COMPOUND_TOKEN);}
 	YY_BREAK
 case 49:
 YY_RULE_SETUP
-#line 109 "./hl/src/H5LTanalyze.l"
+#line 109 "hl/src//H5LTanalyze.l"
 {return token(H5T_ENUM_TOKEN);}
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 110 "./hl/src/H5LTanalyze.l"
+#line 110 "hl/src//H5LTanalyze.l"
 {return token(H5T_ARRAY_TOKEN);}
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 111 "./hl/src/H5LTanalyze.l"
+#line 111 "hl/src//H5LTanalyze.l"
 {return token(H5T_VLEN_TOKEN);}
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 113 "./hl/src/H5LTanalyze.l"
+#line 113 "hl/src//H5LTanalyze.l"
 {return token(H5T_OPAQUE_TOKEN);}
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 114 "./hl/src/H5LTanalyze.l"
+#line 114 "hl/src//H5LTanalyze.l"
 {return token(OPQ_SIZE_TOKEN);}
 	YY_BREAK
 case 54:
 YY_RULE_SETUP
-#line 115 "./hl/src/H5LTanalyze.l"
+#line 115 "hl/src//H5LTanalyze.l"
 {return token(OPQ_TAG_TOKEN);}
 	YY_BREAK
 case 55:
 YY_RULE_SETUP
-#line 117 "./hl/src/H5LTanalyze.l"
+#line 117 "hl/src//H5LTanalyze.l"
 {
                         H5LTyylval.ival = HDatoi(yytext);
                         return NUMBER;
@@ -1487,7 +1488,7 @@ YY_RULE_SETUP
 case 56:
 /* rule 56 can match eol */
 YY_RULE_SETUP
-#line 122 "./hl/src/H5LTanalyze.l"
+#line 122 "hl/src//H5LTanalyze.l"
 {
                     H5LTyylval.sval = trim_quotes(yytext);
                     return STRING;
@@ -1495,46 +1496,46 @@ YY_RULE_SETUP
 	YY_BREAK
 case 57:
 YY_RULE_SETUP
-#line 127 "./hl/src/H5LTanalyze.l"
+#line 127 "hl/src//H5LTanalyze.l"
 {return token('{');}
 	YY_BREAK
 case 58:
 YY_RULE_SETUP
-#line 128 "./hl/src/H5LTanalyze.l"
+#line 128 "hl/src//H5LTanalyze.l"
 {return token('}');}
 	YY_BREAK
 case 59:
 YY_RULE_SETUP
-#line 129 "./hl/src/H5LTanalyze.l"
+#line 129 "hl/src//H5LTanalyze.l"
 {return token('[');}
 	YY_BREAK
 case 60:
 YY_RULE_SETUP
-#line 130 "./hl/src/H5LTanalyze.l"
+#line 130 "hl/src//H5LTanalyze.l"
 {return token(']');}
 	YY_BREAK
 case 61:
 YY_RULE_SETUP
-#line 131 "./hl/src/H5LTanalyze.l"
+#line 131 "hl/src//H5LTanalyze.l"
 {return token(':');}
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 132 "./hl/src/H5LTanalyze.l"
+#line 132 "hl/src//H5LTanalyze.l"
 {return token(';');}
 	YY_BREAK
 case 63:
 /* rule 63 can match eol */
 YY_RULE_SETUP
-#line 133 "./hl/src/H5LTanalyze.l"
+#line 133 "hl/src//H5LTanalyze.l"
 ;
 	YY_BREAK
 case 64:
 YY_RULE_SETUP
-#line 135 "./hl/src/H5LTanalyze.l"
+#line 135 "hl/src//H5LTanalyze.l"
 ECHO;
 	YY_BREAK
-#line 1508 "./hl/src/H5LTanalyze.c"
+#line 1508 "hl/src//H5LTanalyze.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2539,7 +2540,7 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 135 "./hl/src/H5LTanalyze.l"
+#line 135 "hl/src//H5LTanalyze.l"
 
 
 /* Allocate a copy of `quoted` with the double quote character at

--- a/hl/src/H5LTparse.c
+++ b/hl/src/H5LTparse.c
@@ -10,6 +10,7 @@
 #pragma GCC diagnostic ignored "-Wsign-conversion"                
 #pragma GCC diagnostic ignored "-Wstrict-overflow"                
 #pragma GCC diagnostic ignored "-Wstrict-prototypes"              
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"           
 #if !defined (__clang__)                                          
 #pragma GCC diagnostic ignored "-Wlarger-than="                   
 #pragma GCC diagnostic ignored "-Wsuggest-attribute=const"        
@@ -28,11 +29,11 @@
 #elif defined _MSC_VER                                            
 #pragma warning(push, 1)                                          
 #endif                                                            
-/* A Bison parser, made by GNU Bison 3.5.1.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2020 Free Software Foundation,
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
    Inc.
 
    This program is free software: you can redistribute it and/or modify
@@ -46,7 +47,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -64,6 +65,10 @@
 /* C LALR(1) parser skeleton written by Richard Stallman, by
    simplifying the original so-called "semantic" parser.  */
 
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
    variables, as they might otherwise be expanded by user macros.
@@ -71,14 +76,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Undocumented macros, especially those whose name start with YY_,
-   are private implementation details.  Do not rely on them.  */
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30802
 
-/* Identify Bison output.  */
-#define YYBISON 1
-
-/* Bison version.  */
-#define YYBISON_VERSION "3.5.1"
+/* Bison version string.  */
+#define YYBISON_VERSION "3.8.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -103,7 +105,7 @@
 #define yychar          H5LTyychar
 
 /* First part of user prologue.  */
-#line 20 "./hl/src/H5LTparse.y"
+#line 20 "hl/src//H5LTparse.y"
 
 #include <stdio.h>
 #include <string.h>
@@ -153,7 +155,7 @@ static hbool_t     is_enum_memb = 0;       /*flag to lexer for enum member*/
 static char*       enum_memb_symbol;       /*enum member symbol string*/
 
 
-#line 127 "./hl/src/H5LTparse.c"
+#line 128 "hl/src//H5LTparse.c"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -176,114 +178,122 @@ static char*       enum_memb_symbol;       /*enum member symbol string*/
 #  endif
 # endif
 
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE 0
-#endif
-
-/* Use api.header.include to #include this header
-   instead of duplicating it here.  */
-#ifndef YY_H5LTYY_HL_SRC_H5LTPARSE_H_INCLUDED
-# define YY_H5LTYY_HL_SRC_H5LTPARSE_H_INCLUDED
-/* Debug traces.  */
-#ifndef YYDEBUG
-# define YYDEBUG 0
-#endif
-#if YYDEBUG
-extern int H5LTyydebug;
-#endif
-
-/* Token type.  */
-#ifndef YYTOKENTYPE
-# define YYTOKENTYPE
-  enum yytokentype
-  {
-    H5T_STD_I8BE_TOKEN = 258,
-    H5T_STD_I8LE_TOKEN = 259,
-    H5T_STD_I16BE_TOKEN = 260,
-    H5T_STD_I16LE_TOKEN = 261,
-    H5T_STD_I32BE_TOKEN = 262,
-    H5T_STD_I32LE_TOKEN = 263,
-    H5T_STD_I64BE_TOKEN = 264,
-    H5T_STD_I64LE_TOKEN = 265,
-    H5T_STD_U8BE_TOKEN = 266,
-    H5T_STD_U8LE_TOKEN = 267,
-    H5T_STD_U16BE_TOKEN = 268,
-    H5T_STD_U16LE_TOKEN = 269,
-    H5T_STD_U32BE_TOKEN = 270,
-    H5T_STD_U32LE_TOKEN = 271,
-    H5T_STD_U64BE_TOKEN = 272,
-    H5T_STD_U64LE_TOKEN = 273,
-    H5T_NATIVE_CHAR_TOKEN = 274,
-    H5T_NATIVE_SCHAR_TOKEN = 275,
-    H5T_NATIVE_UCHAR_TOKEN = 276,
-    H5T_NATIVE_SHORT_TOKEN = 277,
-    H5T_NATIVE_USHORT_TOKEN = 278,
-    H5T_NATIVE_INT_TOKEN = 279,
-    H5T_NATIVE_UINT_TOKEN = 280,
-    H5T_NATIVE_LONG_TOKEN = 281,
-    H5T_NATIVE_ULONG_TOKEN = 282,
-    H5T_NATIVE_LLONG_TOKEN = 283,
-    H5T_NATIVE_ULLONG_TOKEN = 284,
-    H5T_IEEE_F32BE_TOKEN = 285,
-    H5T_IEEE_F32LE_TOKEN = 286,
-    H5T_IEEE_F64BE_TOKEN = 287,
-    H5T_IEEE_F64LE_TOKEN = 288,
-    H5T_NATIVE_FLOAT_TOKEN = 289,
-    H5T_NATIVE_DOUBLE_TOKEN = 290,
-    H5T_NATIVE_LDOUBLE_TOKEN = 291,
-    H5T_STRING_TOKEN = 292,
-    STRSIZE_TOKEN = 293,
-    STRPAD_TOKEN = 294,
-    CSET_TOKEN = 295,
-    CTYPE_TOKEN = 296,
-    H5T_VARIABLE_TOKEN = 297,
-    H5T_STR_NULLTERM_TOKEN = 298,
-    H5T_STR_NULLPAD_TOKEN = 299,
-    H5T_STR_SPACEPAD_TOKEN = 300,
-    H5T_CSET_ASCII_TOKEN = 301,
-    H5T_CSET_UTF8_TOKEN = 302,
-    H5T_C_S1_TOKEN = 303,
-    H5T_FORTRAN_S1_TOKEN = 304,
-    H5T_OPAQUE_TOKEN = 305,
-    OPQ_SIZE_TOKEN = 306,
-    OPQ_TAG_TOKEN = 307,
-    H5T_COMPOUND_TOKEN = 308,
-    H5T_ENUM_TOKEN = 309,
-    H5T_ARRAY_TOKEN = 310,
-    H5T_VLEN_TOKEN = 311,
-    STRING = 312,
-    NUMBER = 313
-  };
-#endif
-
-/* Value type.  */
-#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-union YYSTYPE
+#include "H5LTparse.h"
+/* Symbol kind.  */
+enum yysymbol_kind_t
 {
-#line 69 "./hl/src/H5LTparse.y"
-
-    int     ival;         /*for integer token*/
-    char    *sval;        /*for name string*/
-    hid_t   hid;          /*for hid_t token*/
-
-#line 244 "./hl/src/H5LTparse.c"
-
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_H5T_STD_I8BE_TOKEN = 3,         /* H5T_STD_I8BE_TOKEN  */
+  YYSYMBOL_H5T_STD_I8LE_TOKEN = 4,         /* H5T_STD_I8LE_TOKEN  */
+  YYSYMBOL_H5T_STD_I16BE_TOKEN = 5,        /* H5T_STD_I16BE_TOKEN  */
+  YYSYMBOL_H5T_STD_I16LE_TOKEN = 6,        /* H5T_STD_I16LE_TOKEN  */
+  YYSYMBOL_H5T_STD_I32BE_TOKEN = 7,        /* H5T_STD_I32BE_TOKEN  */
+  YYSYMBOL_H5T_STD_I32LE_TOKEN = 8,        /* H5T_STD_I32LE_TOKEN  */
+  YYSYMBOL_H5T_STD_I64BE_TOKEN = 9,        /* H5T_STD_I64BE_TOKEN  */
+  YYSYMBOL_H5T_STD_I64LE_TOKEN = 10,       /* H5T_STD_I64LE_TOKEN  */
+  YYSYMBOL_H5T_STD_U8BE_TOKEN = 11,        /* H5T_STD_U8BE_TOKEN  */
+  YYSYMBOL_H5T_STD_U8LE_TOKEN = 12,        /* H5T_STD_U8LE_TOKEN  */
+  YYSYMBOL_H5T_STD_U16BE_TOKEN = 13,       /* H5T_STD_U16BE_TOKEN  */
+  YYSYMBOL_H5T_STD_U16LE_TOKEN = 14,       /* H5T_STD_U16LE_TOKEN  */
+  YYSYMBOL_H5T_STD_U32BE_TOKEN = 15,       /* H5T_STD_U32BE_TOKEN  */
+  YYSYMBOL_H5T_STD_U32LE_TOKEN = 16,       /* H5T_STD_U32LE_TOKEN  */
+  YYSYMBOL_H5T_STD_U64BE_TOKEN = 17,       /* H5T_STD_U64BE_TOKEN  */
+  YYSYMBOL_H5T_STD_U64LE_TOKEN = 18,       /* H5T_STD_U64LE_TOKEN  */
+  YYSYMBOL_H5T_NATIVE_CHAR_TOKEN = 19,     /* H5T_NATIVE_CHAR_TOKEN  */
+  YYSYMBOL_H5T_NATIVE_SCHAR_TOKEN = 20,    /* H5T_NATIVE_SCHAR_TOKEN  */
+  YYSYMBOL_H5T_NATIVE_UCHAR_TOKEN = 21,    /* H5T_NATIVE_UCHAR_TOKEN  */
+  YYSYMBOL_H5T_NATIVE_SHORT_TOKEN = 22,    /* H5T_NATIVE_SHORT_TOKEN  */
+  YYSYMBOL_H5T_NATIVE_USHORT_TOKEN = 23,   /* H5T_NATIVE_USHORT_TOKEN  */
+  YYSYMBOL_H5T_NATIVE_INT_TOKEN = 24,      /* H5T_NATIVE_INT_TOKEN  */
+  YYSYMBOL_H5T_NATIVE_UINT_TOKEN = 25,     /* H5T_NATIVE_UINT_TOKEN  */
+  YYSYMBOL_H5T_NATIVE_LONG_TOKEN = 26,     /* H5T_NATIVE_LONG_TOKEN  */
+  YYSYMBOL_H5T_NATIVE_ULONG_TOKEN = 27,    /* H5T_NATIVE_ULONG_TOKEN  */
+  YYSYMBOL_H5T_NATIVE_LLONG_TOKEN = 28,    /* H5T_NATIVE_LLONG_TOKEN  */
+  YYSYMBOL_H5T_NATIVE_ULLONG_TOKEN = 29,   /* H5T_NATIVE_ULLONG_TOKEN  */
+  YYSYMBOL_H5T_IEEE_F32BE_TOKEN = 30,      /* H5T_IEEE_F32BE_TOKEN  */
+  YYSYMBOL_H5T_IEEE_F32LE_TOKEN = 31,      /* H5T_IEEE_F32LE_TOKEN  */
+  YYSYMBOL_H5T_IEEE_F64BE_TOKEN = 32,      /* H5T_IEEE_F64BE_TOKEN  */
+  YYSYMBOL_H5T_IEEE_F64LE_TOKEN = 33,      /* H5T_IEEE_F64LE_TOKEN  */
+  YYSYMBOL_H5T_NATIVE_FLOAT_TOKEN = 34,    /* H5T_NATIVE_FLOAT_TOKEN  */
+  YYSYMBOL_H5T_NATIVE_DOUBLE_TOKEN = 35,   /* H5T_NATIVE_DOUBLE_TOKEN  */
+  YYSYMBOL_H5T_NATIVE_LDOUBLE_TOKEN = 36,  /* H5T_NATIVE_LDOUBLE_TOKEN  */
+  YYSYMBOL_H5T_STRING_TOKEN = 37,          /* H5T_STRING_TOKEN  */
+  YYSYMBOL_STRSIZE_TOKEN = 38,             /* STRSIZE_TOKEN  */
+  YYSYMBOL_STRPAD_TOKEN = 39,              /* STRPAD_TOKEN  */
+  YYSYMBOL_CSET_TOKEN = 40,                /* CSET_TOKEN  */
+  YYSYMBOL_CTYPE_TOKEN = 41,               /* CTYPE_TOKEN  */
+  YYSYMBOL_H5T_VARIABLE_TOKEN = 42,        /* H5T_VARIABLE_TOKEN  */
+  YYSYMBOL_H5T_STR_NULLTERM_TOKEN = 43,    /* H5T_STR_NULLTERM_TOKEN  */
+  YYSYMBOL_H5T_STR_NULLPAD_TOKEN = 44,     /* H5T_STR_NULLPAD_TOKEN  */
+  YYSYMBOL_H5T_STR_SPACEPAD_TOKEN = 45,    /* H5T_STR_SPACEPAD_TOKEN  */
+  YYSYMBOL_H5T_CSET_ASCII_TOKEN = 46,      /* H5T_CSET_ASCII_TOKEN  */
+  YYSYMBOL_H5T_CSET_UTF8_TOKEN = 47,       /* H5T_CSET_UTF8_TOKEN  */
+  YYSYMBOL_H5T_C_S1_TOKEN = 48,            /* H5T_C_S1_TOKEN  */
+  YYSYMBOL_H5T_FORTRAN_S1_TOKEN = 49,      /* H5T_FORTRAN_S1_TOKEN  */
+  YYSYMBOL_H5T_OPAQUE_TOKEN = 50,          /* H5T_OPAQUE_TOKEN  */
+  YYSYMBOL_OPQ_SIZE_TOKEN = 51,            /* OPQ_SIZE_TOKEN  */
+  YYSYMBOL_OPQ_TAG_TOKEN = 52,             /* OPQ_TAG_TOKEN  */
+  YYSYMBOL_H5T_COMPOUND_TOKEN = 53,        /* H5T_COMPOUND_TOKEN  */
+  YYSYMBOL_H5T_ENUM_TOKEN = 54,            /* H5T_ENUM_TOKEN  */
+  YYSYMBOL_H5T_ARRAY_TOKEN = 55,           /* H5T_ARRAY_TOKEN  */
+  YYSYMBOL_H5T_VLEN_TOKEN = 56,            /* H5T_VLEN_TOKEN  */
+  YYSYMBOL_STRING = 57,                    /* STRING  */
+  YYSYMBOL_NUMBER = 58,                    /* NUMBER  */
+  YYSYMBOL_59_ = 59,                       /* '{'  */
+  YYSYMBOL_60_ = 60,                       /* '}'  */
+  YYSYMBOL_61_ = 61,                       /* '['  */
+  YYSYMBOL_62_ = 62,                       /* ']'  */
+  YYSYMBOL_63_ = 63,                       /* ':'  */
+  YYSYMBOL_64_ = 64,                       /* ';'  */
+  YYSYMBOL_YYACCEPT = 65,                  /* $accept  */
+  YYSYMBOL_start = 66,                     /* start  */
+  YYSYMBOL_ddl_type = 67,                  /* ddl_type  */
+  YYSYMBOL_atomic_type = 68,               /* atomic_type  */
+  YYSYMBOL_integer_type = 69,              /* integer_type  */
+  YYSYMBOL_fp_type = 70,                   /* fp_type  */
+  YYSYMBOL_compound_type = 71,             /* compound_type  */
+  YYSYMBOL_72_1 = 72,                      /* $@1  */
+  YYSYMBOL_memb_list = 73,                 /* memb_list  */
+  YYSYMBOL_memb_def = 74,                  /* memb_def  */
+  YYSYMBOL_75_2 = 75,                      /* $@2  */
+  YYSYMBOL_field_name = 76,                /* field_name  */
+  YYSYMBOL_field_offset = 77,              /* field_offset  */
+  YYSYMBOL_offset = 78,                    /* offset  */
+  YYSYMBOL_array_type = 79,                /* array_type  */
+  YYSYMBOL_80_3 = 80,                      /* $@3  */
+  YYSYMBOL_dim_list = 81,                  /* dim_list  */
+  YYSYMBOL_dim = 82,                       /* dim  */
+  YYSYMBOL_83_4 = 83,                      /* $@4  */
+  YYSYMBOL_84_5 = 84,                      /* $@5  */
+  YYSYMBOL_dimsize = 85,                   /* dimsize  */
+  YYSYMBOL_vlen_type = 86,                 /* vlen_type  */
+  YYSYMBOL_opaque_type = 87,               /* opaque_type  */
+  YYSYMBOL_88_6 = 88,                      /* @6  */
+  YYSYMBOL_89_7 = 89,                      /* $@7  */
+  YYSYMBOL_opaque_size = 90,               /* opaque_size  */
+  YYSYMBOL_opaque_tag = 91,                /* opaque_tag  */
+  YYSYMBOL_string_type = 92,               /* string_type  */
+  YYSYMBOL_93_8 = 93,                      /* $@8  */
+  YYSYMBOL_94_9 = 94,                      /* $@9  */
+  YYSYMBOL_95_10 = 95,                     /* $@10  */
+  YYSYMBOL_96_11 = 96,                     /* @11  */
+  YYSYMBOL_strsize = 97,                   /* strsize  */
+  YYSYMBOL_strpad = 98,                    /* strpad  */
+  YYSYMBOL_cset = 99,                      /* cset  */
+  YYSYMBOL_ctype = 100,                    /* ctype  */
+  YYSYMBOL_enum_type = 101,                /* enum_type  */
+  YYSYMBOL_102_12 = 102,                   /* $@12  */
+  YYSYMBOL_enum_list = 103,                /* enum_list  */
+  YYSYMBOL_enum_def = 104,                 /* enum_def  */
+  YYSYMBOL_105_13 = 105,                   /* $@13  */
+  YYSYMBOL_enum_symbol = 106,              /* enum_symbol  */
+  YYSYMBOL_enum_val = 107                  /* enum_val  */
 };
-typedef union YYSTYPE YYSTYPE;
-# define YYSTYPE_IS_TRIVIAL 1
-# define YYSTYPE_IS_DECLARED 1
-#endif
+typedef enum yysymbol_kind_t yysymbol_kind_t;
 
-
-extern YYSTYPE H5LTyylval;
-
-hid_t H5LTyyparse (void);
-
-#endif /* !YY_H5LTYY_HL_SRC_H5LTPARSE_H_INCLUDED  */
 
 
 
@@ -322,6 +332,18 @@ typedef __INT_LEAST16_TYPE__ yytype_int16;
 typedef int_least16_t yytype_int16;
 #else
 typedef short yytype_int16;
+#endif
+
+/* Work around bug in HP-UX 11.23, which defines these macros
+   incorrectly for preprocessor constants.  This workaround can likely
+   be removed in 2023, as HPE has promised support for HP-UX 11.23
+   (aka HP-UX 11i v2) only through the end of 2022; see Table 2 of
+   <https://h20195.www2.hpe.com/V2/getpdf.aspx/4AA4-7673ENW.pdf>.  */
+#ifdef __hpux
+# undef UINT_LEAST8_MAX
+# undef UINT_LEAST16_MAX
+# define UINT_LEAST8_MAX 255
+# define UINT_LEAST16_MAX 65535
 #endif
 
 #if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
@@ -383,6 +405,7 @@ typedef int yytype_uint16;
 
 #define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
 
+
 /* Stored state numbers (used for stacks). */
 typedef yytype_uint8 yy_state_t;
 
@@ -400,6 +423,7 @@ typedef int yy_state_fast_t;
 #  define YY_(Msgid) Msgid
 # endif
 #endif
+
 
 #ifndef YY_ATTRIBUTE_PURE
 # if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
@@ -419,17 +443,23 @@ typedef int yy_state_fast_t;
 
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
-# define YYUSE(E) ((void) (E))
+# define YY_USE(E) ((void) (E))
 #else
-# define YYUSE(E) /* empty */
+# define YY_USE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && ! defined __ICC && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                            \
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
     _Pragma ("GCC diagnostic push")                                     \
     _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
     _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# endif
 # define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
     _Pragma ("GCC diagnostic pop")
 #else
@@ -458,7 +488,7 @@ typedef int yy_state_fast_t;
 
 #define YY_ASSERT(E) ((void) (0 && (E)))
 
-#if ! defined yyoverflow || YYERROR_VERBOSE
+#if !defined yyoverflow
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
@@ -523,8 +553,7 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 # endif
-#endif /* ! defined yyoverflow || YYERROR_VERBOSE */
-
+#endif /* !defined yyoverflow */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
@@ -600,14 +629,16 @@ union yyalloc
 /* YYNSTATES -- Number of states.  */
 #define YYNSTATES  134
 
-#define YYUNDEFTOK  2
+/* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   313
 
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex, with out-of-bounds checking.  */
-#define YYTRANSLATE(YYX)                                                \
-  (0 <= (YYX) && (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex.  */
@@ -648,7 +679,7 @@ static const yytype_int8 yytranslate[] =
 };
 
 #if YYDEBUG
-  /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
        0,   102,   102,   103,   105,   106,   107,   108,   110,   111,
@@ -664,12 +695,19 @@ static const yytype_int16 yyrline[] =
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || 0
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if YYDEBUG || 0
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "H5T_STD_I8BE_TOKEN",
+  "\"end of file\"", "error", "\"invalid token\"", "H5T_STD_I8BE_TOKEN",
   "H5T_STD_I8LE_TOKEN", "H5T_STD_I16BE_TOKEN", "H5T_STD_I16LE_TOKEN",
   "H5T_STD_I32BE_TOKEN", "H5T_STD_I32LE_TOKEN", "H5T_STD_I64BE_TOKEN",
   "H5T_STD_I64LE_TOKEN", "H5T_STD_U8BE_TOKEN", "H5T_STD_U8LE_TOKEN",
@@ -699,22 +737,13 @@ static const char *const yytname[] =
   "strpad", "cset", "ctype", "enum_type", "$@12", "enum_list", "enum_def",
   "$@13", "enum_symbol", "enum_val", YY_NULLPTR
 };
-#endif
 
-# ifdef YYPRINT
-/* YYTOKNUM[NUM] -- (External) token number corresponding to the
-   (internal) symbol number NUM (which must be that of a token).  */
-static const yytype_int16 yytoknum[] =
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
 {
-       0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
-     265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-     275,   276,   277,   278,   279,   280,   281,   282,   283,   284,
-     285,   286,   287,   288,   289,   290,   291,   292,   293,   294,
-     295,   296,   297,   298,   299,   300,   301,   302,   303,   304,
-     305,   306,   307,   308,   309,   310,   311,   312,   313,   123,
-     125,    91,    93,    58,    59
-};
-# endif
+  return yytname[yysymbol];
+}
+#endif
 
 #define YYPACT_NINF (-25)
 
@@ -726,8 +755,8 @@ static const yytype_int16 yytoknum[] =
 #define yytable_value_is_error(Yyn) \
   0
 
-  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-     STATE-NUM.  */
+/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+   STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
      114,   -25,   -25,   -25,   -25,   -25,   -25,   -25,   -25,   -25,
@@ -746,9 +775,9 @@ static const yytype_int16 yypact[] =
      101,   -25,   103,   -25
 };
 
-  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
-     Performed when YYTABLE does not specify something else to do.  Zero
-     means the default is an error.  */
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE does not specify something else to do.  Zero
+   means the default is an error.  */
 static const yytype_int8 yydefact[] =
 {
        2,    13,    14,    15,    16,    17,    18,    19,    20,    21,
@@ -767,7 +796,7 @@ static const yytype_int8 yydefact[] =
        0,    74,     0,    75
 };
 
-  /* YYPGOTO[NTERM-NUM].  */
+/* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
      -25,   -25,   -15,   -25,   111,   -25,   -25,   -25,   -25,   -25,
@@ -777,19 +806,19 @@ static const yytype_int8 yypgoto[] =
      -25,   -25,   -25
 };
 
-  /* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int16 yydefgoto[] =
+/* YYDEFGOTO[NTERM-NUM].  */
+static const yytype_uint8 yydefgoto[] =
 {
-      -1,    41,    42,    43,    44,    45,    46,    54,    70,    78,
+       0,    41,    42,    43,    44,    45,    46,    54,    70,    78,
       85,    92,   106,   112,    47,    56,    72,    82,    87,   108,
       98,    48,    49,    84,   118,    69,   104,    50,    83,   117,
      126,   132,    67,   102,   124,   130,    51,    79,    86,    95,
      107,    96,   115
 };
 
-  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
-     positive, shift that token.  If negative, reduce the rule whose
-     number is the opposite.  If YYTABLE_NINF, syntax error.  */
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule whose
+   number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_uint8 yytable[] =
 {
        1,     2,     3,     4,     5,     6,     7,     8,     9,    10,
@@ -838,8 +867,8 @@ static const yytype_int8 yycheck[] =
       22,    23,    24,    25,    26,    27,    28,    29
 };
 
-  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-     symbol of state STATE-NUM.  */
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
 static const yytype_int8 yystos[] =
 {
        0,     3,     4,     5,     6,     7,     8,     9,    10,    11,
@@ -858,7 +887,7 @@ static const yytype_int8 yystos[] =
      100,    64,    96,    60
 };
 
-  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr1[] =
 {
        0,    65,    66,    66,    67,    67,    67,    67,    68,    68,
@@ -873,7 +902,7 @@ static const yytype_int8 yyr1[] =
      104,   106,   107
 };
 
-  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr2[] =
 {
        0,     2,     0,     1,     1,     1,     1,     1,     1,     1,
@@ -889,14 +918,15 @@ static const yytype_int8 yyr2[] =
 };
 
 
+enum { YYENOMEM = -2 };
+
 #define yyerrok         (yyerrstatus = 0)
 #define yyclearin       (yychar = YYEMPTY)
-#define YYEMPTY         (-2)
-#define YYEOF           0
 
 #define YYACCEPT        goto yyacceptlab
 #define YYABORT         goto yyabortlab
 #define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
 
 
 #define YYRECOVERING()  (!!yyerrstatus)
@@ -918,10 +948,9 @@ static const yytype_int8 yyr2[] =
       }                                                           \
   while (0)
 
-/* Error token number */
-#define YYTERROR        1
-#define YYERRCODE       256
-
+/* Backward compatibility with an undocumented macro.
+   Use YYerror or YYUNDEF. */
+#define YYERRCODE YYUNDEF
 
 
 /* Enable debugging if requested.  */
@@ -938,19 +967,16 @@ do {                                            \
     YYFPRINTF Args;                             \
 } while (0)
 
-/* This macro is provided for backward compatibility. */
-#ifndef YY_LOCATION_PRINT
-# define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-#endif
 
 
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
+
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
 do {                                                                      \
   if (yydebug)                                                            \
     {                                                                     \
       YYFPRINTF (stderr, "%s ", Title);                                   \
       yy_symbol_print (stderr,                                            \
-                  Type, Value); \
+                  Kind, Value); \
       YYFPRINTF (stderr, "\n");                                           \
     }                                                                     \
 } while (0)
@@ -961,18 +987,15 @@ do {                                                                      \
 `-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep)
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep)
 {
   FILE *yyoutput = yyo;
-  YYUSE (yyoutput);
+  YY_USE (yyoutput);
   if (!yyvaluep)
     return;
-# ifdef YYPRINT
-  if (yytype < YYNTOKENS)
-    YYPRINT (yyo, yytoknum[yytype], *yyvaluep);
-# endif
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
+  YY_USE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
@@ -982,12 +1005,13 @@ yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep)
 `---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep)
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep)
 {
   YYFPRINTF (yyo, "%s %s (",
-             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
-  yy_symbol_value_print (yyo, yytype, yyvaluep);
+  yy_symbol_value_print (yyo, yykind, yyvaluep);
   YYFPRINTF (yyo, ")");
 }
 
@@ -1020,7 +1044,8 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, int yyrule)
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp,
+                 int yyrule)
 {
   int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
@@ -1032,9 +1057,8 @@ yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, int yyrule)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
-                       yystos[+yyssp[yyi + 1 - yynrhs]],
-                       &yyvsp[(yyi + 1) - (yynrhs)]
-                                              );
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)]);
       YYFPRINTF (stderr, "\n");
     }
 }
@@ -1049,8 +1073,8 @@ do {                                    \
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !YYDEBUG */
-# define YYDPRINTF(Args)
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
 # define YY_STACK_PRINT(Bottom, Top)
 # define YY_REDUCE_PRINT(Rule)
 #endif /* !YYDEBUG */
@@ -1073,265 +1097,38 @@ int yydebug;
 #endif
 
 
-#if YYERROR_VERBOSE
 
-# ifndef yystrlen
-#  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
-#  else
-/* Return the length of YYSTR.  */
-static YYPTRDIFF_T
-yystrlen (const char *yystr)
-{
-  YYPTRDIFF_T yylen;
-  for (yylen = 0; yystr[yylen]; yylen++)
-    continue;
-  return yylen;
-}
-#  endif
-# endif
 
-# ifndef yystpcpy
-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#   define yystpcpy stpcpy
-#  else
-/* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
-   YYDEST.  */
-static char *
-yystpcpy (char *yydest, const char *yysrc)
-{
-  char *yyd = yydest;
-  const char *yys = yysrc;
 
-  while ((*yyd++ = *yys++) != '\0')
-    continue;
-
-  return yyd - 1;
-}
-#  endif
-# endif
-
-# ifndef yytnamerr
-/* Copy to YYRES the contents of YYSTR after stripping away unnecessary
-   quotes and backslashes, so that it's suitable for yyerror.  The
-   heuristic is that double-quoting is unnecessary unless the string
-   contains an apostrophe, a comma, or backslash (other than
-   backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
-   null, do not copy; instead, return the length of what the result
-   would have been.  */
-static YYPTRDIFF_T
-yytnamerr (char *yyres, const char *yystr)
-{
-  if (*yystr == '"')
-    {
-      YYPTRDIFF_T yyn = 0;
-      char const *yyp = yystr;
-
-      for (;;)
-        switch (*++yyp)
-          {
-          case '\'':
-          case ',':
-            goto do_not_strip_quotes;
-
-          case '\\':
-            if (*++yyp != '\\')
-              goto do_not_strip_quotes;
-            else
-              goto append;
-
-          append:
-          default:
-            if (yyres)
-              yyres[yyn] = *yyp;
-            yyn++;
-            break;
-
-          case '"':
-            if (yyres)
-              yyres[yyn] = '\0';
-            return yyn;
-          }
-    do_not_strip_quotes: ;
-    }
-
-  if (yyres)
-    return yystpcpy (yyres, yystr) - yyres;
-  else
-    return yystrlen (yystr);
-}
-# endif
-
-/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
-   about the unexpected token YYTOKEN for the state stack whose top is
-   YYSSP.
-
-   Return 0 if *YYMSG was successfully written.  Return 1 if *YYMSG is
-   not large enough to hold the message.  In that case, also set
-   *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
-   required number of bytes is too large to store.  */
-static int
-yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
-                yy_state_t *yyssp, int yytoken)
-{
-  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-  /* Internationalized format string. */
-  const char *yyformat = YY_NULLPTR;
-  /* Arguments of yyformat: reported tokens (one for the "unexpected",
-     one per "expected"). */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  /* Actual size of YYARG. */
-  int yycount = 0;
-  /* Cumulated lengths of YYARG.  */
-  YYPTRDIFF_T yysize = 0;
-
-  /* There are many possibilities here to consider:
-     - If this state is a consistent state with a default action, then
-       the only way this function was invoked is if the default action
-       is an error action.  In that case, don't check for expected
-       tokens because there are none.
-     - The only way there can be no lookahead present (in yychar) is if
-       this state is a consistent state with a default action.  Thus,
-       detecting the absence of a lookahead is sufficient to determine
-       that there is no unexpected or expected token to report.  In that
-       case, just report a simple "syntax error".
-     - Don't assume there isn't a lookahead just because this state is a
-       consistent state with a default action.  There might have been a
-       previous inconsistent state, consistent state with a non-default
-       action, or user semantic action that manipulated yychar.
-     - Of course, the expected token list depends on states to have
-       correct lookahead information, and it depends on the parser not
-       to perform extra reductions after fetching a lookahead from the
-       scanner and before detecting a syntax error.  Thus, state merging
-       (from LALR or IELR) and default reductions corrupt the expected
-       token list.  However, the list is correct for canonical LR with
-       one exception: it will still contain any token that will not be
-       accepted due to an error action in a later state.
-  */
-  if (yytoken != YYEMPTY)
-    {
-      int yyn = yypact[+*yyssp];
-      YYPTRDIFF_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
-      yysize = yysize0;
-      yyarg[yycount++] = yytname[yytoken];
-      if (!yypact_value_is_default (yyn))
-        {
-          /* Start YYX at -YYN if negative to avoid negative indexes in
-             YYCHECK.  In other words, skip the first -YYN actions for
-             this state because they are default actions.  */
-          int yyxbegin = yyn < 0 ? -yyn : 0;
-          /* Stay within bounds of both yycheck and yytname.  */
-          int yychecklim = YYLAST - yyn + 1;
-          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-          int yyx;
-
-          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
-                && !yytable_value_is_error (yytable[yyx + yyn]))
-              {
-                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-                  {
-                    yycount = 1;
-                    yysize = yysize0;
-                    break;
-                  }
-                yyarg[yycount++] = yytname[yyx];
-                {
-                  YYPTRDIFF_T yysize1
-                    = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-                    yysize = yysize1;
-                  else
-                    return 2;
-                }
-              }
-        }
-    }
-
-  switch (yycount)
-    {
-# define YYCASE_(N, S)                      \
-      case N:                               \
-        yyformat = S;                       \
-      break
-    default: /* Avoid compiler warnings. */
-      YYCASE_(0, YY_("syntax error"));
-      YYCASE_(1, YY_("syntax error, unexpected %s"));
-      YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
-      YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
-      YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
-      YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
-# undef YYCASE_
-    }
-
-  {
-    /* Don't count the "%s"s in the final size, but reserve room for
-       the terminator.  */
-    YYPTRDIFF_T yysize1 = yysize + (yystrlen (yyformat) - 2 * yycount) + 1;
-    if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-      yysize = yysize1;
-    else
-      return 2;
-  }
-
-  if (*yymsg_alloc < yysize)
-    {
-      *yymsg_alloc = 2 * yysize;
-      if (! (yysize <= *yymsg_alloc
-             && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
-        *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
-      return 1;
-    }
-
-  /* Avoid sprintf, as that infringes on the user's name space.
-     Don't have undefined behavior even if the translation
-     produced a string with the wrong number of "%s"s.  */
-  {
-    char *yyp = *yymsg;
-    int yyi = 0;
-    while ((*yyp = *yyformat) != '\0')
-      if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
-        {
-          yyp += yytnamerr (yyp, yyarg[yyi++]);
-          yyformat += 2;
-        }
-      else
-        {
-          ++yyp;
-          ++yyformat;
-        }
-  }
-  return 0;
-}
-#endif /* YYERROR_VERBOSE */
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep)
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep)
 {
-  YYUSE (yyvaluep);
+  YY_USE (yyvaluep);
   if (!yymsg)
     yymsg = "Deleting";
-  YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
+  YY_USE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
-
-
-/* The lookahead symbol.  */
+/* Lookahead token kind.  */
 int yychar;
 
 /* The semantic value of the lookahead symbol.  */
 YYSTYPE yylval;
 /* Number of syntax errors so far.  */
 int yynerrs;
+
+
 
 
 /*----------.
@@ -1341,43 +1138,36 @@ int yynerrs;
 hid_t
 yyparse (void)
 {
-    yy_state_fast_t yystate;
+    yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */
-    int yyerrstatus;
+    int yyerrstatus = 0;
 
-    /* The stacks and their tools:
-       'yyss': related to states.
-       'yyvs': related to semantic values.
-
-       Refer to the stacks through separate pointers, to allow yyoverflow
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
 
-    /* The state stack.  */
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
+
+    /* The state stack: array, bottom, top.  */
     yy_state_t yyssa[YYINITDEPTH];
-    yy_state_t *yyss;
-    yy_state_t *yyssp;
+    yy_state_t *yyss = yyssa;
+    yy_state_t *yyssp = yyss;
 
-    /* The semantic value stack.  */
+    /* The semantic value stack: array, bottom, top.  */
     YYSTYPE yyvsa[YYINITDEPTH];
-    YYSTYPE *yyvs;
-    YYSTYPE *yyvsp;
-
-    YYPTRDIFF_T yystacksize;
+    YYSTYPE *yyvs = yyvsa;
+    YYSTYPE *yyvsp = yyvs;
 
   int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
-  /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
 
-#if YYERROR_VERBOSE
-  /* Buffer for error messages, and its allocated size.  */
-  char yymsgbuf[128];
-  char *yymsg = yymsgbuf;
-  YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
-#endif
+
 
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
 
@@ -1385,16 +1175,10 @@ yyparse (void)
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
 
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;
-  yystacksize = YYINITDEPTH;
-
   YYDPRINTF ((stderr, "Starting parse\n"));
 
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
   yychar = YYEMPTY; /* Cause a token to be read.  */
+
   goto yysetstate;
 
 
@@ -1416,10 +1200,11 @@ yysetstate:
   YY_IGNORE_USELESS_CAST_BEGIN
   *yyssp = YY_CAST (yy_state_t, yystate);
   YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
   if (yyss + yystacksize - 1 <= yyssp)
 #if !defined yyoverflow && !defined YYSTACK_RELOCATE
-    goto yyexhaustedlab;
+    YYNOMEM;
 #else
     {
       /* Get the current used size of the three stacks, in elements.  */
@@ -1447,7 +1232,7 @@ yysetstate:
 # else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-        goto yyexhaustedlab;
+        YYNOMEM;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
         yystacksize = YYMAXDEPTH;
@@ -1458,10 +1243,10 @@ yysetstate:
           YY_CAST (union yyalloc *,
                    YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
         if (! yyptr)
-          goto yyexhaustedlab;
+          YYNOMEM;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
-# undef YYSTACK_RELOCATE
+#  undef YYSTACK_RELOCATE
         if (yyss1 != yyssa)
           YYSTACK_FREE (yyss1);
       }
@@ -1479,6 +1264,7 @@ yysetstate:
         YYABORT;
     }
 #endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
+
 
   if (yystate == YYFINAL)
     YYACCEPT;
@@ -1500,17 +1286,28 @@ yybackup:
 
   /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
   if (yychar == YYEMPTY)
     {
-      YYDPRINTF ((stderr, "Reading a token: "));
+      YYDPRINTF ((stderr, "Reading a token\n"));
       yychar = yylex ();
     }
 
   if (yychar <= YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == YYerror)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = YYUNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      goto yyerrlab1;
     }
   else
     {
@@ -1580,246 +1377,246 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-  case 2:
-#line 102 "./hl/src/H5LTparse.y"
+  case 2: /* start: %empty  */
+#line 102 "hl/src//H5LTparse.y"
                 { memset(arr_stack, 0, STACK_SIZE*sizeof(struct arr_info)); /*initialize here?*/ }
-#line 1557 "./hl/src/H5LTparse.c"
+#line 1353 "hl/src//H5LTparse.c"
     break;
 
-  case 3:
-#line 103 "./hl/src/H5LTparse.y"
+  case 3: /* start: ddl_type  */
+#line 103 "hl/src//H5LTparse.y"
                           { return (yyval.hid);}
-#line 1563 "./hl/src/H5LTparse.c"
+#line 1359 "hl/src//H5LTparse.c"
     break;
 
-  case 13:
-#line 117 "./hl/src/H5LTparse.y"
+  case 13: /* integer_type: H5T_STD_I8BE_TOKEN  */
+#line 117 "hl/src//H5LTparse.y"
                                             { (yyval.hid) = H5Tcopy(H5T_STD_I8BE); }
-#line 1569 "./hl/src/H5LTparse.c"
+#line 1365 "hl/src//H5LTparse.c"
     break;
 
-  case 14:
-#line 118 "./hl/src/H5LTparse.y"
+  case 14: /* integer_type: H5T_STD_I8LE_TOKEN  */
+#line 118 "hl/src//H5LTparse.y"
                                             { (yyval.hid) = H5Tcopy(H5T_STD_I8LE); }
-#line 1575 "./hl/src/H5LTparse.c"
+#line 1371 "hl/src//H5LTparse.c"
     break;
 
-  case 15:
-#line 119 "./hl/src/H5LTparse.y"
+  case 15: /* integer_type: H5T_STD_I16BE_TOKEN  */
+#line 119 "hl/src//H5LTparse.y"
                                             { (yyval.hid) = H5Tcopy(H5T_STD_I16BE); }
-#line 1581 "./hl/src/H5LTparse.c"
+#line 1377 "hl/src//H5LTparse.c"
     break;
 
-  case 16:
-#line 120 "./hl/src/H5LTparse.y"
+  case 16: /* integer_type: H5T_STD_I16LE_TOKEN  */
+#line 120 "hl/src//H5LTparse.y"
                                             { (yyval.hid) = H5Tcopy(H5T_STD_I16LE); }
-#line 1587 "./hl/src/H5LTparse.c"
+#line 1383 "hl/src//H5LTparse.c"
     break;
 
-  case 17:
-#line 121 "./hl/src/H5LTparse.y"
+  case 17: /* integer_type: H5T_STD_I32BE_TOKEN  */
+#line 121 "hl/src//H5LTparse.y"
                                             { (yyval.hid) = H5Tcopy(H5T_STD_I32BE); }
-#line 1593 "./hl/src/H5LTparse.c"
+#line 1389 "hl/src//H5LTparse.c"
     break;
 
-  case 18:
-#line 122 "./hl/src/H5LTparse.y"
+  case 18: /* integer_type: H5T_STD_I32LE_TOKEN  */
+#line 122 "hl/src//H5LTparse.y"
                                             { (yyval.hid) = H5Tcopy(H5T_STD_I32LE); }
-#line 1599 "./hl/src/H5LTparse.c"
+#line 1395 "hl/src//H5LTparse.c"
     break;
 
-  case 19:
-#line 123 "./hl/src/H5LTparse.y"
+  case 19: /* integer_type: H5T_STD_I64BE_TOKEN  */
+#line 123 "hl/src//H5LTparse.y"
                                             { (yyval.hid) = H5Tcopy(H5T_STD_I64BE); }
-#line 1605 "./hl/src/H5LTparse.c"
+#line 1401 "hl/src//H5LTparse.c"
     break;
 
-  case 20:
-#line 124 "./hl/src/H5LTparse.y"
+  case 20: /* integer_type: H5T_STD_I64LE_TOKEN  */
+#line 124 "hl/src//H5LTparse.y"
                                             { (yyval.hid) = H5Tcopy(H5T_STD_I64LE); }
-#line 1611 "./hl/src/H5LTparse.c"
+#line 1407 "hl/src//H5LTparse.c"
     break;
 
-  case 21:
-#line 125 "./hl/src/H5LTparse.y"
+  case 21: /* integer_type: H5T_STD_U8BE_TOKEN  */
+#line 125 "hl/src//H5LTparse.y"
                                             { (yyval.hid) = H5Tcopy(H5T_STD_U8BE); }
-#line 1617 "./hl/src/H5LTparse.c"
+#line 1413 "hl/src//H5LTparse.c"
     break;
 
-  case 22:
-#line 126 "./hl/src/H5LTparse.y"
+  case 22: /* integer_type: H5T_STD_U8LE_TOKEN  */
+#line 126 "hl/src//H5LTparse.y"
                                             { (yyval.hid) = H5Tcopy(H5T_STD_U8LE); }
-#line 1623 "./hl/src/H5LTparse.c"
+#line 1419 "hl/src//H5LTparse.c"
     break;
 
-  case 23:
-#line 127 "./hl/src/H5LTparse.y"
+  case 23: /* integer_type: H5T_STD_U16BE_TOKEN  */
+#line 127 "hl/src//H5LTparse.y"
                                             { (yyval.hid) = H5Tcopy(H5T_STD_U16BE); }
-#line 1629 "./hl/src/H5LTparse.c"
+#line 1425 "hl/src//H5LTparse.c"
     break;
 
-  case 24:
-#line 128 "./hl/src/H5LTparse.y"
+  case 24: /* integer_type: H5T_STD_U16LE_TOKEN  */
+#line 128 "hl/src//H5LTparse.y"
                                             { (yyval.hid) = H5Tcopy(H5T_STD_U16LE); }
-#line 1635 "./hl/src/H5LTparse.c"
+#line 1431 "hl/src//H5LTparse.c"
     break;
 
-  case 25:
-#line 129 "./hl/src/H5LTparse.y"
+  case 25: /* integer_type: H5T_STD_U32BE_TOKEN  */
+#line 129 "hl/src//H5LTparse.y"
                                             { (yyval.hid) = H5Tcopy(H5T_STD_U32BE); }
-#line 1641 "./hl/src/H5LTparse.c"
+#line 1437 "hl/src//H5LTparse.c"
     break;
 
-  case 26:
-#line 130 "./hl/src/H5LTparse.y"
+  case 26: /* integer_type: H5T_STD_U32LE_TOKEN  */
+#line 130 "hl/src//H5LTparse.y"
                                             { (yyval.hid) = H5Tcopy(H5T_STD_U32LE); }
-#line 1647 "./hl/src/H5LTparse.c"
+#line 1443 "hl/src//H5LTparse.c"
     break;
 
-  case 27:
-#line 131 "./hl/src/H5LTparse.y"
+  case 27: /* integer_type: H5T_STD_U64BE_TOKEN  */
+#line 131 "hl/src//H5LTparse.y"
                                             { (yyval.hid) = H5Tcopy(H5T_STD_U64BE); }
-#line 1653 "./hl/src/H5LTparse.c"
+#line 1449 "hl/src//H5LTparse.c"
     break;
 
-  case 28:
-#line 132 "./hl/src/H5LTparse.y"
+  case 28: /* integer_type: H5T_STD_U64LE_TOKEN  */
+#line 132 "hl/src//H5LTparse.y"
                                             { (yyval.hid) = H5Tcopy(H5T_STD_U64LE); }
-#line 1659 "./hl/src/H5LTparse.c"
+#line 1455 "hl/src//H5LTparse.c"
     break;
 
-  case 29:
-#line 133 "./hl/src/H5LTparse.y"
+  case 29: /* integer_type: H5T_NATIVE_CHAR_TOKEN  */
+#line 133 "hl/src//H5LTparse.y"
                                                 { (yyval.hid) = H5Tcopy(H5T_NATIVE_CHAR); }
-#line 1665 "./hl/src/H5LTparse.c"
+#line 1461 "hl/src//H5LTparse.c"
     break;
 
-  case 30:
-#line 134 "./hl/src/H5LTparse.y"
+  case 30: /* integer_type: H5T_NATIVE_SCHAR_TOKEN  */
+#line 134 "hl/src//H5LTparse.y"
                                                 { (yyval.hid) = H5Tcopy(H5T_NATIVE_SCHAR); }
-#line 1671 "./hl/src/H5LTparse.c"
+#line 1467 "hl/src//H5LTparse.c"
     break;
 
-  case 31:
-#line 135 "./hl/src/H5LTparse.y"
+  case 31: /* integer_type: H5T_NATIVE_UCHAR_TOKEN  */
+#line 135 "hl/src//H5LTparse.y"
                                                 { (yyval.hid) = H5Tcopy(H5T_NATIVE_UCHAR); }
-#line 1677 "./hl/src/H5LTparse.c"
+#line 1473 "hl/src//H5LTparse.c"
     break;
 
-  case 32:
-#line 136 "./hl/src/H5LTparse.y"
+  case 32: /* integer_type: H5T_NATIVE_SHORT_TOKEN  */
+#line 136 "hl/src//H5LTparse.y"
                                                 { (yyval.hid) = H5Tcopy(H5T_NATIVE_SHORT); }
-#line 1683 "./hl/src/H5LTparse.c"
+#line 1479 "hl/src//H5LTparse.c"
     break;
 
-  case 33:
-#line 137 "./hl/src/H5LTparse.y"
+  case 33: /* integer_type: H5T_NATIVE_USHORT_TOKEN  */
+#line 137 "hl/src//H5LTparse.y"
                                                 { (yyval.hid) = H5Tcopy(H5T_NATIVE_USHORT); }
-#line 1689 "./hl/src/H5LTparse.c"
+#line 1485 "hl/src//H5LTparse.c"
     break;
 
-  case 34:
-#line 138 "./hl/src/H5LTparse.y"
+  case 34: /* integer_type: H5T_NATIVE_INT_TOKEN  */
+#line 138 "hl/src//H5LTparse.y"
                                                 { (yyval.hid) = H5Tcopy(H5T_NATIVE_INT); }
-#line 1695 "./hl/src/H5LTparse.c"
+#line 1491 "hl/src//H5LTparse.c"
     break;
 
-  case 35:
-#line 139 "./hl/src/H5LTparse.y"
+  case 35: /* integer_type: H5T_NATIVE_UINT_TOKEN  */
+#line 139 "hl/src//H5LTparse.y"
                                                 { (yyval.hid) = H5Tcopy(H5T_NATIVE_UINT); }
-#line 1701 "./hl/src/H5LTparse.c"
+#line 1497 "hl/src//H5LTparse.c"
     break;
 
-  case 36:
-#line 140 "./hl/src/H5LTparse.y"
+  case 36: /* integer_type: H5T_NATIVE_LONG_TOKEN  */
+#line 140 "hl/src//H5LTparse.y"
                                                 { (yyval.hid) = H5Tcopy(H5T_NATIVE_LONG); }
-#line 1707 "./hl/src/H5LTparse.c"
+#line 1503 "hl/src//H5LTparse.c"
     break;
 
-  case 37:
-#line 141 "./hl/src/H5LTparse.y"
+  case 37: /* integer_type: H5T_NATIVE_ULONG_TOKEN  */
+#line 141 "hl/src//H5LTparse.y"
                                                 { (yyval.hid) = H5Tcopy(H5T_NATIVE_ULONG); }
-#line 1713 "./hl/src/H5LTparse.c"
+#line 1509 "hl/src//H5LTparse.c"
     break;
 
-  case 38:
-#line 142 "./hl/src/H5LTparse.y"
+  case 38: /* integer_type: H5T_NATIVE_LLONG_TOKEN  */
+#line 142 "hl/src//H5LTparse.y"
                                                 { (yyval.hid) = H5Tcopy(H5T_NATIVE_LLONG); }
-#line 1719 "./hl/src/H5LTparse.c"
+#line 1515 "hl/src//H5LTparse.c"
     break;
 
-  case 39:
-#line 143 "./hl/src/H5LTparse.y"
+  case 39: /* integer_type: H5T_NATIVE_ULLONG_TOKEN  */
+#line 143 "hl/src//H5LTparse.y"
                                                 { (yyval.hid) = H5Tcopy(H5T_NATIVE_ULLONG); }
-#line 1725 "./hl/src/H5LTparse.c"
+#line 1521 "hl/src//H5LTparse.c"
     break;
 
-  case 40:
-#line 146 "./hl/src/H5LTparse.y"
+  case 40: /* fp_type: H5T_IEEE_F32BE_TOKEN  */
+#line 146 "hl/src//H5LTparse.y"
                                              { (yyval.hid) = H5Tcopy(H5T_IEEE_F32BE); }
-#line 1731 "./hl/src/H5LTparse.c"
+#line 1527 "hl/src//H5LTparse.c"
     break;
 
-  case 41:
-#line 147 "./hl/src/H5LTparse.y"
+  case 41: /* fp_type: H5T_IEEE_F32LE_TOKEN  */
+#line 147 "hl/src//H5LTparse.y"
                                              { (yyval.hid) = H5Tcopy(H5T_IEEE_F32LE); }
-#line 1737 "./hl/src/H5LTparse.c"
+#line 1533 "hl/src//H5LTparse.c"
     break;
 
-  case 42:
-#line 148 "./hl/src/H5LTparse.y"
+  case 42: /* fp_type: H5T_IEEE_F64BE_TOKEN  */
+#line 148 "hl/src//H5LTparse.y"
                                              { (yyval.hid) = H5Tcopy(H5T_IEEE_F64BE); }
-#line 1743 "./hl/src/H5LTparse.c"
+#line 1539 "hl/src//H5LTparse.c"
     break;
 
-  case 43:
-#line 149 "./hl/src/H5LTparse.y"
+  case 43: /* fp_type: H5T_IEEE_F64LE_TOKEN  */
+#line 149 "hl/src//H5LTparse.y"
                                              { (yyval.hid) = H5Tcopy(H5T_IEEE_F64LE); }
-#line 1749 "./hl/src/H5LTparse.c"
+#line 1545 "hl/src//H5LTparse.c"
     break;
 
-  case 44:
-#line 150 "./hl/src/H5LTparse.y"
+  case 44: /* fp_type: H5T_NATIVE_FLOAT_TOKEN  */
+#line 150 "hl/src//H5LTparse.y"
                                                   { (yyval.hid) = H5Tcopy(H5T_NATIVE_FLOAT); }
-#line 1755 "./hl/src/H5LTparse.c"
+#line 1551 "hl/src//H5LTparse.c"
     break;
 
-  case 45:
-#line 151 "./hl/src/H5LTparse.y"
+  case 45: /* fp_type: H5T_NATIVE_DOUBLE_TOKEN  */
+#line 151 "hl/src//H5LTparse.y"
                                                   { (yyval.hid) = H5Tcopy(H5T_NATIVE_DOUBLE); }
-#line 1761 "./hl/src/H5LTparse.c"
+#line 1557 "hl/src//H5LTparse.c"
     break;
 
-  case 46:
-#line 152 "./hl/src/H5LTparse.y"
+  case 46: /* fp_type: H5T_NATIVE_LDOUBLE_TOKEN  */
+#line 152 "hl/src//H5LTparse.y"
                                                   { (yyval.hid) = H5Tcopy(H5T_NATIVE_LDOUBLE); }
-#line 1767 "./hl/src/H5LTparse.c"
+#line 1563 "hl/src//H5LTparse.c"
     break;
 
-  case 47:
-#line 156 "./hl/src/H5LTparse.y"
+  case 47: /* $@1: %empty  */
+#line 156 "hl/src//H5LTparse.y"
                             { csindex++; cmpd_stack[csindex].id = H5Tcreate(H5T_COMPOUND, 1); /*temporarily set size to 1*/ }
-#line 1773 "./hl/src/H5LTparse.c"
+#line 1569 "hl/src//H5LTparse.c"
     break;
 
-  case 48:
-#line 158 "./hl/src/H5LTparse.y"
+  case 48: /* compound_type: H5T_COMPOUND_TOKEN $@1 '{' memb_list '}'  */
+#line 158 "hl/src//H5LTparse.y"
                             { (yyval.hid) = cmpd_stack[csindex].id; 
                               cmpd_stack[csindex].id = 0;
                               cmpd_stack[csindex].first_memb = 1; 
                               csindex--;
                             }
-#line 1783 "./hl/src/H5LTparse.c"
+#line 1579 "hl/src//H5LTparse.c"
     break;
 
-  case 51:
-#line 167 "./hl/src/H5LTparse.y"
+  case 51: /* $@2: %empty  */
+#line 167 "hl/src//H5LTparse.y"
                                  { cmpd_stack[csindex].is_field = 1; /*notify lexer a compound member is parsed*/ }
-#line 1789 "./hl/src/H5LTparse.c"
+#line 1585 "hl/src//H5LTparse.c"
     break;
 
-  case 52:
-#line 169 "./hl/src/H5LTparse.y"
+  case 52: /* memb_def: ddl_type $@2 field_name field_offset ';'  */
+#line 169 "hl/src//H5LTparse.y"
                         {   
                             size_t origin_size, new_size;
                             hid_t dtype_id = cmpd_stack[csindex].id;
@@ -1854,108 +1651,108 @@ yyreduce:
                              
                             new_size = H5Tget_size(dtype_id);
                         }
-#line 1828 "./hl/src/H5LTparse.c"
+#line 1624 "hl/src//H5LTparse.c"
     break;
 
-  case 53:
-#line 205 "./hl/src/H5LTparse.y"
+  case 53: /* field_name: STRING  */
+#line 205 "hl/src//H5LTparse.y"
                         {
                             (yyval.sval) = HDstrdup(yylval.sval);
                             HDfree(yylval.sval);
                             yylval.sval = NULL;
                         }
-#line 1838 "./hl/src/H5LTparse.c"
+#line 1634 "hl/src//H5LTparse.c"
     break;
 
-  case 54:
-#line 212 "./hl/src/H5LTparse.y"
+  case 54: /* field_offset: %empty  */
+#line 212 "hl/src//H5LTparse.y"
                         { (yyval.ival) = 0; }
-#line 1844 "./hl/src/H5LTparse.c"
+#line 1640 "hl/src//H5LTparse.c"
     break;
 
-  case 55:
-#line 214 "./hl/src/H5LTparse.y"
+  case 55: /* field_offset: ':' offset  */
+#line 214 "hl/src//H5LTparse.y"
                         { (yyval.ival) = yylval.ival; }
-#line 1850 "./hl/src/H5LTparse.c"
+#line 1646 "hl/src//H5LTparse.c"
     break;
 
-  case 57:
-#line 218 "./hl/src/H5LTparse.y"
+  case 57: /* $@3: %empty  */
+#line 218 "hl/src//H5LTparse.y"
                                         { asindex++; /*pushd onto the stack*/ }
-#line 1856 "./hl/src/H5LTparse.c"
+#line 1652 "hl/src//H5LTparse.c"
     break;
 
-  case 58:
-#line 220 "./hl/src/H5LTparse.y"
+  case 58: /* array_type: H5T_ARRAY_TOKEN $@3 '{' dim_list ddl_type '}'  */
+#line 220 "hl/src//H5LTparse.y"
                         { 
                           (yyval.hid) = H5Tarray_create2((yyvsp[-1].hid), arr_stack[asindex].ndims, arr_stack[asindex].dims);
                           arr_stack[asindex].ndims = 0;
                           asindex--;
                           H5Tclose((yyvsp[-1].hid));
                         }
-#line 1867 "./hl/src/H5LTparse.c"
+#line 1663 "hl/src//H5LTparse.c"
     break;
 
-  case 61:
-#line 230 "./hl/src/H5LTparse.y"
+  case 61: /* $@4: %empty  */
+#line 230 "hl/src//H5LTparse.y"
                             { arr_stack[asindex].is_dim = 1; /*notice lexer of dimension size*/ }
-#line 1873 "./hl/src/H5LTparse.c"
+#line 1669 "hl/src//H5LTparse.c"
     break;
 
-  case 62:
-#line 231 "./hl/src/H5LTparse.y"
+  case 62: /* $@5: %empty  */
+#line 231 "hl/src//H5LTparse.y"
                                 { unsigned ndims = arr_stack[asindex].ndims;
                                   arr_stack[asindex].dims[ndims] = (hsize_t)yylval.ival; 
                                   arr_stack[asindex].ndims++;
                                   arr_stack[asindex].is_dim = 0; 
                                 }
-#line 1883 "./hl/src/H5LTparse.c"
+#line 1679 "hl/src//H5LTparse.c"
     break;
 
-  case 65:
-#line 242 "./hl/src/H5LTparse.y"
+  case 65: /* vlen_type: H5T_VLEN_TOKEN '{' ddl_type '}'  */
+#line 242 "hl/src//H5LTparse.y"
                             { (yyval.hid) = H5Tvlen_create((yyvsp[-1].hid)); H5Tclose((yyvsp[-1].hid)); }
-#line 1889 "./hl/src/H5LTparse.c"
+#line 1685 "hl/src//H5LTparse.c"
     break;
 
-  case 66:
-#line 248 "./hl/src/H5LTparse.y"
+  case 66: /* @6: %empty  */
+#line 248 "hl/src//H5LTparse.y"
                             {   
                                 size_t size = (size_t)yylval.ival;
                                 (yyval.hid) = H5Tcreate(H5T_OPAQUE, size);
                             }
-#line 1898 "./hl/src/H5LTparse.c"
+#line 1694 "hl/src//H5LTparse.c"
     break;
 
-  case 67:
-#line 253 "./hl/src/H5LTparse.y"
+  case 67: /* $@7: %empty  */
+#line 253 "hl/src//H5LTparse.y"
                             {  
                                 H5Tset_tag((yyvsp[-3].hid), yylval.sval);
                                 HDfree(yylval.sval);
                                 yylval.sval = NULL;
                             }
-#line 1908 "./hl/src/H5LTparse.c"
+#line 1704 "hl/src//H5LTparse.c"
     break;
 
-  case 68:
-#line 258 "./hl/src/H5LTparse.y"
+  case 68: /* opaque_type: H5T_OPAQUE_TOKEN '{' OPQ_SIZE_TOKEN opaque_size ';' @6 OPQ_TAG_TOKEN opaque_tag ';' $@7 '}'  */
+#line 258 "hl/src//H5LTparse.y"
                             { (yyval.hid) = (yyvsp[-5].hid); }
-#line 1914 "./hl/src/H5LTparse.c"
+#line 1710 "hl/src//H5LTparse.c"
     break;
 
-  case 71:
-#line 267 "./hl/src/H5LTparse.y"
+  case 71: /* $@8: %empty  */
+#line 267 "hl/src//H5LTparse.y"
                             {  
                                 if((yyvsp[-1].ival) == H5T_VARIABLE_TOKEN)
                                     is_variable = 1;
                                 else 
                                     str_size = yylval.ival;
                             }
-#line 1925 "./hl/src/H5LTparse.c"
+#line 1721 "hl/src//H5LTparse.c"
     break;
 
-  case 72:
-#line 274 "./hl/src/H5LTparse.y"
+  case 72: /* $@9: %empty  */
+#line 274 "hl/src//H5LTparse.y"
                             {
                                 if((yyvsp[-1].ival) == H5T_STR_NULLTERM_TOKEN)
                                     str_pad = H5T_STR_NULLTERM;
@@ -1964,33 +1761,33 @@ yyreduce:
                                 else if((yyvsp[-1].ival) == H5T_STR_SPACEPAD_TOKEN)
                                     str_pad = H5T_STR_SPACEPAD;
                             }
-#line 1938 "./hl/src/H5LTparse.c"
+#line 1734 "hl/src//H5LTparse.c"
     break;
 
-  case 73:
-#line 283 "./hl/src/H5LTparse.y"
+  case 73: /* $@10: %empty  */
+#line 283 "hl/src//H5LTparse.y"
                             {  
                                 if((yyvsp[-1].ival) == H5T_CSET_ASCII_TOKEN)
                                     str_cset = H5T_CSET_ASCII;
                                 else if((yyvsp[-1].ival) == H5T_CSET_UTF8_TOKEN)
                                     str_cset = H5T_CSET_UTF8;
                             }
-#line 1949 "./hl/src/H5LTparse.c"
+#line 1745 "hl/src//H5LTparse.c"
     break;
 
-  case 74:
-#line 290 "./hl/src/H5LTparse.y"
+  case 74: /* @11: %empty  */
+#line 290 "hl/src//H5LTparse.y"
                             {
                                 if((yyvsp[-1].hid) == H5T_C_S1_TOKEN)
                                     (yyval.hid) = H5Tcopy(H5T_C_S1);
                                 else if((yyvsp[-1].hid) == H5T_FORTRAN_S1_TOKEN)
                                     (yyval.hid) = H5Tcopy(H5T_FORTRAN_S1);
                             }
-#line 1960 "./hl/src/H5LTparse.c"
+#line 1756 "hl/src//H5LTparse.c"
     break;
 
-  case 75:
-#line 297 "./hl/src/H5LTparse.y"
+  case 75: /* string_type: H5T_STRING_TOKEN '{' STRSIZE_TOKEN strsize ';' $@8 STRPAD_TOKEN strpad ';' $@9 CSET_TOKEN cset ';' $@10 CTYPE_TOKEN ctype ';' @11 '}'  */
+#line 297 "hl/src//H5LTparse.y"
                             {   
                                 hid_t str_id = (yyvsp[-1].hid);
 
@@ -2007,82 +1804,82 @@ yyreduce:
 
                                 (yyval.hid) = str_id; 
                             }
-#line 1981 "./hl/src/H5LTparse.c"
+#line 1777 "hl/src//H5LTparse.c"
     break;
 
-  case 76:
-#line 314 "./hl/src/H5LTparse.y"
+  case 76: /* strsize: H5T_VARIABLE_TOKEN  */
+#line 314 "hl/src//H5LTparse.y"
                                                {(yyval.ival) = H5T_VARIABLE_TOKEN;}
-#line 1987 "./hl/src/H5LTparse.c"
+#line 1783 "hl/src//H5LTparse.c"
     break;
 
-  case 78:
-#line 317 "./hl/src/H5LTparse.y"
+  case 78: /* strpad: H5T_STR_NULLTERM_TOKEN  */
+#line 317 "hl/src//H5LTparse.y"
                                                {(yyval.ival) = H5T_STR_NULLTERM_TOKEN;}
-#line 1993 "./hl/src/H5LTparse.c"
+#line 1789 "hl/src//H5LTparse.c"
     break;
 
-  case 79:
-#line 318 "./hl/src/H5LTparse.y"
+  case 79: /* strpad: H5T_STR_NULLPAD_TOKEN  */
+#line 318 "hl/src//H5LTparse.y"
                                                {(yyval.ival) = H5T_STR_NULLPAD_TOKEN;}
-#line 1999 "./hl/src/H5LTparse.c"
+#line 1795 "hl/src//H5LTparse.c"
     break;
 
-  case 80:
-#line 319 "./hl/src/H5LTparse.y"
+  case 80: /* strpad: H5T_STR_SPACEPAD_TOKEN  */
+#line 319 "hl/src//H5LTparse.y"
                                                {(yyval.ival) = H5T_STR_SPACEPAD_TOKEN;}
-#line 2005 "./hl/src/H5LTparse.c"
+#line 1801 "hl/src//H5LTparse.c"
     break;
 
-  case 81:
-#line 321 "./hl/src/H5LTparse.y"
+  case 81: /* cset: H5T_CSET_ASCII_TOKEN  */
+#line 321 "hl/src//H5LTparse.y"
                                              {(yyval.ival) = H5T_CSET_ASCII_TOKEN;}
-#line 2011 "./hl/src/H5LTparse.c"
+#line 1807 "hl/src//H5LTparse.c"
     break;
 
-  case 82:
-#line 322 "./hl/src/H5LTparse.y"
+  case 82: /* cset: H5T_CSET_UTF8_TOKEN  */
+#line 322 "hl/src//H5LTparse.y"
                                             {(yyval.ival) = H5T_CSET_UTF8_TOKEN;}
-#line 2017 "./hl/src/H5LTparse.c"
+#line 1813 "hl/src//H5LTparse.c"
     break;
 
-  case 83:
-#line 324 "./hl/src/H5LTparse.y"
+  case 83: /* ctype: H5T_C_S1_TOKEN  */
+#line 324 "hl/src//H5LTparse.y"
                                                {(yyval.hid) = H5T_C_S1_TOKEN;}
-#line 2023 "./hl/src/H5LTparse.c"
+#line 1819 "hl/src//H5LTparse.c"
     break;
 
-  case 84:
-#line 325 "./hl/src/H5LTparse.y"
+  case 84: /* ctype: H5T_FORTRAN_S1_TOKEN  */
+#line 325 "hl/src//H5LTparse.y"
                                                {(yyval.hid) = H5T_FORTRAN_S1_TOKEN;}
-#line 2029 "./hl/src/H5LTparse.c"
+#line 1825 "hl/src//H5LTparse.c"
     break;
 
-  case 85:
-#line 329 "./hl/src/H5LTparse.y"
+  case 85: /* $@12: %empty  */
+#line 329 "hl/src//H5LTparse.y"
                             { is_enum = 1; enum_id = H5Tenum_create((yyvsp[-1].hid)); H5Tclose((yyvsp[-1].hid)); }
-#line 2035 "./hl/src/H5LTparse.c"
+#line 1831 "hl/src//H5LTparse.c"
     break;
 
-  case 86:
-#line 331 "./hl/src/H5LTparse.y"
+  case 86: /* enum_type: H5T_ENUM_TOKEN '{' integer_type ';' $@12 enum_list '}'  */
+#line 331 "hl/src//H5LTparse.y"
                             { is_enum = 0; /*reset*/ (yyval.hid) = enum_id; }
-#line 2041 "./hl/src/H5LTparse.c"
+#line 1837 "hl/src//H5LTparse.c"
     break;
 
-  case 89:
-#line 336 "./hl/src/H5LTparse.y"
+  case 89: /* $@13: %empty  */
+#line 336 "hl/src//H5LTparse.y"
                                             {
                                                 is_enum_memb = 1; /*indicate member of enum*/
                                                 enum_memb_symbol = HDstrdup(yylval.sval); 
                                                 HDfree(yylval.sval);
                                                 yylval.sval = NULL;
                                             }
-#line 2052 "./hl/src/H5LTparse.c"
+#line 1848 "hl/src//H5LTparse.c"
     break;
 
-  case 90:
-#line 343 "./hl/src/H5LTparse.y"
+  case 90: /* enum_def: enum_symbol $@13 enum_val ';'  */
+#line 343 "hl/src//H5LTparse.y"
                             {
                                 char char_val=(char)yylval.ival;
                                 short short_val=(short)yylval.ival;
@@ -2125,11 +1922,11 @@ yyreduce:
                                 H5Tclose(super);
                                 H5Tclose(native);
                             }
-#line 2099 "./hl/src/H5LTparse.c"
+#line 1895 "hl/src//H5LTparse.c"
     break;
 
 
-#line 2103 "./hl/src/H5LTparse.c"
+#line 1899 "hl/src//H5LTparse.c"
 
       default: break;
     }
@@ -2144,11 +1941,10 @@ yyreduce:
      case of YYERROR or YYBACKUP, subsequent parser actions might lead
      to an incorrect destructor call or verbose syntax error message
      before the lookahead is translated.  */
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
   yylen = 0;
-  YY_STACK_PRINT (yyss, yyssp);
 
   *++yyvsp = yyval;
 
@@ -2172,49 +1968,13 @@ yyreduce:
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
-  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
-
+  yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
       ++yynerrs;
-#if ! YYERROR_VERBOSE
       yyerror (YY_("syntax error"));
-#else
-# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
-                                        yyssp, yytoken)
-      {
-        char const *yymsgp = YY_("syntax error");
-        int yysyntax_error_status;
-        yysyntax_error_status = YYSYNTAX_ERROR;
-        if (yysyntax_error_status == 0)
-          yymsgp = yymsg;
-        else if (yysyntax_error_status == 1)
-          {
-            if (yymsg != yymsgbuf)
-              YYSTACK_FREE (yymsg);
-            yymsg = YY_CAST (char *, YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
-            if (!yymsg)
-              {
-                yymsg = yymsgbuf;
-                yymsg_alloc = sizeof yymsgbuf;
-                yysyntax_error_status = 2;
-              }
-            else
-              {
-                yysyntax_error_status = YYSYNTAX_ERROR;
-                yymsgp = yymsg;
-              }
-          }
-        yyerror (yymsgp);
-        if (yysyntax_error_status == 2)
-          goto yyexhaustedlab;
-      }
-# undef YYSYNTAX_ERROR
-#endif
     }
-
-
 
   if (yyerrstatus == 3)
     {
@@ -2248,6 +2008,7 @@ yyerrorlab:
      label yyerrorlab therefore never appears in user code.  */
   if (0)
     YYERROR;
+  ++yynerrs;
 
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
@@ -2264,13 +2025,14 @@ yyerrorlab:
 yyerrlab1:
   yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
+  /* Pop stack until we find a state that shifts the error token.  */
   for (;;)
     {
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
         {
-          yyn += YYTERROR;
-          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
             {
               yyn = yytable[yyn];
               if (0 < yyn)
@@ -2284,7 +2046,7 @@ yyerrlab1:
 
 
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -2296,7 +2058,7 @@ yyerrlab1:
 
 
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -2307,7 +2069,7 @@ yyerrlab1:
 `-------------------------------------*/
 yyacceptlab:
   yyresult = 0;
-  goto yyreturn;
+  goto yyreturnlab;
 
 
 /*-----------------------------------.
@@ -2315,24 +2077,22 @@ yyacceptlab:
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
-  goto yyreturn;
+  goto yyreturnlab;
 
 
-#if !defined yyoverflow || YYERROR_VERBOSE
-/*-------------------------------------------------.
-| yyexhaustedlab -- memory exhaustion comes here.  |
-`-------------------------------------------------*/
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
 yyexhaustedlab:
   yyerror (YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
-#endif
+  goto yyreturnlab;
 
 
-/*-----------------------------------------------------.
-| yyreturn -- parsing is finished, return the result.  |
-`-----------------------------------------------------*/
-yyreturn:
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
   if (yychar != YYEMPTY)
     {
       /* Make sure we have latest lookahead translation.  See comments at
@@ -2348,16 +2108,14 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[+*yyssp], yyvsp);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
   if (yyss != yyssa)
     YYSTACK_FREE (yyss);
 #endif
-#if YYERROR_VERBOSE
-  if (yymsg != yymsgbuf)
-    YYSTACK_FREE (yymsg);
-#endif
+
   return yyresult;
 }
+

--- a/hl/src/H5LTparse.h
+++ b/hl/src/H5LTparse.h
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.5.1.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2020 Free Software Foundation,
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
    Inc.
 
    This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -31,8 +31,9 @@
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
-/* Undocumented macros, especially those whose name start with YY_,
-   are private implementation details.  Do not rely on them.  */
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
 
 #ifndef YY_H5LTYY_HL_SRC_H5LTPARSE_H_INCLUDED
 # define YY_H5LTYY_HL_SRC_H5LTPARSE_H_INCLUDED
@@ -44,81 +45,86 @@
 extern int H5LTyydebug;
 #endif
 
-/* Token type.  */
+/* Token kinds.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
   enum yytokentype
   {
-    H5T_STD_I8BE_TOKEN = 258,
-    H5T_STD_I8LE_TOKEN = 259,
-    H5T_STD_I16BE_TOKEN = 260,
-    H5T_STD_I16LE_TOKEN = 261,
-    H5T_STD_I32BE_TOKEN = 262,
-    H5T_STD_I32LE_TOKEN = 263,
-    H5T_STD_I64BE_TOKEN = 264,
-    H5T_STD_I64LE_TOKEN = 265,
-    H5T_STD_U8BE_TOKEN = 266,
-    H5T_STD_U8LE_TOKEN = 267,
-    H5T_STD_U16BE_TOKEN = 268,
-    H5T_STD_U16LE_TOKEN = 269,
-    H5T_STD_U32BE_TOKEN = 270,
-    H5T_STD_U32LE_TOKEN = 271,
-    H5T_STD_U64BE_TOKEN = 272,
-    H5T_STD_U64LE_TOKEN = 273,
-    H5T_NATIVE_CHAR_TOKEN = 274,
-    H5T_NATIVE_SCHAR_TOKEN = 275,
-    H5T_NATIVE_UCHAR_TOKEN = 276,
-    H5T_NATIVE_SHORT_TOKEN = 277,
-    H5T_NATIVE_USHORT_TOKEN = 278,
-    H5T_NATIVE_INT_TOKEN = 279,
-    H5T_NATIVE_UINT_TOKEN = 280,
-    H5T_NATIVE_LONG_TOKEN = 281,
-    H5T_NATIVE_ULONG_TOKEN = 282,
-    H5T_NATIVE_LLONG_TOKEN = 283,
-    H5T_NATIVE_ULLONG_TOKEN = 284,
-    H5T_IEEE_F32BE_TOKEN = 285,
-    H5T_IEEE_F32LE_TOKEN = 286,
-    H5T_IEEE_F64BE_TOKEN = 287,
-    H5T_IEEE_F64LE_TOKEN = 288,
-    H5T_NATIVE_FLOAT_TOKEN = 289,
-    H5T_NATIVE_DOUBLE_TOKEN = 290,
-    H5T_NATIVE_LDOUBLE_TOKEN = 291,
-    H5T_STRING_TOKEN = 292,
-    STRSIZE_TOKEN = 293,
-    STRPAD_TOKEN = 294,
-    CSET_TOKEN = 295,
-    CTYPE_TOKEN = 296,
-    H5T_VARIABLE_TOKEN = 297,
-    H5T_STR_NULLTERM_TOKEN = 298,
-    H5T_STR_NULLPAD_TOKEN = 299,
-    H5T_STR_SPACEPAD_TOKEN = 300,
-    H5T_CSET_ASCII_TOKEN = 301,
-    H5T_CSET_UTF8_TOKEN = 302,
-    H5T_C_S1_TOKEN = 303,
-    H5T_FORTRAN_S1_TOKEN = 304,
-    H5T_OPAQUE_TOKEN = 305,
-    OPQ_SIZE_TOKEN = 306,
-    OPQ_TAG_TOKEN = 307,
-    H5T_COMPOUND_TOKEN = 308,
-    H5T_ENUM_TOKEN = 309,
-    H5T_ARRAY_TOKEN = 310,
-    H5T_VLEN_TOKEN = 311,
-    STRING = 312,
-    NUMBER = 313
+    YYEMPTY = -2,
+    YYEOF = 0,                     /* "end of file"  */
+    YYerror = 256,                 /* error  */
+    YYUNDEF = 257,                 /* "invalid token"  */
+    H5T_STD_I8BE_TOKEN = 258,      /* H5T_STD_I8BE_TOKEN  */
+    H5T_STD_I8LE_TOKEN = 259,      /* H5T_STD_I8LE_TOKEN  */
+    H5T_STD_I16BE_TOKEN = 260,     /* H5T_STD_I16BE_TOKEN  */
+    H5T_STD_I16LE_TOKEN = 261,     /* H5T_STD_I16LE_TOKEN  */
+    H5T_STD_I32BE_TOKEN = 262,     /* H5T_STD_I32BE_TOKEN  */
+    H5T_STD_I32LE_TOKEN = 263,     /* H5T_STD_I32LE_TOKEN  */
+    H5T_STD_I64BE_TOKEN = 264,     /* H5T_STD_I64BE_TOKEN  */
+    H5T_STD_I64LE_TOKEN = 265,     /* H5T_STD_I64LE_TOKEN  */
+    H5T_STD_U8BE_TOKEN = 266,      /* H5T_STD_U8BE_TOKEN  */
+    H5T_STD_U8LE_TOKEN = 267,      /* H5T_STD_U8LE_TOKEN  */
+    H5T_STD_U16BE_TOKEN = 268,     /* H5T_STD_U16BE_TOKEN  */
+    H5T_STD_U16LE_TOKEN = 269,     /* H5T_STD_U16LE_TOKEN  */
+    H5T_STD_U32BE_TOKEN = 270,     /* H5T_STD_U32BE_TOKEN  */
+    H5T_STD_U32LE_TOKEN = 271,     /* H5T_STD_U32LE_TOKEN  */
+    H5T_STD_U64BE_TOKEN = 272,     /* H5T_STD_U64BE_TOKEN  */
+    H5T_STD_U64LE_TOKEN = 273,     /* H5T_STD_U64LE_TOKEN  */
+    H5T_NATIVE_CHAR_TOKEN = 274,   /* H5T_NATIVE_CHAR_TOKEN  */
+    H5T_NATIVE_SCHAR_TOKEN = 275,  /* H5T_NATIVE_SCHAR_TOKEN  */
+    H5T_NATIVE_UCHAR_TOKEN = 276,  /* H5T_NATIVE_UCHAR_TOKEN  */
+    H5T_NATIVE_SHORT_TOKEN = 277,  /* H5T_NATIVE_SHORT_TOKEN  */
+    H5T_NATIVE_USHORT_TOKEN = 278, /* H5T_NATIVE_USHORT_TOKEN  */
+    H5T_NATIVE_INT_TOKEN = 279,    /* H5T_NATIVE_INT_TOKEN  */
+    H5T_NATIVE_UINT_TOKEN = 280,   /* H5T_NATIVE_UINT_TOKEN  */
+    H5T_NATIVE_LONG_TOKEN = 281,   /* H5T_NATIVE_LONG_TOKEN  */
+    H5T_NATIVE_ULONG_TOKEN = 282,  /* H5T_NATIVE_ULONG_TOKEN  */
+    H5T_NATIVE_LLONG_TOKEN = 283,  /* H5T_NATIVE_LLONG_TOKEN  */
+    H5T_NATIVE_ULLONG_TOKEN = 284, /* H5T_NATIVE_ULLONG_TOKEN  */
+    H5T_IEEE_F32BE_TOKEN = 285,    /* H5T_IEEE_F32BE_TOKEN  */
+    H5T_IEEE_F32LE_TOKEN = 286,    /* H5T_IEEE_F32LE_TOKEN  */
+    H5T_IEEE_F64BE_TOKEN = 287,    /* H5T_IEEE_F64BE_TOKEN  */
+    H5T_IEEE_F64LE_TOKEN = 288,    /* H5T_IEEE_F64LE_TOKEN  */
+    H5T_NATIVE_FLOAT_TOKEN = 289,  /* H5T_NATIVE_FLOAT_TOKEN  */
+    H5T_NATIVE_DOUBLE_TOKEN = 290, /* H5T_NATIVE_DOUBLE_TOKEN  */
+    H5T_NATIVE_LDOUBLE_TOKEN = 291, /* H5T_NATIVE_LDOUBLE_TOKEN  */
+    H5T_STRING_TOKEN = 292,        /* H5T_STRING_TOKEN  */
+    STRSIZE_TOKEN = 293,           /* STRSIZE_TOKEN  */
+    STRPAD_TOKEN = 294,            /* STRPAD_TOKEN  */
+    CSET_TOKEN = 295,              /* CSET_TOKEN  */
+    CTYPE_TOKEN = 296,             /* CTYPE_TOKEN  */
+    H5T_VARIABLE_TOKEN = 297,      /* H5T_VARIABLE_TOKEN  */
+    H5T_STR_NULLTERM_TOKEN = 298,  /* H5T_STR_NULLTERM_TOKEN  */
+    H5T_STR_NULLPAD_TOKEN = 299,   /* H5T_STR_NULLPAD_TOKEN  */
+    H5T_STR_SPACEPAD_TOKEN = 300,  /* H5T_STR_SPACEPAD_TOKEN  */
+    H5T_CSET_ASCII_TOKEN = 301,    /* H5T_CSET_ASCII_TOKEN  */
+    H5T_CSET_UTF8_TOKEN = 302,     /* H5T_CSET_UTF8_TOKEN  */
+    H5T_C_S1_TOKEN = 303,          /* H5T_C_S1_TOKEN  */
+    H5T_FORTRAN_S1_TOKEN = 304,    /* H5T_FORTRAN_S1_TOKEN  */
+    H5T_OPAQUE_TOKEN = 305,        /* H5T_OPAQUE_TOKEN  */
+    OPQ_SIZE_TOKEN = 306,          /* OPQ_SIZE_TOKEN  */
+    OPQ_TAG_TOKEN = 307,           /* OPQ_TAG_TOKEN  */
+    H5T_COMPOUND_TOKEN = 308,      /* H5T_COMPOUND_TOKEN  */
+    H5T_ENUM_TOKEN = 309,          /* H5T_ENUM_TOKEN  */
+    H5T_ARRAY_TOKEN = 310,         /* H5T_ARRAY_TOKEN  */
+    H5T_VLEN_TOKEN = 311,          /* H5T_VLEN_TOKEN  */
+    STRING = 312,                  /* STRING  */
+    NUMBER = 313                   /* NUMBER  */
   };
+  typedef enum yytokentype yytoken_kind_t;
 #endif
 
 /* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 69 "./hl/src/H5LTparse.y"
+#line 69 "hl/src//H5LTparse.y"
 
     int     ival;         /*for integer token*/
     char    *sval;        /*for name string*/
     hid_t   hid;          /*for hid_t token*/
 
-#line 122 "./hl/src/H5LTparse.h"
+#line 128 "hl/src//H5LTparse.h"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -129,6 +135,8 @@ typedef union YYSTYPE YYSTYPE;
 
 extern YYSTYPE H5LTyylval;
 
+
 hid_t H5LTyyparse (void);
+
 
 #endif /* !YY_H5LTYY_HL_SRC_H5LTPARSE_H_INCLUDED  */

--- a/hl/test/gen_test_ld.c
+++ b/hl/test/gen_test_ld.c
@@ -156,23 +156,27 @@ done:
 int
 main(void)
 {
-    hid_t   fid;                             /* File id */
-    hid_t   fapl;                            /* File access property list */
+    hid_t   fid  = H5I_INVALID_HID;          /* File ID */
+    hid_t   fapl = H5I_INVALID_HID;          /* File access property list */
     hsize_t cur_dims[1];                     /* Dimension sizes */
     hsize_t max_dims[1];                     /* Maximum dimension sizes */
     hsize_t cur2_dims[2];                    /* Current dimension sizes */
     hsize_t max2_dims[2];                    /* Maximum dimension sizes */
-    hid_t   set_tid, esc_set_tid;            /* Compound type id */
-    hid_t   sub22_tid;                       /* Compound type id */
-    hid_t   sub2_tid, esc_sub2_tid;          /* Compound type id */
-    hid_t   sub4_tid, esc_sub4_tid;          /* Compound type id */
-    hid_t   null_did, null_sid;              /* H5S_NULL dataset & dataspace ids */
-    hid_t   scalar_did, scalar_sid;          /* H5S_SCALAR dataset & dataspace ids */
+    hid_t   set_tid      = H5I_INVALID_HID;  /* Compound type ID */
+    hid_t   esc_set_tid  = H5I_INVALID_HID;  /* Compound type ID */
+    hid_t   sub22_tid    = H5I_INVALID_HID;  /* Compound type ID */
+    hid_t   sub2_tid     = H5I_INVALID_HID;  /* Compound type ID */
+    hid_t   esc_sub2_tid = H5I_INVALID_HID;  /* Compound type ID */
+    hid_t   sub4_tid     = H5I_INVALID_HID;  /* Compound type ID */
+    hid_t   esc_sub4_tid = H5I_INVALID_HID;  /* Compound type ID */
+    hid_t   null_did     = H5I_INVALID_HID;  /* H5S_NULL dataset ID */
+    hid_t   null_sid     = H5I_INVALID_HID;  /* H5S_NULL dataspace ID */
+    hid_t   scalar_did   = H5I_INVALID_HID;  /* H5S_SCALAR dataset ID */
+    hid_t   scalar_sid   = H5I_INVALID_HID;  /* H5S_SCALAR dataspace ID */
     int     one_data[ONE_DIMS0];             /* Buffer for data */
     int     two_data[TWO_DIMS0 * TWO_DIMS1]; /* Buffer for data */
     set_t   one_cbuf[ONE_DIMS0];             /* Buffer for data with compound type */
     set_t   two_cbuf[TWO_DIMS0 * TWO_DIMS1]; /* Buffer for data with compound type */
-    int     i;                               /* Local index variable */
 
     /* Create a file access property list */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
@@ -189,7 +193,7 @@ main(void)
     /* Initialization for one-dimensional dataset */
     cur_dims[0] = ONE_DIMS0;
     max_dims[0] = MAX_ONE_DIMS0;
-    for (i = 0; i < ONE_DIMS0; i++)
+    for (int i = 0; i < ONE_DIMS0; i++)
         one_data[i] = i;
 
     /* Generate DSET_ONE, DSET_NONE, DSET_NOMAX, DSET_ALLOC_LATE, DSET_EARLY */
@@ -210,7 +214,7 @@ main(void)
     max2_dims[0] = MAX_TWO_DIMS0;
     max2_dims[1] = MAX_TWO_DIMS1;
 
-    for (i = 0; i < (TWO_DIMS0 * TWO_DIMS1); i++)
+    for (int i = 0; i < (TWO_DIMS0 * TWO_DIMS1); i++)
         two_data[i] = i;
 
     /* Generate DSET_TWO */
@@ -221,17 +225,17 @@ main(void)
     cur_dims[0] = ONE_DIMS0;
     max_dims[0] = MAX_ONE_DIMS0;
 
-    for (i = 0; i < ONE_DIMS0; i++) {
+    for (int i = 0; i < ONE_DIMS0; i++) {
         one_cbuf[i].field1     = 1;
         one_cbuf[i].field2.a   = 2;
         one_cbuf[i].field2.c   = 4;
         one_cbuf[i].field2.b.a = 20;
         one_cbuf[i].field2.b.b = 40;
         one_cbuf[i].field2.b.c = 80;
-        one_cbuf[i].field3     = 3.0f;
+        one_cbuf[i].field3     = 3.0;
         one_cbuf[i].field4.a   = 4;
         one_cbuf[i].field4.b   = 8;
-    } /* end for */
+    }
 
     /* Create the compound type */
     if ((sub22_tid = H5Tcreate(H5T_COMPOUND, sizeof(sub22_t))) < 0)
@@ -310,17 +314,17 @@ main(void)
     max2_dims[0] = MAX_TWO_DIMS0;
     max2_dims[0] = MAX_TWO_DIMS1;
 
-    for (i = 0; i < (TWO_DIMS0 * TWO_DIMS1); i++) {
+    for (int i = 0; i < (TWO_DIMS0 * TWO_DIMS1); i++) {
         two_cbuf[i].field1     = 1;
         two_cbuf[i].field2.a   = 2;
         two_cbuf[i].field2.c   = 4;
         two_cbuf[i].field2.b.a = 20;
         two_cbuf[i].field2.b.b = 40;
         two_cbuf[i].field2.b.c = 80;
-        two_cbuf[i].field3     = 3.0f;
+        two_cbuf[i].field3     = 3.0;
         two_cbuf[i].field4.a   = 4;
         two_cbuf[i].field4.b   = 8;
-    } /* end for */
+    }
 
     /* Generate DSET_CMPD_TWO */
     if (generate_dset(fid, DSET_CMPD_TWO, 2, cur2_dims, max2_dims, set_tid, two_cbuf) < 0)

--- a/src/H5FDfamily.c
+++ b/src/H5FDfamily.c
@@ -1531,8 +1531,11 @@ H5FD__family_delete(const char *filename, hid_t fapl_id)
         HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, "unable to allocate temporary member name")
 
     /* Sanity check to make sure that generated names are unique */
+    H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
     HDsnprintf(member_name, H5FD_FAM_MEMB_NAME_BUF_SIZE, filename, 0);
     HDsnprintf(temp, H5FD_FAM_MEMB_NAME_BUF_SIZE, filename, 1);
+    H5_GCC_CLANG_DIAG_ON("format-nonliteral")
+
     if (!HDstrcmp(member_name, temp)) {
         if (default_config) {
             temp = H5MM_xfree(temp);
@@ -1549,7 +1552,9 @@ H5FD__family_delete(const char *filename, hid_t fapl_id)
     current_member = 0;
     while (1) {
         /* Fix up the filename with the current member's number */
+        H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
         HDsnprintf(member_name, H5FD_FAM_MEMB_NAME_BUF_SIZE, filename, current_member);
+        H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
         /* Attempt to delete the member files. If the first file throws an error
          * we always consider this an error. With subsequent member files, however,

--- a/src/H5HFcache.c
+++ b/src/H5HFcache.c
@@ -742,9 +742,11 @@ H5HF__cache_hdr_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG_UN
     HDassert(len == hdr->heap_size);
 
     /* Set the shared heap header's file context for this operation */
-    H5_GCC_CLANG_DIAG_OFF("discarded-qualifiers")
+    H5_GCC_DIAG_OFF("discarded-qualifiers")
+    H5_CLANG_DIAG_OFF("incompatible-pointer-types-discards-qualifiers")
     hdr->f = f;
-    H5_GCC_CLANG_DIAG_ON("discarded-qualifiers")
+    H5_GCC_DIAG_ON("discarded-qualifiers")
+    H5_CLANG_DIAG_ON("incompatible-pointer-types-discards-qualifiers")
 
     /* Magic number */
     H5MM_memcpy(image, H5HF_HDR_MAGIC, (size_t)H5_SIZEOF_MAGIC);
@@ -1330,9 +1332,11 @@ H5HF__cache_iblock_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG
     hdr = iblock->hdr;
 
     /* Set the shared heap header's file context for this operation */
-    H5_GCC_CLANG_DIAG_OFF("discarded-qualifiers")
+    H5_GCC_DIAG_OFF("discarded-qualifiers")
+    H5_CLANG_DIAG_OFF("incompatible-pointer-types-discards-qualifiers")
     hdr->f = f;
-    H5_GCC_CLANG_DIAG_ON("discarded-qualifiers")
+    H5_GCC_DIAG_ON("discarded-qualifiers")
+    H5_CLANG_DIAG_ON("incompatible-pointer-types-discards-qualifiers")
 
     /* Magic number */
     H5MM_memcpy(image, H5HF_IBLOCK_MAGIC, (size_t)H5_SIZEOF_MAGIC);

--- a/src/H5make_libsettings.c
+++ b/src/H5make_libsettings.c
@@ -71,6 +71,7 @@ insert_libhdf5_settings(FILE *flibinfo)
      */
     HDfprintf(flibinfo, "#include \"H5private.h\"\n");
     HDfprintf(flibinfo, "H5_GCC_DIAG_OFF(\"larger-than=\")\n\n");
+    HDfprintf(flibinfo, "H5_CLANG_DIAG_OFF(\"overlength-strings\")\n\n");
 
     /* Print variable definition and the string. Do not use const or some
      * platforms (AIX?) will have issues.
@@ -110,6 +111,7 @@ insert_libhdf5_settings(FILE *flibinfo)
 
     /* Re-enable warnings for large arrays */
     HDfprintf(rawoutstream, "H5_GCC_DIAG_ON(\"larger-than=\")\n");
+    HDfprintf(rawoutstream, "H5_CLANG_DIAG_OFF(\"overlength-strings\")\n");
 #else
     /* Print variable definition and an empty string. Do not use const or some
      * platforms (AIX?) will have issues.

--- a/test/dt_arith.c
+++ b/test/dt_arith.c
@@ -3069,12 +3069,12 @@ test_conv_flt_1(const char *name, int run_test, hid_t src, hid_t dst)
                 hw   = (unsigned char *)&hw_f;
             }
             else if (FLT_DOUBLE == dst_type) {
-                hw_d = *((float *)aligned);
+                hw_d = (double)*((float *)aligned);
                 hw   = (unsigned char *)&hw_d;
 #if H5_SIZEOF_LONG_DOUBLE != H5_SIZEOF_DOUBLE
             }
             else {
-                hw_ld = *((float *)aligned);
+                hw_ld = (long double)*((float *)aligned);
                 hw    = (unsigned char *)&hw_ld;
 #endif
             }
@@ -3093,7 +3093,7 @@ test_conv_flt_1(const char *name, int run_test, hid_t src, hid_t dst)
 #if H5_SIZEOF_LONG_DOUBLE != H5_SIZEOF_DOUBLE
             }
             else {
-                hw_ld = *((double *)aligned);
+                hw_ld = (long double)*((double *)aligned);
                 hw    = (unsigned char *)&hw_ld;
 #endif
             }

--- a/test/gen_plist.c
+++ b/test/gen_plist.c
@@ -164,7 +164,7 @@ main(void)
     if ((ret = encode_plist(dxpl1, little_endian, word_length, "testfiles/plist_files/def_dxpl_")) < 0)
         assert(ret > 0);
 
-    if ((ret = H5Pset_btree_ratios(dxpl1, 0.2f, 0.6f, 0.2f)) < 0)
+    if ((ret = H5Pset_btree_ratios(dxpl1, 0.2, 0.6, 0.2)) < 0)
         assert(ret > 0);
     if ((ret = H5Pset_hyper_vector_size(dxpl1, 5)) < 0)
         assert(ret > 0);
@@ -336,7 +336,7 @@ main(void)
         assert(ret > 0);
     if ((ret = H5Pset_alignment(fapl1, 2, 1024)) < 0)
         assert(ret > 0);
-    if ((ret = H5Pset_cache(fapl1, 1024, 128, 10485760, 0.3f)) < 0)
+    if ((ret = H5Pset_cache(fapl1, 1024, 128, 10485760, 0.3)) < 0)
         assert(ret > 0);
     if ((ret = H5Pset_elink_file_cache_size(fapl1, 10485760)) < 0)
         assert(ret > 0);

--- a/tools/lib/h5diff_array.c
+++ b/tools/lib/h5diff_array.c
@@ -2734,7 +2734,7 @@ diff_long_element(unsigned char *mem1, unsigned char *mem2, hsize_t elem_idx, di
     HDmemcpy(&temp2_long, mem2, sizeof(long));
     /* -d and !-p */
     if (opts->delta_bool && !opts->percent_bool) {
-        if (ABS(temp1_long - temp2_long) > opts->delta) {
+        if (ABS(temp1_long - temp2_long) > (long)opts->delta) {
             opts->print_percentage = 0;
             print_pos(opts, elem_idx, 0);
             if (print_data(opts)) {
@@ -2776,7 +2776,7 @@ diff_long_element(unsigned char *mem1, unsigned char *mem2, hsize_t elem_idx, di
             }
             nfound++;
         }
-        else if (per > opts->percent && ABS(temp1_long - temp2_long) > opts->delta) {
+        else if (per > opts->percent && ABS(temp1_long - temp2_long) > (long)opts->delta) {
             opts->print_percentage = 1;
             print_pos(opts, elem_idx, 0);
             if (print_data(opts)) {
@@ -2822,7 +2822,7 @@ diff_ulong_element(unsigned char *mem1, unsigned char *mem2, hsize_t elem_idx, d
     HDmemcpy(&temp2_ulong, mem2, sizeof(unsigned long));
     /* -d and !-p */
     if (opts->delta_bool && !opts->percent_bool) {
-        if (PDIFF(temp1_ulong, temp2_ulong) > opts->delta) {
+        if (PDIFF(temp1_ulong, temp2_ulong) > (unsigned long)opts->delta) {
             opts->print_percentage = 0;
             print_pos(opts, elem_idx, 0);
             if (print_data(opts)) {
@@ -2866,7 +2866,7 @@ diff_ulong_element(unsigned char *mem1, unsigned char *mem2, hsize_t elem_idx, d
             }
             nfound++;
         }
-        else if (per > opts->percent && PDIFF(temp1_ulong, temp2_ulong) > opts->delta) {
+        else if (per > opts->percent && PDIFF(temp1_ulong, temp2_ulong) > (unsigned long)opts->delta) {
             opts->print_percentage = 1;
             print_pos(opts, elem_idx, 0);
             if (print_data(opts)) {
@@ -2913,7 +2913,7 @@ diff_llong_element(unsigned char *mem1, unsigned char *mem2, hsize_t elem_idx, d
 
     /* -d and !-p */
     if (opts->delta_bool && !opts->percent_bool) {
-        if (ABS(temp1_llong - temp2_llong) > opts->delta) {
+        if (ABS(temp1_llong - temp2_llong) > (long long)opts->delta) {
             opts->print_percentage = 0;
             print_pos(opts, elem_idx, 0);
             if (print_data(opts)) {
@@ -2957,7 +2957,7 @@ diff_llong_element(unsigned char *mem1, unsigned char *mem2, hsize_t elem_idx, d
             }
             nfound++;
         }
-        else if (per > opts->percent && ABS(temp1_llong - temp2_llong) > opts->delta) {
+        else if (per > opts->percent && ABS(temp1_llong - temp2_llong) > (long long)opts->delta) {
             opts->print_percentage = 1;
             print_pos(opts, elem_idx, 0);
             if (print_data(opts)) {

--- a/tools/lib/h5tools_dump.c
+++ b/tools/lib/h5tools_dump.c
@@ -740,8 +740,10 @@ h5tools_dump_region_data_blocks(hid_t region_space, hid_t region_id, FILE *strea
     for (indx = 0; indx < nblocks; indx++) {
         unsigned loop_indx;
 
+        H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
         h5tools_str_append(buffer, outputformat.dset_blockformat_pre, indx ? "," OPTIONAL_LINE_BREAK " " : "",
                            (unsigned long)indx);
+        H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
         /* Start coordinates and opposite corner */
         for (loop_indx = 0; loop_indx < ndims; loop_indx++)
@@ -1097,8 +1099,10 @@ h5tools_dump_region_data_points(hid_t region_space, hid_t region_id, FILE *strea
     for (indx = 0; indx < npoints; indx++) {
         unsigned loop_indx;
 
+        H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
         h5tools_str_append(buffer, outputformat.dset_ptformat_pre, indx ? "," OPTIONAL_LINE_BREAK " " : "",
                            (unsigned long)indx);
+        H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
         for (loop_indx = 0; loop_indx < ndims; loop_indx++)
             h5tools_str_append(buffer, "%s%" PRIuHSIZE, loop_indx ? "," : "(",

--- a/tools/lib/h5tools_str.c
+++ b/tools/lib/h5tools_str.c
@@ -264,7 +264,9 @@ h5tools_str_fmt(h5tools_str_t *str /*in,out*/, size_t start, const char *fmt)
 
     /* Reset the output string and append a formatted version */
     h5tools_str_trunc(str, start);
+    H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
     h5tools_str_append(str, fmt, temp);
+    H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
     /* Free the temp buffer if we allocated one */
     if (temp != _temp)
@@ -300,11 +302,18 @@ h5tools_str_prefix(h5tools_str_t *str /*in,out*/, const h5tool_format_t *info, h
             if (i)
                 h5tools_str_append(str, "%s", OPT(info->idx_sep, ","));
 
+            H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
             h5tools_str_append(str, OPT(info->idx_n_fmt, "%" PRIuHSIZE), (hsize_t)ctx->pos[i]);
+            H5_GCC_CLANG_DIAG_ON("format-nonliteral")
         }
     }
-    else /* Scalar */
+    else {
+        /* Scalar */
+        H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
         h5tools_str_append(str, OPT(info->idx_n_fmt, "%" PRIuHSIZE), (hsize_t)elmtno);
+        H5_GCC_CLANG_DIAG_ON("format-nonliteral")
+    }
+
     H5TOOLS_DEBUG("str=%s", str->s);
 
     H5TOOLS_ENDDEBUG(" ");
@@ -341,11 +350,18 @@ h5tools_str_region_prefix(h5tools_str_t *str /*in,out*/, const h5tool_format_t *
             if (i)
                 h5tools_str_append(str, "%s", OPT(info->idx_sep, ","));
 
+            H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
             h5tools_str_append(str, OPT(info->idx_n_fmt, "%" PRIuHSIZE), (hsize_t)ctx->pos[i]);
+            H5_GCC_CLANG_DIAG_ON("format-nonliteral")
         }
     }
-    else /* Scalar */
+    else {
+        /* Scalar */
+        H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
         h5tools_str_append(str, OPT(info->idx_n_fmt, "%" PRIuHSIZE), (hsize_t)0);
+        H5_GCC_CLANG_DIAG_ON("format-nonliteral")
+    }
+
     H5TOOLS_DEBUG("str=%s", str->s);
 
     H5TOOLS_ENDDEBUG(" ");
@@ -463,6 +479,7 @@ h5tools_str_dump_space_blocks(h5tools_str_t *str, hid_t rspace, const h5tool_for
         for (u = 0; u < nblocks; u++) {
             unsigned v;
 
+            H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
             h5tools_str_append(str, info->dset_blockformat_pre, u ? "," OPTIONAL_LINE_BREAK " " : "",
                                (unsigned long)u);
 
@@ -474,6 +491,7 @@ h5tools_str_dump_space_blocks(h5tools_str_t *str, hid_t rspace, const h5tool_for
                 h5tools_str_append(str, "%s%" PRIuHSIZE, v ? "," : ")-(", ptdata[u * 2 * ndims + v + ndims]);
 
             h5tools_str_append(str, ")");
+            H5_GCC_CLANG_DIAG_ON("format-nonliteral")
         }
 
         HDfree(ptdata);
@@ -522,6 +540,7 @@ h5tools_str_dump_space_points(h5tools_str_t *str, hid_t rspace, const h5tool_for
         for (u = 0; u < npoints; u++) {
             unsigned v;
 
+            H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
             h5tools_str_append(str, info->dset_ptformat_pre, u ? "," OPTIONAL_LINE_BREAK " " : "",
                                (unsigned long)u);
 
@@ -529,6 +548,7 @@ h5tools_str_dump_space_points(h5tools_str_t *str, hid_t rspace, const h5tool_for
                 h5tools_str_append(str, "%s%" PRIuHSIZE, v ? "," : "(", (ptdata[u * ndims + v]));
 
             h5tools_str_append(str, ")");
+            H5_GCC_CLANG_DIAG_ON("format-nonliteral")
         }
 
         HDfree(ptdata);
@@ -656,6 +676,8 @@ h5tools_str_sprint(h5tools_str_t *str, const h5tool_format_t *info, hid_t contai
     H5T_str_t      pad;
     H5T_class_t    type_class;
     char *         ret_value = NULL;
+
+    H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
 
     H5TOOLS_START_DEBUG(" ");
     /* Build default formats for long long types */
@@ -1319,6 +1341,8 @@ h5tools_str_sprint(h5tools_str_t *str, const h5tool_format_t *info, hid_t contai
     }
 
     ret_value = h5tools_str_fmt(str, start, OPT(info->elmt_fmt, "%s"));
+
+    H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
     H5TOOLS_ENDDEBUG(" with %s", ret_value);
     return ret_value;

--- a/tools/src/h5import/h5import.c
+++ b/tools/src/h5import/h5import.c
@@ -91,6 +91,8 @@ main(int argc, char *argv[])
     const char *err9  = "Cannot specify more than 30 input files in one call to h5import.\n";
     const char *err10 = "Length of output file name limited to 255 chars.\n";
 
+    H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
+
     h5tools_setprogname(PROGRAMNAME);
     h5tools_setstatus(EXIT_SUCCESS);
 
@@ -236,6 +238,8 @@ main(int argc, char *argv[])
     if (process(opt) == -1)
         goto err;
 
+    H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
+
     for (i = 0; i < opt->fcount; i++) {
         in = &(opt->infiles[i].in);
         if (in->sizeOfDimension)
@@ -364,6 +368,8 @@ processDataFile(char *infile, struct Input *in, hid_t file_id)
     const char *err11  = "Error in reading string data.\n";
     int         retval = -1;
 
+    H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
+
     /*-------------------------------------------------------------------------
      * special case for opening binary classes in H5_HAVE_WIN32_API
      * "FP" denotes a floating point binary file,
@@ -450,13 +456,15 @@ processDataFile(char *infile, struct Input *in, hid_t file_id)
             goto error;
     }
 
+    H5_GCC_CLANG_DIAG_ON("format-nonliteral")
+
     /* Set success return value */
     retval = 0;
 
 error:
     if (strm)
         HDfclose(strm);
-    return (retval);
+    return retval;
 }
 
 static int
@@ -1429,10 +1437,12 @@ processConfigurationFile(char *infile, struct Input *in)
     const char *err19  = "Unable to get integer value.\n";
     const char *err20  = "Unable to get subset values.\n";
 
-    /* create vector to map which keywords have been found
-     check vector after each keyword to check for violation
-     at the end check vector to see if required fields have been provided
-     process the output file according to the options
+    H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
+
+    /* - create vector to map which keywords have been found
+     * - check vector after each keyword to check for violation
+     * - at the end check vector to see if required fields have been provided
+     * - process the output file according to the options
      */
 
     /* Initialize machine endian */
@@ -2429,13 +2439,15 @@ processConfigurationFile(char *infile, struct Input *in)
         }
     }
 
+    H5_GCC_CLANG_DIAG_ON("format-nonliteral")
+
     /* Set success return value */
     retval = 0;
 
 error:
     if (strm)
         HDfclose(strm);
-    return (retval);
+    return retval;
 }
 
 static int
@@ -4610,6 +4622,8 @@ process(struct Options *opt)
         "Error in creating the output data set. Dataset with the same name may exist at the specified path\n";
     const char *err6 = "Error in writing the output data set.\n";
 
+    H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
+
     H5E_BEGIN_TRY
     {
         if ((file_id = H5Fopen(opt->outfile, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -4742,8 +4756,10 @@ process(struct Options *opt)
 
     } /* STR */
 
+    H5_GCC_CLANG_DIAG_ON("format-nonliteral")
+
     H5Fclose(file_id);
-    return (0);
+    return 0;
 }
 
 uint16_t

--- a/tools/src/h5perf/pio_perf.c
+++ b/tools/src/h5perf/pio_perf.c
@@ -1087,7 +1087,9 @@ output_report(const char *fmt, ...)
         va_list ap;
 
         HDva_start(ap, fmt);
+        H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
         HDvfprintf(output, fmt, ap);
+        H5_GCC_CLANG_DIAG_ON("format-nonliteral")
         HDva_end(ap);
     }
 }

--- a/tools/src/h5perf/sio_engine.c
+++ b/tools/src/h5perf/sio_engine.c
@@ -1298,7 +1298,9 @@ do_cleanupfile(iotype iot, char *filename)
 
                 if (driver == H5FD_FAMILY) {
                     for (j = 0; /*void*/; j++) {
+                        H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
                         HDsnprintf(temp, temp_sz, filename, j);
+                        H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
                         if (HDaccess(temp, F_OK) < 0)
                             break;

--- a/tools/src/h5perf/sio_perf.c
+++ b/tools/src/h5perf/sio_perf.c
@@ -647,7 +647,9 @@ output_report(const char *fmt, ...)
     va_list ap;
 
     HDva_start(ap, fmt);
+    H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
     HDvfprintf(output, fmt, ap);
+    H5_GCC_CLANG_DIAG_ON("format-nonliteral")
     HDva_end(ap);
 }
 

--- a/tools/src/misc/h5repart.c
+++ b/tools/src/misc/h5repart.c
@@ -509,4 +509,3 @@ main(int argc, char *argv[])
     return EXIT_SUCCESS;
 } /* end main */
 H5_GCC_CLANG_DIAG_ON("format-nonliteral")
-

--- a/tools/src/misc/h5repart.c
+++ b/tools/src/misc/h5repart.c
@@ -151,6 +151,7 @@ get_size(const char *progname, int *argno, int argc, char *argv[])
  *
  *-------------------------------------------------------------------------
  */
+H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
 int
 main(int argc, char *argv[])
 {
@@ -507,3 +508,5 @@ main(int argc, char *argv[])
     HDfree(buf);
     return EXIT_SUCCESS;
 } /* end main */
+H5_GCC_CLANG_DIAG_ON("format-nonliteral")
+

--- a/tools/test/perform/zip_perf.c
+++ b/tools/test/perform/zip_perf.c
@@ -87,7 +87,9 @@ error(const char *fmt, ...)
 
     va_start(ap, fmt);
     HDfprintf(stderr, "%s: error: ", prog);
+    H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
     HDvfprintf(stderr, fmt, ap);
+    H5_GCC_CLANG_DIAG_ON("format-nonliteral")
     HDfprintf(stderr, "\n");
     va_end(ap);
     HDexit(EXIT_FAILURE);


### PR DESCRIPTION
This brings the number of warnings with clang-14 (debug, Autotools) to 16.