### PR TITLE
Fix memory bug in selection I/O

### DIFF
--- a/src/H5FDint.c
+++ b/src/H5FDint.c
@@ -1171,7 +1171,7 @@ H5FD_read_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t **mem_s
             if ((file_space_ids[num_spaces] = H5I_register(H5I_DATASPACE, file_spaces[num_spaces], TRUE)) <
                 0) {
                 if (NULL == H5I_remove(mem_space_ids[num_spaces]))
-                    HDONE_ERROR(H5E_VFL, H5E_CANTDEC, FAIL, "problem freeing id")
+                    HDONE_ERROR(H5E_VFL, H5E_CANTREMOVE, FAIL, "problem removing id")
                 HGOTO_ERROR(H5E_VFL, H5E_CANTREGISTER, FAIL, "unable to register dataspace ID")
             }
         }
@@ -1205,9 +1205,9 @@ done:
      */
     for (i = 0; i < num_spaces; i++) {
         if (NULL == H5I_remove(mem_space_ids[i]))
-            HDONE_ERROR(H5E_VFL, H5E_CANTDEC, FAIL, "problem freeing id")
+            HDONE_ERROR(H5E_VFL, H5E_CANTREMOVE, FAIL, "problem removing id")
         if (NULL == H5I_remove(file_space_ids[i]))
-            HDONE_ERROR(H5E_VFL, H5E_CANTDEC, FAIL, "problem freeing id")
+            HDONE_ERROR(H5E_VFL, H5E_CANTREMOVE, FAIL, "problem removing id")
     }
     if (mem_space_ids != mem_space_ids_local)
         mem_space_ids = H5MM_xfree(mem_space_ids);
@@ -1808,7 +1808,7 @@ H5FD_write_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t **mem_
             if ((file_space_ids[num_spaces] = H5I_register(H5I_DATASPACE, file_spaces[num_spaces], TRUE)) <
                 0) {
                 if (NULL == H5I_remove(mem_space_ids[num_spaces]))
-                    HDONE_ERROR(H5E_VFL, H5E_CANTDEC, FAIL, "problem freeing id")
+                    HDONE_ERROR(H5E_VFL, H5E_CANTREMOVE, FAIL, "problem removing id")
                 HGOTO_ERROR(H5E_VFL, H5E_CANTREGISTER, FAIL, "unable to register dataspace ID")
             }
         }
@@ -1842,9 +1842,9 @@ done:
      */
     for (i = 0; i < num_spaces; i++) {
         if (NULL == H5I_remove(mem_space_ids[i]))
-            HDONE_ERROR(H5E_VFL, H5E_CANTDEC, FAIL, "problem freeing id")
+            HDONE_ERROR(H5E_VFL, H5E_CANTREMOVE, FAIL, "problem removing id")
         if (NULL == H5I_remove(file_space_ids[i]))
-            HDONE_ERROR(H5E_VFL, H5E_CANTDEC, FAIL, "problem freeing id")
+            HDONE_ERROR(H5E_VFL, H5E_CANTREMOVE, FAIL, "problem removing id")
     }
     if (mem_space_ids != mem_space_ids_local)
         mem_space_ids = H5MM_xfree(mem_space_ids);

--- a/src/H5FDint.c
+++ b/src/H5FDint.c
@@ -1170,7 +1170,7 @@ H5FD_read_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t **mem_s
 
             if ((file_space_ids[num_spaces] = H5I_register(H5I_DATASPACE, file_spaces[num_spaces], TRUE)) <
                 0) {
-                if (H5I_dec_app_ref(mem_space_ids[num_spaces]) < 0)
+                if (NULL == H5I_remove(mem_space_ids[num_spaces]))
                     HDONE_ERROR(H5E_VFL, H5E_CANTDEC, FAIL, "problem freeing id")
                 HGOTO_ERROR(H5E_VFL, H5E_CANTREGISTER, FAIL, "unable to register dataspace ID")
             }
@@ -1200,11 +1200,13 @@ done:
         }
     }
 
-    /* Cleanup dataspace arrays */
+    /* Cleanup dataspace arrays.  Use H5I_remove() so we only close the IDs and
+     * not the underlying dataspaces, which were not created by this function.
+     */
     for (i = 0; i < num_spaces; i++) {
-        if (H5I_dec_app_ref(mem_space_ids[i]) < 0)
+        if (NULL == H5I_remove(mem_space_ids[i]))
             HDONE_ERROR(H5E_VFL, H5E_CANTDEC, FAIL, "problem freeing id")
-        if (H5I_dec_app_ref(file_space_ids[i]) < 0)
+        if (NULL == H5I_remove(file_space_ids[i]))
             HDONE_ERROR(H5E_VFL, H5E_CANTDEC, FAIL, "problem freeing id")
     }
     if (mem_space_ids != mem_space_ids_local)
@@ -1805,7 +1807,7 @@ H5FD_write_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t **mem_
 
             if ((file_space_ids[num_spaces] = H5I_register(H5I_DATASPACE, file_spaces[num_spaces], TRUE)) <
                 0) {
-                if (H5I_dec_app_ref(mem_space_ids[num_spaces]) < 0)
+                if (NULL == H5I_remove(mem_space_ids[num_spaces]))
                     HDONE_ERROR(H5E_VFL, H5E_CANTDEC, FAIL, "problem freeing id")
                 HGOTO_ERROR(H5E_VFL, H5E_CANTREGISTER, FAIL, "unable to register dataspace ID")
             }
@@ -1835,11 +1837,13 @@ done:
         }
     }
 
-    /* Cleanup dataspace arrays */
+    /* Cleanup dataspace arrays.  Use H5I_remove() so we only close the IDs and
+     * not the underlying dataspaces, which were not created by this function.
+     */
     for (i = 0; i < num_spaces; i++) {
-        if (H5I_dec_app_ref(mem_space_ids[i]) < 0)
+        if (NULL == H5I_remove(mem_space_ids[i]))
             HDONE_ERROR(H5E_VFL, H5E_CANTDEC, FAIL, "problem freeing id")
-        if (H5I_dec_app_ref(file_space_ids[i]) < 0)
+        if (NULL == H5I_remove(file_space_ids[i]))
             HDONE_ERROR(H5E_VFL, H5E_CANTDEC, FAIL, "problem freeing id")
     }
     if (mem_space_ids != mem_space_ids_local)


### PR DESCRIPTION
H5FD_read/write_selection() is passed an array of H5S_t *s and in some cases needs to create to pass an array of hid_ts referencing these H5S_t *s to the underlying callback. The function does this using H5I_register(). When freeing memory at the end of the function, it would previously call H5I_dec_app_ref on the ids, which had the side effect of freeing the H5S_t *s, even though they were not created by H5FD_read/write_selection(), causing problems when the calling function(s) tried to use these spaces afterwards. Changed to H5I_remove().