### PR TITLE
Fixes for production mode gcc warnings

### DIFF
--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -6527,8 +6527,11 @@ H5D__chunk_copy_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
         }             /* end if */
 
         if (udata->chunk_in_cache) {
+
+            if (NULL == ent)
+                HGOTO_ERROR(H5E_IO, H5E_BADVALUE, H5_ITER_ERROR, "NULL chunk entry pointer")
+
             HDassert(H5F_addr_defined(chunk_rec->chunk_addr));
-            HDassert(ent);
             HDassert(H5F_addr_defined(ent->chunk_block.offset));
 
             H5_CHECKED_ASSIGN(nbytes, size_t, shared_fo->layout.u.chunk.size, uint32_t);

--- a/src/H5FL.c
+++ b/src/H5FL.c
@@ -1047,7 +1047,8 @@ H5FL_blk_free(H5FL_blk_head_t *head, void *block)
     if (NULL == (free_list = H5FL__blk_find_list(&(head->head), free_size)))
         /* No free list available, create a new list node and insert it to the queue */
         free_list = H5FL__blk_create_list(&(head->head), free_size);
-    HDassert(free_list);
+    if (NULL == free_list)
+        HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, NULL, "couldn't create new list node")
 
     /* Prepend the free'd native block to the front of the free list */
     temp->next      = free_list->list; /* Note: Overwrites the size field in union */

--- a/src/H5HLcache.c
+++ b/src/H5HLcache.c
@@ -361,6 +361,8 @@ H5HL__cache_prefix_get_final_load_size(const void *_image, size_t H5_ATTR_NDEBUG
     HDassert(actual_len);
     HDassert(*actual_len == image_len);
 
+    HDmemset(&heap, 0, sizeof(H5HL_t));
+
     /* Deserialize the heap's header */
     if (H5HL__hdr_deserialize(&heap, (const uint8_t *)image, udata) < 0)
         HGOTO_ERROR(H5E_HEAP, H5E_CANTDECODE, FAIL, "can't decode local heap header")

--- a/src/H5L.c
+++ b/src/H5L.c
@@ -95,8 +95,8 @@ H5Lmove(hid_t src_loc_id, const char *src_name, hid_t dst_loc_id, const char *ds
         hid_t lapl_id)
 {
     H5VL_object_t *   vol_obj1 = NULL; /* Object of src_id */
-    H5VL_loc_params_t loc_params1;
     H5VL_object_t *   vol_obj2 = NULL; /* Object of dst_id */
+    H5VL_loc_params_t loc_params1;
     H5VL_loc_params_t loc_params2;
     H5VL_object_t     tmp_vol_obj;         /* Temporary object */
     herr_t            ret_value = SUCCEED; /* Return value */
@@ -157,19 +157,20 @@ H5Lmove(hid_t src_loc_id, const char *src_name, hid_t dst_loc_id, const char *ds
         if (same_connector)
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL,
                         "Objects are accessed through different VOL connectors and can't be linked")
-    } /* end if */
+    }
 
     /* Construct a temporary source VOL object */
     if (vol_obj1) {
         tmp_vol_obj.connector = vol_obj1->connector;
         tmp_vol_obj.data      = vol_obj1->data;
-    } /* end if */
+    }
     else {
-        HDassert(vol_obj2);
+        if (NULL == vol_obj2)
+            HGOTO_ERROR(H5E_LINK, H5E_BADVALUE, FAIL, "NULL VOL object")
 
         tmp_vol_obj.connector = vol_obj2->connector;
         tmp_vol_obj.data      = NULL;
-    } /* end else */
+    }
 
     /* Move the link */
     if (H5VL_link_move(&tmp_vol_obj, &loc_params1, vol_obj2, &loc_params2, lcpl_id, lapl_id,
@@ -269,7 +270,8 @@ H5Lcopy(hid_t src_loc_id, const char *src_name, hid_t dst_loc_id, const char *ds
         tmp_vol_obj.data      = vol_obj1->data;
     } /* end if */
     else {
-        HDassert(vol_obj2);
+        if (NULL == vol_obj2)
+            HGOTO_ERROR(H5E_LINK, H5E_BADVALUE, FAIL, "NULL VOL object pointer")
 
         tmp_vol_obj.connector = vol_obj2->connector;
         tmp_vol_obj.data      = NULL;
@@ -505,7 +507,8 @@ H5L__create_hard_api_common(hid_t cur_loc_id, const char *cur_name, hid_t link_l
     if (curr_vol_obj)
         (*tmp_vol_obj_ptr_ptr)->connector = curr_vol_obj->connector;
     else {
-        HDassert(link_vol_obj);
+        if (NULL == link_vol_obj)
+            HGOTO_ERROR(H5E_LINK, H5E_BADVALUE, FAIL, "NULL VOL object pointer")
 
         (*tmp_vol_obj_ptr_ptr)->connector = link_vol_obj->connector;
     } /* end else */

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -6610,8 +6610,8 @@ H5S__hyper_project_scalar(const H5S_t *space, hsize_t *offset)
 static herr_t
 H5S__hyper_project_simple_lower(const H5S_t *base_space, H5S_t *new_space)
 {
-    H5S_hyper_span_info_t *down;     /* Pointer to list of spans */
-    unsigned               curr_dim; /* Current dimension being operated on */
+    H5S_hyper_span_info_t *down;                /* Pointer to list of spans */
+    unsigned               curr_dim;            /* Current dimension being operated on */
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -6612,8 +6612,9 @@ H5S__hyper_project_simple_lower(const H5S_t *base_space, H5S_t *new_space)
 {
     H5S_hyper_span_info_t *down;     /* Pointer to list of spans */
     unsigned               curr_dim; /* Current dimension being operated on */
+    herr_t                 ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_PACKAGE_NOERR
+    FUNC_ENTER_PACKAGE
 
     /* Check args */
     HDassert(base_space && H5S_SEL_HYPERSLABS == H5S_GET_SELECT_TYPE(base_space));
@@ -6631,13 +6632,15 @@ H5S__hyper_project_simple_lower(const H5S_t *base_space, H5S_t *new_space)
         down = down->head->down;
         curr_dim++;
     } /* end while */
-    HDassert(down);
+    if (NULL == down)
+        HGOTO_ERROR(H5E_DATASPACE, H5E_BADVALUE, FAIL, "NULL span list pointer")
 
     /* Share the underlying hyperslab span information */
     new_space->select.sel_info.hslab->span_lst = down;
     new_space->select.sel_info.hslab->span_lst->count++;
 
-    FUNC_LEAVE_NOAPI(SUCCEED)
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5S__hyper_project_simple_lower() */
 
 /*-------------------------------------------------------------------------
@@ -6723,7 +6726,8 @@ H5S__hyper_project_simple_higher(const H5S_t *base_space, H5S_t *new_space)
         /* Advance to next dimension */
         curr_dim++;
     } /* end while */
-    HDassert(new_space->select.sel_info.hslab->span_lst);
+    if (NULL == new_space->select.sel_info.hslab->span_lst)
+        HGOTO_ERROR(H5E_DATASPACE, H5E_BADVALUE, FAIL, "NULL span list pointer")
     HDassert(prev_span);
 
     /* Share the underlying hyperslab span information */

--- a/test/cache_common.c
+++ b/test/cache_common.c
@@ -4977,13 +4977,17 @@ check_and_validate_cache_hit_rate(hid_t file_id, double *hit_rate_ptr, hbool_t d
         else {
 
             cache_ptr = file_ptr->shared->cache;
+            if (NULL == cache_ptr) {
+                pass         = FALSE;
+                failure_mssg = "NULL cache pointer";
+            }
         }
     }
 
     /* verify that we can access the cache data structure */
     if (pass) {
 
-        if ((cache_ptr == NULL) || (cache_ptr->magic != H5C__H5C_T_MAGIC)) {
+        if (cache_ptr->magic != H5C__H5C_T_MAGIC) {
 
             pass         = FALSE;
             failure_mssg = "Can't access cache resize_ctl.";
@@ -5102,13 +5106,17 @@ check_and_validate_cache_size(hid_t file_id, size_t *max_size_ptr, size_t *min_c
         else {
 
             cache_ptr = file_ptr->shared->cache;
+            if (NULL == cache_ptr) {
+                pass         = FALSE;
+                failure_mssg = "NULL cache pointer";
+            }
         }
     }
 
     /* verify that we can access the cache data structure */
     if (pass) {
 
-        if ((cache_ptr == NULL) || (cache_ptr->magic != H5C__H5C_T_MAGIC)) {
+        if (cache_ptr->magic != H5C__H5C_T_MAGIC) {
 
             pass         = FALSE;
             failure_mssg = "Can't access cache data structure.";

--- a/test/h5test.c
+++ b/test/h5test.c
@@ -99,10 +99,10 @@ static const char *multi_letters = "msbrglo";
 #define MESSAGE_TIMEOUT 300 /* Timeout in seconds */
 
 /* Buffer to construct path in and return pointer to */
-static char srcdir_path[1024] = "";
+static char srcdir_path[1024];
 
 /* Buffer to construct file in and return pointer to */
-static char srcdir_testpath[1024] = "";
+static char srcdir_testpath[1024];
 
 /*  The strings that correspond to library version bounds H5F_libver_t in H5Fpublic.h */
 /*  This is used by h5_get_version_string() */
@@ -1997,7 +1997,7 @@ done:
  *
  * Purpose:     Append the test file name to the srcdir path and return the whole string
  *
- * Return:      The string
+ * Return:      The string or NULL (errors or not enought space)
  *
  *-------------------------------------------------------------------------
  */
@@ -2008,16 +2008,20 @@ H5_get_srcdir_filename(const char *filename)
 
     /* Check for error */
     if (NULL == srcdir)
-        return (NULL);
-    else {
-        /* Build path to test file */
-        if ((HDstrlen(srcdir) + HDstrlen(filename) + 1) < sizeof(srcdir_testpath)) {
-            HDsnprintf(srcdir_testpath, sizeof(srcdir_testpath), "%s%s", srcdir, filename);
-            return (srcdir_testpath);
-        } /* end if */
-        else
-            return (NULL);
-    } /* end else */
+        return NULL;
+
+    /* Build path to test file. We're checking the length so suppress
+     * the gcc format-truncation warning.
+     */
+    if ((HDstrlen(srcdir) + HDstrlen(filename) + 1) < sizeof(srcdir_testpath)) {
+        H5_GCC_DIAG_OFF("format-truncation")
+        HDsnprintf(srcdir_testpath, sizeof(srcdir_testpath), "%s%s", srcdir, filename);
+        H5_GCC_DIAG_ON("format-truncation")
+        return srcdir_testpath;
+    }
+
+    /* If not enough space, just return NULL */
+    return NULL;
 } /* end H5_get_srcdir_filename() */
 
 /*-------------------------------------------------------------------------

--- a/test/h5test.c
+++ b/test/h5test.c
@@ -1997,7 +1997,7 @@ done:
  *
  * Purpose:     Append the test file name to the srcdir path and return the whole string
  *
- * Return:      The string or NULL (errors or not enought space)
+ * Return:      The string or NULL (errors or not enough space)
  *
  *-------------------------------------------------------------------------
  */

--- a/tools/src/h5dump/h5dump_ddl.c
+++ b/tools/src/h5dump/h5dump_ddl.c
@@ -1713,7 +1713,7 @@ handle_datasets(hid_t fid, const char *dset, void *data, int pe, const char *dis
                     sset->start.data = (hsize_t *)HDcalloc((size_t)ndims, sizeof(hsize_t));
                 else
                     sset->start.data = NULL;
-                sset->start.len  = ndims;
+                sset->start.len = ndims;
             }
 
             if (!sset->stride.data) {
@@ -1721,7 +1721,7 @@ handle_datasets(hid_t fid, const char *dset, void *data, int pe, const char *dis
                     sset->stride.data = (hsize_t *)HDcalloc((size_t)ndims, sizeof(hsize_t));
                 else
                     sset->stride.data = NULL;
-                sset->stride.len  = ndims;
+                sset->stride.len = ndims;
                 for (i = 0; i < ndims; i++)
                     sset->stride.data[i] = 1;
             }
@@ -1731,7 +1731,7 @@ handle_datasets(hid_t fid, const char *dset, void *data, int pe, const char *dis
                     sset->count.data = (hsize_t *)HDcalloc((size_t)ndims, sizeof(hsize_t));
                 else
                     sset->count.data = NULL;
-                sset->count.len  = ndims;
+                sset->count.len = ndims;
                 for (i = 0; i < ndims; i++)
                     sset->count.data[i] = 1;
             }
@@ -1741,7 +1741,7 @@ handle_datasets(hid_t fid, const char *dset, void *data, int pe, const char *dis
                     sset->block.data = (hsize_t *)HDcalloc((size_t)ndims, sizeof(hsize_t));
                 else
                     sset->block.data = NULL;
-                sset->block.len  = ndims;
+                sset->block.len = ndims;
                 for (i = 0; i < ndims; i++)
                     sset->block.data[i] = 1;
             }

--- a/tools/src/h5dump/h5dump_ddl.c
+++ b/tools/src/h5dump/h5dump_ddl.c
@@ -1709,26 +1709,38 @@ handle_datasets(hid_t fid, const char *dset, void *data, int pe, const char *dis
              * dimensions */
             if (!sset->start.data) {
                 /* default to (0, 0, ...) for the start coord */
-                sset->start.data = (hsize_t *)HDcalloc((size_t)ndims, sizeof(hsize_t));
+                if (ndims > 0)
+                    sset->start.data = (hsize_t *)HDcalloc((size_t)ndims, sizeof(hsize_t));
+                else
+                    sset->start.data = NULL;
                 sset->start.len  = ndims;
             }
 
             if (!sset->stride.data) {
-                sset->stride.data = (hsize_t *)HDcalloc((size_t)ndims, sizeof(hsize_t));
+                if (ndims > 0)
+                    sset->stride.data = (hsize_t *)HDcalloc((size_t)ndims, sizeof(hsize_t));
+                else
+                    sset->stride.data = NULL;
                 sset->stride.len  = ndims;
                 for (i = 0; i < ndims; i++)
                     sset->stride.data[i] = 1;
             }
 
             if (!sset->count.data) {
-                sset->count.data = (hsize_t *)HDcalloc((size_t)ndims, sizeof(hsize_t));
+                if (ndims > 0)
+                    sset->count.data = (hsize_t *)HDcalloc((size_t)ndims, sizeof(hsize_t));
+                else
+                    sset->count.data = NULL;
                 sset->count.len  = ndims;
                 for (i = 0; i < ndims; i++)
                     sset->count.data[i] = 1;
             }
 
             if (!sset->block.data) {
-                sset->block.data = (hsize_t *)HDcalloc((size_t)ndims, sizeof(hsize_t));
+                if (ndims > 0)
+                    sset->block.data = (hsize_t *)HDcalloc((size_t)ndims, sizeof(hsize_t));
+                else
+                    sset->block.data = NULL;
                 sset->block.len  = ndims;
                 for (i = 0; i < ndims; i++)
                     sset->block.data[i] = 1;


### PR DESCRIPTION
With the strict-overflow changes, this brings the number of warnings
in the C library w/ gcc 12 to zero.