### PR TITLE
Updates the warnhist script to report gfortran generic warnings

### DIFF
--- a/bin/warnhist
+++ b/bin/warnhist
@@ -247,6 +247,18 @@ while (<>) {
     } elsif($_ =~ /^\s*[Ww]arning:.*/) {
         $name = $last_c_name;
         ($toss, $warning, $extra, $extra2) = split /\:/, $_;
+    # Check for file-scope gcc Fortran warning output
+    } elsif($_ =~ /f\d\d\d: Warning:/) {
+        # These are interspersed with the "compiling a file" output
+        # when compiling with `make -j` and thus difficult to tie to
+        # any particular file. They are due to things like inappropriate
+        # build options and don't have a line number.
+        #
+        # They start with f, as in f951
+        $name = "(generic)";
+        $line = int(rand(1000000)); # Hack to avoid counting as duplictates
+
+        ($warning) = $_ =~ /\[(.*)\]/x;
     # Check for FORTRAN warning output
     } elsif($_ =~ /^Warning:.*/) {
         $name = $last_fort_name;


### PR DESCRIPTION
These are not associated with a file and line number, like specifying
a non-existent include directory on the compile line.