### PR TITLE
Cleanup some warnings in Java JNI code

### DIFF
--- a/java/src/jni/h5aImp.c
+++ b/java/src/jni/h5aImp.c
@@ -1067,10 +1067,9 @@ Java_hdf_hdf5lib_H5_H5AreadVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem
     H5T_class_t type_class;
     hsize_t     dims[H5S_MAX_RANK];
     hid_t       sid = H5I_INVALID_HID;
-    jsize       n;
+    jsize       n   = 0;
     htri_t      vl_data_class;
-    herr_t      status = FAIL;
-    jboolean    readBufIsCopy;
+    herr_t      status  = FAIL;
     jbyteArray *readBuf = NULL;
 
     UNUSED(clss);
@@ -1104,7 +1103,6 @@ Java_hdf_hdf5lib_H5_H5AreadVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem
         jobject    *jList  = NULL;
 
         size_t i, j, x;
-        char  *cp_vp = NULL;
 
         if (!(typeSize = H5Tget_size(mem_type_id)))
             H5_LIBRARY_ERROR(ENVONLY);
@@ -1123,7 +1121,7 @@ Java_hdf_hdf5lib_H5_H5AreadVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem
             H5_LIBRARY_ERROR(ENVONLY);
 
         /* Cache class types */
-        jclass cBool   = ENVPTR->FindClass(ENVONLY, "java/lang/Boolean");
+        /* jclass cBool   = ENVPTR->FindClass(ENVONLY, "java/lang/Boolean"); */
         jclass cByte   = ENVPTR->FindClass(ENVONLY, "java/lang/Byte");
         jclass cShort  = ENVPTR->FindClass(ENVONLY, "java/lang/Short");
         jclass cInt    = ENVPTR->FindClass(ENVONLY, "java/lang/Integer");
@@ -1131,8 +1129,10 @@ Java_hdf_hdf5lib_H5_H5AreadVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem
         jclass cFloat  = ENVPTR->FindClass(ENVONLY, "java/lang/Float");
         jclass cDouble = ENVPTR->FindClass(ENVONLY, "java/lang/Double");
 
+        /*
         jmethodID boolValueMid =
             ENVPTR->GetStaticMethodID(ENVONLY, cBool, "valueOf", "(Z)Ljava/lang/Boolean;");
+        */
         jmethodID byteValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cByte, "valueOf", "(B)Ljava/lang/Byte;");
         jmethodID shortValueMid =
             ENVPTR->GetStaticMethodID(ENVONLY, cShort, "valueOf", "(S)Ljava/lang/Short;");
@@ -1149,21 +1149,28 @@ Java_hdf_hdf5lib_H5_H5AreadVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem
 
         /* Convert each element to a list */
         for (i = 0; i < (size_t)n; i++) {
+            hvl_t vl_elem;
+
             // The list we're going to return:
             if (NULL == (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)buf, (jsize)i)))
                 CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
-            cp_vp = (char *)rawBuf + i * typeSize;
             /* Get the number of sequence elements */
-            jsize nelmts = ((hvl_t *)cp_vp)->len;
+            HDmemcpy(&vl_elem, (char *)rawBuf + i * typeSize, sizeof(hvl_t));
+
+            jsize nelmts = (jsize)vl_elem.len;
+            if (vl_elem.len != (size_t)nelmts)
+                H5_JNI_FATAL_ERROR(ENVONLY, "H5AreadVL: overflow of number of VL elements");
+            if (nelmts < 0)
+                H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5AreadVL: number of VL elements < 0");
 
             jobject jobj = NULL;
-            for (j = 0; j < nelmts; j++) {
+            for (j = 0; j < (size_t)nelmts; j++) {
                 switch (vlClass) {
                     /* case H5T_BOOL: {
                         jboolean boolValue;
-                        for (x = 0; x < (int)vlSize; x++) {
-                            ((char *)&boolValue)[x] = ((char *)((hvl_t *)cp_vp)->p)[j*vlSize+x];
+                        for (x = 0; x < vlSize; x++) {
+                            ((char *)&boolValue)[x] = ((char *)vl_elem.p)[j*vlSize+x];
                         }
 
                         jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cBool, boolValueMid, boolValue);
@@ -1174,8 +1181,8 @@ Java_hdf_hdf5lib_H5_H5AreadVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem
                         switch (vlSize) {
                             case sizeof(jbyte): {
                                 jbyte byteValue;
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)&byteValue)[x] = ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&byteValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                 }
 
                                 jobj =
@@ -1185,8 +1192,8 @@ Java_hdf_hdf5lib_H5_H5AreadVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem
                             }
                             case sizeof(jshort): {
                                 jshort shortValue;
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)&shortValue)[x] = ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&shortValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                 }
 
                                 jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cShort, shortValueMid,
@@ -1196,8 +1203,8 @@ Java_hdf_hdf5lib_H5_H5AreadVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem
                             }
                             case sizeof(jint): {
                                 jint intValue;
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)&intValue)[x] = ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&intValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                 }
 
                                 jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cInt, intValueMid, intValue);
@@ -1206,8 +1213,8 @@ Java_hdf_hdf5lib_H5_H5AreadVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem
                             }
                             case sizeof(jlong): {
                                 jlong longValue;
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)&longValue)[x] = ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&longValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                 }
 
                                 jobj =
@@ -1222,8 +1229,8 @@ Java_hdf_hdf5lib_H5_H5AreadVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem
                         switch (vlSize) {
                             case sizeof(jfloat): {
                                 jfloat floatValue;
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)&floatValue)[x] = ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&floatValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                 }
 
                                 jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cFloat, floatValueMid,
@@ -1233,8 +1240,8 @@ Java_hdf_hdf5lib_H5_H5AreadVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem
                             }
                             case sizeof(jdouble): {
                                 jdouble doubleValue;
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)&doubleValue)[x] = ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&doubleValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                 }
 
                                 jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cDouble, doubleValueMid,
@@ -1248,14 +1255,19 @@ Java_hdf_hdf5lib_H5_H5AreadVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem
                     case H5T_REFERENCE: {
                         jboolean bb;
                         jbyte   *barray = NULL;
-                        if (NULL == (jobj = ENVPTR->NewByteArray(ENVONLY, vlSize)))
+
+                        jsize byteArraySize = (jsize)vlSize;
+                        if (vlSize != (size_t)byteArraySize)
+                            H5_JNI_FATAL_ERROR(ENVONLY, "H5AreadVL: overflow of byteArraySize");
+
+                        if (NULL == (jobj = ENVPTR->NewByteArray(ENVONLY, byteArraySize)))
                             CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
                         PIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, &bb,
                                        "readVL reference: byte array not pinned");
 
-                        for (x = 0; x < (int)vlSize; x++) {
-                            barray[x] = ((jbyte *)((hvl_t *)cp_vp)->p)[j * vlSize + x];
+                        for (x = 0; x < vlSize; x++) {
+                            barray[x] = ((jbyte *)vl_elem.p)[j * vlSize + x];
                         }
                         if (barray)
                             UNPIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, jobj ? 0 : JNI_ABORT);
@@ -1340,7 +1352,6 @@ Java_hdf_hdf5lib_H5_H5AwriteVL(JNIEnv *env, jclass clss, jlong attr_id, jlong me
         jobject    *jList  = NULL;
 
         size_t i, j, x;
-        char  *cp_vp = NULL;
 
         if (!(typeSize = H5Tget_size(mem_type_id)))
             H5_LIBRARY_ERROR(ENVONLY);
@@ -1356,7 +1367,7 @@ Java_hdf_hdf5lib_H5_H5AwriteVL(JNIEnv *env, jclass clss, jlong attr_id, jlong me
             H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5AwriteVL: failed to allocate raw VL write buffer");
 
         /* Cache class types */
-        jclass cBool   = ENVPTR->FindClass(ENVONLY, "java/lang/Boolean");
+        /* jclass cBool   = ENVPTR->FindClass(ENVONLY, "java/lang/Boolean"); */
         jclass cByte   = ENVPTR->FindClass(ENVONLY, "java/lang/Byte");
         jclass cShort  = ENVPTR->FindClass(ENVONLY, "java/lang/Short");
         jclass cInt    = ENVPTR->FindClass(ENVONLY, "java/lang/Integer");
@@ -1364,7 +1375,7 @@ Java_hdf_hdf5lib_H5_H5AwriteVL(JNIEnv *env, jclass clss, jlong attr_id, jlong me
         jclass cFloat  = ENVPTR->FindClass(ENVONLY, "java/lang/Float");
         jclass cDouble = ENVPTR->FindClass(ENVONLY, "java/lang/Double");
 
-        jmethodID boolValueMid   = ENVPTR->GetMethodID(ENVONLY, cBool, "booleanValue", "()Z");
+        /* jmethodID boolValueMid   = ENVPTR->GetMethodID(ENVONLY, cBool, "booleanValue", "()Z"); */
         jmethodID byteValueMid   = ENVPTR->GetMethodID(ENVONLY, cByte, "byteValue", "()B");
         jmethodID shortValueMid  = ENVPTR->GetMethodID(ENVONLY, cShort, "shortValue", "()S");
         jmethodID intValueMid    = ENVPTR->GetMethodID(ENVONLY, cInt, "intValue", "()I");
@@ -1374,6 +1385,8 @@ Java_hdf_hdf5lib_H5_H5AwriteVL(JNIEnv *env, jclass clss, jlong attr_id, jlong me
 
         /* Convert each list to a vlen element */
         for (i = 0; i < (size_t)n; i++) {
+            hvl_t vl_elem;
+
             if (NULL == (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)buf, (jsize)i)))
                 CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
@@ -1387,22 +1400,25 @@ Java_hdf_hdf5lib_H5_H5AwriteVL(JNIEnv *env, jclass clss, jlong attr_id, jlong me
             jobjectArray array   = (jobjectArray)ENVPTR->CallObjectMethod(ENVONLY, jList, mToArray);
             jsize        jnelmts = ENVPTR->GetArrayLength(ENVONLY, array);
 
-            cp_vp                 = (char *)rawBuf + i * typeSize;
-            ((hvl_t *)cp_vp)->len = jnelmts;
+            if (jnelmts < 0)
+                H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5AwriteVL: number of VL elements < 0");
 
-            if (NULL == (((hvl_t *)cp_vp)->p = HDmalloc(jnelmts * vlSize)))
+            HDmemcpy(&vl_elem, (char *)rawBuf + i * typeSize, sizeof(hvl_t));
+            vl_elem.len = (size_t)jnelmts;
+
+            if (NULL == (vl_elem.p = HDmalloc((size_t)jnelmts * vlSize)))
                 H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5AwriteVL: failed to allocate vlen ptr buffer");
 
             jobject jobj = NULL;
-            for (j = 0; j < (int)jnelmts; j++) {
+            for (j = 0; j < (size_t)jnelmts; j++) {
                 if (NULL == (jobj = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)array, (jsize)j)))
                     CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
                 switch (vlClass) {
                     /* case H5T_BOOL: {
                             jboolean boolValue = ENVPTR->CallBooleanMethod(ENVONLY, jobj, boolValueMid);
-                            for (x = 0; x < (int)vlSize; x++) {
-                                ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x] = ((char *)&boolValue)[x];
+                            for (x = 0; x < vlSize; x++) {
+                                ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&boolValue)[x];
                             }
                             break;
                     } */
@@ -1410,29 +1426,29 @@ Java_hdf_hdf5lib_H5_H5AwriteVL(JNIEnv *env, jclass clss, jlong attr_id, jlong me
                         switch (vlSize) {
                             case sizeof(jbyte): {
                                 jbyte byteValue = ENVPTR->CallByteMethod(ENVONLY, jobj, byteValueMid);
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x] = ((char *)&byteValue)[x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&byteValue)[x];
                                 }
                                 break;
                             }
                             case sizeof(jshort): {
                                 jshort shortValue = ENVPTR->CallShortMethod(ENVONLY, jobj, shortValueMid);
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x] = ((char *)&shortValue)[x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&shortValue)[x];
                                 }
                                 break;
                             }
                             case sizeof(jint): {
                                 jint intValue = ENVPTR->CallIntMethod(ENVONLY, jobj, intValueMid);
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x] = ((char *)&intValue)[x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&intValue)[x];
                                 }
                                 break;
                             }
                             case sizeof(jlong): {
                                 jlong longValue = ENVPTR->CallLongMethod(ENVONLY, jobj, longValueMid);
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x] = ((char *)&longValue)[x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&longValue)[x];
                                 }
                                 break;
                             }
@@ -1443,15 +1459,15 @@ Java_hdf_hdf5lib_H5_H5AwriteVL(JNIEnv *env, jclass clss, jlong attr_id, jlong me
                         switch (vlSize) {
                             case sizeof(jfloat): {
                                 jfloat floatValue = ENVPTR->CallFloatMethod(ENVONLY, jobj, floatValueMid);
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x] = ((char *)&floatValue)[x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&floatValue)[x];
                                 }
                                 break;
                             }
                             case sizeof(jdouble): {
                                 jdouble doubleValue = ENVPTR->CallDoubleMethod(ENVONLY, jobj, doubleValueMid);
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x] = ((char *)&doubleValue)[x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&doubleValue)[x];
                                 }
                                 break;
                             }
@@ -1460,8 +1476,8 @@ Java_hdf_hdf5lib_H5_H5AwriteVL(JNIEnv *env, jclass clss, jlong attr_id, jlong me
                     }
                     case H5T_REFERENCE: {
                         jbyte *barray = (jbyte *)ENVPTR->GetByteArrayElements(ENVONLY, jobj, 0);
-                        for (x = 0; x < (int)vlSize; x++) {
-                            ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x] = ((char *)barray)[x];
+                        for (x = 0; x < vlSize; x++) {
+                            ((char *)vl_elem.p)[j * vlSize + x] = ((char *)barray)[x];
                         }
                         ENVPTR->ReleaseByteArrayElements(ENVONLY, jobj, barray, 0);
                         break;
@@ -1472,6 +1488,9 @@ Java_hdf_hdf5lib_H5_H5AwriteVL(JNIEnv *env, jclass clss, jlong attr_id, jlong me
                 }
                 ENVPTR->DeleteLocalRef(ENVONLY, jobj);
             }
+
+            HDmemcpy((char *)rawBuf + i * typeSize, &vl_elem, sizeof(hvl_t));
+
             ENVPTR->DeleteLocalRef(ENVONLY, jList);
         } /* end for (i = 0; i < n; i++) */
 

--- a/java/src/jni/h5dImp.c
+++ b/java/src/jni/h5dImp.c
@@ -1090,8 +1090,7 @@ Java_hdf_hdf5lib_H5_H5DreadVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong 
     H5T_class_t type_class;
     jsize       n;
     htri_t      vl_data_class;
-    herr_t      status = FAIL;
-    jboolean    readBufIsCopy;
+    herr_t      status  = FAIL;
     jbyteArray *readBuf = NULL;
 
     UNUSED(clss);
@@ -1119,7 +1118,6 @@ Java_hdf_hdf5lib_H5_H5DreadVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong 
         jobject    *jList  = NULL;
 
         size_t i, j, x;
-        char  *cp_vp = NULL;
 
         if (!(typeSize = H5Tget_size(mem_type_id)))
             H5_LIBRARY_ERROR(ENVONLY);
@@ -1139,7 +1137,7 @@ Java_hdf_hdf5lib_H5_H5DreadVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong 
             H5_LIBRARY_ERROR(ENVONLY);
 
         /* Cache class types */
-        jclass cBool   = ENVPTR->FindClass(ENVONLY, "java/lang/Boolean");
+        /* jclass cBool   = ENVPTR->FindClass(ENVONLY, "java/lang/Boolean"); */
         jclass cByte   = ENVPTR->FindClass(ENVONLY, "java/lang/Byte");
         jclass cShort  = ENVPTR->FindClass(ENVONLY, "java/lang/Short");
         jclass cInt    = ENVPTR->FindClass(ENVONLY, "java/lang/Integer");
@@ -1147,8 +1145,10 @@ Java_hdf_hdf5lib_H5_H5DreadVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong 
         jclass cFloat  = ENVPTR->FindClass(ENVONLY, "java/lang/Float");
         jclass cDouble = ENVPTR->FindClass(ENVONLY, "java/lang/Double");
 
+        /*
         jmethodID boolValueMid =
             ENVPTR->GetStaticMethodID(ENVONLY, cBool, "valueOf", "(Z)Ljava/lang/Boolean;");
+        */
         jmethodID byteValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cByte, "valueOf", "(B)Ljava/lang/Byte;");
         jmethodID shortValueMid =
             ENVPTR->GetStaticMethodID(ENVONLY, cShort, "valueOf", "(S)Ljava/lang/Short;");
@@ -1165,21 +1165,28 @@ Java_hdf_hdf5lib_H5_H5DreadVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong 
 
         /* Convert each element to a list */
         for (i = 0; i < (size_t)n; i++) {
+            hvl_t vl_elem;
+
             // The list we're going to return:
             if (NULL == (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)buf, (jsize)i)))
                 CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
-            cp_vp = (char *)rawBuf + i * typeSize;
             /* Get the number of sequence elements */
-            jsize nelmts = ((hvl_t *)cp_vp)->len;
+            HDmemcpy(&vl_elem, (char *)rawBuf + i * typeSize, sizeof(hvl_t));
+
+            jsize nelmts = (jsize)vl_elem.len;
+            if (vl_elem.len != (size_t)nelmts)
+                H5_JNI_FATAL_ERROR(ENVONLY, "H5DreadVL: overflow of number of VL elements");
+            if (nelmts < 0)
+                H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5DreadVL: number of VL elements < 0");
 
             jobject jobj = NULL;
-            for (j = 0; j < nelmts; j++) {
+            for (j = 0; j < (size_t)nelmts; j++) {
                 switch (vlClass) {
                     /*case H5T_BOOL: {
                         jboolean boolValue;
-                        for (x = 0; x < (int)vlSize; x++) {
-                            ((char *)&boolValue)[x] = ((char *)((hvl_t *)cp_vp)->p)[j*vlSize+x];
+                        for (x = 0; x < vlSize; x++) {
+                            ((char *)&boolValue)[x] = ((char *)vl_elem.p)[j*vlSize+x];
                         }
 
                         jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cBool, boolValueMid, boolValue);
@@ -1190,8 +1197,8 @@ Java_hdf_hdf5lib_H5_H5DreadVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong 
                         switch (vlSize) {
                             case sizeof(jbyte): {
                                 jbyte byteValue;
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)&byteValue)[x] = ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&byteValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                 }
 
                                 jobj =
@@ -1201,8 +1208,8 @@ Java_hdf_hdf5lib_H5_H5DreadVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong 
                             }
                             case sizeof(jshort): {
                                 jshort shortValue;
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)&shortValue)[x] = ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&shortValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                 }
 
                                 jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cShort, shortValueMid,
@@ -1212,8 +1219,8 @@ Java_hdf_hdf5lib_H5_H5DreadVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong 
                             }
                             case sizeof(jint): {
                                 jint intValue;
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)&intValue)[x] = ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&intValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                 }
 
                                 jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cInt, intValueMid, intValue);
@@ -1222,8 +1229,8 @@ Java_hdf_hdf5lib_H5_H5DreadVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong 
                             }
                             case sizeof(jlong): {
                                 jlong longValue;
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)&longValue)[x] = ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&longValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                 }
 
                                 jobj =
@@ -1238,8 +1245,8 @@ Java_hdf_hdf5lib_H5_H5DreadVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong 
                         switch (vlSize) {
                             case sizeof(jfloat): {
                                 jfloat floatValue;
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)&floatValue)[x] = ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&floatValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                 }
 
                                 jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cFloat, floatValueMid,
@@ -1249,8 +1256,8 @@ Java_hdf_hdf5lib_H5_H5DreadVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong 
                             }
                             case sizeof(jdouble): {
                                 jdouble doubleValue;
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)&doubleValue)[x] = ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&doubleValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                 }
 
                                 jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cDouble, doubleValueMid,
@@ -1264,14 +1271,19 @@ Java_hdf_hdf5lib_H5_H5DreadVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong 
                     case H5T_REFERENCE: {
                         jboolean bb;
                         jbyte   *barray = NULL;
-                        if (NULL == (jobj = ENVPTR->NewByteArray(ENVONLY, vlSize)))
+
+                        jsize byteArraySize = (jsize)vlSize;
+                        if (vlSize != (size_t)byteArraySize)
+                            H5_JNI_FATAL_ERROR(ENVONLY, "H5DreadVL: overflow of byteArraySize");
+
+                        if (NULL == (jobj = ENVPTR->NewByteArray(ENVONLY, byteArraySize)))
                             CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
                         PIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, &bb,
                                        "readVL reference: byte array not pinned");
 
-                        for (x = 0; x < (int)vlSize; x++) {
-                            barray[x] = ((jbyte *)((hvl_t *)cp_vp)->p)[j * vlSize + x];
+                        for (x = 0; x < vlSize; x++) {
+                            barray[x] = ((jbyte *)vl_elem.p)[j * vlSize + x];
                         }
                         if (barray)
                             UNPIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, jobj ? 0 : JNI_ABORT);
@@ -1349,7 +1361,6 @@ Java_hdf_hdf5lib_H5_H5DwriteVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong
         jobject    *jList  = NULL;
 
         size_t i, j, x;
-        char  *cp_vp = NULL;
 
         if (!(typeSize = H5Tget_size(mem_type_id)))
             H5_LIBRARY_ERROR(ENVONLY);
@@ -1365,7 +1376,7 @@ Java_hdf_hdf5lib_H5_H5DwriteVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong
             H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5DwriteVL: failed to allocate raw VL write buffer");
 
         /* Cache class types */
-        jclass cBool   = ENVPTR->FindClass(ENVONLY, "java/lang/Boolean");
+        /* jclass cBool   = ENVPTR->FindClass(ENVONLY, "java/lang/Boolean"); */
         jclass cByte   = ENVPTR->FindClass(ENVONLY, "java/lang/Byte");
         jclass cShort  = ENVPTR->FindClass(ENVONLY, "java/lang/Short");
         jclass cInt    = ENVPTR->FindClass(ENVONLY, "java/lang/Integer");
@@ -1373,7 +1384,7 @@ Java_hdf_hdf5lib_H5_H5DwriteVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong
         jclass cFloat  = ENVPTR->FindClass(ENVONLY, "java/lang/Float");
         jclass cDouble = ENVPTR->FindClass(ENVONLY, "java/lang/Double");
 
-        jmethodID boolValueMid   = ENVPTR->GetMethodID(ENVONLY, cBool, "booleanValue", "()Z");
+        /* jmethodID boolValueMid   = ENVPTR->GetMethodID(ENVONLY, cBool, "booleanValue", "()Z"); */
         jmethodID byteValueMid   = ENVPTR->GetMethodID(ENVONLY, cByte, "byteValue", "()B");
         jmethodID shortValueMid  = ENVPTR->GetMethodID(ENVONLY, cShort, "shortValue", "()S");
         jmethodID intValueMid    = ENVPTR->GetMethodID(ENVONLY, cInt, "intValue", "()I");
@@ -1383,6 +1394,8 @@ Java_hdf_hdf5lib_H5_H5DwriteVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong
 
         /* Convert each list to a vlen element */
         for (i = 0; i < (size_t)n; i++) {
+            hvl_t vl_elem;
+
             if (NULL == (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)buf, (jsize)i)))
                 CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
@@ -1396,21 +1409,25 @@ Java_hdf_hdf5lib_H5_H5DwriteVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong
             jobjectArray array   = (jobjectArray)ENVPTR->CallObjectMethod(ENVONLY, jList, mToArray);
             jsize        jnelmts = ENVPTR->GetArrayLength(ENVONLY, array);
 
-            cp_vp                 = (char *)rawBuf + i * typeSize;
-            ((hvl_t *)cp_vp)->len = jnelmts;
+            if (jnelmts < 0)
+                H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5DwriteVL: number of VL elements < 0");
 
-            if (NULL == (((hvl_t *)cp_vp)->p = HDmalloc(jnelmts * vlSize)))
+            HDmemcpy(&vl_elem, (char *)rawBuf + i * typeSize, sizeof(hvl_t));
+            vl_elem.len = (size_t)jnelmts;
+
+            if (NULL == (vl_elem.p = HDmalloc((size_t)jnelmts * vlSize)))
                 H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5DwriteVL: failed to allocate vlen ptr buffer");
+
             jobject jobj = NULL;
-            for (j = 0; j < (int)jnelmts; j++) {
+            for (j = 0; j < (size_t)jnelmts; j++) {
                 if (NULL == (jobj = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)array, (jsize)j)))
                     CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
                 switch (vlClass) {
                     /* case H5T_BOOL: {
                             jboolean boolValue = ENVPTR->CallBooleanMethod(ENVONLY, jobj, boolValueMid);
-                            for (x = 0; x < (int)vlSize; x++) {
-                                ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x] = ((char *)&boolValue)[x];
+                            for (x = 0; x < vlSize; x++) {
+                                ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&boolValue)[x];
                             }
                             break;
                     } */
@@ -1418,29 +1435,29 @@ Java_hdf_hdf5lib_H5_H5DwriteVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong
                         switch (vlSize) {
                             case sizeof(jbyte): {
                                 jbyte byteValue = ENVPTR->CallByteMethod(ENVONLY, jobj, byteValueMid);
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x] = ((char *)&byteValue)[x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&byteValue)[x];
                                 }
                                 break;
                             }
                             case sizeof(jshort): {
                                 jshort shortValue = ENVPTR->CallShortMethod(ENVONLY, jobj, shortValueMid);
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x] = ((char *)&shortValue)[x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&shortValue)[x];
                                 }
                                 break;
                             }
                             case sizeof(jint): {
                                 jint intValue = ENVPTR->CallIntMethod(ENVONLY, jobj, intValueMid);
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x] = ((char *)&intValue)[x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&intValue)[x];
                                 }
                                 break;
                             }
                             case sizeof(jlong): {
                                 jlong longValue = ENVPTR->CallLongMethod(ENVONLY, jobj, longValueMid);
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x] = ((char *)&longValue)[x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&longValue)[x];
                                 }
                                 break;
                             }
@@ -1451,15 +1468,15 @@ Java_hdf_hdf5lib_H5_H5DwriteVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong
                         switch (vlSize) {
                             case sizeof(jfloat): {
                                 jfloat floatValue = ENVPTR->CallFloatMethod(ENVONLY, jobj, floatValueMid);
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x] = ((char *)&floatValue)[x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&floatValue)[x];
                                 }
                                 break;
                             }
                             case sizeof(jdouble): {
                                 jdouble doubleValue = ENVPTR->CallDoubleMethod(ENVONLY, jobj, doubleValueMid);
-                                for (x = 0; x < (int)vlSize; x++) {
-                                    ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x] = ((char *)&doubleValue)[x];
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&doubleValue)[x];
                                 }
                                 break;
                             }
@@ -1468,8 +1485,8 @@ Java_hdf_hdf5lib_H5_H5DwriteVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong
                     }
                     case H5T_REFERENCE: {
                         jbyte *barray = (jbyte *)ENVPTR->GetByteArrayElements(ENVONLY, jobj, 0);
-                        for (x = 0; x < (int)vlSize; x++) {
-                            ((char *)((hvl_t *)cp_vp)->p)[j * vlSize + x] = ((char *)barray)[x];
+                        for (x = 0; x < vlSize; x++) {
+                            ((char *)vl_elem.p)[j * vlSize + x] = ((char *)barray)[x];
                         }
                         ENVPTR->ReleaseByteArrayElements(ENVONLY, jobj, barray, 0);
                         break;
@@ -1480,6 +1497,9 @@ Java_hdf_hdf5lib_H5_H5DwriteVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong
                 }
                 ENVPTR->DeleteLocalRef(ENVONLY, jobj);
             }
+
+            HDmemcpy((char *)rawBuf + i * typeSize, &vl_elem, sizeof(hvl_t));
+
             ENVPTR->DeleteLocalRef(ENVONLY, jList);
         } /* end for (i = 0; i < n; i++) */
 

--- a/java/src/jni/h5rImp.c
+++ b/java/src/jni/h5rImp.c
@@ -51,8 +51,12 @@ Java_hdf_hdf5lib_H5_H5Rcreate_1object(JNIEnv *env, jclass clss, jlong loc_id, js
     if (NULL == (refBuf = HDcalloc(1, H5R_REF_BUF_SIZE)))
         H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5Rcreate_object: failed to allocate reference buffer");
 
-    if ((status = H5Rcreate_object((hid_t)loc_id, refName, (hid_t)aid, (const H5R_ref_t *)refBuf)) < 0)
+    H5R_ref_t loc_ref;
+    if ((status = H5Rcreate_object((hid_t)loc_id, refName, (hid_t)aid, &loc_ref)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
+
+    HDcompile_assert(H5R_REF_BUF_SIZE <= sizeof(H5R_ref_t));
+    HDmemcpy(refBuf, &loc_ref, H5R_REF_BUF_SIZE);
 
     if (NULL == (ref = ENVPTR->NewByteArray(ENVONLY, (jsize)H5R_REF_BUF_SIZE)))
         CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
@@ -93,9 +97,12 @@ Java_hdf_hdf5lib_H5_H5Rcreate_1region(JNIEnv *env, jclass clss, jlong loc_id, js
     if (NULL == (refBuf = HDcalloc(1, H5R_REF_BUF_SIZE)))
         H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5Rcreate_region: failed to allocate reference buffer");
 
-    if ((status = H5Rcreate_region((hid_t)loc_id, refName, space_id, (hid_t)aid, (const H5R_ref_t *)refBuf)) <
-        0)
+    H5R_ref_t loc_ref;
+    if ((status = H5Rcreate_region((hid_t)loc_id, refName, space_id, (hid_t)aid, &loc_ref)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
+
+    HDcompile_assert(H5R_REF_BUF_SIZE <= sizeof(H5R_ref_t));
+    HDmemcpy(refBuf, &loc_ref, H5R_REF_BUF_SIZE);
 
     if (NULL == (ref = ENVPTR->NewByteArray(ENVONLY, (jsize)H5R_REF_BUF_SIZE)))
         CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
@@ -141,9 +148,12 @@ Java_hdf_hdf5lib_H5_H5Rcreate_1attr(JNIEnv *env, jclass clss, jlong loc_id, jstr
     if (NULL == (refBuf = HDcalloc(1, H5R_REF_BUF_SIZE)))
         H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5Rcreate_attr: failed to allocate reference buffer");
 
-    if ((status = H5Rcreate_attr((hid_t)loc_id, refName, attrName, (hid_t)aid, (const H5R_ref_t *)refBuf)) <
-        0)
+    H5R_ref_t loc_ref;
+    if ((status = H5Rcreate_attr((hid_t)loc_id, refName, attrName, (hid_t)aid, &loc_ref)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
+
+    HDcompile_assert(H5R_REF_BUF_SIZE <= sizeof(H5R_ref_t));
+    HDmemcpy(refBuf, &loc_ref, H5R_REF_BUF_SIZE);
 
     if (NULL == (ref = ENVPTR->NewByteArray(ENVONLY, (jsize)H5R_REF_BUF_SIZE)))
         CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
@@ -187,7 +197,12 @@ Java_hdf_hdf5lib_H5_H5Rdestroy(JNIEnv *env, jclass clss, jbyteArray ref)
 
     PIN_BYTE_ARRAY(ENVONLY, ref, refBuf, &isCopy, "H5Rdestroy: reference buffer not pinned");
 
-    if ((status = H5Rdestroy((const H5R_ref_t *)refBuf)) < 0)
+    H5R_ref_t loc_ref;
+
+    HDcompile_assert(H5R_REF_BUF_SIZE <= sizeof(H5R_ref_t));
+    HDmemcpy(&loc_ref, refBuf, H5R_REF_BUF_SIZE);
+
+    if ((status = H5Rdestroy(&loc_ref)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
 
 done:
@@ -220,7 +235,12 @@ Java_hdf_hdf5lib_H5_H5Rget_1type(JNIEnv *env, jclass clss, jbyteArray ref)
 
     PIN_BYTE_ARRAY(ENVONLY, ref, refBuf, &isCopy, "H5Rget_type: reference buffer not pinned");
 
-    if ((ref_type = H5Rget_type((const H5R_ref_t *)refBuf)) < 0)
+    H5R_ref_t loc_ref;
+
+    HDcompile_assert(H5R_REF_BUF_SIZE <= sizeof(H5R_ref_t));
+    HDmemcpy(&loc_ref, refBuf, H5R_REF_BUF_SIZE);
+
+    if ((ref_type = H5Rget_type(&loc_ref)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
 
 done:
@@ -267,7 +287,13 @@ Java_hdf_hdf5lib_H5_H5Requal(JNIEnv *env, jclass clss, jbyteArray ref1, jbyteArr
 
     PIN_BYTE_ARRAY(ENVONLY, ref2, refBuf2, &isCopy, "H5Requal: reference2 buffer not pinned");
 
-    if ((bval = H5Requal((const H5R_ref_t *)refBuf1, (const H5R_ref_t *)refBuf2)) < 0)
+    H5R_ref_t loc_ref1, loc_ref2;
+
+    HDcompile_assert(H5R_REF_BUF_SIZE <= sizeof(H5R_ref_t));
+    HDmemcpy(&loc_ref1, refBuf1, H5R_REF_BUF_SIZE);
+    HDmemcpy(&loc_ref2, refBuf2, H5R_REF_BUF_SIZE);
+
+    if ((bval = H5Requal(&loc_ref1, &loc_ref2)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
     status = bval;
 
@@ -312,8 +338,16 @@ Java_hdf_hdf5lib_H5_H5Rcopy(JNIEnv *env, jclass clss, jbyteArray src_ref)
     if (NULL == (dst_refBuf = HDcalloc(1, H5R_REF_BUF_SIZE)))
         H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5Rcreate_attr: failed to allocate dst reference buffer");
 
-    if ((status = H5Rcopy((const H5R_ref_t *)src_refBuf, (const H5R_ref_t *)dst_refBuf)) < 0)
+    H5R_ref_t loc_src_ref, loc_dst_ref;
+
+    HDcompile_assert(H5R_REF_BUF_SIZE <= sizeof(H5R_ref_t));
+    HDmemcpy(&loc_src_ref, src_refBuf, H5R_REF_BUF_SIZE);
+    HDmemcpy(&loc_dst_ref, dst_refBuf, H5R_REF_BUF_SIZE);
+
+    if ((status = H5Rcopy(&loc_src_ref, &loc_dst_ref)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
+
+    HDmemcpy(dst_refBuf, &loc_dst_ref, H5R_REF_BUF_SIZE);
 
     if (NULL == (dst_ref = ENVPTR->NewByteArray(ENVONLY, (jsize)H5R_REF_BUF_SIZE)))
         CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
@@ -355,7 +389,12 @@ Java_hdf_hdf5lib_H5__1H5Ropen_1object(JNIEnv *env, jclass clss, jbyteArray ref, 
 
     PIN_BYTE_ARRAY(ENVONLY, ref, refBuf, &isCopy, "H5Ropen_object: reference buffer not pinned");
 
-    if ((retVal = H5Ropen_object((const H5R_ref_t *)refBuf, (hid_t)rapl_id, (hid_t)oapl_id)) < 0)
+    H5R_ref_t loc_ref;
+
+    HDcompile_assert(H5R_REF_BUF_SIZE <= sizeof(H5R_ref_t));
+    HDmemcpy(&loc_ref, refBuf, H5R_REF_BUF_SIZE);
+
+    if ((retVal = H5Ropen_object(&loc_ref, (hid_t)rapl_id, (hid_t)oapl_id)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
 
 done:
@@ -390,7 +429,12 @@ Java_hdf_hdf5lib_H5__1H5Ropen_1region(JNIEnv *env, jclass clss, jbyteArray ref, 
 
     PIN_BYTE_ARRAY(ENVONLY, ref, refBuf, &isCopy, "H5Ropen_region: reference buffer not pinned");
 
-    if ((retVal = H5Ropen_region((const H5R_ref_t *)refBuf, (hid_t)rapl_id, (hid_t)oapl_id)) < 0)
+    H5R_ref_t loc_ref;
+
+    HDcompile_assert(H5R_REF_BUF_SIZE <= sizeof(H5R_ref_t));
+    HDmemcpy(&loc_ref, refBuf, H5R_REF_BUF_SIZE);
+
+    if ((retVal = H5Ropen_region(&loc_ref, (hid_t)rapl_id, (hid_t)oapl_id)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
 
 done:
@@ -425,7 +469,12 @@ Java_hdf_hdf5lib_H5__1H5Ropen_1attr(JNIEnv *env, jclass clss, jbyteArray ref, jl
 
     PIN_BYTE_ARRAY(ENVONLY, ref, refBuf, &isCopy, "H5Ropen_attr: reference buffer not pinned");
 
-    if ((retVal = H5Ropen_attr((const H5R_ref_t *)refBuf, (hid_t)rapl_id, (hid_t)aapl_id)) < 0)
+    H5R_ref_t loc_ref;
+
+    HDcompile_assert(H5R_REF_BUF_SIZE <= sizeof(H5R_ref_t));
+    HDmemcpy(&loc_ref, refBuf, H5R_REF_BUF_SIZE);
+
+    if ((retVal = H5Ropen_attr(&loc_ref, (hid_t)rapl_id, (hid_t)aapl_id)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
 
 done:
@@ -455,7 +504,12 @@ Java_hdf_hdf5lib_H5_H5Rget_1obj_1type3(JNIEnv *env, jclass clss, jbyteArray ref,
 
     PIN_BYTE_ARRAY(ENVONLY, ref, refBuf, &isCopy, "H5Rget_obj_type3: reference buffer not pinned");
 
-    if ((retVal = H5Rget_obj_type3((const H5R_ref_t *)refBuf, (hid_t)rapl_id, &object_info)) < 0)
+    H5R_ref_t loc_ref;
+
+    HDcompile_assert(H5R_REF_BUF_SIZE <= sizeof(H5R_ref_t));
+    HDmemcpy(&loc_ref, refBuf, H5R_REF_BUF_SIZE);
+
+    if ((retVal = H5Rget_obj_type3(&loc_ref, (hid_t)rapl_id, &object_info)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
 
     if (retVal >= 0)
@@ -490,14 +544,19 @@ Java_hdf_hdf5lib_H5_H5Rget_1file_1name(JNIEnv *env, jclass clss, jbyteArray ref)
 
     PIN_BYTE_ARRAY(ENVONLY, ref, refBuf, &isCopy, "H5Rget_file_name: reference buffer not pinned");
 
+    H5R_ref_t loc_ref;
+
+    HDcompile_assert(H5R_REF_BUF_SIZE <= sizeof(H5R_ref_t));
+    HDmemcpy(&loc_ref, refBuf, H5R_REF_BUF_SIZE);
+
     /* Get the length of the name */
-    if ((buf_size = H5Rget_file_name((const H5R_ref_t *)refBuf, NULL, 0)) < 0)
+    if ((buf_size = H5Rget_file_name(&loc_ref, NULL, 0)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
 
     if (NULL == (namePtr = HDmalloc(sizeof(char) * (size_t)buf_size + 1)))
         H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5Rget_file_name: malloc failed");
 
-    if ((check_size = H5Rget_file_name((const H5R_ref_t *)refBuf, namePtr, (size_t)buf_size + 1)) < 0)
+    if ((check_size = H5Rget_file_name(&loc_ref, namePtr, (size_t)buf_size + 1)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
     namePtr[buf_size] = '\0';
 
@@ -535,15 +594,19 @@ Java_hdf_hdf5lib_H5_H5Rget_1obj_1name(JNIEnv *env, jclass clss, jbyteArray ref, 
 
     PIN_BYTE_ARRAY(ENVONLY, ref, refBuf, &isCopy, "H5Rget_obj_name: reference buffer not pinned");
 
+    H5R_ref_t loc_ref;
+
+    HDcompile_assert(H5R_REF_BUF_SIZE <= sizeof(H5R_ref_t));
+    HDmemcpy(&loc_ref, refBuf, H5R_REF_BUF_SIZE);
+
     /* Get the length of the name */
-    if ((buf_size = H5Rget_obj_name((const H5R_ref_t *)refBuf, (hid_t)rapl_id, NULL, 0)) < 0)
+    if ((buf_size = H5Rget_obj_name(&loc_ref, (hid_t)rapl_id, NULL, 0)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
 
     if (NULL == (namePtr = HDmalloc(sizeof(char) * (size_t)buf_size + 1)))
         H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5Rget_obj_name: malloc failed");
 
-    if ((check_size =
-             H5Rget_obj_name((const H5R_ref_t *)refBuf, (hid_t)rapl_id, namePtr, (size_t)buf_size + 1)) < 0)
+    if ((check_size = H5Rget_obj_name(&loc_ref, (hid_t)rapl_id, namePtr, (size_t)buf_size + 1)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
     namePtr[buf_size] = '\0';
 
@@ -581,14 +644,19 @@ Java_hdf_hdf5lib_H5_H5Rget_1attr_1name(JNIEnv *env, jclass clss, jbyteArray ref)
 
     PIN_BYTE_ARRAY(ENVONLY, ref, refBuf, &isCopy, "H5Rget_attr_name: reference buffer not pinned");
 
+    H5R_ref_t loc_ref;
+
+    HDcompile_assert(H5R_REF_BUF_SIZE <= sizeof(H5R_ref_t));
+    HDmemcpy(&loc_ref, refBuf, H5R_REF_BUF_SIZE);
+
     /* Get the length of the name */
-    if ((buf_size = H5Rget_attr_name((const H5R_ref_t *)refBuf, NULL, 0)) < 0)
+    if ((buf_size = H5Rget_attr_name(&loc_ref, NULL, 0)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
 
     if (NULL == (namePtr = HDmalloc(sizeof(char) * (size_t)buf_size + 1)))
         H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5Rget_attr_name: malloc failed");
 
-    if ((check_size = H5Rget_attr_name((const H5R_ref_t *)refBuf, namePtr, (size_t)buf_size + 1)) < 0)
+    if ((check_size = H5Rget_attr_name(&loc_ref, namePtr, (size_t)buf_size + 1)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
     namePtr[buf_size] = '\0';
 
@@ -887,7 +955,7 @@ Java_hdf_hdf5lib_H5_H5Rget_1name_1string(JNIEnv *env, jclass clss, jlong loc_id,
                                          jbyteArray ref)
 {
     jboolean isCopy;
-    jstring  str;
+    jstring  str = NULL;
     jsize    refBufLen;
     jbyte   *refBuf   = NULL;
     char    *aName    = NULL;


### PR DESCRIPTION
Picks off some of the more concerning warnings in the Java JNI code.

@byrnHDF Probably worth testing references after this PR to make sure I didn't make a mistake, but the JNI code was doing some bad things with reference buffers that would certainly cause issues down the line.