### PR TITLE
Removes definitions for (U)LLONG_MAX and (S)SIZET_MAX

### DIFF
--- a/src/H5Defl.c
+++ b/src/H5Defl.c
@@ -255,7 +255,7 @@ H5D__efl_read(const H5O_efl_t *efl, const H5D_t *dset, haddr_t addr, size_t size
     /* Check args */
     HDassert(efl && efl->nused > 0);
     HDassert(H5F_addr_defined(addr));
-    HDassert(size < SIZET_MAX);
+    HDassert(size < SIZE_MAX);
     HDassert(buf || 0 == size);
 
     /* Find the first efl member from which to read */
@@ -343,7 +343,7 @@ H5D__efl_write(const H5O_efl_t *efl, const H5D_t *dset, haddr_t addr, size_t siz
     /* Check args */
     HDassert(efl && efl->nused > 0);
     HDassert(H5F_addr_defined(addr));
-    HDassert(size < SIZET_MAX);
+    HDassert(size < SIZE_MAX);
     HDassert(buf || 0 == size);
 
     /* Find the first efl member in which to write */

--- a/src/H5FDfamily.c
+++ b/src/H5FDfamily.c
@@ -1249,8 +1249,8 @@ H5FD__family_read(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, s
          * is 4 bytes, to prevent overflow when user application is trying to
          * write files bigger than 4GB. */
         tempreq = file->memb_size - sub;
-        if (tempreq > SIZET_MAX)
-            tempreq = SIZET_MAX;
+        if (tempreq > SIZE_MAX)
+            tempreq = SIZE_MAX;
         req = MIN(size, (size_t)tempreq);
 
         HDassert(u < file->nmembs);
@@ -1314,8 +1314,8 @@ H5FD__family_write(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, 
          * is 4 bytes, to prevent overflow when user application is trying to
          * write files bigger than 4GB. */
         tempreq = file->memb_size - sub;
-        if (tempreq > SIZET_MAX)
-            tempreq = SIZET_MAX;
+        if (tempreq > SIZE_MAX)
+            tempreq = SIZE_MAX;
         req = MIN(size, (size_t)tempreq);
 
         HDassert(u < file->nmembs);

--- a/src/H5MM.c
+++ b/src/H5MM.c
@@ -152,7 +152,7 @@ H5MM__sanity_check_block(const H5MM_block_t *block)
     HDassert(block->u.info.size > 0);
     HDassert(block->u.info.in_use);
     /* Check for head & tail guards, if not head of linked list */
-    if (block->u.info.size != SIZET_MAX) {
+    if (block->u.info.size != SIZE_MAX) {
         HDassert(0 == HDmemcmp(block->b, H5MM_block_head_guard_s, H5MM_HEAD_GUARD_SIZE));
         HDassert(0 == HDmemcmp(block->b + H5MM_HEAD_GUARD_SIZE + block->u.info.size, H5MM_block_tail_guard_s,
                                H5MM_TAIL_GUARD_SIZE));
@@ -267,7 +267,7 @@ H5MM_malloc(size_t size)
         H5MM_memcpy(H5MM_block_head_s.sig, H5MM_block_signature_s, H5MM_SIG_SIZE);
         H5MM_block_head_s.next          = &H5MM_block_head_s;
         H5MM_block_head_s.prev          = &H5MM_block_head_s;
-        H5MM_block_head_s.u.info.size   = SIZET_MAX;
+        H5MM_block_head_s.u.info.size   = SIZE_MAX;
         H5MM_block_head_s.u.info.in_use = TRUE;
 
         H5MM_init_s = TRUE;

--- a/src/H5VM.c
+++ b/src/H5VM.c
@@ -605,7 +605,7 @@ H5VM_stride_fill(unsigned n, hsize_t elmt_size, const hsize_t *size, const hsize
 
     FUNC_ENTER_NOAPI_NOINIT_NOERR
 
-    HDassert(elmt_size < SIZET_MAX);
+    HDassert(elmt_size < SIZE_MAX);
 
     H5VM_vector_cpy(n, idx, size);
     nelmts = H5VM_vector_reduce_product(n, size);
@@ -663,7 +663,7 @@ H5VM_stride_copy(unsigned n, hsize_t elmt_size, const hsize_t *size, const hsize
 
     FUNC_ENTER_NOAPI_NOINIT_NOERR
 
-    HDassert(elmt_size < SIZET_MAX);
+    HDassert(elmt_size < SIZE_MAX);
 
     if (n) {
         H5VM_vector_cpy(n, idx, size);
@@ -729,7 +729,7 @@ H5VM_stride_copy_s(unsigned n, hsize_t elmt_size, const hsize_t *size, const hss
 
     FUNC_ENTER_NOAPI_NOINIT_NOERR
 
-    HDassert(elmt_size < SIZET_MAX);
+    HDassert(elmt_size < SIZE_MAX);
 
     if (n) {
         H5VM_vector_cpy(n, idx, size);
@@ -794,7 +794,7 @@ H5VM__stride_copy2(hsize_t nelmts, hsize_t elmt_size, unsigned dst_n, const hsiz
 
     FUNC_ENTER_PACKAGE_NOERR
 
-    HDassert(elmt_size < SIZET_MAX);
+    HDassert(elmt_size < SIZE_MAX);
     HDassert(dst_n > 0);
     HDassert(src_n > 0);
 
@@ -858,8 +858,8 @@ H5VM_array_fill(void *_dst, const void *src, size_t size, size_t count)
 
     HDassert(dst);
     HDassert(src);
-    HDassert(size < SIZET_MAX && size > 0);
-    HDassert(count < SIZET_MAX && count > 0);
+    HDassert(size < SIZE_MAX && size > 0);
+    HDassert(count < SIZE_MAX && count > 0);
 
     H5MM_memcpy(dst, src, size); /* copy first item */
 

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -381,23 +381,16 @@
 #endif
 
 /*
- * Maximum and minimum values.  These should be defined in <limits.h> for the
- * most part.
+ * The max value for ssize_t.
+ *
+ * Only needed where ssize_t isn't a thing (e.g., Windows)
  */
-#ifndef LLONG_MAX
-#define LLONG_MAX ((long long)(((unsigned long long)1 << (8 * sizeof(long long) - 1)) - 1))
-#define LLONG_MIN ((long long)(-LLONG_MAX) - 1)
-#endif
-#ifndef ULLONG_MAX
-#define ULLONG_MAX ((unsigned long long)((long long)(-1)))
-#endif
-#ifndef SIZET_MAX
-#define SIZET_MAX  ((size_t)(ssize_t)(-1))
-#define SSIZET_MAX ((ssize_t)(((size_t)1 << (8 * sizeof(ssize_t) - 1)) - 1))
+#ifndef SSIZE_MAX
+#define SSIZE_MAX ((ssize_t)(((size_t)1 << (8 * sizeof(ssize_t) - 1)) - 1))
 #endif
 
 /*
- * Maximum & minimum values for our typedefs.
+ * Maximum & minimum values for HDF5 typedefs.
  */
 #define HSIZET_MAX  ((hsize_t)ULLONG_MAX)
 #define HSSIZET_MAX ((hssize_t)LLONG_MAX)
@@ -437,7 +430,7 @@
 #else
 #define h5_posix_io_t         size_t
 #define h5_posix_io_ret_t     ssize_t
-#define H5_POSIX_MAX_IO_BYTES SSIZET_MAX
+#define H5_POSIX_MAX_IO_BYTES SSIZE_MAX
 #endif
 
 /* POSIX I/O mode used as the third parameter to open/_open


### PR DESCRIPTION
LLONG_MAX and ULLONG_MAX are defined in limits.h in C99. SIZET_MAX
should be SIZE_MAX, which has been around forever. SSIZET_MAX should
be SSIZE_MAX, which is defined whereever ssize_t is found. I've kept
the definition for SSIZE_MAX (renamed from SSIZET_MAX) for platforms
where ssize_T is not present (e.g., Windows).