### PR TITLE
1.12: Cherry-pick of Autotools updates from develop

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -236,7 +236,10 @@ ${automake_cmd} || exit 1
 echo
 
 # AUTOCONF
-autoconf_cmd="${HDF5_AUTOCONF} --force"
+# The "obsolete" warnings category flags our Java macros as obsolete.
+# Since there is no clear way to upgrade them (Java support in the Autotools
+# is not great) and they work well enough for now, we suppress those warnings.
+autoconf_cmd="${HDF5_AUTOCONF} --force --warnings=no-obsolete"
 echo "${autoconf_cmd}"
 if [ "$verbose" = true ] ; then
     ${HDF5_AUTOCONF} --version

--- a/configure.ac
+++ b/configure.ac
@@ -1366,8 +1366,9 @@ case "`uname`" in
     UNAME_CYGWIN="yes"
     ;;
   MINGW*)
+    # The Winsock library
     AC_CHECK_HEADERS([io.h winsock2.h sys/timeb.h])
-    AC_HAVE_LIBRARY([ws2_32])
+    AC_CHECK_LIB([ws2_32], [GetUserName])
     ;;
   *)
     AC_CHECK_HEADERS([io.h winsock2.h sys/timeb.h])


### PR DESCRIPTION
* Suppress Autoconf "obsolete" warnings in Java checks (#1853)
* Use AC_CHECK_LIB instead of AC_HAVE_LIBRARY for Winsock (#1837)