### PR TITLE
Adds a TODO section to bin/README.md

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -25,3 +25,8 @@ Programs run via `autogen.sh` (or the equivalent in CMake) are indicated.
 |`switch_maint_mode`|Switches maintainer mode on/off in `configure.ac`|
 |`trace`|Adds `TRACE` macros to HDF5 C library source files (run by `autogen.sh`)|
 |`warnhist`|Generates compiler warning statistics for gcc/clang when fed output of make|
+
+##TODO
+
+* chkcopyright is currently semi-broken as it doesn't handle the full variety of copyright headers we need. We're leaving it in place, though, in the hopes that someone will update it in the future.
+* Extending warnhist to better understand the output of additional compilers/languages would be nice.


### PR DESCRIPTION
Mainly to address the semi-broken state of chkcopyright