### PR TITLE
Align arg types of H5D_chunk_iter_op_t with H5Dget_chunk_info

### DIFF
--- a/src/H5D.c
+++ b/src/H5D.c
@@ -2515,18 +2515,18 @@ done:
  *
  *        typedef int (*H5D_chunk_iter_op_t)(
  *            const hsize_t *offset,
- *            uint32_t filter_mask,
+ *            unsigned filter_mask,
  *            haddr_t addr,
- *            uint32_t nbytes,
+ *            hsize_t size,
  *            void *op_data);
  *
  *      H5D_chunk_iter_op_t parameters:
- *          hsize_t *offset;        IN/OUT: Array of starting logical coordinates of chunk.
- *          uint32_t filter_mask;   IN: Filter mask of chunk.
- *          haddr_t addr;           IN: Offset in file of chunk data.
- *          uint32_t nbytes;        IN: Size in number of bytes of chunk data in file.
- *          void *op_data;          IN/OUT: Pointer to any user-defined data
- *                                  associated with the operation.
+ *          hsize_t *offset;        IN/OUT: Logical position of the chunk’s first element in units of dataset
+ *                                          elements
+ *          unsigned filter_mask;   IN: Bitmask indicating the filters used when the chunk was written haddr_t
+ *          addr;                   IN: Chunk address in the file
+ *          hsize_t;                IN: Chunk size in bytes, 0 if the chunk does not exist
+ *          void *op_data;          IN/OUT: Pointer to any user-defined data associated with the operation.
  *
  *      The return values from an operator are:
  *          Zero (H5_ITER_CONT) causes the iterator to continue, returning zero when all

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -8278,8 +8278,8 @@ H5D__chunk_iter_cb(const H5D_chunk_rec_t *chunk_rec, void *udata)
     FUNC_ENTER_PACKAGE_NOERR
 
     /* Check for callback failure and pass along return value */
-    if ((ret_value = (data->op)(offset, chunk_rec->filter_mask, chunk_rec->chunk_addr, chunk_rec->nbytes,
-                                data->op_data)) < 0)
+    if ((ret_value = (data->op)(offset, (unsigned)chunk_rec->filter_mask, chunk_rec->chunk_addr,
+                                (hsize_t)chunk_rec->nbytes, data->op_data)) < 0)
         HERROR(H5E_DATASET, H5E_CANTNEXT, "iteration operator failed");
 
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Dpublic.h
+++ b/src/H5Dpublic.h
@@ -238,7 +238,7 @@ typedef herr_t (*H5D_gather_func_t)(const void *dst_buf, size_t dst_buf_bytes_us
  *          \li A negative (#H5_ITER_ERROR) causes the iterator to immediately
  *              return that value, indicating failure.
  */
-typedef int (*H5D_chunk_iter_op_t)(const hsize_t *offset, uint32_t filter_mask, haddr_t addr, uint32_t size,
+typedef int (*H5D_chunk_iter_op_t)(const hsize_t *offset, unsigned filter_mask, haddr_t addr, hsize_t size,
                                    void *op_data);
 //! <!-- [H5D_chunk_iter_op_t_snip] -->
 

--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -1510,7 +1510,7 @@ typedef struct chunk_iter_info_t {
     hsize_t  offset[2];
     uint32_t filter_mask;
     haddr_t  addr;
-    uint32_t nbytes;
+    uint32_t size;
 } chunk_iter_info_t;
 
 typedef struct chunk_iter_udata_t {
@@ -1519,7 +1519,7 @@ typedef struct chunk_iter_udata_t {
 } chunk_iter_udata_t;
 
 static int
-iter_cb(const hsize_t *offset, uint32_t filter_mask, haddr_t addr, uint32_t nbytes, void *op_data)
+iter_cb(const hsize_t *offset, unsigned filter_mask, haddr_t addr, hsize_t size, void *op_data)
 {
     chunk_iter_udata_t *cidata = (chunk_iter_udata_t *)op_data;
     int                 idx    = cidata->last_index + 1;
@@ -1528,7 +1528,7 @@ iter_cb(const hsize_t *offset, uint32_t filter_mask, haddr_t addr, uint32_t nbyt
     cidata->chunk_info[idx].offset[1]   = offset[1];
     cidata->chunk_info[idx].filter_mask = filter_mask;
     cidata->chunk_info[idx].addr        = addr;
-    cidata->chunk_info[idx].nbytes      = nbytes;
+    cidata->chunk_info[idx].size        = size;
 
     cidata->last_index++;
 
@@ -1536,8 +1536,8 @@ iter_cb(const hsize_t *offset, uint32_t filter_mask, haddr_t addr, uint32_t nbyt
 }
 
 static int
-iter_cb_stop(const hsize_t H5_ATTR_UNUSED *offset, uint32_t H5_ATTR_UNUSED filter_mask,
-             haddr_t H5_ATTR_UNUSED addr, uint32_t H5_ATTR_UNUSED nbytes, void *op_data)
+iter_cb_stop(const hsize_t H5_ATTR_UNUSED *offset, unsigned H5_ATTR_UNUSED filter_mask,
+             haddr_t H5_ATTR_UNUSED addr, hsize_t H5_ATTR_UNUSED size, void *op_data)
 {
     chunk_iter_info_t **chunk_info = (chunk_iter_info_t **)op_data;
     *chunk_info += 1;
@@ -1545,8 +1545,8 @@ iter_cb_stop(const hsize_t H5_ATTR_UNUSED *offset, uint32_t H5_ATTR_UNUSED filte
 }
 
 static int
-iter_cb_fail(const hsize_t H5_ATTR_UNUSED *offset, uint32_t H5_ATTR_UNUSED filter_mask,
-             haddr_t H5_ATTR_UNUSED addr, uint32_t H5_ATTR_UNUSED nbytes, void *op_data)
+iter_cb_fail(const hsize_t H5_ATTR_UNUSED *offset, unsigned H5_ATTR_UNUSED filter_mask,
+             haddr_t H5_ATTR_UNUSED addr, hsize_t H5_ATTR_UNUSED size, void *op_data)
 {
     chunk_iter_info_t **chunk_info = (chunk_iter_info_t **)op_data;
     *chunk_info += 1;
@@ -1718,7 +1718,7 @@ test_basic_query(hid_t fapl)
         FAIL_PUTS_ERROR("offset[1] mismatch");
     if (chunk_infos[0].filter_mask != 0)
         FAIL_PUTS_ERROR("filter mask mismatch");
-    if (chunk_infos[0].nbytes != 96)
+    if (chunk_infos[0].size != 96)
         FAIL_PUTS_ERROR("size mismatch");
 
     if (chunk_infos[1].offset[0] != CHUNK_NX)

--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -1508,9 +1508,9 @@ error:
 
 typedef struct chunk_iter_info_t {
     hsize_t  offset[2];
-    uint32_t filter_mask;
+    unsigned filter_mask;
     haddr_t  addr;
-    uint32_t size;
+    hsize_t  size;
 } chunk_iter_info_t;
 
 typedef struct chunk_iter_udata_t {


### PR DESCRIPTION
Fix #2056 

For `H5D_chunk_iter_op_t`
* `filter_mask` changes from type `uint32_t` to `unsigned`
* `size` changes from `uint32_t` to `hsize_t`

The practical change is that `size` argument is now a [64-bit unsigned integer](https://github.com/HDFGroup/hdf5/blob/08aebb6d1af481272bda391f19e03c330fddf149/src/H5public.h#L292).

These changes make `H5D_chunk_iter_op_t` similar the argument similar to the `size` argument in [`H5Dget_chunk_info`](https://github.com/HDFGroup/hdf5/blob/08aebb6d1af481272bda391f19e03c330fddf149/src/H5Dpublic.h#L736-L737).

```C
H5_DLL herr_t H5Dget_chunk_info(hid_t dset_id, hid_t fspace_id, hsize_t chk_idx, hsize_t *offset,
                                unsigned *filter_mask, haddr_t *addr, hsize_t *size);
```

The change is important because it allows the internal chunk size to change to be a 64-bit value in the future without modifying the public API.