### PR TITLE
Fix some hard-coded MPI I/O VFD checks

### DIFF
--- a/src/H5Dmpio.c
+++ b/src/H5Dmpio.c
@@ -1003,7 +1003,7 @@ H5D__contig_collective_read(H5D_io_info_t *io_info, const H5D_type_info_t *type_
     FUNC_ENTER_PACKAGE
 
     /* Sanity check */
-    HDassert(H5FD_MPIO == H5F_DRIVER_ID(io_info->dset->oloc.file));
+    HDassert(H5F_HAS_FEATURE(io_info->dset->oloc.file, H5FD_FEAT_HAS_MPI));
 
     /* Call generic internal collective I/O routine */
     if (H5D__inter_collective_io(io_info, type_info, file_space, mem_space) < 0)
@@ -1042,7 +1042,7 @@ H5D__contig_collective_write(H5D_io_info_t *io_info, const H5D_type_info_t *type
     FUNC_ENTER_PACKAGE
 
     /* Sanity check */
-    HDassert(H5FD_MPIO == H5F_DRIVER_ID(io_info->dset->oloc.file));
+    HDassert(H5F_HAS_FEATURE(io_info->dset->oloc.file, H5FD_FEAT_HAS_MPI));
 
     /* Call generic internal collective I/O routine */
     if (H5D__inter_collective_io(io_info, type_info, file_space, mem_space) < 0)

--- a/src/H5Fmpi.c
+++ b/src/H5Fmpi.c
@@ -390,12 +390,24 @@ H5F_mpi_retrieve_comm(hid_t loc_id, hid_t acspl_id, MPI_Comm *mpi_comm)
     }
     /* otherwise, this is from H5Fopen or H5Fcreate and has to be collective */
     else {
-        H5P_genplist_t *plist; /* Property list pointer */
+        H5FD_driver_prop_t driver_prop; /* Property for driver ID & info */
+        H5P_genplist_t *   plist;       /* Property list pointer */
+        unsigned long      driver_feat_flags;
+        H5FD_class_t *     driver_class = NULL;
 
         if (NULL == (plist = H5P_object_verify(acspl_id, H5P_FILE_ACCESS)))
             HGOTO_ERROR(H5E_FILE, H5E_BADTYPE, FAIL, "not a file access list")
 
-        if (H5FD_MPIO == H5P_peek_driver(plist))
+        if (H5P_peek(plist, H5F_ACS_FILE_DRV_NAME, &driver_prop) < 0)
+            HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get driver ID & info")
+
+        if (NULL == (driver_class = H5FD_get_class(driver_prop.driver_id)))
+            HGOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL, "can't get driver class structure")
+
+        if (H5FD_driver_query(driver_class, &driver_feat_flags) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL, "can't get driver feature flags")
+
+        if (driver_feat_flags & H5FD_FEAT_HAS_MPI)
             if (H5P_peek(plist, H5F_ACS_MPI_PARAMS_COMM_NAME, mpi_comm) < 0)
                 HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "can't get MPI communicator")
     }


### PR DESCRIPTION
With development on the subfiling VFD, the MPI I/O VFD is not the only parallel VFD we have any more.