### PR TITLE
Fix for a tools compile issue when deprecated symbols are disabled

### DIFF
--- a/java/src/jni/h5util.c
+++ b/java/src/jni/h5util.c
@@ -1180,8 +1180,9 @@ h5str_sprintf(JNIEnv *env, h5str_t *out_str, hid_t container, hid_t tid, void *i
                     CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
             }
             else if (H5R_OBJ_REF_BUF_SIZE == typeSize) {
-                H5O_info1_t oi;
+                H5O_info2_t oi;
                 hid_t       obj = H5I_INVALID_HID;
+                char *      obj_tok_str = NULL;
 
                 /*
                  * Object references -- show the type and OID of the referenced
@@ -1194,33 +1195,40 @@ h5str_sprintf(JNIEnv *env, h5str_t *out_str, hid_t container, hid_t tid, void *i
                 if ((obj = H5Rdereference2(container, H5P_DEFAULT, H5R_OBJECT, cptr)) < 0)
                     H5_LIBRARY_ERROR(ENVONLY);
 
-                if (H5Oget_info2(obj, &oi, H5O_INFO_ALL) < 0)
+                if (H5Oget_info3(obj, &oi, H5O_INFO_ALL) < 0)
                     H5_LIBRARY_ERROR(ENVONLY);
 
                 /* Print object data and close object */
+                H5Otoken_to_str(obj, &oi.token, &obj_tok_str);
+
                 switch (oi.type) {
                     case H5O_TYPE_GROUP:
-                        if (HDsprintf(this_str, "%s %llu", H5_TOOLS_GROUP, oi.addr) < 0)
+                        if (HDsprintf(this_str, "%s %s", H5_TOOLS_GROUP, obj_tok_str) < 0)
                             H5_JNI_FATAL_ERROR(ENVONLY, "h5str_sprintf: HDsprintf failure");
                         break;
 
                     case H5O_TYPE_DATASET:
-                        if (HDsprintf(this_str, "%s %llu", H5_TOOLS_DATASET, oi.addr) < 0)
+                        if (HDsprintf(this_str, "%s %s", H5_TOOLS_DATASET, obj_tok_str) < 0)
                             H5_JNI_FATAL_ERROR(ENVONLY, "h5str_sprintf: HDsprintf failure");
                         break;
 
                     case H5O_TYPE_NAMED_DATATYPE:
-                        if (HDsprintf(this_str, "%s %llu", H5_TOOLS_DATATYPE, oi.addr) < 0)
+                        if (HDsprintf(this_str, "%s %s", H5_TOOLS_DATATYPE, obj_tok_str) < 0)
                             H5_JNI_FATAL_ERROR(ENVONLY, "h5str_sprintf: HDsprintf failure");
                         break;
 
                     case H5O_TYPE_UNKNOWN:
                     case H5O_TYPE_NTYPES:
                     default:
-                        if (HDsprintf(this_str, "%u-%llu", (unsigned)oi.type, oi.addr) < 0)
+                        if (HDsprintf(this_str, "%u-%s", (unsigned)oi.type, obj_tok_str) < 0)
                             H5_JNI_FATAL_ERROR(ENVONLY, "h5str_sprintf: HDsprintf failure");
                         break;
-                } /* end switch */
+                }
+
+                if (obj_tok_str) {
+                    H5free_memory(obj_tok_str);
+                    obj_tok_str = NULL;
+                }
 
                 if (H5Oclose(obj) < 0)
                     H5_LIBRARY_ERROR(ENVONLY);

--- a/java/src/jni/h5util.c
+++ b/java/src/jni/h5util.c
@@ -1181,7 +1181,7 @@ h5str_sprintf(JNIEnv *env, h5str_t *out_str, hid_t container, hid_t tid, void *i
             }
             else if (H5R_OBJ_REF_BUF_SIZE == typeSize) {
                 H5O_info2_t oi;
-                hid_t       obj = H5I_INVALID_HID;
+                hid_t       obj         = H5I_INVALID_HID;
                 char *      obj_tok_str = NULL;
 
                 /*

--- a/tools/lib/h5tools_str.c
+++ b/tools/lib/h5tools_str.c
@@ -1196,7 +1196,7 @@ h5tools_str_sprint(h5tools_str_t *str, const h5tool_format_t *info, hid_t contai
                             case H5R_MAXTYPE:
                             default:
                                 break;
-                        } /* end switch */
+                        }
                         H5TOOLS_DEBUG("H5T_REFERENCE:H5T_STD_REF end");
                     }
                     else if (H5Tequal(type, H5T_STD_REF_DSETREG)) {
@@ -1210,11 +1210,12 @@ h5tools_str_sprint(h5tools_str_t *str, const h5tool_format_t *info, hid_t contai
                         /*
                          * Object references -- show the type and OID of the referenced object.
                          */
-                        H5O_info1_t oi;
+                        H5O_info2_t oi;
+                        char *      obj_tok_str = NULL;
 
                         H5TOOLS_DEBUG("H5T_REFERENCE:H5T_STD_REF_OBJ");
                         obj = H5Rdereference2(container, H5P_DEFAULT, H5R_OBJECT, vp);
-                        H5Oget_info2(obj, &oi, H5O_INFO_BASIC);
+                        H5Oget_info3(obj, &oi, H5O_INFO_BASIC);
 
                         /* Print object type and close object */
                         switch (oi.type) {
@@ -1235,14 +1236,21 @@ h5tools_str_sprint(h5tools_str_t *str, const h5tool_format_t *info, hid_t contai
                             default:
                                 h5tools_str_append(str, "%u-", (unsigned)oi.type);
                                 break;
-                        } /* end switch */
+                        }
                         H5Oclose(obj);
 
                         /* Print OID */
+                        H5Otoken_to_str(obj, &oi.token, &obj_tok_str);
+
                         if (info->obj_hidefileno)
-                            h5tools_str_append(str, info->obj_format, oi.addr);
+                            h5tools_str_append(str, info->obj_format, obj_tok_str);
                         else
-                            h5tools_str_append(str, info->obj_format, oi.fileno, oi.addr);
+                            h5tools_str_append(str, info->obj_format, oi.fileno, obj_tok_str);
+
+                        if (obj_tok_str) {
+                            H5free_memory(obj_tok_str);
+                            obj_tok_str = NULL;
+                        }
 
                         h5tools_str_sprint_old_reference(str, container, vp);
                     } /* end else if (H5Tequal(type, H5T_STD_REF_OBJ)) */


### PR DESCRIPTION
Introduced in #1811, also uses VOL token instead of addr