### PR TITLE
Fortran module directory improvements

### DIFF
--- a/config/cmake/libhdf5.settings.cmake.in
+++ b/config/cmake/libhdf5.settings.cmake.in
@@ -50,6 +50,7 @@ Languages:
 @BUILD_FORTRAN_CONDITIONAL_TRUE@               AM Fortran Flags: @AM_FCFLAGS@
 @BUILD_FORTRAN_CONDITIONAL_TRUE@         Shared Fortran Library: @H5_ENABLE_SHARED_LIB@
 @BUILD_FORTRAN_CONDITIONAL_TRUE@         Static Fortran Library: @H5_ENABLE_STATIC_LIB@
+@BUILD_FORTRAN_CONDITIONAL_TRUE@               Module Directory: @CMAKE_Fortran_MODULE_DIRECTORY@
 
                             C++: @HDF5_BUILD_CPP_LIB@
 @BUILD_CXX_CONDITIONAL_TRUE@                   C++ Compiler: @CMAKE_CXX_COMPILER@ @CMAKE_CXX_COMPILER_VERSION@

--- a/fortran/src/Makefile.am
+++ b/fortran/src/Makefile.am
@@ -22,7 +22,7 @@ include $(top_srcdir)/config/lt_vers.am
 # Include src directory in both Fortran and C flags (C compiler is used
 # for linking).
 AM_CPPFLAGS+=-I$(top_srcdir)/src
-AM_FCFLAGS+=-I$(top_srcdir)/src -I$(top_srcdir)/fortran/src $(F9XMODFLAG)$(fmoddir)
+AM_FCFLAGS+=-I$(top_srcdir)/src -I$(top_srcdir)/fortran/src
 
 AM_FCLIBS=$(LIBHDF5)
 

--- a/hl/fortran/src/Makefile.am
+++ b/hl/fortran/src/Makefile.am
@@ -22,7 +22,7 @@ include $(top_srcdir)/config/lt_vers.am
 
 AM_CPPFLAGS+=-I$(top_srcdir)/src -I$(top_srcdir)/hl/src -I$(top_builddir)/hl/src \
          -I$(top_srcdir)/fortran/src -I$(top_builddir)/fortran/src
-AM_FCFLAGS+=-I$(top_builddir)/fortran/src $(F9XMODFLAG)$(top_builddir)/fortran/src $(F9XMODFLAG)$(fmoddir)
+AM_FCFLAGS+=-I$(top_builddir)/fortran/src $(F9XMODFLAG)$(top_builddir)/fortran/src
 
 # Our main target, the high-level fortran library
 lib_LTLIBRARIES=libhdf5hl_fortran.la

--- a/src/libhdf5.settings.in
+++ b/src/libhdf5.settings.in
@@ -52,6 +52,7 @@ Languages:
 @BUILD_FORTRAN_CONDITIONAL_TRUE@               AM Fortran Flags: @AM_FCFLAGS@
 @BUILD_FORTRAN_CONDITIONAL_TRUE@         Shared Fortran Library: @H5_FORTRAN_SHARED@
 @BUILD_FORTRAN_CONDITIONAL_TRUE@         Static Fortran Library: @enable_static@
+@BUILD_FORTRAN_CONDITIONAL_TRUE@               Module Directory: @fmoddir@
 
                             C++: @HDF_CXX@
 @BUILD_CXX_CONDITIONAL_TRUE@                   C++ Compiler: @CXX_VERSION@


### PR DESCRIPTION
* Removes the module directory from the Automake flags as this
  generated a large number of "missing include directory" warnings
  and is unecessary
* Adds the module path to libhdf5.settings