### PR TITLE
Removed compiler F03 messages for language elements that are not standard…

### DIFF
--- a/config/cmake/HDFFortranCompilerFlags.cmake
+++ b/config/cmake/HDFFortranCompilerFlags.cmake
@@ -62,7 +62,7 @@ if (NOT MSVC AND NOT MINGW)
   # General flags
   if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
     ADD_H5_FLAGS (HDF5_CMAKE_Fortran_FLAGS "${HDF5_SOURCE_DIR}/config/intel-warnings/ifort-general")
-    list (APPEND HDF5_CMAKE_Fortran_FLAGS "-stand f03" "-free")
+    list (APPEND HDF5_CMAKE_Fortran_FLAGS "-free")
   elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
     ADD_H5_FLAGS (HDF5_CMAKE_Fortran_FLAGS "${HDF5_SOURCE_DIR}/config/gnu-warnings/gfort-general")
     list (APPEND HDF5_CMAKE_Fortran_FLAGS "-ffree-form" "-fimplicit-none")

--- a/config/intel-fflags
+++ b/config/intel-fflags
@@ -123,7 +123,7 @@ if test "X-ifort" = "X-$f9x_vendor"; then
     # General #
     ###########
 
-    H5_FCFLAGS="$H5_FCFLAGS -stand:f03 -free"
+    H5_FCFLAGS="$H5_FCFLAGS -free"
     H5_FCFLAGS="$H5_FCFLAGS $(load_intel_arguments ifort-general)"
 
     #############################


### PR DESCRIPTION
Removed compiler F03 messages for language elements that are not standard  in Fortran 2003, Ref.  #1344 