### PR TITLE
Backport H5Dchunk_iter to 1.10 branch

### DIFF
--- a/bin/trace
+++ b/bin/trace
@@ -44,6 +44,7 @@ $Source = "";
                "H5D_vds_view_t"             => "Dv",
                "H5FD_mpio_xfer_t"           => "Dt",
                "H5FD_splitter_vfd_config_t" => "Dr",
+               "H5D_chunk_iter_op_t"        => "x",
                "herr_t"                     => "e",
                "H5E_direction_t"            => "Ed",
                "H5E_error_t"                => "Ee",

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -1247,18 +1247,18 @@ done:
  *
  *        typedef int (*H5D_chunk_iter_op_t)(
  *            const hsize_t *offset,
- *            uint32_t filter_mask,
+ *            unsigned filter_mask,
  *            haddr_t addr,
- *            uint32_t nbytes,
+ *            hsize_t size,
  *            void *op_data);
  *
  *      H5D_chunk_iter_op_t parameters:
- *          hsize_t *offset;        IN/OUT: Array of starting logical coordinates of chunk.
- *          uint32_t filter_mask;   IN: Filter mask of chunk.
- *          haddr_t addr;           IN: Offset in file of chunk data.
- *          uint32_t nbytes;        IN: Size in number of bytes of chunk data in file.
- *          void *op_data;          IN/OUT: Pointer to any user-defined data
- *                                  associated with the operation.
+ *          hsize_t *offset;        IN/OUT: Logical position of the chunk’s first element in units of dataset
+ *                                          elements
+ *          unsigned filter_mask;   IN: Bitmask indicating the filters used when the chunk was written haddr_t
+ *          addr;                   IN: Chunk address in the file
+ *          hsize_t;                IN: Chunk size in bytes, 0 if the chunk does not exist
+ *          void *op_data;          IN/OUT: Pointer to any user-defined data associated with the operation.
  *
  *      The return values from an operator are:
  *          Zero (H5_ITER_CONT) causes the iterator to continue, returning zero when all

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -1278,8 +1278,8 @@ done:
 herr_t
 H5Dchunk_iter(hid_t dset_id, hid_t dxpl_id, H5D_chunk_iter_op_t op, void *op_data)
 {
-    H5D_t *dset = NULL;
-    herr_t                              ret_value = SUCCEED;
+    H5D_t *dset      = NULL;
+    herr_t ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
     H5TRACE4("e", "iix*x", dset_id, dxpl_id, op, op_data);

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -1230,3 +1230,83 @@ H5Dget_chunk_info_by_coord(hid_t dset_id, const hsize_t *offset, unsigned *filte
 done:
     FUNC_LEAVE_API(ret_value)
 } /* end H5Dget_chunk_info_by_coord() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5Dchunk_iter
+ *
+ * Purpose:     Iterates over all chunks in dataset with given callback and user data.
+ *
+ * Parameters:
+ *              hid_t dset_id;          IN: Chunked dataset ID
+ *              hid_t dxpl_id;          IN: Dataset transfer property list ID
+ *              H5D_chunk_iter_op_t cb  IN: User callback function, called for every chunk.
+ *              void *op_data           IN/OUT: Optional user data passed on to user callback.
+ *
+ * Callback information:
+ *      H5D_chunk_iter_op_t is defined as:
+ *
+ *        typedef int (*H5D_chunk_iter_op_t)(
+ *            const hsize_t *offset,
+ *            uint32_t filter_mask,
+ *            haddr_t addr,
+ *            uint32_t nbytes,
+ *            void *op_data);
+ *
+ *      H5D_chunk_iter_op_t parameters:
+ *          hsize_t *offset;        IN/OUT: Array of starting logical coordinates of chunk.
+ *          uint32_t filter_mask;   IN: Filter mask of chunk.
+ *          haddr_t addr;           IN: Offset in file of chunk data.
+ *          uint32_t nbytes;        IN: Size in number of bytes of chunk data in file.
+ *          void *op_data;          IN/OUT: Pointer to any user-defined data
+ *                                  associated with the operation.
+ *
+ *      The return values from an operator are:
+ *          Zero (H5_ITER_CONT) causes the iterator to continue, returning zero when all
+ *              elements have been processed.
+ *          Positive (H5_ITER_STOP) causes the iterator to immediately return that positive
+ *              value, indicating short-circuit success.
+ *          Negative (H5_ITER_ERROR) causes the iterator to immediately return that value,
+ *              indicating failure.
+ *
+ * Return:      Non-negative on success, negative on failure
+ *
+ * Programmer:  Gaute Hope
+ *              August 2020
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5Dchunk_iter(hid_t dset_id, hid_t dxpl_id, H5D_chunk_iter_op_t op, void *op_data)
+{
+    H5D_t *dset = NULL;
+    herr_t                              ret_value = SUCCEED;
+
+    FUNC_ENTER_API(FAIL)
+    H5TRACE4("e", "iix*x", dset_id, dxpl_id, op, op_data);
+
+    /* Check arguments */
+    if (NULL == (dset = (H5D_t *)H5I_object_verify(dset_id, H5I_DATASET)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid dataset identifier")
+    if (NULL == op)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid callback to chunk iteration")
+
+    /* Get the default dataset transfer property list if the user didn't provide one */
+    if (H5P_DEFAULT == dxpl_id)
+        dxpl_id = H5P_DATASET_XFER_DEFAULT;
+    else if (TRUE != H5P_isa_class(dxpl_id, H5P_DATASET_XFER))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "dxpl_id is not a dataset transfer property list ID")
+
+    /* Sanity check */
+    HDassert(dset->shared);
+
+    /* Make sure the dataset is chunked */
+    if (H5D_CHUNKED != dset->shared->layout.type)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a chunked dataset")
+
+    /* Call private function */
+    if ((ret_value = H5D__chunk_iter(dset, op, op_data)) < 0)
+        HERROR(H5E_DATASET, H5E_BADITER, "error iterating over dataset chunks");
+
+done:
+    FUNC_LEAVE_API(ret_value)
+} /* end H5Dchunk_iter() */

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -7694,7 +7694,7 @@ H5D__chunk_iter_cb(const H5D_chunk_rec_t *chunk_rec, void *udata)
     FUNC_ENTER_PACKAGE_NOERR
 
     /* Check for callback failure and pass along return value */
-    if ((ret_value = (data->op)(chunk_rec->scaled, (unsigned)chunk_rec->filter_mask, chunk_rec->chunk_addr,
+    if ((ret_value = (data->op)(offset, (unsigned)chunk_rec->filter_mask, chunk_rec->chunk_addr,
                                 (hsize_t)chunk_rec->nbytes, data->op_data)) < 0)
         HERROR(H5E_DATASET, H5E_CANTNEXT, "iteration operator failed");
 

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -250,7 +250,7 @@ typedef struct H5D_chunk_coll_fill_info_t {
 
 typedef struct H5D_chunk_iter_ud_t {
     H5D_chunk_iter_op_t op;      /* User defined callback */
-    void *              op_data; /* User data for user defined callback */
+    void               *op_data; /* User data for user defined callback */
 } H5D_chunk_iter_ud_t;
 
 /********************/
@@ -7707,11 +7707,11 @@ H5D__chunk_iter_cb(const H5D_chunk_rec_t *chunk_rec, void *udata)
  *-------------------------------------------------------------------------
  */
 herr_t
-H5D__chunk_iter(H5D_t *dset, H5D_chunk_iter_op_t op, void *op_data)
+H5D__chunk_iter(const H5D_t *dset, H5D_chunk_iter_op_t op, void *op_data)
 {
-    const H5D_rdcc_t * rdcc   = NULL;       /* Raw data chunk cache */
-    H5O_layout_t *     layout = NULL;       /* Dataset layout */
-    H5D_rdcc_ent_t *   ent;                 /* Cache entry index */
+    const H5D_rdcc_t  *rdcc   = NULL;       /* Raw data chunk cache */
+    H5O_layout_t      *layout = NULL;       /* Dataset layout */
+    H5D_rdcc_ent_t    *ent;                 /* Cache entry index */
     H5D_chk_idx_info_t idx_info;            /* Chunked index info */
     herr_t             ret_value = SUCCEED; /* Return value */
 

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -248,6 +248,11 @@ typedef struct H5D_chunk_coll_fill_info_t {
 } H5D_chunk_coll_fill_info_t;
 #endif /* H5_HAVE_PARALLEL */
 
+typedef struct H5D_chunk_iter_ud_t {
+    H5D_chunk_iter_op_t op;      /* User defined callback */
+    void *              op_data; /* User data for user defined callback */
+} H5D_chunk_iter_ud_t;
+
 /********************/
 /* Local Prototypes */
 /********************/
@@ -271,6 +276,7 @@ static herr_t H5D__chunk_dest(H5D_t *dset);
 static int H5D__get_num_chunks_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata);
 static int H5D__get_chunk_info_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata);
 static int H5D__get_chunk_info_by_coord_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata);
+static int H5D__chunk_iter_cb(const H5D_chunk_rec_t *chunk_rec, void *udata);
 
 /* "Nonexistent" layout operation callback */
 static ssize_t H5D__nonexistent_readvv(const H5D_io_info_t *io_info, size_t chunk_max_nseq,
@@ -7655,3 +7661,98 @@ H5D__get_chunk_info_by_coord(const H5D_t *dset, const hsize_t *offset, unsigned 
 done:
     FUNC_LEAVE_NOAPI_TAG(ret_value)
 } /* end H5D__get_chunk_info_by_coord() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5D__chunk_iter_cb
+ *
+ * Purpose:     Call the user-defined function with the chunk data. The iterator continues if
+ *              the user-defined function returns H5_ITER_CONT, and stops if H5_ITER_STOP is
+ *              returned.
+ *
+ * Return:      Success:    H5_ITER_CONT or H5_ITER_STOP
+ *              Failure:    Negative (H5_ITER_ERROR)
+ *
+ * Programmer:  Gaute Hope
+ *              August 2020
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+H5D__chunk_iter_cb(const H5D_chunk_rec_t *chunk_rec, void *udata)
+{
+    const H5D_chunk_iter_ud_t *data      = (H5D_chunk_iter_ud_t *)udata;
+    int                        ret_value = H5_ITER_CONT;
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    /* Check for callback failure and pass along return value */
+    if ((ret_value = (data->op)(chunk_rec->scaled, chunk_rec->filter_mask, chunk_rec->chunk_addr,
+                                chunk_rec->nbytes, data->op_data)) < 0)
+        HERROR(H5E_DATASET, H5E_CANTNEXT, "iteration operator failed");
+
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5D__chunk_iter_cb */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5D__chunk_iter
+ *
+ * Purpose:     Iterate over all the chunks in the dataset with given callback.
+ *
+ * Return:      Success:        Non-negative
+ *              Failure:        Negative
+ *
+ * Programmer:  Gaute Hope
+ *              August 2020
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5D__chunk_iter(H5D_t *dset, H5D_chunk_iter_op_t op, void *op_data)
+{
+    const H5D_rdcc_t * rdcc   = NULL;       /* Raw data chunk cache */
+    H5O_layout_t *     layout = NULL;       /* Dataset layout */
+    H5D_rdcc_ent_t *   ent;                 /* Cache entry index */
+    H5D_chk_idx_info_t idx_info;            /* Chunked index info */
+    herr_t             ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE_TAG(dset->oloc.addr)
+
+    /* Check args */
+    HDassert(dset);
+    HDassert(dset->shared);
+
+    /* Get dataset layout and raw data chunk cache */
+    layout = &(dset->shared->layout);
+    rdcc   = &(dset->shared->cache.chunk);
+    HDassert(layout);
+    HDassert(rdcc);
+    HDassert(H5D_CHUNKED == layout->type);
+
+    /* Search for cached chunks that haven't been written out */
+    for (ent = rdcc->head; ent; ent = ent->next)
+        /* Flush the chunk out to disk, to make certain the size is correct later */
+        if (H5D__chunk_flush_entry(dset, ent, FALSE) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTFLUSH, FAIL, "cannot flush indexed storage buffer")
+
+    /* Compose chunked index info struct */
+    idx_info.f       = dset->oloc.file;
+    idx_info.pline   = &dset->shared->dcpl_cache.pline;
+    idx_info.layout  = &layout->u.chunk;
+    idx_info.storage = &layout->storage.u.chunk;
+
+    /* If the dataset is not written, return without errors */
+    if (H5F_addr_defined(idx_info.storage->idx_addr)) {
+        H5D_chunk_iter_ud_t ud;
+
+        /* Set up info for iteration callback */
+        ud.op      = op;
+        ud.op_data = op_data;
+
+        /* Iterate over the allocated chunks calling the iterator callback */
+        if ((ret_value = (layout->storage.u.chunk.ops->iterate)(&idx_info, H5D__chunk_iter_cb, &ud)) < 0)
+            HERROR(H5E_DATASET, H5E_CANTNEXT, "chunk iteration failed");
+    } /* end if H5F_addr_defined */
+
+done:
+    FUNC_LEAVE_NOAPI_TAG(ret_value)
+} /* end H5D__chunk_iter() */

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -251,6 +251,7 @@ typedef struct H5D_chunk_coll_fill_info_t {
 typedef struct H5D_chunk_iter_ud_t {
     H5D_chunk_iter_op_t op;      /* User defined callback */
     void               *op_data; /* User data for user defined callback */
+    H5O_layout_chunk_t *chunk;   /* Chunk layout */
 } H5D_chunk_iter_ud_t;
 
 /********************/
@@ -7681,7 +7682,14 @@ static int
 H5D__chunk_iter_cb(const H5D_chunk_rec_t *chunk_rec, void *udata)
 {
     const H5D_chunk_iter_ud_t *data      = (H5D_chunk_iter_ud_t *)udata;
+    const H5O_layout_chunk_t  *chunk     = data->chunk;
     int                        ret_value = H5_ITER_CONT;
+    hsize_t                    offset[H5O_LAYOUT_NDIMS];
+    unsigned                   ii; /* Match H5O_layout_chunk_t.ndims */
+
+    /* Similar to H5D__get_chunk_info */
+    for (ii = 0; ii < chunk->ndims; ii++)
+        offset[ii] = chunk_rec->scaled[ii] * chunk->dim[ii];
 
     FUNC_ENTER_PACKAGE_NOERR
 
@@ -7747,6 +7755,7 @@ H5D__chunk_iter(H5D_t *dset, H5D_chunk_iter_op_t op, void *op_data)
         /* Set up info for iteration callback */
         ud.op      = op;
         ud.op_data = op_data;
+        ud.chunk   = &dset->shared->layout.u.chunk;
 
         /* Iterate over the allocated chunks calling the iterator callback */
         if ((ret_value = (layout->storage.u.chunk.ops->iterate)(&idx_info, H5D__chunk_iter_cb, &ud)) < 0)

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -7686,8 +7686,8 @@ H5D__chunk_iter_cb(const H5D_chunk_rec_t *chunk_rec, void *udata)
     FUNC_ENTER_PACKAGE_NOERR
 
     /* Check for callback failure and pass along return value */
-    if ((ret_value = (data->op)(chunk_rec->scaled, chunk_rec->filter_mask, chunk_rec->chunk_addr,
-                                chunk_rec->nbytes, data->op_data)) < 0)
+    if ((ret_value = (data->op)(chunk_rec->scaled, (unsigned)chunk_rec->filter_mask, chunk_rec->chunk_addr,
+                                (hsize_t)chunk_rec->nbytes, data->op_data)) < 0)
         HERROR(H5E_DATASET, H5E_CANTNEXT, "iteration operator failed");
 
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -7707,7 +7707,7 @@ H5D__chunk_iter_cb(const H5D_chunk_rec_t *chunk_rec, void *udata)
  *-------------------------------------------------------------------------
  */
 herr_t
-H5D__chunk_iter(const H5D_t *dset, H5D_chunk_iter_op_t op, void *op_data)
+H5D__chunk_iter(H5D_t *dset, H5D_chunk_iter_op_t op, void *op_data)
 {
     const H5D_rdcc_t  *rdcc   = NULL;       /* Raw data chunk cache */
     H5O_layout_t      *layout = NULL;       /* Dataset layout */

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -571,7 +571,7 @@ H5_DLL herr_t  H5D__get_chunk_info(const H5D_t *dset, const H5S_t *space, hsize_
                                    unsigned *filter_mask, haddr_t *offset, hsize_t *size);
 H5_DLL herr_t  H5D__get_chunk_info_by_coord(const H5D_t *dset, const hsize_t *coord, unsigned *filter_mask,
                                             haddr_t *addr, hsize_t *size);
-H5_DLL herr_t  H5D__chunk_iter(const H5D_t *dset, H5D_chunk_iter_op_t cb, void *op_data);
+H5_DLL herr_t  H5D__chunk_iter(H5D_t *dset, H5D_chunk_iter_op_t cb, void *op_data);
 H5_DLL haddr_t H5D__get_offset(const H5D_t *dset);
 H5_DLL void   *H5D__vlen_get_buf_size_alloc(size_t size, void *info);
 H5_DLL herr_t  H5D__vlen_get_buf_size(void *elem, hid_t type_id, unsigned ndim, const hsize_t *point,

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -571,6 +571,7 @@ H5_DLL herr_t  H5D__get_chunk_info(const H5D_t *dset, const H5S_t *space, hsize_
                                    unsigned *filter_mask, haddr_t *offset, hsize_t *size);
 H5_DLL herr_t  H5D__get_chunk_info_by_coord(const H5D_t *dset, const hsize_t *coord, unsigned *filter_mask,
                                             haddr_t *addr, hsize_t *size);
+H5_DLL herr_t  H5D__chunk_iter(const H5D_t *dset, H5D_chunk_iter_op_t cb, void *op_data);
 H5_DLL haddr_t H5D__get_offset(const H5D_t *dset);
 H5_DLL void   *H5D__vlen_get_buf_size_alloc(size_t size, void *info);
 H5_DLL herr_t  H5D__vlen_get_buf_size(void *elem, hid_t type_id, unsigned ndim, const hsize_t *point,

--- a/src/H5Dpublic.h
+++ b/src/H5Dpublic.h
@@ -226,10 +226,10 @@ typedef herr_t (*H5D_gather_func_t)(const void *dst_buf, size_t dst_buf_bytes_us
 /**
  * \brief Callback for H5Dchunk_iter()
  *
- * \param[in]     offset      Array of starting logical coordinates of chunk.
- * \param[in]     filter_mask Filter mask of chunk.
- * \param[in]     addr        Offset in file of chunk data.
- * \param[in]     nbytes      Size in bytes of chunk data in file.
+ * \param[in]     offset      Logical position of the chunk’s first element in units of dataset elements
+ * \param[in]     filter_mask Bitmask indicating the filters used when the chunk was written
+ * \param[in]     addr        Chunk address in the file
+ * \param[in]     size        Chunk size in bytes, 0 if the chunk does not exist
  * \param[in,out] op_data     Pointer to any user-defined data associated with
  *                            the operation.
  * \returns \li Zero (#H5_ITER_CONT) causes the iterator to continue, returning
@@ -647,7 +647,7 @@ H5_DLL herr_t H5Dget_chunk_info_by_coord(hid_t dset_id, const hsize_t *offset, u
  *
  * \return \herr_t
  *
- * \details H5Dget_chunk_iter iterates over all chunks in the dataset, calling the
+ * \details H5Dchunk_iter iterates over all chunks in the dataset, calling the
  *          user supplied callback with the details of the chunk and the supplied
  *          context \p op_data.
  *

--- a/src/H5Dpublic.h
+++ b/src/H5Dpublic.h
@@ -222,6 +222,27 @@ typedef herr_t (*H5D_scatter_func_t)(const void **src_buf /*out*/, size_t *src_b
 typedef herr_t (*H5D_gather_func_t)(const void *dst_buf, size_t dst_buf_bytes_used, void *op_data);
 //! <!-- [H5D_gather_func_t_snip] -->
 
+//! <!-- [H5D_chunk_iter_op_t_snip] -->
+/**
+ * \brief Callback for H5Dchunk_iter()
+ *
+ * \param[in]     offset      Array of starting logical coordinates of chunk.
+ * \param[in]     filter_mask Filter mask of chunk.
+ * \param[in]     addr        Offset in file of chunk data.
+ * \param[in]     nbytes      Size in bytes of chunk data in file.
+ * \param[in,out] op_data     Pointer to any user-defined data associated with
+ *                            the operation.
+ * \returns \li Zero (#H5_ITER_CONT) causes the iterator to continue, returning
+ *              zero when all elements have been processed.
+ *          \li A positive value (#H5_ITER_STOP) causes the iterator to
+ *              immediately return that value, indicating short-circuit success.
+ *          \li A negative (#H5_ITER_ERROR) causes the iterator to immediately
+ *              return that value, indicating failure.
+ */
+typedef int (*H5D_chunk_iter_op_t)(const hsize_t *offset, uint32_t filter_mask, haddr_t addr, uint32_t nbytes,
+                                   void *op_data);
+//! <!-- [H5D_chunk_iter_op_t_snip] -->
+
 /********************/
 /* Public Variables */
 /********************/
@@ -612,6 +633,34 @@ H5_DLL herr_t H5Dget_num_chunks(hid_t dset_id, hid_t fspace_id, hsize_t *nchunks
  */
 H5_DLL herr_t H5Dget_chunk_info_by_coord(hid_t dset_id, const hsize_t *offset, unsigned *filter_mask,
                                          haddr_t *addr, hsize_t *size);
+
+/**
+ * --------------------------------------------------------------------------
+ * \ingroup H5D
+ *
+ * \brief Iterate over all chunks of a chunked dataset
+ *
+ * \dset_id
+ * \param[in] dxpl_id       Identifier of a transfer property list
+ * \param[in]  cb       User callback function, called for every chunk.
+ * \param[in]  op_data  User-defined pointer to data required by op
+ *
+ * \return \herr_t
+ *
+ * \details H5Dget_chunk_iter iterates over all chunks in the dataset, calling the
+ *          user supplied callback with the details of the chunk and the supplied
+ *          context \p op_data.
+ *
+ * \par Example
+ * For each chunk, print the allocated chunk size (0 for un-allocated chunks).
+ * \snippet H5D_examples.c H5Dchunk_iter_cb
+ * Iterate over all chunked datasets and chunks in a file.
+ * \snippet H5D_examples.c H5Ovisit_cb
+ *
+ * \since 1.10.9, 1.13.0
+ *
+ */
+H5_DLL herr_t H5Dchunk_iter(hid_t dset_id, hid_t dxpl_id, H5D_chunk_iter_op_t cb, void *op_data);
 
 /**
  * --------------------------------------------------------------------------

--- a/src/H5Dpublic.h
+++ b/src/H5Dpublic.h
@@ -239,7 +239,7 @@ typedef herr_t (*H5D_gather_func_t)(const void *dst_buf, size_t dst_buf_bytes_us
  *          \li A negative (#H5_ITER_ERROR) causes the iterator to immediately
  *              return that value, indicating failure.
  */
-typedef int (*H5D_chunk_iter_op_t)(const hsize_t *offset, uint32_t filter_mask, haddr_t addr, uint32_t nbytes,
+typedef int (*H5D_chunk_iter_op_t)(const hsize_t *offset, unsigned filter_mask, haddr_t addr, hsize_t size,
                                    void *op_data);
 //! <!-- [H5D_chunk_iter_op_t_snip] -->
 

--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -45,7 +45,7 @@ const char *FILENAME[] = {"tchunk_info_18", "tchunk_info_110", "chunk_info", NUL
 /* From original test */
 #define DATASETNAME "2d"
 
-#define BASIC_FILE      "basic_query"
+#define BASIC_FILE "basic_query"
 
 /* Parameters for testing chunk querying */
 #define RANK                 2
@@ -86,11 +86,11 @@ void reinit_vars(unsigned *read_flt_msk, haddr_t *addr, hsize_t *size);
 
 /* Helper function containing common code that verifies indexing type
    and number of chunks */
-static int         verify_get_chunk_info(hid_t dset, hid_t dspace, hsize_t chk_index, hsize_t exp_chk_size,
-                                         const hsize_t *exp_offset, unsigned exp_flt_msk);
-static int         verify_get_chunk_info_by_coord(hid_t dset, hsize_t *offset, hsize_t exp_chk_size,
-                                                  unsigned exp_flt_msk);
-static int         verify_empty_chunk_info(hid_t dset, hsize_t *offset);
+static int verify_get_chunk_info(hid_t dset, hid_t dspace, hsize_t chk_index, hsize_t exp_chk_size,
+                                 const hsize_t *exp_offset, unsigned exp_flt_msk);
+static int verify_get_chunk_info_by_coord(hid_t dset, hsize_t *offset, hsize_t exp_chk_size,
+                                          unsigned exp_flt_msk);
+static int verify_empty_chunk_info(hid_t dset, hsize_t *offset);
 
 /*-------------------------------------------------------------------------
  * Function:    read_each_chunk (helper function)
@@ -1916,8 +1916,8 @@ test_basic_query(hid_t fapl)
         TEST_ERROR;
 
     /* Create a new dataset using cparms creation properties */
-    dset = H5Dcreate2(basicfile, DSET_SIMPLE_CHUNKED, H5T_NATIVE_INT, dspace, H5P_DEFAULT, cparms,
-                      H5P_DEFAULT);
+    dset =
+        H5Dcreate2(basicfile, DSET_SIMPLE_CHUNKED, H5T_NATIVE_INT, dspace, H5P_DEFAULT, cparms, H5P_DEFAULT);
     if (dset < 0)
         TEST_ERROR;
 

--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -1666,6 +1666,50 @@ error:
     return FAIL;
 } /* test_chunk_info_version2_btrees() */
 
+typedef struct chunk_iter_info_t {
+    hsize_t  offset[2];
+    uint32_t filter_mask;
+    haddr_t  addr;
+    uint32_t nbytes;
+} chunk_iter_info_t;
+
+static int
+iter_cb(const hsize_t *offset, uint32_t filter_mask, haddr_t addr, uint32_t nbytes, void *op_data)
+{
+    chunk_iter_info_t **chunk_info = (chunk_iter_info_t **)op_data;
+
+    (*chunk_info)->offset[0]   = offset[0];
+    (*chunk_info)->offset[1]   = offset[1];
+    (*chunk_info)->filter_mask = filter_mask;
+    (*chunk_info)->addr        = addr;
+    (*chunk_info)->nbytes      = nbytes;
+
+    /* printf("offset: [%lld, %lld], addr: %ld, size: %d, filter mask: %d\n", offset[0], offset[1], addr,
+     * nbytes, filter_mask); */
+
+    *chunk_info += 1;
+
+    return H5_ITER_CONT;
+}
+
+static int
+iter_cb_stop(const hsize_t H5_ATTR_UNUSED *offset, uint32_t H5_ATTR_UNUSED filter_mask,
+             haddr_t H5_ATTR_UNUSED addr, uint32_t H5_ATTR_UNUSED nbytes, void *op_data)
+{
+    chunk_iter_info_t **chunk_info = (chunk_iter_info_t **)op_data;
+    *chunk_info += 1;
+    return H5_ITER_STOP;
+}
+
+static int
+iter_cb_fail(const hsize_t H5_ATTR_UNUSED *offset, uint32_t H5_ATTR_UNUSED filter_mask,
+             haddr_t H5_ATTR_UNUSED addr, uint32_t H5_ATTR_UNUSED nbytes, void *op_data)
+{
+    chunk_iter_info_t **chunk_info = (chunk_iter_info_t **)op_data;
+    *chunk_info += 1;
+    return H5_ITER_ERROR;
+}
+
 /*-------------------------------------------------------------------------
  * Function:    test_get_chunk_info_110
  *

--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -1961,8 +1961,11 @@ test_basic_query(hid_t fapl)
         ret = H5Dget_chunk_info(dset, dspace, chk_index, out_offset, &read_flt_msk, &addr, &size);
     }
     H5E_END_TRY;
-    //if (ret != FAIL)
-    //    TEST_ERROR;
+    /* In HDF5 1.10 this will not fail. It will fail in 1.12 and older. */
+    /*
+    if (ret != FAIL)
+        TEST_ERROR;
+    */
 
     /* Write the chunk of data to another location */
     offset[0] = 0;


### PR DESCRIPTION
This backports H5Dchunk_iter #6 to the 1.10 branch from the 1.13 development branch.
xref: https://forum.hdfgroup.org/t/possibility-of-backporting-h5dchunk-iter-to-1-12/9971/2

To do:
- [x] Backport tests from `test/chunk_iter.c`
- [x] Backport #1969 to fix offsets that were not multiplied by the chunk dimensions (see #1419)
- [x] Finish backport of `H5Dchunk_iter` to 1.12: #1970
