### PR TITLE
Reduce -Wstrict-overflow= from 5 to 2

### DIFF
--- a/config/gnu-warnings/4.8
+++ b/config/gnu-warnings/4.8
@@ -8,7 +8,7 @@
 -Wsync-nand
 
 # warning flag added for GCC >= 4.5
--Wstrict-overflow=5
+-Wstrict-overflow=2
 
 # This warning can only be truly addressed using the gcc extension of
 # using D to indicate doubles (e.g., 1.23D).

--- a/config/gnu-warnings/cxx-4.8
+++ b/config/gnu-warnings/cxx-4.8
@@ -8,7 +8,7 @@
 -Wsync-nand
 
 # warning flag added for GCC >= 4.5
--Wstrict-overflow=5
+-Wstrict-overflow=2
 
 # warning flags added for GCC >= 4.6
 -Wdouble-promotion


### PR DESCRIPTION
The signal-to-noise ratio of the higher warning level is very low
and the noise obscures things we should fix

gcc docs here:

https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html