### PR TITLE
H5Location::getLinkval: Fix a bug that it always returns empty string

### DIFF
--- a/c++/src/H5Location.cpp
+++ b/c++/src/H5Location.cpp
@@ -1842,9 +1842,10 @@ H5Location::getLinkval(const char *name, size_t size) const
 
         size_t last_notnull_pos(value.find_last_not_of('\0'));
         if (last_notnull_pos == H5std_string::npos) {
-          value.resize(0);
-        } else {
-          value.resize(last_notnull_pos + 1);
+            value.resize(0);
+        }
+        else {
+            value.resize(last_notnull_pos + 1);
         }
     }
     return (value);

--- a/c++/src/H5Location.cpp
+++ b/c++/src/H5Location.cpp
@@ -1834,7 +1834,8 @@ H5Location::getLinkval(const char *name, size_t size) const
     // if link has value, retrieve the value, otherwise, return null string
     if (val_size > 0) {
         // Create buffer for C string
-        value_C = new char[val_size + 1]();
+        ++val_size;
+        value_C = new char[val_size]();
 
         ret_value = H5Lget_val(getId(), name, value_C, val_size, H5P_DEFAULT);
         if (ret_value < 0) {
@@ -1842,7 +1843,7 @@ H5Location::getLinkval(const char *name, size_t size) const
             throwException("getLinkval", "H5Lget_val failed");
         }
 
-        value = H5std_string(value_C);
+        value = H5std_string(value_C, val_size);
         delete[] value_C;
     }
     return (value);

--- a/c++/src/H5Location.cpp
+++ b/c++/src/H5Location.cpp
@@ -1817,7 +1817,6 @@ H5std_string
 H5Location::getLinkval(const char *name, size_t size) const
 {
     H5L_info2_t  linkinfo;
-    char        *value_C; // value in C string
     size_t       val_size = size;
     H5std_string value;
     herr_t       ret_value;
@@ -1834,17 +1833,12 @@ H5Location::getLinkval(const char *name, size_t size) const
     // if link has value, retrieve the value, otherwise, return null string
     if (val_size > 0) {
         // Create buffer for C string
-        ++val_size;
-        value_C = new char[val_size]();
+        value.assign(val_size + 1, '\0');
 
-        ret_value = H5Lget_val(getId(), name, value_C, val_size, H5P_DEFAULT);
+        ret_value = H5Lget_val(getId(), name, &value[0], val_size, H5P_DEFAULT);
         if (ret_value < 0) {
-            delete[] value_C;
             throwException("getLinkval", "H5Lget_val failed");
         }
-
-        value = H5std_string(value_C, val_size);
-        delete[] value_C;
     }
     return (value);
 }

--- a/c++/src/H5Location.cpp
+++ b/c++/src/H5Location.cpp
@@ -1833,11 +1833,18 @@ H5Location::getLinkval(const char *name, size_t size) const
     // if link has value, retrieve the value, otherwise, return null string
     if (val_size > 0) {
         // Create buffer for C string
-        value.assign(val_size + 1, '\0');
+        value.assign(val_size, '\0');
 
         ret_value = H5Lget_val(getId(), name, &value[0], val_size, H5P_DEFAULT);
         if (ret_value < 0) {
             throwException("getLinkval", "H5Lget_val failed");
+        }
+
+        size_t last_notnull_pos(value.find_last_not_of('\0'));
+        if (last_notnull_pos == H5std_string::npos) {
+          value.resize(0);
+        } else {
+          value.resize(last_notnull_pos + 1);
         }
     }
     return (value);


### PR DESCRIPTION
Update:
Actually, we could initialize the string and use it's internal buffer as the char array for `H5Lget_val` so we don't have to copy from the char array to string.

Original:
The return of `H5Lget_val` for external link always starts with a null so the return from `getLinkval` is always an empty string. Moreover, the values in the char array buffer is null terminated so we must specify the length of char array in the string constructor.