### PR TITLE
Fix typos found in src/ subdirectory

### DIFF
--- a/src/H5ACpkg.h
+++ b/src/H5ACpkg.h
@@ -124,7 +124,7 @@ H5FL_EXTERN(H5AC_aux_t);
  * Maintaining this count is easy for all processes not on process 0 --
  * all that is necessary is to add the size of the entry to the total
  * whenever there is an insertion, a move of a previously clean entry,
- * or whever a previously clean entry is marked dirty in an unprotect.
+ * or wherever a previously clean entry is marked dirty in an unprotect.
  *
  * On process 0, we have to be careful not to count dirty bytes twice.
  * If an entry is marked dirty, flushed, and marked dirty again, all
@@ -293,12 +293,12 @@ H5FL_EXTERN(H5AC_aux_t);
  *		   dirtied flag set and the entry does not already appear
  *		   in the dirty entry list.
  *
- *		Entries are added to the dirty entry list whever they cause
+ *		Entries are added to the dirty entry list wherever they cause
  *		the dirty bytes count to be increased.  They are removed
  *		when they appear in a clean entries broadcast.  Note that
  *		moves must be reflected in the dirty entry list.
  *
- *		To reitterate, this field is only used on process 0 -- it
+ *		To reiterate, this field is only used on process 0 -- it
  *		should be NULL on all other processes.
  *
  * c_slist_ptr: Pointer to an instance of H5SL_t used to maintain a list

--- a/src/H5ACpublic.h
+++ b/src/H5ACpublic.h
@@ -760,7 +760,7 @@ typedef struct H5AC_cache_image_config_t {
      *   H5AC__CACHE_IMAGE__ENTRY_AGEOUT__MAX (100).
      *
      *   \ref H5AC__CACHE_IMAGE__ENTRY_AGEOUT__NONE means that no limit is
-     *   imposed on number of times a prefeteched entry can appear in subsequent
+     *   imposed on number of times a prefetched entry can appear in subsequent
      *   cache images.
      *
      *   A value of 0 prevents prefetched entries from being included in cache

--- a/src/H5Abtree2.c
+++ b/src/H5Abtree2.c
@@ -177,7 +177,7 @@ H5A__dense_fh_name_cmp(const void *obj, size_t obj_len, void *_udata)
     } /* end if */
 
 done:
-    /* Release the space allocated for the attrbute */
+    /* Release the space allocated for the attribute */
     if (attr && !took_ownership)
         H5O_msg_free(H5O_ATTR_ID, attr);
 

--- a/src/H5Aint.c
+++ b/src/H5Aint.c
@@ -2265,7 +2265,7 @@ H5A__attr_copy_file(const H5A_t *attr_src, H5F_t *file_dst, hbool_t *recompute_s
             if ((tid_mem = H5I_register(H5I_DATATYPE, dt_mem, FALSE)) < 0)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, NULL, "unable to register memory datatype")
 
-            /* create variable-length datatype at the destinaton file */
+            /* create variable-length datatype at the destination file */
             if ((tid_dst = H5I_register(H5I_DATATYPE, attr_dst->shared->dt, FALSE)) < 0)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, NULL,
                             "unable to register destination file datatype")

--- a/src/H5B.c
+++ b/src/H5B.c
@@ -1457,7 +1457,7 @@ H5B__remove_helper(H5F_t *f, haddr_t addr, const H5B_class_t *type, int level, u
              */
             if (type->critical_key == H5B_LEFT)
                 /* Slide the rightmost key down one, overwriting the left key of
-                 * the deleted (righmost) child */
+                 * the deleted (rightmost) child */
                 HDmemmove(H5B_NKEY(bt, shared, bt->nchildren - 1), H5B_NKEY(bt, shared, bt->nchildren),
                           type->sizeof_nkey);
             else {

--- a/src/H5C.c
+++ b/src/H5C.c
@@ -358,7 +358,7 @@ H5C_create(size_t max_cache_size, size_t min_clean_size, int max_type_id,
     cache_ptr->slist_size    = (size_t)0;
 
     /* slist_ring_len, slist_ring_size, and
-     * slist_ptr initializaed above.
+     * slist_ptr initialized above.
      */
 
 #if H5C_DO_SANITY_CHECKS
@@ -2948,7 +2948,7 @@ H5C_set_slist_enabled(H5C_t *cache_ptr, hbool_t slist_enabled, hbool_t clear_sli
         }
 
         /* set cache_ptr->slist_enabled to TRUE so that the slist
-         * mainenance macros will be enabled.
+         * maintenance macros will be enabled.
          */
         cache_ptr->slist_enabled = TRUE;
 
@@ -4055,7 +4055,7 @@ H5C_destroy_flush_dependency(void *parent_thing, void *child_thing)
                         "can't notify parent about child entry serialized flag set")
     } /* end if */
 
-    /* Shrink or free the parent array if apporpriate */
+    /* Shrink or free the parent array if appropriate */
     if (child_entry->flush_dep_nparents == 0) {
         child_entry->flush_dep_parent = H5FL_SEQ_FREE(H5C_cache_entry_ptr_t, child_entry->flush_dep_parent);
         child_entry->flush_dep_parent_nalloc = 0;

--- a/src/H5CX.c
+++ b/src/H5CX.c
@@ -237,7 +237,7 @@ typedef struct H5CX_t {
     H5FD_mpio_chunk_opt_t
              mpio_chunk_opt_mode;        /* Collective chunk option (H5D_XFER_MPIO_CHUNK_OPT_HARD_NAME) */
     hbool_t  mpio_chunk_opt_mode_valid;  /* Whether collective chunk option is valid */
-    unsigned mpio_chunk_opt_num;         /* Collective chunk thrreshold (H5D_XFER_MPIO_CHUNK_OPT_NUM_NAME) */
+    unsigned mpio_chunk_opt_num;         /* Collective chunk threshold (H5D_XFER_MPIO_CHUNK_OPT_NUM_NAME) */
     hbool_t  mpio_chunk_opt_num_valid;   /* Whether collective chunk threshold is valid */
     unsigned mpio_chunk_opt_ratio;       /* Collective chunk ratio (H5D_XFER_MPIO_CHUNK_OPT_RATIO_NAME) */
     hbool_t  mpio_chunk_opt_ratio_valid; /* Whether collective chunk ratio is valid */
@@ -371,7 +371,7 @@ typedef struct H5CX_dxpl_cache_t {
                                                  (H5D_MPIO_GLOBAL_NO_COLLECTIVE_CAUSE_NAME) */
     H5FD_mpio_chunk_opt_t
              mpio_chunk_opt_mode;         /* Collective chunk option (H5D_XFER_MPIO_CHUNK_OPT_HARD_NAME) */
-    unsigned mpio_chunk_opt_num;          /* Collective chunk thrreshold (H5D_XFER_MPIO_CHUNK_OPT_NUM_NAME) */
+    unsigned mpio_chunk_opt_num;          /* Collective chunk threshold (H5D_XFER_MPIO_CHUNK_OPT_NUM_NAME) */
     unsigned mpio_chunk_opt_ratio;        /* Collective chunk ratio (H5D_XFER_MPIO_CHUNK_OPT_RATIO_NAME) */
 #endif                                    /* H5_HAVE_PARALLEL */
     H5Z_EDC_t             err_detect;     /* Error detection info (H5D_XFER_EDC_NAME) */

--- a/src/H5Cpkg.h
+++ b/src/H5Cpkg.h
@@ -4731,7 +4731,7 @@ typedef struct H5C_tag_info_t {
  *
  * Fields for tracking prefetched entries.  Note that flushes and evictions
  * of prefetched entries are tracked in the flushes and evictions arrays
- * discused above.
+ * discussed above.
  *
  * prefetches:    Number of prefetched entries that are loaded to the
  *        cache.

--- a/src/H5Cprivate.h
+++ b/src/H5Cprivate.h
@@ -924,7 +924,7 @@ typedef herr_t (*H5C_log_flush_func_t)(H5C_t *cache_ptr, haddr_t addr, hbool_t w
  * instead would apply unnecessary constraints on flushes under normal
  * operating circumstances.
  *
- * As of this writing, all metadata entries pretaining to data sets and
+ * As of this writing, all metadata entries pertaining to data sets and
  * groups must be flushed first, and are thus assigned to the outermost
  * ring.
  *
@@ -2161,7 +2161,7 @@ typedef struct H5C_auto_size_ctl_t {
  *      H5AC__CACHE_IMAGE__ENTRY_AGEOUT__MAX (100).
  *
  *      H5AC__CACHE_IMAGE__ENTRY_AGEOUT__NONE means that no limit
- *      is imposed on number of times a prefeteched entry can appear
+ *      is imposed on number of times a prefetched entry can appear
  *      in subsequent cache images.
  *
  *      A value of 0 prevents prefetched entries from being included

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -1041,7 +1041,7 @@ H5D__chunk_is_space_alloc(const H5O_storage_t *storage)
  * Return:      Non-negative on success/Negative on failure
  *
  * Programmer:  Neil Fortner
- *              Wednessday, March 6, 2016
+ *              Wednesday, March 6, 2016
  *
  *-------------------------------------------------------------------------
  */
@@ -1650,7 +1650,7 @@ H5D__create_chunk_file_map_all(H5D_chunk_map_t *fm, const H5D_io_info_t
         coords[u] = 0;
         end[u]    = fm->chunk_dim[u] - 1;
 
-        /* Iniitialize partial chunk dimension information */
+        /* Initialize partial chunk dimension information */
         partial_dim_size[u] = file_dims[u] % fm->chunk_dim[u];
         if (file_dims[u] < fm->chunk_dim[u]) {
             curr_partial_clip[u] = partial_dim_size[u];
@@ -6776,7 +6776,7 @@ H5D__chunk_copy(H5F_t *f_src, H5O_storage_chunk_t *storage_src, H5O_layout_chunk
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL, "unable to register memory datatype")
         } /* end if */
 
-        /* create variable-length datatype at the destinaton file */
+        /* create variable-length datatype at the destination file */
         if (NULL == (dt_dst = H5T_copy(dt_src, H5T_COPY_TRANSIENT)))
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "unable to copy")
         if (H5T_set_loc(dt_dst, H5F_VOL_OBJ(f_dst), H5T_LOC_DISK) < 0) {

--- a/src/H5Dcompact.c
+++ b/src/H5Dcompact.c
@@ -547,7 +547,7 @@ H5D__compact_copy(H5F_t *f_src, H5O_storage_compact_t *_storage_src, H5F_t *f_ds
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL, "unable to register memory datatype")
         } /* end if */
 
-        /* create variable-length datatype at the destinaton file */
+        /* create variable-length datatype at the destination file */
         if (NULL == (dt_dst = H5T_copy(dt_src, H5T_COPY_TRANSIENT)))
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "unable to copy")
         if (H5T_set_loc(dt_dst, H5F_VOL_OBJ(f_dst), H5T_LOC_DISK) < 0) {

--- a/src/H5Dcontig.c
+++ b/src/H5Dcontig.c
@@ -540,7 +540,7 @@ H5D__contig_is_space_alloc(const H5O_storage_t *storage)
  * Return:      Non-negative on success/Negative on failure
  *
  * Programmer:  Neil Fortner
- *              Wednessday, March 6, 2016
+ *              Wednesday, March 6, 2016
  *
  *-------------------------------------------------------------------------
  */
@@ -1474,7 +1474,7 @@ H5D__contig_copy(H5F_t *f_src, const H5O_storage_contig_t *storage_src, H5F_t *f
             HGOTO_ERROR(H5E_DATASET, H5E_CANTREGISTER, FAIL, "unable to register memory datatype")
         } /* end if */
 
-        /* create variable-length datatype at the destinaton file */
+        /* create variable-length datatype at the destination file */
         if (NULL == (dt_dst = H5T_copy(dt_src, H5T_COPY_TRANSIENT)))
             HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to copy")
         if (H5T_set_loc(dt_dst, H5F_VOL_OBJ(f_dst), H5T_LOC_DISK) < 0) {

--- a/src/H5Dint.c
+++ b/src/H5Dint.c
@@ -3105,7 +3105,7 @@ H5D__set_extent(H5D_t *dset, const hsize_t *size)
         }
         /*-------------------------------------------------------------------------
          * Remove chunk information in the case of chunked datasets
-         * This removal takes place only in case we are shrinking the dateset
+         * This removal takes place only in case we are shrinking the dataset
          * and if the chunks are written
          *-------------------------------------------------------------------------
          */

--- a/src/H5Dvirtual.c
+++ b/src/H5Dvirtual.c
@@ -2330,7 +2330,7 @@ H5D__virtual_is_space_alloc(const H5O_storage_t H5_ATTR_UNUSED *storage)
  * Return:      Non-negative on success/Negative on failure
  *
  * Programmer:  Neil Fortner
- *              Wednessday, March 6, 2016
+ *              Wednesday, March 6, 2016
  *
  *-------------------------------------------------------------------------
  */

--- a/src/H5FDmirror.c
+++ b/src/H5FDmirror.c
@@ -321,9 +321,9 @@ H5FD__mirror_xmit_decode_uint32(uint32_t *out, const unsigned char *_buf)
 /* ---------------------------------------------------------------------------
  * Function:    is_host_little_endian
  *
- * Purpose:     Determine whether the host machine is is little-endian.
+ * Purpose:     Determine whether the host machine is little-endian.
  *
- *              Store an intger with a known value, re-map the memory to a
+ *              Store an integer with a known value, re-map the memory to a
  *              character array, and inspect the array's contents.
  *
  * Return:      The number of bytes written to the buffer (8).
@@ -1554,7 +1554,7 @@ H5FD__mirror_query(const H5FD_t H5_ATTR_UNUSED *_file, unsigned long *flags)
     LOG_OP_CALL(__func__);
 
     /* Notice: the Mirror VFD Writer currently uses only the Sec2 driver as
-     * the underying driver -- as such, the Mirror VFD implementation copies
+     * the underlying driver -- as such, the Mirror VFD implementation copies
      * the Sec2 feature flags as its own.
      *
      * File pointer is always NULL/unused -- the H5FD_FEAT_IGNORE_DRVRINFO flag

--- a/src/H5FDmpio.c
+++ b/src/H5FDmpio.c
@@ -2890,7 +2890,7 @@ H5FD__mpio_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t H5_ATTR
          * call.
          *
          * In practice, most (all?) truncate calls will come after a barrier
-         * and with no interviening writes to the file (with the possible
+         * and with no intervening writes to the file (with the possible
          * exception of sueprblock / superblock extension message updates).
          *
          * Check the "MPI file closing" flag in the API context to determine

--- a/src/H5FDonion.c
+++ b/src/H5FDonion.c
@@ -978,7 +978,7 @@ H5FD__onion_open(const char *filename, unsigned flags, hid_t fapl_id, haddr_t ma
         HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, NULL, "unable to allocate recovery name string")
     HDsnprintf(file->recovery_file_name, HDstrlen(name_onion) + 10, "%s.recovery", name_onion);
 
-    /* Translate H5P_DEFAULT to a a real fapl ID, if necessary */
+    /* Translate H5P_DEFAULT to a real fapl ID, if necessary */
     backing_fapl_id = H5FD__onion_get_legit_fapl_id(file->fa.backing_fapl_id);
     if (H5I_INVALID_HID == backing_fapl_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "invalid backing FAPL ID");

--- a/src/H5FDsec2.c
+++ b/src/H5FDsec2.c
@@ -536,7 +536,7 @@ H5FD__sec2_query(const H5FD_t *_file, unsigned long *flags /* out */)
 
     /* Set the VFL feature flags that this driver supports */
     /* Notice: the Mirror VFD Writer currently uses only the Sec2 driver as
-     * the underying driver -- as such, the Mirror VFD implementation copies
+     * the underlying driver -- as such, the Mirror VFD implementation copies
      * these feature flags as its own. Any modifications made here must be
      * reflected in H5FDmirror.c
      * -- JOS 2020-01-13

--- a/src/H5FDsubfiling/mercury/src/util/mercury_dlog.h
+++ b/src/H5FDsubfiling/mercury/src/util/mercury_dlog.h
@@ -175,7 +175,7 @@ HG_UTIL_PUBLIC void hg_dlog_mkcount64(struct hg_dlog *d, hg_atomic_int64_t **cpt
 /**
  * attempt to add a log record to a dlog.  the id and msg should point
  * to static strings that are valid throughout the life of the program
- * (not something that is is on the stack).
+ * (not something that is on the stack).
  *
  * \param d [IN]                the dlog to add the log record to
  * \param file [IN]             file entry

--- a/src/H5Gtraverse.c
+++ b/src/H5Gtraverse.c
@@ -191,7 +191,7 @@ H5G__traverse_ud(const H5G_loc_t *grp_loc /*in,out*/, const H5O_link_t *lnk, H5G
 
         /* User-defined callback function */
 #ifndef H5_NO_DEPRECATED_SYMBOLS
-    /* (Backwardly compatible with v0 H5L_class_t traverssal callback) */
+    /* (Backwardly compatible with v0 H5L_class_t traversal callback) */
     if (link_class->version == H5L_LINK_CLASS_T_VERS_0)
         cb_return = (((const H5L_class_0_t *)link_class)->trav_func)(lnk->name, cur_grp, lnk->u.ud.udata,
                                                                      lnk->u.ud.size, H5CX_get_lapl());

--- a/src/H5HFcache.c
+++ b/src/H5HFcache.c
@@ -2640,7 +2640,7 @@ H5HF__cache_dblock_fsf_size(const void *_thing, hsize_t *fsf_size)
  *
  *		For example, it is now possible for a dirty fractal heap
  *		header to be flushed before a dirty dblock, as long as the
- *		there in an interviening iblock, and the header has no
+ *		there in an intervening iblock, and the header has no
  *		dirty immediate flush dependency children.
  *
  *		Also, I gather that under some circumstances, a dblock
@@ -3005,7 +3005,7 @@ done:
  *
  *		For example, it is now possible for a dirty fractal heap
  *		header to be flushed before a dirty dblock, as long as the
- *		there in an interviening iblock, and the header has no
+ *		there in an intervening iblock, and the header has no
  *		dirty immediate flush dependency children.
  *
  *		Also, I gather that under some circumstances, a dblock
@@ -3122,7 +3122,7 @@ done:
  *
  *		For example, it is now possible for a dirty fractal heap
  *		header to be flushed before a dirty dblock, as long as the
- *		there in an interviening iblock, and the header has no
+ *		there in an intervening iblock, and the header has no
  *		dirty immediate flush dependency children.
  *
  *		Also, I gather that under some circumstances, a dblock
@@ -3285,7 +3285,7 @@ done:
  *
  *		For example, it is now possible for a dirty fractal heap
  *		header to be flushed before a dirty dblock, as long as the
- *		there in an interviening iblock, and the header has no
+ *		there in an intervening iblock, and the header has no
  *		dirty immediate flush dependency children.
  *
  *		Also, I gather that under some circumstances, a dblock

--- a/src/H5L.c
+++ b/src/H5L.c
@@ -626,7 +626,7 @@ done:
  *
  *              External links are links to objects in other HDF5 files.  They
  *              are allowed to "dangle" like soft links internal to a file.
- *              FILE_NAME is the name of the file that OBJ_NAME is is contained
+ *              FILE_NAME is the name of the file that OBJ_NAME is contained
  *              within.  If OBJ_NAME is given as a relative path name, the
  *              path will be relative to the root group of FILE_NAME.
  *              LINK_NAME is interpreted relative to LINK_LOC_ID, which is

--- a/src/H5Lint.c
+++ b/src/H5Lint.c
@@ -1703,7 +1703,7 @@ H5L__exists_inter_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_ATT
     if (lnk != NULL) {
         /* Check for more components to the path */
         if (udata->sep) {
-            H5G_traverse_t cb_func; /* Callback function for tranversal */
+            H5G_traverse_t cb_func; /* Callback function for traversal */
             char          *next;    /* Pointer to next component name */
 
             /* Look for another separator */
@@ -1754,7 +1754,7 @@ herr_t
 H5L_exists_tolerant(const H5G_loc_t *loc, const char *name, hbool_t *exists)
 {
     H5L_trav_le_t  udata;               /* User data for traversal */
-    H5G_traverse_t cb_func;             /* Callback function for tranversal */
+    H5G_traverse_t cb_func;             /* Callback function for traversal */
     char          *name_copy = NULL;    /* Duplicate of name */
     char          *name_trav;           /* Name to traverse */
     herr_t         ret_value = SUCCEED; /* Return value */

--- a/src/H5O.c
+++ b/src/H5O.c
@@ -1771,7 +1771,7 @@ done:
  *              iteration index and iteration order given) will be used to in
  *              the callback about the object.
  *
- *              NOTE: Add a a parameter "fields" to indicate selection of
+ *              NOTE: Add a parameter "fields" to indicate selection of
  *              object info to be retrieved to the callback "op".
  *
  * Return:      Success:    The return value of the first operator that
@@ -1853,7 +1853,7 @@ done:
  *              iteration index and iteration order given) will be used to in
  *              the callback about the object.
  *
- *              NOTE: Add a a parameter "fields" to indicate selection of
+ *              NOTE: Add a parameter "fields" to indicate selection of
  *              object info to be retrieved to the callback "op".
  *
  * Return:      Success:    The return value of the first operator that

--- a/src/H5Ocopy.c
+++ b/src/H5Ocopy.c
@@ -749,7 +749,7 @@ H5O__copy_header_real(const H5O_loc_t *oloc_src, H5O_loc_t *oloc_dst /*out*/, H5
     oh_dst   = NULL;
     inserted = TRUE;
 
-    /* Reset metadat tag */
+    /* Reset metadata tag */
     H5_END_TAG
 
     /* Set obj_type and udata, if requested */

--- a/src/H5Ocopy_ref.c
+++ b/src/H5Ocopy_ref.c
@@ -126,7 +126,7 @@ H5O__copy_obj_by_ref(H5O_loc_t *src_oloc, H5O_loc_t *dst_oloc, H5G_loc_t *dst_ro
 
         /* Create a link to the newly copied object */
         /* Note: since H5O_copy_header_map actually copied the target object, it
-         * must exist either in cache or on disk, therefore it is is safe to not
+         * must exist either in cache or on disk, therefore it is safe to not
          * pass the obj_type and udata fields returned by H5O_copy_header_map.
          * This could be changed in the future to slightly improve performance
          * --NAF */
@@ -319,7 +319,7 @@ H5O__copy_expand_ref_object2(H5O_loc_t *src_oloc, hid_t tid_src, const H5T_t *dt
         HGOTO_ERROR(H5E_OHDR, H5E_CANTREGISTER, FAIL, "unable to register memory datatype")
     } /* end if */
 
-    /* create reference datatype at the destinaton file */
+    /* create reference datatype at the destination file */
     if (NULL == (dt_dst = H5T_copy(dt_src, H5T_COPY_TRANSIENT)))
         HGOTO_ERROR(H5E_OHDR, H5E_CANTINIT, FAIL, "unable to copy")
     if (H5T_set_loc(dt_dst, H5F_VOL_OBJ(dst_oloc->file), H5T_LOC_DISK) < 0) {

--- a/src/H5Odeprec.c
+++ b/src/H5Odeprec.c
@@ -931,7 +931,7 @@ done:
  *              iteration index and iteration order given) will be used to in
  *              the callback about the object.
  *
- *              NOTE: Add a a parameter "fields" to indicate selection of
+ *              NOTE: Add a parameter "fields" to indicate selection of
  *              object info to be retrieved to the callback "op".
  *
  * Return:      Success:    The return value of the first operator that
@@ -1028,7 +1028,7 @@ done:
  *              iteration index and iteration order given) will be used to in
  *              the callback about the object.
  *
- *              NOTE: Add a a parameter "fields" to indicate selection of
+ *              NOTE: Add a parameter "fields" to indicate selection of
  *              object info to be retrieved to the callback "op".
  *
  * Return:      Success:    The return value of the first operator that

--- a/src/H5Oint.c
+++ b/src/H5Oint.c
@@ -1437,7 +1437,7 @@ H5O_touch(const H5O_loc_t *loc, hbool_t force)
 
     /* Create/Update the modification time message */
     if (H5O_touch_oh(loc->file, oh, force) < 0)
-        HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, FAIL, "unable to update object modificaton time")
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, FAIL, "unable to update object modification time")
 
     /* Mark object header as changed */
     oh_flags |= H5AC__DIRTIED_FLAG;

--- a/src/H5Omessage.c
+++ b/src/H5Omessage.c
@@ -693,7 +693,7 @@ H5O_msg_free_real(const H5O_msg_class_t *type, void *msg_native)
 /*-------------------------------------------------------------------------
  * Function:	H5O_msg_copy
  *
- * Purpose:	Copies a message.  If MESG is is the null pointer then a null
+ * Purpose:	Copies a message.  If MESG is the null pointer then a null
  *		pointer is returned with no error.
  *
  * Return:	Success:	Ptr to the new message
@@ -1752,7 +1752,7 @@ done:
 /*-------------------------------------------------------------------------
  * Function:    H5O__msg_copy_file
  *
- * Purpose:     Copies a message to file.  If MESG is is the null pointer then a null
+ * Purpose:     Copies a message to file.  If MESG is the null pointer then a null
  *              pointer is returned with no error.
  *
  *              Attempts to share the message in the destination and sets

--- a/src/H5Oshared.c
+++ b/src/H5Oshared.c
@@ -626,7 +626,7 @@ done:
  * Function:    H5O__shared_post_copy_file
  *
  * Purpose:     Delete a shared message and replace with a new one.
- *              The function is needed at cases such as coping a shared reg_ref attribute.
+ *              The function is needed at cases such as copying a shared reg_ref attribute.
  *              When a shared reg_ref attribute is copied from one file to
  *              another, the values in file need to be replaced. The only way
  *              to complish that is to delete the old message and write the

--- a/src/H5P.c
+++ b/src/H5P.c
@@ -661,7 +661,7 @@ H5Pset(hid_t plist_id, const char *name, const void *value)
     if (!name || !*name)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid property name");
     if (value == NULL)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalied property value");
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid property value");
 
     /* Go set the value */
     if (H5P_set(plist, name, value) < 0)
@@ -1273,7 +1273,7 @@ H5Pget(hid_t plist_id, const char *name, void *value /*out*/)
     if (!name || !*name)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid property name");
     if (value == NULL)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalied property value");
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid property value");
 
     /* Go get the value */
     if (H5P_get(plist, name, value) < 0)

--- a/src/H5Pdapl.c
+++ b/src/H5Pdapl.c
@@ -739,7 +739,7 @@ H5P__dapl_efile_pref_close(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSE
  * Purpose:    Set the number of objects in the meta data cache and the
  *        maximum number of chunks and bytes in the raw data chunk cache.
  *        Once set, these values will override the values in the file access
- *        property list.  Each of thhese values can be individually unset
+ *        property list.  Each of these values can be individually unset
  *        (or not set at all) by passing the macros:
  *        H5D_CHUNK_CACHE_NCHUNKS_DEFAULT,
  *        H5D_CHUNK_CACHE_NSLOTS_DEFAULT, and/or

--- a/src/H5S.c
+++ b/src/H5S.c
@@ -1943,7 +1943,7 @@ done:
     htri_t H5S_extent_equal(ds1, ds2)
         H5S_t *ds1, *ds2;            IN: Dataspace objects to compare
  RETURNS
-     TRUE if equal, FALSE if unequal on succeess/Negative on failure
+     TRUE if equal, FALSE if unequal on success/Negative on failure
  DESCRIPTION
     Compare two dataspaces if their extents are identical.
 --------------------------------------------------------------------------*/

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -3514,7 +3514,7 @@ done:
  USAGE
     hssize_t H5S__hyper_get_enc_size_real(max_size, enc_size)
         hsize_t max_size:       IN: The maximum size of the hyperslab selection info
-        unint8_t *enc_size:     OUT:The encoding size
+        uint8_t *enc_size:      OUT:The encoding size
  RETURNS
     The size to encode hyperslab selection info
  DESCRIPTION

--- a/src/H5Sselect.c
+++ b/src/H5Sselect.c
@@ -2476,7 +2476,7 @@ H5S_select_fill(const void *fill, size_t fill_size, H5S_t *space, void *_buf)
     /* Loop, while elements left in selection */
     while (max_elem > 0) {
         size_t nseq;     /* Number of sequences generated */
-        size_t curr_seq; /* Current sequnce being worked on */
+        size_t curr_seq; /* Current sequence being worked on */
         size_t nelem;    /* Number of elements used in sequences */
 
         /* Get the sequences of bytes */

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -2742,7 +2742,7 @@ done:
  *        All arguments are optional. Missing arguments are wild cards.
  *        The special no-op path cannot be removed.
  *
- * Return:    Succeess:    non-negative
+ * Return:    Success:    non-negative
  *            Failure:    negative
  *
  * Programmer:    Robb Matzke
@@ -2846,7 +2846,7 @@ H5T__unregister(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_c
  *        All arguments are optional. Missing arguments are wild cards.
  *        The special no-op path cannot be removed.
  *
- * Return:    Succeess:    non-negative
+ * Return:    Success:    non-negative
  *
  *            Failure:    negative
  *

--- a/src/H5Tbit.c
+++ b/src/H5Tbit.c
@@ -372,7 +372,7 @@ H5T__bit_set(uint8_t *buf, size_t offset, size_t size, hbool_t value)
  * Purpose:     Finds the first bit with the specified VALUE within a region
  *              of a bit vector.  The region begins at OFFSET and continues
  *              for SIZE bits, but the region can be searched from the least
- *              significat end toward the most significant end(H5T_BIT_LSB
+ *              significant end toward the most significant end(H5T_BIT_LSB
  *              as DIRECTION), or from the most significant end to the least
  *              significant end(H5T_BIT_MSB as DIRECTION).
  *

--- a/src/H5Tconv.c
+++ b/src/H5Tconv.c
@@ -3107,7 +3107,7 @@ H5T__conv_vlen(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, si
     H5T_path_t           *tpath         = NULL;       /* Type conversion path             */
     hbool_t               noop_conv     = FALSE;      /* Flag to indicate a noop conversion */
     hbool_t               write_to_file = FALSE;      /* Flag to indicate writing to file */
-    htri_t                parent_is_vlen;             /* Flag to indicate parent is vlen datatyp */
+    htri_t                parent_is_vlen;             /* Flag to indicate parent is vlen datatype */
     size_t                bg_seq_len = 0;             /* The number of elements in the background sequence */
     hid_t                 tsrc_id = -1, tdst_id = -1; /*temporary type atoms         */
     H5T_t                *src = NULL;                 /*source datatype             */
@@ -5085,7 +5085,7 @@ H5T__conv_s_s(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
             break;
 
         default:
-            HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, FAIL, "unknown converson command")
+            HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, FAIL, "unknown conversion command")
     } /* end switch */
 
 done:

--- a/src/H5Toffset.c
+++ b/src/H5Toffset.c
@@ -70,7 +70,7 @@ H5Tget_offset(hid_t type_id)
 
     /* Get offset */
     if ((ret_value = H5T_get_offset(dt)) < 0)
-        HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, FAIL, "cant't get offset for specified datatype")
+        HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, FAIL, "can't get offset for specified datatype")
 
 done:
     FUNC_LEAVE_API(ret_value)

--- a/src/H5Tprecis.c
+++ b/src/H5Tprecis.c
@@ -59,7 +59,7 @@ H5Tget_precision(hid_t type_id)
 
     /* Get precision */
     if ((ret_value = H5T_get_precision(dt)) == 0)
-        HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, 0, "cant't get precision for specified datatype")
+        HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, 0, "can't get precision for specified datatype")
 
 done:
     FUNC_LEAVE_API(ret_value)

--- a/src/H5VL.c
+++ b/src/H5VL.c
@@ -12,7 +12,7 @@
 
 /*
  * Purpose:     The Virtual Object Layer as described in documentation.
- *              The pupose is to provide an abstraction on how to access the
+ *              The purpose is to provide an abstraction on how to access the
  *              underlying HDF5 container, whether in a local file with
  *              a specific file format, or remotely on other machines, etc...
  */

--- a/src/H5VLcallback.c
+++ b/src/H5VLcallback.c
@@ -12,7 +12,7 @@
 
 /*
  * Purpose:     The Virtual Object Layer as described in documentation.
- *              The pupose is to provide an abstraction on how to access the
+ *              The purpose is to provide an abstraction on how to access the
  *              underlying HDF5 container, whether in a local file with
  *              a specific file format, or remotely on other machines, etc...
  */
@@ -485,7 +485,7 @@ H5VL_cmp_connector_info(const H5VL_class_t *connector, int *cmp_value, const voi
     } /* end if */
 
     /* Use the class's info comparison routine to compare the info objects,
-     * if there is a a callback, otherwise just compare the info objects as
+     * if there is a callback, otherwise just compare the info objects as
      * memory buffers
      */
     if (connector->info_cls.cmp) {

--- a/src/H5VLdyn_ops.c
+++ b/src/H5VLdyn_ops.c
@@ -12,7 +12,7 @@
 
 /*
  * Purpose:     The Virtual Object Layer as described in documentation.
- *              The pupose is to provide an abstraction on how to access the
+ *              The purpose is to provide an abstraction on how to access the
  *              underlying HDF5 container, whether in a local file with
  *              a specific file format, or remotely on other machines, etc...
  */

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -12,7 +12,7 @@
 
 /*
  * Purpose:     The Virtual Object Layer as described in documentation.
- *              The pupose is to provide an abstraction on how to access the
+ *              The purpose is to provide an abstraction on how to access the
  *              underlying HDF5 container, whether in a local file with
  *              a specific file format, or remotely on other machines, etc...
  */

--- a/src/H5VLnative_group.c
+++ b/src/H5VLnative_group.c
@@ -140,7 +140,7 @@ H5VL__native_group_open(void *obj, const H5VL_loc_params_t *loc_params, const ch
                         hid_t H5_ATTR_UNUSED gapl_id, hid_t H5_ATTR_UNUSED dxpl_id, void H5_ATTR_UNUSED **req)
 {
     H5G_loc_t loc;        /* Location to open group   */
-    H5G_t    *grp = NULL; /* New group opend          */
+    H5G_t    *grp = NULL; /* New group opened         */
     void     *ret_value;
 
     FUNC_ENTER_PACKAGE

--- a/src/H5VMprivate.h
+++ b/src/H5VMprivate.h
@@ -435,7 +435,7 @@ static const unsigned MultiplyDeBruijnBitPosition[32] = {0,  1,  28, 2,  29, 14,
  * Return:      log2(n) (always - no failure condition)
  *
  * Programmer:  Quincey Koziol
- *              Monday, Febraury 27, 2006
+ *              Monday, February 27, 2006
  *
  *-------------------------------------------------------------------------
  */

--- a/src/H5Ztrans.c
+++ b/src/H5Ztrans.c
@@ -363,7 +363,7 @@ H5Z__unget_token(H5Z_token *current)
  *              kept internal to the H5Z_token and handled by this and the
  *              unget_H5Z_token function.
  *
- * Return:      Succeess:       The passed in H5Z_token with a valid tok_type
+ * Return:      Success:        The passed in H5Z_token with a valid tok_type
  *                              field.
  *              Failure:        The passed in H5Z_token but with the tok_type
  *                              field set to ERROR.

--- a/src/H5checksum.c
+++ b/src/H5checksum.c
@@ -111,7 +111,7 @@ H5_checksum_fletcher32(const void *_data, size_t _len)
     HDassert(_len > 0);
 
     /* Compute checksum for pairs of bytes */
-    /* (the magic "360" value is is the largest number of sums that can be
+    /* (the magic "360" value is the largest number of sums that can be
      *  performed without numeric overflow)
      */
     while (len) {

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -60,7 +60,7 @@
 
 /*
  * The `struct stat' data type for stat() and fstat(). This is a POSIX file
- * but often apears on non-POSIX systems also.  The `struct stat' is required
+ * but often appears on non-POSIX systems also.  The `struct stat' is required
  * for HDF5 to compile, although only a few fields are actually used.
  */
 #ifdef H5_HAVE_SYS_STAT_H

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -658,7 +658,7 @@ H5_DLL herr_t H5get_libversion(unsigned *majnum, unsigned *minnum, unsigned *rel
  *          currently linked. If this check fails, H5check_version() causes the
  *          application to abort (by means of a standard C abort() call) and
  *          prints information that is usually useful for debugging. This
- *          precaution is is taken to avoid the risks of data corruption or
+ *          precaution is taken to avoid the risks of data corruption or
  *          segmentation faults.
  *
  *          The most common cause of this failure is that an application was


### PR DESCRIPTION
## Describe your changes

Fix various source comment typos found within the src/ subdirectory. 

Found via `codespell -q 3 -S ./release_docs,./bin/trace,./hl/tools/h5watch/h5watch.c,./tools/test/h5jam/tellub.c -L isnt,inout,nd,parms,parm,ba,offsetP,ser,ois,had,fiter,fo,clude,refere,minnum,offsetp,creat,ans:,eiter,lastr,ans,isn\'t,ifset,sur,trun,dne,tthe,hda,filname,te,htmp,minnum,ake,gord,numer,ro,oce`

## Issue ticket number (GitHub or JIRA)
n/a

## Checklist before requesting a review
- [ ] My code conforms to the guidelines in CONTRIBUTING.md :arrow_left: **Couldn't find the file**
- [ ] I made an entry in release_docs/RELEASE.txt (bug fixes, new features)
- [ ] I added a test (bug fixes, new features)
