### PR TITLE
Removes Windows getlogin() equivalent

### DIFF
--- a/bin/checkposix
+++ b/bin/checkposix
@@ -136,7 +136,7 @@ foreach $arg (@ARGV) {
 
             # These are Windows system calls. Ignore them.
             next if $name =~ /^(_get_osfhandle|GetFileInformationByHandle|SetFilePointer|GetLastError|SetEndOfFile)$/;
-            next if $name =~ /^(FindNextFile|FindClose|_tzset|Wgettimeofday|GetSystemTimeAsFileTime|Wgetlogin|GetUserName)$/;
+            next if $name =~ /^(FindNextFile|FindClose|_tzset|Wgettimeofday|GetSystemTimeAsFileTime|GetUserName)$/;
             next if $name =~ /^(DeleteCriticalSection|TlsFree|TlsGetValue|CreateThread)$/;
             next if $name =~ /^(ExpandEnvironmentStringsA|LockFileEx|UnlockFileEx)$/;
             next if $name =~ /^(DllMain|LocalAlloc|LocalFree)$/;

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -948,9 +948,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #ifndef HDgethostname
 #define HDgethostname(N, L) gethostname(N, L)
 #endif
-#ifndef HDgetlogin
-#define HDgetlogin() getlogin()
-#endif
 #ifndef HDgetpgrp
 #define HDgetpgrp() getpgrp()
 #endif

--- a/src/H5system.c
+++ b/src/H5system.c
@@ -443,22 +443,6 @@ H5_get_win32_times(H5_timevals_t *tvs /*in,out*/)
 } /* end H5_get_win32_times() */
 #endif
 
-#define WloginBuffer_count 256
-static char Wlogin_buffer[WloginBuffer_count];
-
-char *
-Wgetlogin(void)
-{
-
-#ifdef H5_HAVE_WIN32_API
-    DWORD bufferCount = WloginBuffer_count;
-    if (GetUserName(Wlogin_buffer, &bufferCount) != 0)
-        return (Wlogin_buffer);
-    else
-#endif
-        return NULL;
-}
-
 /*-------------------------------------------------------------------------
  * Function:    Wflock
  *

--- a/src/H5win32defs.h
+++ b/src/H5win32defs.h
@@ -53,7 +53,6 @@ struct timezone {
 #define HDgetcwd(S, Z)       _getcwd(S, Z)
 #define HDgetdcwd(D, S, Z)   _getdcwd(D, S, Z)
 #define HDgetdrive()         _getdrive()
-#define HDgetlogin()         Wgetlogin()
 #define HDgettimeofday(V, Z) Wgettimeofday(V, Z)
 #define HDisatty(F)          _isatty(F)
 #define HDlseek(F, O, W)     _lseeki64(F, O, W)
@@ -102,7 +101,6 @@ extern "C" {
 H5_DLL int      Wgettimeofday(struct timeval *tv, struct timezone *tz);
 H5_DLL int      Wsetenv(const char *name, const char *value, int overwrite);
 H5_DLL int      Wflock(int fd, int operation);
-H5_DLL char    *Wgetlogin(void);
 H5_DLL herr_t   H5_expand_windows_env_vars(char **env_var);
 H5_DLL wchar_t *H5_get_utf16_str(const char *s);
 H5_DLL int      Wopen_utf8(const char *path, int oflag, ...);


### PR DESCRIPTION
This function is no longer used in the library