### PR TITLE
Fixed an issue that could occur when combining hyperslab selections

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -121,6 +121,13 @@ Bug Fixes since HDF5-1.13.2 release
 ===================================
     Library
     -------
+    - Fixed an issue with hyperslab selections
+
+      Previously, when combining hyperslab selections, it was possible for the
+      library to produce an incorrect combined selection.
+
+      (NAF - 2022/09/25)
+
     - Fixed an issue with attribute type conversion with compound datatypes
 
       Previously, when performing type conversion for attribute I/O with a

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -8796,14 +8796,14 @@ H5S__hyper_update_diminfo(H5S_t *space, H5S_seloper_t op, const H5S_hyper_dim_t 
                 }     /* end if */
                 else {
                     /* Check if block values are the same */
-                    if (tmp_diminfo[curr_dim].block != new_hyper_diminfo[curr_dim].block) {
+                    if (tmp_diminfo[curr_dim].block != high_block) {
                         space->select.sel_info.hslab->diminfo_valid = H5S_DIMINFO_VALID_NO;
                         break;
                     } /* end if */
 
                     /* Check phase of strides */
                     if ((tmp_diminfo[curr_dim].start % tmp_diminfo[curr_dim].stride) !=
-                        (new_hyper_diminfo[curr_dim].start % tmp_diminfo[curr_dim].stride)) {
+                        (high_start % tmp_diminfo[curr_dim].stride)) {
                         space->select.sel_info.hslab->diminfo_valid = H5S_DIMINFO_VALID_NO;
                         break;
                     } /* end if */

--- a/test/th5s.c
+++ b/test/th5s.c
@@ -3263,6 +3263,57 @@ test_h5s_bug1(void)
     CHECK(ret, FAIL, "H5Sclose");
 } /* test_h5s_bug1() */
 
+/****************************************************************
+**
+**  test_h5s_bug2(): Test combining hyperslabs in a way that used
+**                   to trip up H5S__hyper_update_diminfo()
+**
+****************************************************************/
+static void
+test_h5s_bug2(void)
+{
+    hid_t    space;             /* Dataspace to copy extent to */
+    hsize_t  dims[2]  = {1, 5}; /* Dimensions */
+    hsize_t  start[2] = {0, 0}; /* Hyperslab start */
+    hsize_t  count[2] = {1, 1}; /* Hyperslab start */
+    htri_t   select_valid;      /* Whether the dataspace selection is valid */
+    hssize_t elements_selected; /* Number of elements selected */
+    herr_t   ret;               /* Generic error return */
+
+    /* Create dataspace */
+    space = H5Screate_simple(2, dims, NULL);
+    CHECK(space, FAIL, "H5Screate");
+
+    /* Select hyperslab in space containing first element */
+    ret = H5Sselect_hyperslab(space, H5S_SELECT_SET, start, NULL, count, NULL);
+    CHECK(ret, FAIL, "H5Sselect_hyperslab");
+
+    /* Add hyperslab in space containing last element */
+    start[1] = 4;
+    ret = H5Sselect_hyperslab(space, H5S_SELECT_OR, start, NULL, count, NULL);
+    CHECK(ret, FAIL, "H5Sselect_hyperslab");
+
+    /* Add hyperslab in space containing the first 3 elements */
+    start[1] = 0;
+    count[1] = 3;
+    ret = H5Sselect_hyperslab(space, H5S_SELECT_OR, start, NULL, count, NULL);
+    CHECK(ret, FAIL, "H5Sselect_hyperslab");
+
+    /* Check that space's selection is valid */
+    select_valid = H5Sselect_valid(space);
+    CHECK(select_valid, FAIL, "H5Sselect_valid");
+    VERIFY(select_valid, TRUE, "H5Sselect_valid result");
+
+    /* Check that 4 elements are selected */
+    elements_selected = H5Sget_select_npoints(space);
+    CHECK(elements_selected, FAIL, "H5Sselect_valid");
+    VERIFY(elements_selected, 4, "H5Sselect_valid result");
+
+    /* Close dataspaces */
+    ret = H5Sclose(space);
+    CHECK(ret, FAIL, "H5Sclose");
+} /* test_h5s_bug2() */
+
 /*-------------------------------------------------------------------------
  * Function:    test_versionbounds
  *
@@ -3435,6 +3486,7 @@ test_h5s(void)
     test_h5s_extent_equal(); /* Test extent comparison code */
     test_h5s_extent_copy();  /* Test extent copy code */
     test_h5s_bug1();         /* Test bug in offset initialization */
+    test_h5s_bug2();         /* Test bug found in H5S__hyper_update_diminfo() */
     test_versionbounds();    /* Test version bounds with dataspace */
 } /* test_h5s() */
 

--- a/test/th5s.c
+++ b/test/th5s.c
@@ -3290,13 +3290,13 @@ test_h5s_bug2(void)
 
     /* Add hyperslab in space containing last element */
     start[1] = 4;
-    ret = H5Sselect_hyperslab(space, H5S_SELECT_OR, start, NULL, count, NULL);
+    ret      = H5Sselect_hyperslab(space, H5S_SELECT_OR, start, NULL, count, NULL);
     CHECK(ret, FAIL, "H5Sselect_hyperslab");
 
     /* Add hyperslab in space containing the first 3 elements */
     start[1] = 0;
     count[1] = 3;
-    ret = H5Sselect_hyperslab(space, H5S_SELECT_OR, start, NULL, count, NULL);
+    ret      = H5Sselect_hyperslab(space, H5S_SELECT_OR, start, NULL, count, NULL);
     CHECK(ret, FAIL, "H5Sselect_hyperslab");
 
     /* Check that space's selection is valid */


### PR DESCRIPTION
Remove inappropriate use of new_hyper_diminfo in H5S__hyper_update_diminfo() after its use with tmp_diminfo has been superseded by use of tmp_diminfo with high_start/count/block. This fix will allow us to remove a restriction in the multi dataset test.