### PR TITLE
Backport H5Dchunk_iter to 1.12 branch

### DIFF
--- a/bin/trace
+++ b/bin/trace
@@ -44,6 +44,7 @@ $Source = "";
                "H5D_vds_view_t"             => "Dv",
                "H5FD_mpio_xfer_t"           => "Dt",
                "H5FD_splitter_vfd_config_t" => "Dr",
+               "H5D_chunk_iter_op_t"        => "x",
                "herr_t"                     => "e",
                "H5E_direction_t"            => "Ed",
                "H5E_error_t"                => "Ee",

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -1126,3 +1126,68 @@ H5Dget_chunk_info_by_coord(hid_t dset_id, const hsize_t *offset, unsigned *filte
 done:
     FUNC_LEAVE_API(ret_value)
 } /* end H5Dget_chunk_info_by_coord() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5Dchunk_iter
+ *
+ * Purpose:     Iterates over all chunks in dataset with given callback and user data.
+ *
+ * Parameters:
+ *              hid_t dset_id;          IN: Chunked dataset ID
+ *              H5D_chunk_iter_op_t cb  IN: User callback function, called for every chunk.
+ *              void *op_data           IN/OUT: Optional user data passed on to user callback.
+ *
+ * Callback information:
+ *      H5D_chunk_iter_op_t is defined as:
+ *
+ *        typedef int (*H5D_chunk_iter_op_t)(
+ *            const hsize_t *offset,
+ *            uint32_t filter_mask,
+ *            haddr_t addr,
+ *            uint32_t nbytes,
+ *            void *op_data);
+ *
+ *      H5D_chunk_iter_op_t parameters:
+ *          hsize_t *offset;        IN/OUT: Array of starting logical coordinates of chunk.
+ *          uint32_t filter_mask;   IN: Filter mask of chunk.
+ *          haddr_t addr;           IN: Offset in file of chunk data.
+ *          uint32_t nbytes;        IN: Size in number of bytes of chunk data in file.
+ *          void *op_data;          IN/OUT: Pointer to any user-defined data
+ *                                  associated with the operation.
+ *
+ *      The return values from an operator are:
+ *          Zero (H5_ITER_CONT) causes the iterator to continue, returning zero when all
+ *              elements have been processed.
+ *          Positive (H5_ITER_STOP) causes the iterator to immediately return that positive
+ *              value, indicating short-circuit success.
+ *          Negative (H5_ITER_ERROR) causes the iterator to immediately return that value,
+ *              indicating failure.
+ *
+ * Return:      Non-negative on success, negative on failure
+ *
+ * Programmer:  Gaute Hope
+ *              August 2020
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5Dchunk_iter(hid_t dset_id, H5D_chunk_iter_op_t cb, void *op_data)
+{
+    H5VL_object_t *vol_obj   = NULL; /* Dataset for this operation */
+    herr_t         ret_value = SUCCEED;
+
+    FUNC_ENTER_API(FAIL)
+    H5TRACE3("e", "ix*x", dset_id, cb, op_data);
+
+    /* Check arguments */
+    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(dset_id, H5I_DATASET)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid dataset identifier")
+
+    /* Call private function to get the chunk info given the chunk's index */
+    if (H5VL_dataset_specific(vol_obj, H5VL_DATASET_CHUNK_ITER, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL, cb,
+                              op_data) < 0)
+        HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "Can't iterate over chunks")
+
+done:
+    FUNC_LEAVE_API(ret_value)
+} /* end H5Dchunk_iter() */

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -7659,7 +7659,7 @@ done:
 /*-------------------------------------------------------------------------
  * Function:    H5D__chunk_iter
  *
- * Purpose:     Iterate over all the chunks in the dataset with given callbak.
+ * Purpose:     Iterate over all the chunks in the dataset with given callback.
  *
  * Return:      Success:        Non-negative
  *              Failure:        Negative

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -251,7 +251,7 @@ typedef struct H5D_chunk_coll_fill_info_t {
 
 typedef struct H5D_chunk_iter_cb_data_t {
     H5D_chunk_iter_op_t cb;      /* User defined callback */
-    void *              op_data; /* User data for user defined callback */
+    void               *op_data; /* User data for user defined callback */
 } H5D_chunk_iter_cb_data_t;
 
 /********************/
@@ -7673,8 +7673,8 @@ herr_t
 H5D__chunk_iter(const H5D_t *dset, H5D_chunk_iter_op_t cb, void *op_data)
 {
     const H5O_layout_t *layout = NULL;       /* Dataset layout */
-    const H5D_rdcc_t *  rdcc   = NULL;       /* Raw data chunk cache */
-    H5D_rdcc_ent_t *    ent;                 /* Cache entry index */
+    const H5D_rdcc_t   *rdcc   = NULL;       /* Raw data chunk cache */
+    H5D_rdcc_ent_t     *ent;                 /* Cache entry index */
     H5D_chk_idx_info_t  idx_info;            /* Chunked index info */
     herr_t              ret_value = SUCCEED; /* Return value */
 

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -249,6 +249,11 @@ typedef struct H5D_chunk_coll_fill_info_t {
 } H5D_chunk_coll_fill_info_t;
 #endif /* H5_HAVE_PARALLEL */
 
+typedef struct H5D_chunk_iter_cb_data_t {
+    H5D_chunk_iter_op_t cb;      /* User defined callback */
+    void *              op_data; /* User data for user defined callback */
+} H5D_chunk_iter_cb_data_t;
+
 /********************/
 /* Local Prototypes */
 /********************/
@@ -272,6 +277,7 @@ static herr_t H5D__chunk_dest(H5D_t *dset);
 static int H5D__get_num_chunks_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata);
 static int H5D__get_chunk_info_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata);
 static int H5D__get_chunk_info_by_coord_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata);
+static int H5D__chunk_iter_cb(const H5D_chunk_rec_t *chunk_rec, void *udata);
 
 /* "Nonexistent" layout operation callback */
 static ssize_t H5D__nonexistent_readvv(const H5D_io_info_t *io_info, size_t chunk_max_nseq,
@@ -7649,3 +7655,95 @@ H5D__get_chunk_info_by_coord(const H5D_t *dset, const hsize_t *offset, unsigned 
 done:
     FUNC_LEAVE_NOAPI_TAG(ret_value)
 } /* end H5D__get_chunk_info_by_coord() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5D__chunk_iter
+ *
+ * Purpose:     Iterate over all the chunks in the dataset with given callbak.
+ *
+ * Return:      Success:        Non-negative
+ *              Failure:        Negative
+ *
+ * Programmer:  Gaute Hope
+ *              August 2020
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5D__chunk_iter(const H5D_t *dset, H5D_chunk_iter_op_t cb, void *op_data)
+{
+    const H5O_layout_t *layout = NULL;       /* Dataset layout */
+    const H5D_rdcc_t *  rdcc   = NULL;       /* Raw data chunk cache */
+    H5D_rdcc_ent_t *    ent;                 /* Cache entry index */
+    H5D_chk_idx_info_t  idx_info;            /* Chunked index info */
+    herr_t              ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE_TAG(dset->oloc.addr)
+
+    /* Check args */
+    HDassert(dset);
+    HDassert(dset->shared);
+
+    /* Get dataset layout and raw data chunk cache */
+    layout = &(dset->shared->layout);
+    rdcc   = &(dset->shared->cache.chunk);
+    HDassert(layout);
+    HDassert(rdcc);
+    HDassert(H5D_CHUNKED == layout->type);
+
+    /* Search for cached chunks that haven't been written out */
+    for (ent = rdcc->head; ent; ent = ent->next)
+        /* Flush the chunk out to disk, to make certain the size is correct later */
+        if (H5D__chunk_flush_entry(dset, ent, FALSE) < 0)
+            HGOTO_ERROR(H5E_IO, H5E_WRITEERROR, FAIL, "cannot flush indexed storage buffer")
+
+    /* Compose chunked index info struct */
+    idx_info.f       = dset->oloc.file;
+    idx_info.pline   = &dset->shared->dcpl_cache.pline;
+    idx_info.layout  = &dset->shared->layout.u.chunk;
+    idx_info.storage = &dset->shared->layout.storage.u.chunk;
+
+    /* If the dataset is not written, return without errors */
+    if (H5F_addr_defined(idx_info.storage->idx_addr)) {
+        H5D_chunk_iter_cb_data_t data;
+        data.cb      = cb;
+        data.op_data = op_data;
+
+        /* Iterate over the allocated chunks calling the iterator callback */
+        if ((dset->shared->layout.storage.u.chunk.ops->iterate)(&idx_info, H5D__chunk_iter_cb, &data) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to iterate over chunks.")
+    } /* end if H5F_addr_defined */
+
+done:
+    FUNC_LEAVE_NOAPI_TAG(ret_value)
+} /* end H5D__chunk_iter() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5D__chunk_iter_cb
+ *
+ * Purpose:     Call the user-defined function with the chunk data. The iterator continues if
+ *              the user-defined function returns H5_ITER_CONT, and stops if H5_ITER_STOP is
+ *              returned.
+ *
+ * Return:      Success:    H5_ITER_CONT or H5_ITER_STOP
+ *              Failure:    Negative (H5_ITER_ERROR)
+ *
+ * Programmer:  Gaute Hope
+ *              August 2020
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+H5D__chunk_iter_cb(const H5D_chunk_rec_t *chunk_rec, void *udata)
+{
+    int ret_value = 0;
+
+    FUNC_ENTER_STATIC_NOERR
+
+    const H5D_chunk_iter_cb_data_t *data = (H5D_chunk_iter_cb_data_t *)udata;
+
+    ret_value = (data->cb)(chunk_rec->scaled, chunk_rec->filter_mask, chunk_rec->chunk_addr,
+                           chunk_rec->nbytes, data->op_data);
+
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5D__chunk_iter_cb */

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -565,6 +565,7 @@ H5_DLL herr_t  H5D__get_chunk_info(const H5D_t *dset, const H5S_t *space, hsize_
                                    unsigned *filter_mask, haddr_t *offset, hsize_t *size);
 H5_DLL herr_t  H5D__get_chunk_info_by_coord(const H5D_t *dset, const hsize_t *coord, unsigned *filter_mask,
                                             haddr_t *addr, hsize_t *size);
+H5_DLL herr_t  H5D__chunk_iter(const H5D_t *dset, H5D_chunk_iter_op_t cb, void *op_data);
 H5_DLL haddr_t H5D__get_offset(const H5D_t *dset);
 H5_DLL herr_t  H5D__vlen_get_buf_size(H5D_t *dset, hid_t type_id, hid_t space_id, hsize_t *size);
 H5_DLL herr_t  H5D__vlen_get_buf_size_gen(H5VL_object_t *vol_obj, hid_t type_id, hid_t space_id,

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -565,7 +565,7 @@ H5_DLL herr_t  H5D__get_chunk_info(const H5D_t *dset, const H5S_t *space, hsize_
                                    unsigned *filter_mask, haddr_t *offset, hsize_t *size);
 H5_DLL herr_t  H5D__get_chunk_info_by_coord(const H5D_t *dset, const hsize_t *coord, unsigned *filter_mask,
                                             haddr_t *addr, hsize_t *size);
-H5_DLL herr_t  H5D__chunk_iter(const H5D_t *dset, H5D_chunk_iter_op_t cb, void *op_data);
+H5_DLL herr_t  H5D__chunk_iter(H5D_t *dset, H5D_chunk_iter_op_t cb, void *op_data);
 H5_DLL haddr_t H5D__get_offset(const H5D_t *dset);
 H5_DLL herr_t  H5D__vlen_get_buf_size(H5D_t *dset, hid_t type_id, hid_t space_id, hsize_t *size);
 H5_DLL herr_t  H5D__vlen_get_buf_size_gen(H5VL_object_t *vol_obj, hid_t type_id, hid_t space_id,

--- a/src/H5Dpublic.h
+++ b/src/H5Dpublic.h
@@ -633,14 +633,14 @@ H5_DLL herr_t H5Dget_num_chunks(hid_t dset_id, hid_t fspace_id, hsize_t *nchunks
  */
 H5_DLL herr_t H5Dget_chunk_info_by_coord(hid_t dset_id, const hsize_t *offset, unsigned *filter_mask,
                                          haddr_t *addr, hsize_t *size);
-
 /**
  * --------------------------------------------------------------------------
  * \ingroup H5D
  *
- * \brief Iterate over all chunks
+ * \brief Iterate over all chunks of a chunked dataset
  *
  * \dset_id
+ * \param[in]  dxpl_id  Identifier of a transfer property list
  * \param[in]  cb       User callback function, called for every chunk.
  * \param[in]  op_data  User-defined pointer to data required by op
  *
@@ -648,38 +648,18 @@ H5_DLL herr_t H5Dget_chunk_info_by_coord(hid_t dset_id, const hsize_t *offset, u
  *
  * \details H5Dchunk_iter iterates over all chunks in the dataset, calling the
  *          user supplied callback with the details of the chunk and the supplied
- *          \p op_data.
+ *          context \p op_data.
  *
- *          Callback information:
- *            H5D_chunk_iter_op_t is defined as:
+ * \par Example
+ * For each chunk, print the allocated chunk size (0 for un-allocated chunks).
+ * \snippet H5D_examples.c H5Dchunk_iter_cb
+ * Iterate over all chunked datasets and chunks in a file.
+ * \snippet H5D_examples.c H5Ovisit_cb
  *
- *              typedef int (*H5D_chunk_iter_op_t)(
- *                const hsize_t *offset,
- *                uint32_t filter_mask,
- *                haddr_t addr,
- *                uint32_t nbytes,
- *                void *op_data);
- *
- *          H5D_chunk_iter_op_t parameters:
- *              hsize_t *offset;        IN/OUT: Array of starting logical coordinates of chunk.
- *              uint32_t filter_mask;   IN: Filter mask of chunk.
- *              haddr_t addr;           IN: Offset in file of chunk data.
- *              uint32_t nbytes;        IN: Size in number of bytes of chunk data in file.
- *              void *op_data;          IN/OUT: Pointer to any user-defined data
- *                                      associated with the operation.
- *
- *          The return values from an operator are:
- *              Zero (H5_ITER_CONT) causes the iterator to continue, returning zero when all
- *                  elements have been processed.
- *              Positive (H5_ITER_STOP) causes the iterator to immediately return that positive
- *                  value, indicating short-circuit success.
- *              Negative (H5_ITER_ERROR) causes the iterator to immediately return that value,
- *                  indicating failure.
- *
- * \since 1.12.1
+ * \since 1.12.3, 1.13.0
  *
  */
-H5_DLL herr_t H5Dchunk_iter(hid_t dset_id, H5D_chunk_iter_op_t cb, void *op_data);
+H5_DLL herr_t H5Dchunk_iter(hid_t dset_id, hid_t dxpl_id, H5D_chunk_iter_op_t cb, void *op_data);
 
 /**
  * --------------------------------------------------------------------------

--- a/src/H5Dpublic.h
+++ b/src/H5Dpublic.h
@@ -222,6 +222,14 @@ typedef herr_t (*H5D_scatter_func_t)(const void **src_buf /*out*/, size_t *src_b
 typedef herr_t (*H5D_gather_func_t)(const void *dst_buf, size_t dst_buf_bytes_used, void *op_data);
 //! <!-- [H5D_gather_func_t_snip] -->
 
+//! <!-- [H5D_chunk_iter_op_t_snip] -->
+/**
+ * Define the operator function pointer for H5Dchunk_iter()
+ */
+//! <!-- [H5D_chunk_iter_op_t_snip] -->
+typedef int (*H5D_chunk_iter_op_t)(const hsize_t *offset, uint32_t filter_mask, haddr_t addr, uint32_t nbytes,
+                                   void *op_data);
+
 /********************/
 /* Public Variables */
 /********************/
@@ -612,6 +620,53 @@ H5_DLL herr_t H5Dget_num_chunks(hid_t dset_id, hid_t fspace_id, hsize_t *nchunks
  */
 H5_DLL herr_t H5Dget_chunk_info_by_coord(hid_t dset_id, const hsize_t *offset, unsigned *filter_mask,
                                          haddr_t *addr, hsize_t *size);
+
+/**
+ * --------------------------------------------------------------------------
+ * \ingroup H5D
+ *
+ * \brief Iterate over all chunks
+ *
+ * \dset_id
+ * \param[in]  cb       User callback function, called for every chunk.
+ * \param[in]  op_data  User-defined pointer to data required by op
+ *
+ * \return \herr_t
+ *
+ * \details H5Dget_chunk_iter iterates over all chunks in the dataset, calling the
+ *          user supplied callback with the details of the chunk and the supplied
+ *          \p op_data.
+ *
+ *          Callback information:
+ *            H5D_chunk_iter_op_t is defined as:
+ *
+ *              typedef int (*H5D_chunk_iter_op_t)(
+ *                const hsize_t *offset,
+ *                uint32_t filter_mask,
+ *                haddr_t addr,
+ *                uint32_t nbytes,
+ *                void *op_data);
+ *
+ *          H5D_chunk_iter_op_t parameters:
+ *              hsize_t *offset;        IN/OUT: Array of starting logical coordinates of chunk.
+ *              uint32_t filter_mask;   IN: Filter mask of chunk.
+ *              haddr_t addr;           IN: Offset in file of chunk data.
+ *              uint32_t nbytes;        IN: Size in number of bytes of chunk data in file.
+ *              void *op_data;          IN/OUT: Pointer to any user-defined data
+ *                                      associated with the operation.
+ *
+ *          The return values from an operator are:
+ *              Zero (H5_ITER_CONT) causes the iterator to continue, returning zero when all
+ *                  elements have been processed.
+ *              Positive (H5_ITER_STOP) causes the iterator to immediately return that positive
+ *                  value, indicating short-circuit success.
+ *              Negative (H5_ITER_ERROR) causes the iterator to immediately return that value,
+ *                  indicating failure.
+ *
+ * \since 1.12.1
+ *
+ */
+H5_DLL herr_t H5Dchunk_iter(hid_t dset_id, H5D_chunk_iter_op_t cb, void *op_data);
 
 /**
  * --------------------------------------------------------------------------

--- a/src/H5Dpublic.h
+++ b/src/H5Dpublic.h
@@ -224,11 +224,24 @@ typedef herr_t (*H5D_gather_func_t)(const void *dst_buf, size_t dst_buf_bytes_us
 
 //! <!-- [H5D_chunk_iter_op_t_snip] -->
 /**
- * Define the operator function pointer for H5Dchunk_iter()
+ * \brief Callback for H5Dchunk_iter()
+ *
+ * \param[in]     offset      Logical position of the chunk’s first element in units of dataset elements
+ * \param[in]     filter_mask Bitmask indicating the filters used when the chunk was written
+ * \param[in]     addr        Chunk address in the file
+ * \param[in]     size        Chunk size in bytes, 0 if the chunk does not exist
+ * \param[in,out] op_data     Pointer to any user-defined data associated with
+ *                            the operation.
+ * \returns \li Zero (#H5_ITER_CONT) causes the iterator to continue, returning
+ *              zero when all elements have been processed.
+ *          \li A positive value (#H5_ITER_STOP) causes the iterator to
+ *              immediately return that value, indicating short-circuit success.
+ *          \li A negative (#H5_ITER_ERROR) causes the iterator to immediately
+ *              return that value, indicating failure.
  */
-//! <!-- [H5D_chunk_iter_op_t_snip] -->
-typedef int (*H5D_chunk_iter_op_t)(const hsize_t *offset, uint32_t filter_mask, haddr_t addr, uint32_t nbytes,
+typedef int (*H5D_chunk_iter_op_t)(const hsize_t *offset, uint32_t filter_mask, haddr_t addr, uint32_t size,
                                    void *op_data);
+//! <!-- [H5D_chunk_iter_op_t_snip] -->
 
 /********************/
 /* Public Variables */
@@ -596,10 +609,10 @@ H5_DLL herr_t H5Dget_num_chunks(hid_t dset_id, hid_t fspace_id, hsize_t *nchunks
  * \brief Retrieves information about a chunk specified by its coordinates
  *
  * \dset_id
- * \param[in]  offset      Logical position of the chunk’s first element
- * \param[out] filter_mask Indicating filters used with the chunk when written
+ * \param[in]  offset      Logical position of the chunk’s first element in units of dataset elements
+ * \param[out] filter_mask Bitmask indicating the filters used when the chunk was written
  * \param[out] addr        Chunk address in the file
- * \param[out] size        Chunk size in bytes, 0 if chunk doesn’t exist
+ * \param[out] size        Chunk size in bytes, 0 if the chunk does not exist
  *
  * \return \herr_t
  *
@@ -633,7 +646,7 @@ H5_DLL herr_t H5Dget_chunk_info_by_coord(hid_t dset_id, const hsize_t *offset, u
  *
  * \return \herr_t
  *
- * \details H5Dget_chunk_iter iterates over all chunks in the dataset, calling the
+ * \details H5Dchunk_iter iterates over all chunks in the dataset, calling the
  *          user supplied callback with the details of the chunk and the supplied
  *          \p op_data.
  *
@@ -677,10 +690,10 @@ H5_DLL herr_t H5Dchunk_iter(hid_t dset_id, H5D_chunk_iter_op_t cb, void *op_data
  * \dset_id
  * \param[in]  fspace_id File dataspace selection identifier (See Note below)
  * \param[in]  chk_idx   Index of the chunk
- * \param[out] offset    Logical position of the chunk’s first element
- * \param[out] filter_mask Indicating filters used with the chunk when written
+ * \param[out] offset    Logical position of the chunk’s first element in units of dataset elements
+ * \param[out] filter_mask Bitmask indicating the filters used when the chunk was written
  * \param[out] addr      Chunk address in the file
- * \param[out] size      Chunk size in bytes, 0 if chunk doesn’t exist
+ * \param[out] size      Chunk size in bytes, 0 if the chunk does not exist
  *
  * \return \herr_t
  *

--- a/src/H5VLconnector.h
+++ b/src/H5VLconnector.h
@@ -81,7 +81,9 @@ typedef enum H5VL_dataset_get_t {
 typedef enum H5VL_dataset_specific_t {
     H5VL_DATASET_SET_EXTENT, /* H5Dset_extent                       */
     H5VL_DATASET_FLUSH,      /* H5Dflush                            */
-    H5VL_DATASET_REFRESH     /* H5Drefresh                          */
+    H5VL_DATASET_REFRESH,    /* H5Drefresh                          */
+    H5VL_DATASET_WAIT,       /* H5Dwait                             */
+    H5VL_DATASET_CHUNK_ITER  /* H5Dchunk_iter                       */
 } H5VL_dataset_specific_t;
 
 /* Typedef for VOL connector dataset optional VOL operations */

--- a/src/H5VLconnector.h
+++ b/src/H5VLconnector.h
@@ -81,8 +81,7 @@ typedef enum H5VL_dataset_get_t {
 typedef enum H5VL_dataset_specific_t {
     H5VL_DATASET_SET_EXTENT, /* H5Dset_extent                       */
     H5VL_DATASET_FLUSH,      /* H5Dflush                            */
-    H5VL_DATASET_REFRESH,    /* H5Drefresh                          */
-    H5VL_DATASET_CHUNK_ITER  /* H5Dchunk_iter                       */
+    H5VL_DATASET_REFRESH     /* H5Drefresh                          */
 } H5VL_dataset_specific_t;
 
 /* Typedef for VOL connector dataset optional VOL operations */

--- a/src/H5VLconnector.h
+++ b/src/H5VLconnector.h
@@ -82,7 +82,6 @@ typedef enum H5VL_dataset_specific_t {
     H5VL_DATASET_SET_EXTENT, /* H5Dset_extent                       */
     H5VL_DATASET_FLUSH,      /* H5Dflush                            */
     H5VL_DATASET_REFRESH,    /* H5Drefresh                          */
-    H5VL_DATASET_WAIT,       /* H5Dwait                             */
     H5VL_DATASET_CHUNK_ITER  /* H5Dchunk_iter                       */
 } H5VL_dataset_specific_t;
 

--- a/src/H5VLnative.h
+++ b/src/H5VLnative.h
@@ -38,16 +38,17 @@
 #endif                                 /* H5_NO_DEPRECATED_SYMBOLS */
 
 /* Values for native VOL connector dataset optional VOL operations */
-#define H5VL_NATIVE_DATASET_FORMAT_CONVERT          0 /* H5Dformat_convert (internal) */
-#define H5VL_NATIVE_DATASET_GET_CHUNK_INDEX_TYPE    1 /* H5Dget_chunk_index_type      */
-#define H5VL_NATIVE_DATASET_GET_CHUNK_STORAGE_SIZE  2 /* H5Dget_chunk_storage_size    */
-#define H5VL_NATIVE_DATASET_GET_NUM_CHUNKS          3 /* H5Dget_num_chunks            */
-#define H5VL_NATIVE_DATASET_GET_CHUNK_INFO_BY_IDX   4 /* H5Dget_chunk_info            */
-#define H5VL_NATIVE_DATASET_GET_CHUNK_INFO_BY_COORD 5 /* H5Dget_chunk_info_by_coord   */
-#define H5VL_NATIVE_DATASET_CHUNK_READ              6 /* H5Dchunk_read                */
-#define H5VL_NATIVE_DATASET_CHUNK_WRITE             7 /* H5Dchunk_write               */
-#define H5VL_NATIVE_DATASET_GET_VLEN_BUF_SIZE       8 /* H5Dvlen_get_buf_size         */
-#define H5VL_NATIVE_DATASET_GET_OFFSET              9 /* H5Dget_offset                */
+#define H5VL_NATIVE_DATASET_FORMAT_CONVERT          0  /* H5Dformat_convert (internal) */
+#define H5VL_NATIVE_DATASET_GET_CHUNK_INDEX_TYPE    1  /* H5Dget_chunk_index_type      */
+#define H5VL_NATIVE_DATASET_GET_CHUNK_STORAGE_SIZE  2  /* H5Dget_chunk_storage_size    */
+#define H5VL_NATIVE_DATASET_GET_NUM_CHUNKS          3  /* H5Dget_num_chunks            */
+#define H5VL_NATIVE_DATASET_GET_CHUNK_INFO_BY_IDX   4  /* H5Dget_chunk_info            */
+#define H5VL_NATIVE_DATASET_GET_CHUNK_INFO_BY_COORD 5  /* H5Dget_chunk_info_by_coord   */
+#define H5VL_NATIVE_DATASET_CHUNK_READ              6  /* H5Dchunk_read                */
+#define H5VL_NATIVE_DATASET_CHUNK_WRITE             7  /* H5Dchunk_write               */
+#define H5VL_NATIVE_DATASET_GET_VLEN_BUF_SIZE       8  /* H5Dvlen_get_buf_size         */
+#define H5VL_NATIVE_DATASET_GET_OFFSET              9  /* H5Dget_offset                */
+#define H5VL_NATIVE_DATASET_CHUNK_ITER              10 /* H5Dchunk_iter                */
 
 /* Values for native VOL connector file optional VOL operations */
 #define H5VL_NATIVE_FILE_CLEAR_ELINK_CACHE            0  /* H5Fclear_elink_file_cache            */

--- a/src/H5VLnative_dataset.c
+++ b/src/H5VLnative_dataset.c
@@ -346,6 +346,31 @@ H5VL__native_dataset_specific(void *obj, H5VL_dataset_specific_t specific_type, 
             break;
         }
 
+        case H5VL_DATASET_WAIT: { /* H5Dwait */
+            /* The native VOL connector doesn't support asynchronous
+             *      operations, so this is a no-op.
+             */
+            break;
+        }
+
+        case H5VL_DATASET_CHUNK_ITER: { /* H5Dchunk_iter */
+            H5D_chunk_iter_op_t cb      = HDva_arg(arguments, H5D_chunk_iter_op_t);
+            void *              op_data = HDva_arg(arguments, void *);
+
+            HDassert(dset->shared);
+
+            /* Make sure the dataset is chunked */
+            if (H5D_CHUNKED != dset->shared->layout.type) {
+                HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a chunked dataset")
+            }
+
+            /* Call private function */
+            if (H5D__chunk_iter(dset, cb, op_data) < 0)
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't iterate over chunks")
+
+            break;
+        }
+
         default:
             HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "invalid specific operation")
     } /* end switch */

--- a/src/H5VLnative_dataset.c
+++ b/src/H5VLnative_dataset.c
@@ -346,13 +346,6 @@ H5VL__native_dataset_specific(void *obj, H5VL_dataset_specific_t specific_type, 
             break;
         }
 
-        case H5VL_DATASET_WAIT: { /* H5Dwait */
-            /* The native VOL connector doesn't support asynchronous
-             *      operations, so this is a no-op.
-             */
-            break;
-        }
-
         case H5VL_DATASET_CHUNK_ITER: { /* H5Dchunk_iter */
             H5D_chunk_iter_op_t cb      = HDva_arg(arguments, H5D_chunk_iter_op_t);
             void               *op_data = HDva_arg(arguments, void *);

--- a/src/H5VLnative_dataset.c
+++ b/src/H5VLnative_dataset.c
@@ -355,7 +355,7 @@ H5VL__native_dataset_specific(void *obj, H5VL_dataset_specific_t specific_type, 
 
         case H5VL_DATASET_CHUNK_ITER: { /* H5Dchunk_iter */
             H5D_chunk_iter_op_t cb      = HDva_arg(arguments, H5D_chunk_iter_op_t);
-            void *              op_data = HDva_arg(arguments, void *);
+            void               *op_data = HDva_arg(arguments, void *);
 
             HDassert(dset->shared);
 

--- a/src/H5VLnative_dataset.c
+++ b/src/H5VLnative_dataset.c
@@ -346,24 +346,6 @@ H5VL__native_dataset_specific(void *obj, H5VL_dataset_specific_t specific_type, 
             break;
         }
 
-        case H5VL_DATASET_CHUNK_ITER: { /* H5Dchunk_iter */
-            H5D_chunk_iter_op_t cb      = HDva_arg(arguments, H5D_chunk_iter_op_t);
-            void               *op_data = HDva_arg(arguments, void *);
-
-            HDassert(dset->shared);
-
-            /* Make sure the dataset is chunked */
-            if (H5D_CHUNKED != dset->shared->layout.type) {
-                HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a chunked dataset")
-            }
-
-            /* Call private function */
-            if (H5D__chunk_iter(dset, cb, op_data) < 0)
-                HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't iterate over chunks")
-
-            break;
-        }
-
         default:
             HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "invalid specific operation")
     } /* end switch */
@@ -602,6 +584,25 @@ H5VL__native_dataset_optional(void *obj, H5VL_dataset_optional_t optional_type, 
             *ret = H5D__get_offset(dset);
             if (!H5F_addr_defined(*ret))
                 *ret = HADDR_UNDEF;
+            break;
+        }
+
+        /* H5Dchunk_iter */
+        case H5VL_NATIVE_DATASET_CHUNK_ITER: {
+            H5D_chunk_iter_op_t op      = HDva_arg(arguments, H5D_chunk_iter_op_t);
+            void               *op_data = HDva_arg(arguments, void *);
+
+            /* Sanity check */
+            HDassert(dset->shared);
+
+            /* Make sure the dataset is chunked */
+            if (H5D_CHUNKED != dset->shared->layout.type)
+                HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a chunked dataset")
+
+            /* Call private function */
+            if ((ret_value = H5D__chunk_iter(dset, op, op_data)) < 0)
+                HERROR(H5E_DATASET, H5E_BADITER, "chunk iteration failed");
+
             break;
         }
 

--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -1483,6 +1483,50 @@ error:
     return FAIL;
 } /* test_chunk_info_version2_btrees() */
 
+typedef struct chunk_iter_info_t {
+    hsize_t  offset[2];
+    uint32_t filter_mask;
+    haddr_t  addr;
+    uint32_t nbytes;
+} chunk_iter_info_t;
+
+static int
+iter_cb(const hsize_t *offset, uint32_t filter_mask, haddr_t addr, uint32_t nbytes, void *op_data)
+{
+    chunk_iter_info_t **chunk_info = (chunk_iter_info_t **)op_data;
+
+    (*chunk_info)->offset[0]   = offset[0];
+    (*chunk_info)->offset[1]   = offset[1];
+    (*chunk_info)->filter_mask = filter_mask;
+    (*chunk_info)->addr        = addr;
+    (*chunk_info)->nbytes      = nbytes;
+
+    /* printf("offset: [%lld, %lld], addr: %ld, size: %d, filter mask: %d\n", offset[0], offset[1], addr,
+     * nbytes, filter_mask); */
+
+    *chunk_info += 1;
+
+    return H5_ITER_CONT;
+}
+
+static int
+iter_cb_stop(const hsize_t H5_ATTR_UNUSED *offset, uint32_t H5_ATTR_UNUSED filter_mask,
+             haddr_t H5_ATTR_UNUSED addr, uint32_t H5_ATTR_UNUSED nbytes, void *op_data)
+{
+    chunk_iter_info_t **chunk_info = (chunk_iter_info_t **)op_data;
+    *chunk_info += 1;
+    return H5_ITER_STOP;
+}
+
+static int
+iter_cb_fail(const hsize_t H5_ATTR_UNUSED *offset, uint32_t H5_ATTR_UNUSED filter_mask,
+             haddr_t H5_ATTR_UNUSED addr, uint32_t H5_ATTR_UNUSED nbytes, void *op_data)
+{
+    chunk_iter_info_t **chunk_info = (chunk_iter_info_t **)op_data;
+    *chunk_info += 1;
+    return H5_ITER_ERROR;
+}
+
 /*-------------------------------------------------------------------------
  * Function:    test_basic_query
  *
@@ -1503,24 +1547,26 @@ error:
 static herr_t
 test_basic_query(hid_t fapl)
 {
-    char     filename[FILENAME_BUF_SIZE];          /* File name */
-    hid_t    basicfile     = H5I_INVALID_HID;      /* File ID */
-    hid_t    dspace        = H5I_INVALID_HID;      /* Dataspace ID */
-    hid_t    dset          = H5I_INVALID_HID;      /* Dataset ID */
-    hid_t    cparms        = H5I_INVALID_HID;      /* Creation plist */
-    hsize_t  dims[2]       = {NX, NY};             /* Dataset dimensions */
-    hsize_t  chunk_dims[2] = {CHUNK_NX, CHUNK_NY}; /* Chunk dimensions */
-    int      direct_buf[CHUNK_NX][CHUNK_NY];       /* Data in chunks */
-    unsigned flt_msk      = 0;                     /* Filter mask */
-    unsigned read_flt_msk = 0;                     /* Filter mask after direct read */
-    hsize_t  offset[2];                            /* Offset coordinates of a chunk */
-    hsize_t  out_offset[2] = {0, 0};               /* Buffer to get offset coordinates */
-    hsize_t  size          = 0;                    /* Size of an allocated/written chunk */
-    hsize_t  nchunks       = 0;                    /* Number of chunks */
-    haddr_t  addr          = 0;                    /* Address of an allocated/written chunk */
-    hsize_t  chk_index     = 0;                    /* Index of a chunk */
-    hsize_t  ii, jj;                               /* Array indices */
-    herr_t   ret;                                  /* Temporary returned value for verifying failure */
+    char               filename[FILENAME_BUF_SIZE];          /* File name */
+    hid_t              basicfile     = H5I_INVALID_HID;      /* File ID */
+    hid_t              dspace        = H5I_INVALID_HID;      /* Dataspace ID */
+    hid_t              dset          = H5I_INVALID_HID;      /* Dataset ID */
+    hid_t              cparms        = H5I_INVALID_HID;      /* Creation plist */
+    hsize_t            dims[2]       = {NX, NY};             /* Dataset dimensions */
+    hsize_t            chunk_dims[2] = {CHUNK_NX, CHUNK_NY}; /* Chunk dimensions */
+    int                direct_buf[CHUNK_NX][CHUNK_NY];       /* Data in chunks */
+    unsigned           flt_msk      = 0;                     /* Filter mask */
+    unsigned           read_flt_msk = 0;                     /* Filter mask after direct read */
+    hsize_t            offset[2];                            /* Offset coordinates of a chunk */
+    hsize_t            out_offset[2] = {0, 0};               /* Buffer to get offset coordinates */
+    hsize_t            size          = 0;                    /* Size of an allocated/written chunk */
+    hsize_t            nchunks       = 0;                    /* Number of chunks */
+    haddr_t            addr          = 0;                    /* Address of an allocated/written chunk */
+    hsize_t            chk_index     = 0;                    /* Index of a chunk */
+    hsize_t            ii, jj;                               /* Array indices */
+    chunk_iter_info_t  chunk_infos[2];                       /* chunk infos filled up by iterator */
+    chunk_iter_info_t *cptr;                                 /* pointer to array of chunks */
+    herr_t             ret; /* Temporary returned value for verifying failure */
 
     TESTING("basic operations");
 
@@ -1627,6 +1673,37 @@ test_basic_query(hid_t fapl)
     /* Get and verify info of the chunk at the offset (CHUNK_NX, CHUNK_NY) */
     if (verify_empty_chunk_info(dset, offset) == FAIL)
         FAIL_PUTS_ERROR("Verification of H5Dget_chunk_info_by_coord on empty chunk failed\n");
+
+    /* iterate over all chunks */
+    cptr = &(chunk_infos[0]);
+    if (H5Dchunk_iter(dset, &iter_cb, &cptr) < 0)
+        TEST_ERROR;
+
+    VERIFY(cptr, &(chunk_infos[2]), "Iterator did not iterate all chunks");
+    VERIFY(chunk_infos[0].offset[0], 0, "Offset mismatch");
+    VERIFY(chunk_infos[0].offset[1], 0, "Offset mismatch");
+    VERIFY(chunk_infos[0].filter_mask, 0, "Filter mismatch");
+    VERIFY(chunk_infos[0].nbytes, 96, "Size mismatch");
+
+    VERIFY(chunk_infos[1].offset[0], 1, "Offset mismatch");
+    VERIFY(chunk_infos[1].offset[1], 1, "Offset mismatch");
+
+    /* iterate and stop after one iteration */
+    cptr = &(chunk_infos[0]);
+    if (H5Dchunk_iter(dset, &iter_cb_stop, &cptr) < 0)
+        TEST_ERROR;
+    VERIFY(cptr, &(chunk_infos[1]), "Verification of halted iterator failed\n");
+
+    /* iterate and fail after one iteration */
+    cptr = &(chunk_infos[0]);
+    H5E_BEGIN_TRY
+    {
+        ret = H5Dchunk_iter(dset, &iter_cb_fail, &cptr);
+    }
+    H5E_END_TRY;
+    if (ret >= 0)
+        TEST_ERROR;
+    VERIFY(cptr, &(chunk_infos[1]), "Verification of halted iterator failed\n");
 
     /* Release resourse */
     if (H5Dclose(dset) < 0)

--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -178,12 +178,19 @@ verify_get_chunk_info(hid_t dset, hid_t dspace, hsize_t chk_index, hsize_t exp_c
     haddr_t  addr          = 0;      /* Address of an allocated/written chunk */
 
     if (H5Dget_chunk_info(dset, dspace, chk_index, out_offset, &read_flt_msk, &addr, &size) < 0)
-        TEST_ERROR
-    CHECK(addr, HADDR_UNDEF, "H5Dget_chunk_info");
-    VERIFY(size, exp_chk_size, "H5Dget_chunk_info, chunk size");
-    VERIFY(read_flt_msk, exp_flt_msk, "H5Dget_chunk_info, filter mask");
-    VERIFY(out_offset[0], exp_offset[0], "H5Dget_chunk_info, offset[0]");
-    VERIFY(out_offset[1], exp_offset[1], "H5Dget_chunk_info, offset[1]");
+        TEST_ERROR;
+
+    if (HADDR_UNDEF == addr)
+        FAIL_PUTS_ERROR("address cannot be HADDR_UNDEF");
+    if (size != exp_chk_size)
+        FAIL_PUTS_ERROR("unexpected chunk size");
+    if (read_flt_msk != exp_flt_msk)
+        FAIL_PUTS_ERROR("unexpected filter mask");
+    if (out_offset[0] != exp_offset[0])
+        FAIL_PUTS_ERROR("unexpected offset[0]");
+    if (out_offset[1] != exp_offset[1])
+        FAIL_PUTS_ERROR("unexpected offset[1]");
+
     return SUCCEED;
 
 error:
@@ -212,10 +219,15 @@ verify_get_chunk_info_by_coord(hid_t dset, hsize_t *offset, hsize_t exp_chk_size
 
     /* Get info of the chunk at logical coordinates specified by offset */
     if (H5Dget_chunk_info_by_coord(dset, offset, &read_flt_msk, &addr, &size) < 0)
-        TEST_ERROR
-    CHECK(addr, HADDR_UNDEF, "H5Dget_chunk_info_by_coord");
-    VERIFY(size, exp_chk_size, "H5Dget_chunk_info_by_coord, chunk size");
-    VERIFY(read_flt_msk, exp_flt_msk, "H5Dget_chunk_info_by_coord, filter mask");
+        TEST_ERROR;
+
+    if (HADDR_UNDEF == addr)
+        FAIL_PUTS_ERROR("address cannot be HADDR_UNDEF");
+    if (size != exp_chk_size)
+        FAIL_PUTS_ERROR("unexpected chunk size");
+    if (read_flt_msk != exp_flt_msk)
+        FAIL_PUTS_ERROR("unexpected filter mask");
+
     return SUCCEED;
 
 error:
@@ -244,9 +256,13 @@ verify_empty_chunk_info(hid_t dset, hsize_t *offset)
 
     /* Get info of the chunk at logical coordinates specified by offset */
     if (H5Dget_chunk_info_by_coord(dset, offset, &read_flt_msk, &addr, &size) < 0)
-        TEST_ERROR
-    VERIFY(addr, HADDR_UNDEF, "H5Dget_chunk_info_by_coord, chunk address");
-    VERIFY(size, EMPTY_CHK_SIZE, "H5Dget_chunk_info_by_coord, chunk size");
+        TEST_ERROR;
+
+    if (HADDR_UNDEF != addr)
+        FAIL_PUTS_ERROR("address was not HADDR_UNDEF");
+    if (EMPTY_CHK_SIZE != size)
+        FAIL_PUTS_ERROR("size was not EMPTY_CHK_SIZE");
+
     return SUCCEED;
 
 error:
@@ -427,13 +443,15 @@ verify_idx_nchunks(hid_t dset, hid_t dspace, H5D_chunk_index_t exp_idx_type, hsi
 
     /* Get and verify the number of chunks */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
-    VERIFY(nchunks, exp_num_chunks, "H5Dget_num_chunks, number of chunks");
+        TEST_ERROR;
+    if (nchunks != exp_num_chunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify the number of chunks again, passing in H5S_ALL */
     if (H5Dget_num_chunks(dset, H5S_ALL, &nchunks) < 0)
-        TEST_ERROR
-    VERIFY(nchunks, exp_num_chunks, "H5Dget_num_chunks, number of chunks");
+        TEST_ERROR;
+    if (nchunks != exp_num_chunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     return SUCCEED;
 
@@ -601,8 +619,9 @@ test_get_chunk_info_highest_v18(hid_t fapl)
 
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
-    VERIFY(nchunks, NUM_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
+        TEST_ERROR;
+    if (NUM_CHUNKS_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of the last written chunk again, passing in H5S_ALL
        this time */
@@ -664,8 +683,9 @@ test_get_chunk_info_highest_v18(hid_t fapl)
 
     /* Verify that the number of chunks is 0 */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
-    VERIFY(nchunks, NO_CHUNK_WRITTEN, "H5Dget_num_chunks, number of chunks");
+        TEST_ERROR;
+    if (NO_CHUNK_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Attempt to get info of a chunk from an empty dataset, should fail */
     chk_index = OUTOFRANGE_CHK_INDEX;
@@ -1126,8 +1146,9 @@ test_chunk_info_fixed_array(const char *filename, hid_t fapl)
 
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
-    VERIFY(nchunks, NUM_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
+        TEST_ERROR;
+    if (NUM_CHUNKS_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of each written chunk */
     chk_index = 0;
@@ -1269,8 +1290,9 @@ test_chunk_info_extensible_array(const char *filename, hid_t fapl)
 
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
-    VERIFY(nchunks, NUM_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
+        TEST_ERROR;
+    if (NUM_CHUNKS_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of each written chunk */
     chk_index = 0;
@@ -1417,8 +1439,9 @@ test_chunk_info_version2_btrees(const char *filename, hid_t fapl)
 
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
-    VERIFY(nchunks, NUM_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
+        TEST_ERROR;
+    if (NUM_CHUNKS_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Go through all written chunks, get their info and verify the values */
     chk_index = 0;
@@ -1600,8 +1623,9 @@ test_basic_query(hid_t fapl)
 
     /* Get the number of chunks and verify that no chunk has been written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
-    VERIFY(nchunks, NO_CHUNK_WRITTEN, "H5Dget_num_chunks, number of chunks");
+        TEST_ERROR;
+    if (NO_CHUNK_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Initialize the array of chunk data for the single chunk */
     for (ii = 0; ii < CHUNK_NX; ii++)
@@ -1616,8 +1640,9 @@ test_basic_query(hid_t fapl)
 
     /* Get and verify that one chunk had been written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
-    VERIFY(nchunks, ONE_CHUNK_WRITTEN, "H5Dget_num_chunks, number of chunks");
+        TEST_ERROR;
+    if (ONE_CHUNK_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of the first and only chunk */
     if (verify_get_chunk_info(dset, H5S_ALL, 0, CHK_SIZE, offset, flt_msk) == FAIL)
@@ -1647,8 +1672,9 @@ test_basic_query(hid_t fapl)
 
     /* Get and verify that two chunks had been written */
     if (H5Dget_num_chunks(dset, dspace, &nchunks) < 0)
-        TEST_ERROR
-    VERIFY(nchunks, TWO_CHUNKS_WRITTEN, "H5Dget_num_chunks, number of chunks");
+        TEST_ERROR;
+    if (TWO_CHUNKS_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of the first written chunk in the dataset, its
        offset should be (0,0) */
@@ -1684,20 +1710,28 @@ test_basic_query(hid_t fapl)
     if (H5Dchunk_iter(dset, H5P_DEFAULT, &iter_cb, &udata) < 0)
         TEST_ERROR;
 
-    VERIFY(udata.last_index, 1, "Iterator did not iterate all chunks");
-    VERIFY(chunk_infos[0].offset[0], 0, "Offset mismatch");
-    VERIFY(chunk_infos[0].offset[1], 0, "Offset mismatch");
-    VERIFY(chunk_infos[0].filter_mask, 0, "Filter mismatch");
-    VERIFY(chunk_infos[0].nbytes, 96, "Size mismatch");
+    if (udata.last_index != 1)
+        FAIL_PUTS_ERROR("Iterator did not iterate over all chunks");
+    if (chunk_infos[0].offset[0] != 0)
+        FAIL_PUTS_ERROR("offset[0] mismatch");
+    if (chunk_infos[0].offset[1] != 0)
+        FAIL_PUTS_ERROR("offset[1] mismatch");
+    if (chunk_infos[0].filter_mask != 0)
+        FAIL_PUTS_ERROR("filter mask mismatch");
+    if (chunk_infos[0].nbytes != 96)
+        FAIL_PUTS_ERROR("size mismatch");
 
-    VERIFY(chunk_infos[1].offset[0], 1, "Offset mismatch");
-    VERIFY(chunk_infos[1].offset[1], 1, "Offset mismatch");
+    if (chunk_infos[1].offset[0] != 1)
+        FAIL_PUTS_ERROR("offset[0] mismatch");
+    if (chunk_infos[1].offset[1] != 1)
+        FAIL_PUTS_ERROR("offset[1] mismatch");
 
     /* Iterate and stop after one iteration */
     cptr = &(chunk_infos[0]);
     if (H5Dchunk_iter(dset, &iter_cb_stop, &cptr) < 0)
         TEST_ERROR;
-    VERIFY(cptr, &(chunk_infos[1]), "Verification of halted iterator failed\n");
+    if (cptr != &(chunk_infos[1]))
+        FAIL_PUTS_ERROR("Verification of halted iterator failed");
 
     /* Iterate and fail after one iteration */
     cptr = &(chunk_infos[0]);
@@ -1708,7 +1742,8 @@ test_basic_query(hid_t fapl)
     H5E_END_TRY;
     if (ret >= 0)
         TEST_ERROR;
-    VERIFY(cptr, &(chunk_infos[1]), "Verification of halted iterator failed\n");
+    if (cptr != &(chunk_infos[1]))
+        FAIL_PUTS_ERROR("Verification of halted iterator failed");
 
     /* Release resourse */
     if (H5Dclose(dset) < 0)
@@ -2100,8 +2135,9 @@ test_flt_msk_with_skip_compress(hid_t fapl)
 
     /* Get and verify the number of chunks written */
     if (H5Dget_num_chunks(dset, H5S_ALL, &nchunks) < 0)
-        TEST_ERROR
-    VERIFY(nchunks, ONE_CHUNK_WRITTEN, "H5Dget_num_chunks, number of chunks");
+        TEST_ERROR;
+    if (ONE_CHUNK_WRITTEN != nchunks)
+        FAIL_PUTS_ERROR("unexpected number of chunks");
 
     /* Get and verify info of the first and only chunk */
     chk_index = 0;

--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -1721,9 +1721,9 @@ test_basic_query(hid_t fapl)
     if (chunk_infos[0].nbytes != 96)
         FAIL_PUTS_ERROR("size mismatch");
 
-    if (chunk_infos[1].offset[0] != 1)
+    if (chunk_infos[1].offset[0] != CHUNK_NX)
         FAIL_PUTS_ERROR("offset[0] mismatch");
-    if (chunk_infos[1].offset[1] != 1)
+    if (chunk_infos[1].offset[1] != CHUNK_NY)
         FAIL_PUTS_ERROR("offset[1] mismatch");
 
     /* Iterate and stop after one iteration */

--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -1490,21 +1490,24 @@ typedef struct chunk_iter_info_t {
     uint32_t nbytes;
 } chunk_iter_info_t;
 
+typedef struct chunk_iter_udata_t {
+    chunk_iter_info_t *chunk_info;
+    int                last_index;
+} chunk_iter_udata_t;
+
 static int
 iter_cb(const hsize_t *offset, uint32_t filter_mask, haddr_t addr, uint32_t nbytes, void *op_data)
 {
-    chunk_iter_info_t **chunk_info = (chunk_iter_info_t **)op_data;
+    chunk_iter_udata_t *cidata = (chunk_iter_udata_t *)op_data;
+    int                 idx    = cidata->last_index + 1;
 
-    (*chunk_info)->offset[0]   = offset[0];
-    (*chunk_info)->offset[1]   = offset[1];
-    (*chunk_info)->filter_mask = filter_mask;
-    (*chunk_info)->addr        = addr;
-    (*chunk_info)->nbytes      = nbytes;
+    cidata->chunk_info[idx].offset[0]   = offset[0];
+    cidata->chunk_info[idx].offset[1]   = offset[1];
+    cidata->chunk_info[idx].filter_mask = filter_mask;
+    cidata->chunk_info[idx].addr        = addr;
+    cidata->chunk_info[idx].nbytes      = nbytes;
 
-    /* printf("offset: [%lld, %lld], addr: %ld, size: %d, filter mask: %d\n", offset[0], offset[1], addr,
-     * nbytes, filter_mask); */
-
-    *chunk_info += 1;
+    cidata->last_index++;
 
     return H5_ITER_CONT;
 }
@@ -1564,8 +1567,9 @@ test_basic_query(hid_t fapl)
     haddr_t            addr          = 0;                    /* Address of an allocated/written chunk */
     hsize_t            chk_index     = 0;                    /* Index of a chunk */
     hsize_t            ii, jj;                               /* Array indices */
-    chunk_iter_info_t  chunk_infos[2];                       /* chunk infos filled up by iterator */
-    chunk_iter_info_t *cptr;                                 /* pointer to array of chunks */
+    chunk_iter_info_t  chunk_infos[2];                       /* Chunk infos filled up by iterator */
+    chunk_iter_info_t *cptr;                                 /* Pointer to array of chunks */
+    chunk_iter_udata_t udata;                                /* udata for iteration */
     herr_t             ret; /* Temporary returned value for verifying failure */
 
     TESTING("basic operations");
@@ -1674,12 +1678,13 @@ test_basic_query(hid_t fapl)
     if (verify_empty_chunk_info(dset, offset) == FAIL)
         FAIL_PUTS_ERROR("Verification of H5Dget_chunk_info_by_coord on empty chunk failed\n");
 
-    /* iterate over all chunks */
-    cptr = &(chunk_infos[0]);
-    if (H5Dchunk_iter(dset, &iter_cb, &cptr) < 0)
+    /* Iterate over all chunks */
+    udata.chunk_info = chunk_infos;
+    udata.last_index = -1;
+    if (H5Dchunk_iter(dset, H5P_DEFAULT, &iter_cb, &udata) < 0)
         TEST_ERROR;
 
-    VERIFY(cptr, &(chunk_infos[2]), "Iterator did not iterate all chunks");
+    VERIFY(udata.last_index, 1, "Iterator did not iterate all chunks");
     VERIFY(chunk_infos[0].offset[0], 0, "Offset mismatch");
     VERIFY(chunk_infos[0].offset[1], 0, "Offset mismatch");
     VERIFY(chunk_infos[0].filter_mask, 0, "Filter mismatch");
@@ -1688,13 +1693,13 @@ test_basic_query(hid_t fapl)
     VERIFY(chunk_infos[1].offset[0], 1, "Offset mismatch");
     VERIFY(chunk_infos[1].offset[1], 1, "Offset mismatch");
 
-    /* iterate and stop after one iteration */
+    /* Iterate and stop after one iteration */
     cptr = &(chunk_infos[0]);
     if (H5Dchunk_iter(dset, &iter_cb_stop, &cptr) < 0)
         TEST_ERROR;
     VERIFY(cptr, &(chunk_infos[1]), "Verification of halted iterator failed\n");
 
-    /* iterate and fail after one iteration */
+    /* Iterate and fail after one iteration */
     cptr = &(chunk_infos[0]);
     H5E_BEGIN_TRY
     {

--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -1728,7 +1728,7 @@ test_basic_query(hid_t fapl)
 
     /* Iterate and stop after one iteration */
     cptr = &(chunk_infos[0]);
-    if (H5Dchunk_iter(dset, &iter_cb_stop, &cptr) < 0)
+    if (H5Dchunk_iter(dset, H5P_DEFAULT, &iter_cb_stop, &cptr) < 0)
         TEST_ERROR;
     if (cptr != &(chunk_infos[1]))
         FAIL_PUTS_ERROR("Verification of halted iterator failed");
@@ -1737,7 +1737,7 @@ test_basic_query(hid_t fapl)
     cptr = &(chunk_infos[0]);
     H5E_BEGIN_TRY
     {
-        ret = H5Dchunk_iter(dset, &iter_cb_fail, &cptr);
+        ret = H5Dchunk_iter(dset, H5P_DEFAULT, &iter_cb_fail, &cptr);
     }
     H5E_END_TRY;
     if (ret >= 0)


### PR DESCRIPTION
H5Dchunk_iter was reintegrated reverting #733.

Incorporates changes to `H5chunk_iter` from
* #161
* #722
* #733
* #1474
* #1820 
* #1969

To do:
- [x] Backport #1969 
xref: #1968 (for 1.10 branch)