### PR TITLE
Sanity checks for H5Xcreate_anon functions to make sure the IDs passed in are valid

### DIFF
--- a/src/H5D.c
+++ b/src/H5D.c
@@ -279,11 +279,20 @@ H5Dcreate_anon(hid_t loc_id, hid_t type_id, hid_t space_id, hid_t dcpl_id, hid_t
     FUNC_ENTER_API(H5I_INVALID_HID)
     H5TRACE5("i", "iiiii", loc_id, type_id, space_id, dcpl_id, dapl_id);
 
+    /* Sanity check */
+    if (loc_id < 0 || type_id < 0 || space_id < 0 || dcpl_id < 0 || dapl_id < 0)
+        HGOTO_ERROR(H5E_ID, H5E_BADID, (-1), "ID must be valid")
+
     /* Check arguments */
     if (H5P_DEFAULT == dcpl_id)
         dcpl_id = H5P_DATASET_CREATE_DEFAULT;
     else if (TRUE != H5P_isa_class(dcpl_id, H5P_DATASET_CREATE))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not dataset create property list ID")
+
+    if (H5P_DEFAULT == dapl_id)
+        dapl_id = H5P_DATASET_ACCESS_DEFAULT;
+    else if (TRUE != H5P_isa_class(dapl_id, H5P_DATASET_ACCESS))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not dataset access property list ID")
 
     /* Set the DCPL for the API context */
     H5CX_set_dcpl(dcpl_id);

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -279,10 +279,6 @@ H5Dcreate_anon(hid_t loc_id, hid_t type_id, hid_t space_id, hid_t dcpl_id, hid_t
     FUNC_ENTER_API(H5I_INVALID_HID)
     H5TRACE5("i", "iiiii", loc_id, type_id, space_id, dcpl_id, dapl_id);
 
-    /* Sanity check */
-    if (loc_id < 0 || type_id < 0 || space_id < 0 || dcpl_id < 0 || dapl_id < 0)
-        HGOTO_ERROR(H5E_ID, H5E_BADID, (-1), "ID must be valid")
-
     /* Check arguments */
     if (H5P_DEFAULT == dcpl_id)
         dcpl_id = H5P_DATASET_CREATE_DEFAULT;

--- a/src/H5G.c
+++ b/src/H5G.c
@@ -325,10 +325,6 @@ H5Gcreate_anon(hid_t loc_id, hid_t gcpl_id, hid_t gapl_id)
     FUNC_ENTER_API(H5I_INVALID_HID)
     H5TRACE3("i", "iii", loc_id, gcpl_id, gapl_id);
 
-    /* Sanity check */
-    if (loc_id < 0 || gcpl_id < 0 || gapl_id < 0)
-        HGOTO_ERROR(H5E_ID, H5E_BADID, (-1), "ID must be valid")
-
     /* Check group property list */
     if (H5P_DEFAULT == gcpl_id)
         gcpl_id = H5P_GROUP_CREATE_DEFAULT;

--- a/src/H5G.c
+++ b/src/H5G.c
@@ -325,11 +325,20 @@ H5Gcreate_anon(hid_t loc_id, hid_t gcpl_id, hid_t gapl_id)
     FUNC_ENTER_API(H5I_INVALID_HID)
     H5TRACE3("i", "iii", loc_id, gcpl_id, gapl_id);
 
-    /* Check group creation property list */
+    /* Sanity check */
+    if (loc_id < 0 || gcpl_id < 0 || gapl_id < 0)
+        HGOTO_ERROR(H5E_ID, H5E_BADID, (-1), "ID must be valid")
+
+    /* Check group property list */
     if (H5P_DEFAULT == gcpl_id)
         gcpl_id = H5P_GROUP_CREATE_DEFAULT;
     else if (TRUE != H5P_isa_class(gcpl_id, H5P_GROUP_CREATE))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not group create property list")
+
+    if (H5P_DEFAULT == gapl_id)
+        gapl_id = H5P_GROUP_ACCESS_DEFAULT;
+    else if (TRUE != H5P_isa_class(gapl_id, H5P_GROUP_ACCESS))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not group access property list")
 
     /* Verify access property list and set up collective metadata if appropriate */
     if (H5CX_set_apl(&gapl_id, H5P_CLS_GACC, loc_id, TRUE) < 0)

--- a/src/H5Iint.c
+++ b/src/H5Iint.c
@@ -1069,8 +1069,7 @@ H5I_dec_ref(hid_t id)
     FUNC_ENTER_NOAPI((-1))
 
     /* Sanity check */
-    if (id < 0)
-        HGOTO_ERROR(H5E_ID, H5E_BADID, (-1), "ID must be valid")
+    HDassert(id >= 0);
 
     /* Synchronously decrement refcount on ID */
     if ((ret_value = H5I__dec_ref(id, H5_REQUEST_NULL)) < 0)

--- a/src/H5Iint.c
+++ b/src/H5Iint.c
@@ -1069,7 +1069,8 @@ H5I_dec_ref(hid_t id)
     FUNC_ENTER_NOAPI((-1))
 
     /* Sanity check */
-    HDassert(id >= 0);
+    if (id < 0)
+        HGOTO_ERROR(H5E_ID, H5E_BADID, (-1), "ID must be valid")
 
     /* Synchronously decrement refcount on ID */
     if ((ret_value = H5I__dec_ref(id, H5_REQUEST_NULL)) < 0)

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -337,6 +337,10 @@ H5Tcommit_anon(hid_t loc_id, hid_t type_id, hid_t tcpl_id, hid_t tapl_id)
     FUNC_ENTER_API(FAIL)
     H5TRACE4("e", "iiii", loc_id, type_id, tcpl_id, tapl_id);
 
+    /* Sanity check */
+    if (loc_id < 0 || type_id < 0 || tcpl_id < 0 || tapl_id < 0)
+        HGOTO_ERROR(H5E_ID, H5E_BADID, (-1), "ID must be valid")
+
     /* Check arguments */
     if (NULL == (type = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype")
@@ -348,6 +352,11 @@ H5Tcommit_anon(hid_t loc_id, hid_t type_id, hid_t tcpl_id, hid_t tapl_id)
         tcpl_id = H5P_DATATYPE_CREATE_DEFAULT;
     else if (TRUE != H5P_isa_class(tcpl_id, H5P_DATATYPE_CREATE))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not datatype creation property list")
+
+    if (H5P_DEFAULT == tapl_id)
+        tapl_id = H5P_DATATYPE_ACCESS_DEFAULT;
+    else if (TRUE != H5P_isa_class(tapl_id, H5P_DATATYPE_ACCESS))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not datatype access property list")
 
     /* Verify access property list and set up collective metadata if appropriate */
     if (H5CX_set_apl(&tapl_id, H5P_CLS_TACC, loc_id, TRUE) < 0)

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -337,10 +337,6 @@ H5Tcommit_anon(hid_t loc_id, hid_t type_id, hid_t tcpl_id, hid_t tapl_id)
     FUNC_ENTER_API(FAIL)
     H5TRACE4("e", "iiii", loc_id, type_id, tcpl_id, tapl_id);
 
-    /* Sanity check */
-    if (loc_id < 0 || type_id < 0 || tcpl_id < 0 || tapl_id < 0)
-        HGOTO_ERROR(H5E_ID, H5E_BADID, (-1), "ID must be valid")
-
     /* Check arguments */
     if (NULL == (type = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype")


### PR DESCRIPTION
vol_tests tests H5Dcreate_anon, H5Gcreate_anon, and H5Tcommit_anon with invalid property list IDs.  I verified the fixes with vol_tests.