### PR TITLE
Updates comments in the gcc 4.8 warnings files

### DIFF
--- a/config/gnu-warnings/4.8
+++ b/config/gnu-warnings/4.8
@@ -16,10 +16,6 @@
 -Wtrampolines
 
 # warning flag added for GCC >= 4.7
-#
-# -Wstack-usage=8192 warnings need to be swept up on a branch so
-# that we can stop burdening the whole development team.
-#
 -Wstack-usage=8192
 
 # warning flag added for GCC >= 4.8

--- a/config/gnu-warnings/cxx-4.8
+++ b/config/gnu-warnings/cxx-4.8
@@ -12,10 +12,6 @@
 -Wtrampolines
 
 # warning flag added for GCC >= 4.7
-#
-# -Wstack-usage=8192 warnings need to be swept up on a branch so
-# that we can stop burdening the whole development team.
-#
 -Wstack-usage=8192
 
 # warning flag added for GCC >= 4.8


### PR DESCRIPTION
There are no more size warnings in the library