### PR TITLE
Remove usage of libgen.h

### DIFF
--- a/src/H5FDsubfiling/H5FDioc.c
+++ b/src/H5FDsubfiling/H5FDioc.c
@@ -16,8 +16,6 @@
  *              another underlying VFD. Maintains two files simultaneously.
  */
 
-#include <libgen.h>
-
 /* This source code file is part of the H5FD driver module */
 #include "H5FDdrvr_module.h"
 

--- a/src/H5FDsubfiling/H5FDioc_priv.h
+++ b/src/H5FDsubfiling/H5FDioc_priv.h
@@ -22,7 +22,6 @@
 /********************/
 
 #include <stdatomic.h>
-#include <libgen.h>
 
 /**************/
 /* H5 Headers */

--- a/src/H5FDsubfiling/H5FDsubfiling_priv.h
+++ b/src/H5FDsubfiling/H5FDsubfiling_priv.h
@@ -22,7 +22,6 @@
 /********************/
 
 #include <stdatomic.h>
-#include <libgen.h>
 
 /**************/
 /* H5 Headers */

--- a/src/H5FDsubfiling/H5subfiling_common.c
+++ b/src/H5FDsubfiling/H5subfiling_common.c
@@ -14,8 +14,6 @@
  * Generic code for integrating an HDF5 VFD with the subfiling feature
  */
 
-#include <libgen.h>
-
 #include "H5subfiling_common.h"
 #include "H5subfiling_err.h"
 

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -15,7 +15,6 @@
  */
 
 #include <mpi.h>
-#include <libgen.h>
 
 #include "testpar.h"
 #include "H5srcdir.h"

--- a/testpar/t_vfd.c
+++ b/testpar/t_vfd.c
@@ -15,8 +15,6 @@
  *              This file is a catchall for parallel VFD tests.
  */
 
-#include <libgen.h>
-
 #include "testphdf5.h"
 
 #ifdef H5_HAVE_SUBFILING_VFD


### PR DESCRIPTION
Libgen.h should no longer be needed and causes problems with building on Windows.