### PR TITLE
Simplify the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,41 +2,10 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @lrknox
+*       @lrknox @derobins @byrnHDF @fortnern @jhendersonHDF @ChristopherHogan @gnuoyd @qkoziol @vchoi-hdfgroup @bmribler
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners
 # will be requested to review.
-*.cmake           @byrnHDF @ChristopherHogan @gnuoyd @derobins
-CMakeLists.txt    @byrnHDF @ChristopherHogan @gnuoyd @derobins
-CMakeTests.*      @byrnHDF @ChristopherHogan @gnuoyd @derobins
-
-/bin/             @lrknox @ChristopherHogan @gnuoyd @derobins @qkoziol
-
-/c++/             @bmribler @byrnHDF @ChristopherHogan @gnuoyd @derobins
-
-/config/          @lrknox @byrnHDF @ChristopherHogan @gnuoyd @derobins @qkoziol
-
-/doc/             @ChristopherHogan @gnuoyd @jrmainzer
-
-/examples/        @lrknox @bmribler @ChristopherHogan @gnuoyd @derobins
-
-/fortran/         @brtnfld @epourmal
-
-/hl/              @bmribler @byrnHDF @ChristopherHogan @gnuoyd @derobins
-
+/fortran/         @brtnfld
 /java/            @jhendersonHDF @byrnHDF
-
-/m4/              @lrknox @ChristopherHogan @gnuoyd @derobins
-
-/release_docs/    @lrknox @bmribler @byrnHDF
-
-/src/             @jhendersonHDF @fortnern @soumagne @vchoi-hdfgroup @ChristopherHogan @gnuoyd @derobins @jrmainzer @qkoziol
-
-/test/            @jhendersonHDF @fortnern @soumagne @vchoi-hdfgroup @ChristopherHogan @gnuoyd @derobins @jrmainzer @qkoziol
-
-/testpar/         @jhendersonHDF @ChristopherHogan @gnuoyd @jrmainzer @qkoziol
-
-/tools/           @byrnHDF @bmribler @ChristopherHogan @gnuoyd @derobins
-
-/utils/           @lrknox @byrnHDF @ChristopherHogan @gnuoyd @derobins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 # So if a pull request only touches javascript files, only these owners
 # will be requested to review.
 /fortran/         @brtnfld
-/java/            @jhendersonHDF @byrnHDF
+/java/            @jhendersonHDF @byrnHDF @derobins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @lrknox @derobins @byrnHDF @fortnern @jhendersonHDF @ChristopherHogan @gnuoyd @qkoziol @vchoi-hdfgroup @bmribler
+* @lrknox @derobins @byrnHDF @fortnern @jhendersonHDF @ChristopherHogan @gnuoyd @qkoziol @vchoi-hdfgroup @bmribler @raylu-hdf
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners


### PR DESCRIPTION
All HDF Group developers are responsible for everything in the repo, aside from Java and Fortran, which sometimes have special concerns.

Also removes people who have left the company and are no longer active code reviewers.