### PR TITLE
Turns off clang optimizations on a couple of onion VFD functions

### DIFF
--- a/src/H5FDonion_history.c
+++ b/src/H5FDonion_history.c
@@ -154,7 +154,7 @@ done:
  *              Failure:    0
  *-----------------------------------------------------------------------------
  */
-size_t
+size_t H5_ATTR_NO_OPTIMIZE
 H5FD__onion_history_decode(unsigned char *buf, H5FD_onion_history_t *history)
 {
     uint32_t       ui32        = 0;

--- a/src/H5FDonion_index.c
+++ b/src/H5FDonion_index.c
@@ -583,7 +583,7 @@ H5FD__onion_revision_index_find(const H5FD_onion_revision_index_t *rix, uint64_t
  *              Failure:    0
  *-----------------------------------------------------------------------------
  */
-size_t
+size_t H5_ATTR_NO_OPTIMIZE
 H5FD__onion_revision_record_decode(unsigned char *buf, H5FD_onion_revision_record_t *record)
 {
     uint32_t       ui32         = 0;

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -289,6 +289,18 @@
 #       define H5_ATTR_MALLOC /*void*/
 #  endif
 
+/* Turns off optimizations for a function. Goes after the return type.
+ * Not generally needed in the library, but ancient versions of clang
+ * (7.3.3, possibly others) have trouble with some of the onion VFD decode
+ * functions and need the optimizer turned off. This macro can go away when
+ * we figure out what's going on and can engineer another solution.
+ */
+#  if defined(__clang__)
+#       define H5_ATTR_NO_OPTIMIZE __attribute__((optnone))
+#  else
+#       define H5_ATTR_NO_OPTIMIZE /*void*/
+#  endif
+
 #else
 #   define H5_ATTR_FORMAT(X, Y, Z) /*void*/
 #   define H5_ATTR_UNUSED          /*void*/
@@ -302,6 +314,7 @@
 #   define H5_ATTR_PURE            /*void*/
 #   define H5_ATTR_FALLTHROUGH     /*void*/
 #   define H5_ATTR_MALLOC          /*void*/
+#   define H5_ATTR_NO_OPTIMIZE     /*void*/
 #endif
 /* clang-format on */
 


### PR DESCRIPTION
Ancient clang (7.7.3 on OS X) emits problematic code with -O2 or -O3