### PR TITLE
Adds a compile-only option to GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,8 +120,7 @@ jobs:
             flags: ""
             run_tests: "YES"
           # Build that ensures no new warnings sneak into the library.
-          - name: "-Werror Ubuntu Debug Autotools GCC"
-            artifact: "LinuxA.tar.xz"
+          - name: "-Werror Ubuntu Debug Autotools GCC (compile only)"
             os: ubuntu-latest
             build_type: "debug"
             cpp: enable
@@ -135,6 +134,21 @@ jobs:
             toolchain: ""
             generator: "autogen"
             flags: "CFLAGS=-Werror"
+            run_tests: "NO"
+          - name: "Parallel Ubuntu Autotools GCC (compile only)"
+            os: ubuntu-latest
+            build_type: "production"
+            cpp: disable
+            fortran: enable
+            java: disable
+            ts: enable
+            hl: disable
+            parallel: enable
+            mirror_vfd: enable
+            direct_vfd: enable
+            toolchain: ""
+            generator: "autogen"
+            flags: ""
             run_tests: "NO"
 #  Threadsafe runs
           - name: "Windows TS MSVC"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
             direct_vfd: OFF
             generator: "-G \"Visual Studio 17 2022\" -A x64"
             flags: ""
+            run_tests: "YES"
           - name: "Ubuntu Latest GCC"
             artifact: "Linux.tar.xz"
             os: ubuntu-latest
@@ -53,6 +54,7 @@ jobs:
             toolchain: "config/toolchain/GCC.cmake"
             generator: "-G Ninja"
             flags: ""
+            run_tests: "YES"
           - name: "macOS Latest Clang"
             artifact: "macOS.tar.xz"
             os: macos-latest
@@ -68,6 +70,7 @@ jobs:
             toolchain: "config/toolchain/clang.cmake"
             generator: "-G Ninja"
             flags: ""
+            run_tests: "YES"
           - name: "Ubuntu Debug GCC"
             artifact: "LinuxDBG.tar.xz"
             os: ubuntu-latest
@@ -83,6 +86,7 @@ jobs:
             toolchain: "config/toolchain/GCC.cmake"
             generator: "-G Ninja"
             flags: ""
+            run_tests: "YES"
           - name: "Ubuntu Autotools GCC"
             artifact: "LinuxA.tar.xz"
             os: ubuntu-latest
@@ -98,6 +102,7 @@ jobs:
             toolchain: ""
             generator: "autogen"
             flags: ""
+            run_tests: "YES"
           - name: "Ubuntu Debug Autotools GCC"
             artifact: "LinuxA.tar.xz"
             os: ubuntu-latest
@@ -113,6 +118,7 @@ jobs:
             toolchain: ""
             generator: "autogen"
             flags: ""
+            run_tests: "YES"
           # Build that ensures no new warnings sneak into the library.
           - name: "-Werror Ubuntu Debug Autotools GCC"
             artifact: "LinuxA.tar.xz"
@@ -129,6 +135,7 @@ jobs:
             toolchain: ""
             generator: "autogen"
             flags: "CFLAGS=-Werror"
+            run_tests: "NO"
 #  Threadsafe runs
           - name: "Windows TS MSVC"
             artifact: "Windows-MSVCTS.tar.xz"
@@ -145,6 +152,7 @@ jobs:
             direct_vfd: OFF
             generator: "-G \"Visual Studio 16 2019\" -A x64"
             flags: ""
+            run_tests: "YES"
           - name: "Ubuntu TS GCC"
             artifact: "LinuxTS.tar.xz"
             os: ubuntu-latest
@@ -160,6 +168,7 @@ jobs:
             toolchain: "config/toolchain/GCC.cmake"
             generator: "-G Ninja"
             flags: ""
+            run_tests: "YES"
           - name: "macOS TS Clang"
             artifact: "macOSTS.tar.xz"
             os: macos-latest
@@ -175,6 +184,7 @@ jobs:
             toolchain: "config/toolchain/clang.cmake"
             generator: "-G Ninja"
             flags: ""
+            run_tests: "YES"
           - name: "TS Debug GCC"
             artifact: "LinuxTSDBG.tar.xz"
             os: ubuntu-latest
@@ -190,6 +200,7 @@ jobs:
             toolchain: "config/toolchain/GCC.cmake"
             generator: "-G Ninja"
             flags: ""
+            run_tests: "YES"
           - name: "TS Autotools GCC"
             artifact: "LinuxATS.tar.xz"
             os: ubuntu-latest
@@ -205,6 +216,7 @@ jobs:
             toolchain: ""
             generator: "autogen"
             flags: ""
+            run_tests: "YES"
 
     name: ${{ matrix.name }}
     # The type of runner that the job will run on
@@ -272,11 +284,11 @@ jobs:
       working-directory: ${{ runner.workspace }}/build      
 
     - name: Autotools Test
-      if: matrix.generator == 'autogen'
+      if: (matrix.generator == 'autogen') && (matrix.run_tests == 'YES')
       run: make check
       working-directory: ${{ runner.workspace }}/build
 
     - name: Test
-      if: matrix.generator != 'autogen'
+      if: (matrix.generator != 'autogen') && (matrix.run_tests == 'YES')
       run: ctest --build . -C ${{ matrix.build_type }} -V
       working-directory: ${{ runner.workspace }}/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,11 +141,11 @@ jobs:
             cpp: disable
             fortran: enable
             java: disable
-            ts: enable
+            ts: disable
             hl: disable
             parallel: enable
-            mirror_vfd: enable
-            direct_vfd: enable
+            mirror_vfd: disable
+            direct_vfd: disable
             toolchain: ""
             generator: "autogen"
             flags: ""

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
             flags: ""
             run_tests: "YES"
           # Build that ensures no new warnings sneak into the library.
-          - name: "-Werror Ubuntu Debug Autotools GCC (compile only)"
+          - name: "-Werror Ubuntu Debug Autotools GCC compile only"
             os: ubuntu-latest
             build_type: "debug"
             cpp: enable
@@ -135,7 +135,7 @@ jobs:
             generator: "autogen"
             flags: "CFLAGS=-Werror"
             run_tests: "NO"
-          - name: "Parallel Ubuntu Autotools GCC (compile only)"
+          - name: "Parallel Ubuntu Autotools GCC compile only"
             os: ubuntu-latest
             build_type: "production"
             cpp: disable

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -119,7 +119,7 @@ jobs:
             flags: ""
             run_tests: "YES"
           # Build that ensures no new warnings sneak into the library.
-          - name: "-Werror Ubuntu Debug Autotools GCC (compile only)"
+          - name: "-Werror Ubuntu Debug Autotools GCC compile only"
             os: ubuntu-latest
             build_type: "debug"
             cpp: enable
@@ -134,7 +134,7 @@ jobs:
             generator: "autogen"
             flags: "CFLAGS=-Werror"
             run_tests: "NO"
-          - name: "Parallel Ubuntu Autotools GCC (compile only)"
+          - name: "Parallel Ubuntu Autotools GCC compile only"
             os: ubuntu-latest
             build_type: "production"
             cpp: disable

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -119,8 +119,7 @@ jobs:
             flags: ""
             run_tests: "YES"
           # Build that ensures no new warnings sneak into the library.
-          - name: "-Werror Ubuntu Debug Autotools GCC"
-            artifact: "LinuxDBG.tar.xz"
+          - name: "-Werror Ubuntu Debug Autotools GCC (compile only)"
             os: ubuntu-latest
             build_type: "debug"
             cpp: enable
@@ -134,6 +133,21 @@ jobs:
             toolchain: ""
             generator: "autogen"
             flags: "CFLAGS=-Werror"
+            run_tests: "NO"
+          - name: "Parallel Ubuntu Autotools GCC (compile only)"
+            os: ubuntu-latest
+            build_type: "production"
+            cpp: disable
+            fortran: enable
+            java: disable
+            ts: enable
+            hl: disable
+            parallel: enable
+            mirror_vfd: enable
+            direct_vfd: enable
+            toolchain: ""
+            generator: "autogen"
+            flags: ""
             run_tests: "NO"
 #  Threadsafe runs
           - name: "Windows TS MSVC"

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -37,6 +37,7 @@ jobs:
             direct_vfd: OFF
             generator: "-G \"Visual Studio 17 2022\" -A x64"
             flags: ""
+            run_tests: "YES"
           - name: "Ubuntu Latest GCC"
             artifact: "Linux.tar.xz"
             os: ubuntu-latest
@@ -52,6 +53,7 @@ jobs:
             toolchain: "config/toolchain/GCC.cmake"
             generator: "-G Ninja"
             flags: ""
+            run_tests: "YES"
           - name: "macOS Latest Clang"
             artifact: "macOS.tar.xz"
             os: macos-latest
@@ -67,6 +69,7 @@ jobs:
             toolchain: "config/toolchain/clang.cmake"
             generator: "-G Ninja"
             flags: ""
+            run_tests: "YES"
           - name: "Ubuntu Debug GCC"
             artifact: "LinuxDBG.tar.xz"
             os: ubuntu-latest
@@ -82,6 +85,7 @@ jobs:
             toolchain: "config/toolchain/GCC.cmake"
             generator: "-G Ninja"
             flags: ""
+            run_tests: "YES"
           - name: "Ubuntu Autotools GCC"
             artifact: "LinuxA.tar.xz"
             os: ubuntu-latest
@@ -97,6 +101,7 @@ jobs:
             toolchain: ""
             generator: "autogen"
             flags: ""
+            run_tests: "YES"
           - name: "Ubuntu Debug Autotools GCC"
             artifact: "LinuxA.tar.xz"
             os: ubuntu-latest
@@ -112,6 +117,7 @@ jobs:
             toolchain: ""
             generator: "autogen"
             flags: ""
+            run_tests: "YES"
           # Build that ensures no new warnings sneak into the library.
           - name: "-Werror Ubuntu Debug Autotools GCC"
             artifact: "LinuxDBG.tar.xz"
@@ -128,6 +134,7 @@ jobs:
             toolchain: ""
             generator: "autogen"
             flags: "CFLAGS=-Werror"
+            run_tests: "NO"
 #  Threadsafe runs
           - name: "Windows TS MSVC"
             artifact: "Windows-MSVCTS.tar.xz"
@@ -144,6 +151,7 @@ jobs:
             direct_vfd: OFF
             generator: "-G \"Visual Studio 16 2019\" -A x64"
             flags: ""
+            run_tests: "YES"
           - name: "Ubuntu TS GCC"
             artifact: "LinuxTS.tar.xz"
             os: ubuntu-latest
@@ -159,6 +167,7 @@ jobs:
             toolchain: "config/toolchain/GCC.cmake"
             generator: "-G Ninja"
             flags: ""
+            run_tests: "YES"
           - name: "macOS TS Clang"
             artifact: "macOSTS.tar.xz"
             os: macos-latest
@@ -174,6 +183,7 @@ jobs:
             toolchain: "config/toolchain/clang.cmake"
             generator: "-G Ninja"
             flags: ""
+            run_tests: "YES"
           - name: "TS Debug GCC"
             artifact: "LinuxTSDBG.tar.xz"
             os: ubuntu-latest
@@ -189,6 +199,7 @@ jobs:
             toolchain: "config/toolchain/GCC.cmake"
             generator: "-G Ninja"
             flags: ""
+            run_tests: "YES"
           - name: "TS Autotools GCC"
             artifact: "LinuxATS.tar.xz"
             os: ubuntu-latest
@@ -204,6 +215,7 @@ jobs:
             toolchain: ""
             generator: "autogen"
             flags: ""
+            run_tests: "YES"
 
     name: ${{ matrix.name }}
     # The type of runner that the job will run on
@@ -271,11 +283,11 @@ jobs:
       working-directory: ${{ runner.workspace }}/build      
 
     - name: Autotools Test
-      if: matrix.generator == 'autogen'
+      if: (matrix.generator == 'autogen') && (matrix.run_tests == 'YES')
       run: make check
       working-directory: ${{ runner.workspace }}/build
 
     - name: Test
-      if: matrix.generator != 'autogen'
+      if: (matrix.generator != 'autogen') && (matrix.run_tests == 'YES')
       run: ctest --build . -C ${{ matrix.build_type }} -V
       working-directory: ${{ runner.workspace }}/build

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -140,11 +140,11 @@ jobs:
             cpp: disable
             fortran: enable
             java: disable
-            ts: enable
+            ts: disable
             hl: disable
             parallel: enable
-            mirror_vfd: enable
-            direct_vfd: enable
+            mirror_vfd: disable
+            direct_vfd: disable
             toolchain: ""
             generator: "autogen"
             flags: ""

--- a/configure.ac
+++ b/configure.ac
@@ -2542,7 +2542,7 @@ AC_SUBST([INTERNAL_DEBUG_OUTPUT])
 ## are not listed in the "all" packages list.
 ##
 ## all_packages="AC,B,B2,D,F,FA,FL,FS,HL,I,O,S,T,Z"
-all_packages="AC,CX,D,F,HL,I,O,S,T,Z"
+all_packages="AC,B2,CX,D,F,HL,I,O,S,T,Z"
 
 case "X-$INTERNAL_DEBUG_OUTPUT" in
   X-yes|X-all)

--- a/configure.ac
+++ b/configure.ac
@@ -2541,8 +2541,8 @@ AC_SUBST([INTERNAL_DEBUG_OUTPUT])
 ## too specialized or have huge performance hits. These
 ## are not listed in the "all" packages list.
 ##
-## all_packages="AC,B,B2,D,F,FA,FL,FS,HL,I,O,S,ST,T,Z"
-all_packages="AC,B2,CX,D,F,HL,I,O,S,ST,T,Z"
+## all_packages="AC,B,B2,D,F,FA,FL,FS,HL,I,O,S,T,Z"
+all_packages="AC,CX,D,F,HL,I,O,S,T,Z"
 
 case "X-$INTERNAL_DEBUG_OUTPUT" in
   X-yes|X-all)


### PR DESCRIPTION
Each test in the matrix has a run_tests field.

Currently, just the -Werror check and a new parallel check run with compile-only, but more will be added soon.