### PR TITLE
Removes padding-right from Doxygen href tags

### DIFF
--- a/doxygen/hdf5doxy.css
+++ b/doxygen/hdf5doxy.css
@@ -247,5 +247,4 @@ a {
 a[href*="http"] {
   background: url('https://mdn.mozillademos.org/files/12982/external-link-52.png') no-repeat 100% 0;
   background-size: 12px 12px;
-  padding-right: 16px;
 }


### PR DESCRIPTION
This makes links look bad when inserted into normal text. If there are special links that need this to look pretty, we should define a different class for them.