### PR TITLE
Fix bug in attribute type conversion wiith compound types - merge to 1.8

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -329,6 +329,15 @@ Bug Fixes since HDF5-1.8.22
 
     Library
     -------
+    - Fixed an issue with attribute type conversion with compound datatypes
+
+      Previously, when performing type conversion for attribute I/O with a
+      compound datatype, the library would not fill the background buffer with
+      the contents of the destination, potentially causing data to be lost when
+      only writing to a subset of the compound fields.
+
+      (NAF - 2022/09/12, GitHub #2016)
+
     - Issue #1436 identified a problem with the H5_VERS_RELEASE check in the
       H5check_version function.
 

--- a/src/H5Aint.c
+++ b/src/H5Aint.c
@@ -684,7 +684,7 @@ H5A_read(const H5A_t *attr, const H5T_t *mem_type, void *buf, hid_t dxpl_id)
                     /* Copy the application buffer into the background buffer if necessary */
                     if (need_bkg == H5T_BKG_YES) {
                         HDassert(buf_size >= (dst_type_size * nelmts));
-                        H5MM_memcpy(bkg_buf, buf, dst_type_size * nelmts);
+                        HDmemcpy(bkg_buf, buf, dst_type_size * nelmts);
                     }
                 }
 

--- a/src/H5Aint.c
+++ b/src/H5Aint.c
@@ -479,9 +479,8 @@ done:
 herr_t
 H5A_write(H5A_t *attr, const H5T_t *mem_type, const void *buf, hid_t dxpl_id)
 {
-    uint8_t    *tconv_buf   = NULL;       /* datatype conv buffer */
-    hbool_t     tconv_owned = FALSE;      /* Whether the datatype conv buffer is owned by attribute */
-    uint8_t    *bkg_buf     = NULL;       /* temp conversion buffer */
+    uint8_t    *tconv_buf = NULL;         /* datatype conv buffer */
+    uint8_t    *bkg_buf   = NULL;         /* temp conversion buffer */
     hssize_t    snelmts;                  /* elements in attribute */
     size_t      nelmts;                   /* elements in attribute */
     H5T_path_t *tpath  = NULL;            /* conversion information*/
@@ -515,6 +514,8 @@ H5A_write(H5A_t *attr, const H5T_t *mem_type, const void *buf, hid_t dxpl_id)
 
         /* Check for type conversion required */
         if (!H5T_path_noop(tpath)) {
+            H5T_bkg_t need_bkg; /* Background buffer type */
+
             if ((src_id = H5I_register(H5I_DATATYPE, H5T_copy(mem_type, H5T_COPY_ALL), FALSE)) < 0 ||
                 (dst_id = H5I_register(H5I_DATATYPE, H5T_copy(attr->shared->dt, H5T_COPY_ALL), FALSE)) < 0)
                 HGOTO_ERROR(H5E_ATTR, H5E_CANTREGISTER, FAIL, "unable to register types for conversion")
@@ -523,11 +524,32 @@ H5A_write(H5A_t *attr, const H5T_t *mem_type, const void *buf, hid_t dxpl_id)
             buf_size = nelmts * MAX(src_type_size, dst_type_size);
             if (NULL == (tconv_buf = H5FL_BLK_MALLOC(attr_buf, buf_size)))
                 HGOTO_ERROR(H5E_ATTR, H5E_CANTALLOC, FAIL, "memory allocation failed")
-            if (NULL == (bkg_buf = H5FL_BLK_CALLOC(attr_buf, buf_size)))
-                HGOTO_ERROR(H5E_ATTR, H5E_CANTALLOC, FAIL, "memory allocation failed")
 
             /* Copy the user's data into the buffer for conversion */
             HDmemcpy(tconv_buf, buf, (src_type_size * nelmts));
+
+            /* Check if we need a background buffer */
+            if (H5T_detect_class(attr->shared->dt, H5T_VLEN, FALSE))
+                need_bkg = H5T_BKG_YES;
+            else
+                need_bkg = H5T_path_bkg(tpath);
+
+            if (need_bkg) {
+                /* Use the existing attribute data buffer, if present, as the background buffer,
+                 * otherwise allocate one.  Note we don't need to track which one it is since both
+                 * use the "attr_buf" free list block. */
+                if (attr->shared->data) {
+                    bkg_buf            = attr->shared->data;
+                    attr->shared->data = NULL;
+
+                    /* Clear background buffer if it's not supposed to be initialized with file
+                     * contents */
+                    if (need_bkg == H5T_BKG_TEMP)
+                        HDmemset(bkg_buf, 0, dst_type_size * nelmts);
+                }
+                else if (NULL == (bkg_buf = H5FL_BLK_CALLOC(attr_buf, buf_size)))
+                    HGOTO_ERROR(H5E_ATTR, H5E_CANTALLOC, FAIL, "memory allocation failed")
+            }
 
             /* Perform datatype conversion */
             if (H5T_convert(tpath, src_id, dst_id, nelmts, (size_t)0, (size_t)0, tconv_buf, bkg_buf,
@@ -540,7 +562,7 @@ H5A_write(H5A_t *attr, const H5T_t *mem_type, const void *buf, hid_t dxpl_id)
 
             /* Set the pointer to the attribute data to the converted information */
             attr->shared->data = tconv_buf;
-            tconv_owned        = TRUE;
+            tconv_buf          = NULL;
         } /* end if */
         /* No type conversion necessary */
         else {
@@ -566,7 +588,7 @@ done:
         HDONE_ERROR(H5E_ATTR, H5E_CANTDEC, FAIL, "unable to close temporary object")
     if (dst_id >= 0 && H5I_dec_ref(dst_id) < 0)
         HDONE_ERROR(H5E_ATTR, H5E_CANTDEC, FAIL, "unable to close temporary object")
-    if (tconv_buf && !tconv_owned)
+    if (tconv_buf)
         tconv_buf = H5FL_BLK_FREE(attr_buf, tconv_buf);
     if (bkg_buf)
         bkg_buf = H5FL_BLK_FREE(attr_buf, bkg_buf);
@@ -636,6 +658,8 @@ H5A_read(const H5A_t *attr, const H5T_t *mem_type, void *buf, hid_t dxpl_id)
 
             /* Check for type conversion required */
             if (!H5T_path_noop(tpath)) {
+                H5T_bkg_t need_bkg; /* Background buffer type */
+
                 if ((src_id = H5I_register(H5I_DATATYPE, H5T_copy(attr->shared->dt, H5T_COPY_ALL), FALSE)) <
                         0 ||
                     (dst_id = H5I_register(H5I_DATATYPE, H5T_copy(mem_type, H5T_COPY_ALL), FALSE)) < 0)
@@ -645,11 +669,24 @@ H5A_read(const H5A_t *attr, const H5T_t *mem_type, void *buf, hid_t dxpl_id)
                 buf_size = nelmts * MAX(src_type_size, dst_type_size);
                 if (NULL == (tconv_buf = H5FL_BLK_MALLOC(attr_buf, buf_size)))
                     HGOTO_ERROR(H5E_ATTR, H5E_NOSPACE, FAIL, "memory allocation failed")
-                if (NULL == (bkg_buf = H5FL_BLK_CALLOC(attr_buf, buf_size)))
-                    HGOTO_ERROR(H5E_ATTR, H5E_NOSPACE, FAIL, "memory allocation failed")
 
                 /* Copy the attribute data into the buffer for conversion */
                 HDmemcpy(tconv_buf, attr->shared->data, (src_type_size * nelmts));
+
+                /* Check if we need a background buffer */
+                need_bkg = H5T_path_bkg(tpath);
+
+                if (need_bkg) {
+                    /* Allocate background buffer */
+                    if (NULL == (bkg_buf = H5FL_BLK_CALLOC(attr_buf, buf_size)))
+                        HGOTO_ERROR(H5E_ATTR, H5E_CANTALLOC, FAIL, "memory allocation failed")
+
+                    /* Copy the application buffer into the background buffer if necessary */
+                    if (need_bkg == H5T_BKG_YES) {
+                        HDassert(buf_size >= (dst_type_size * nelmts));
+                        H5MM_memcpy(bkg_buf, buf, dst_type_size * nelmts);
+                    }
+                }
 
                 /* Perform datatype conversion.  */
                 if (H5T_convert(tpath, src_id, dst_id, nelmts, (size_t)0, (size_t)0, tconv_buf, bkg_buf,


### PR DESCRIPTION
Fix bug in attribute type conversion where the background buffer would
not be initialized with the destination contents when necessary. Other
minor simplification.