### PR TITLE
Avoid calling H5FD_subfiling_init from h5open_f.

### DIFF
--- a/fortran/src/H5_f.c
+++ b/fortran/src/H5_f.c
@@ -574,14 +574,14 @@ h5init_flags_c(int_f *h5d_flags, size_t_f *h5d_size_flags, int_f *h5e_flags, hid
     int mpi_code;
 
     if (MPI_SUCCESS == (mpi_code = MPI_Initialized(&mpi_initialized))) {
-      if (mpi_initialized) {
-        /* If MPI is initialized, validate that it was initialized with MPI_THREAD_MULTIPLE */
-        if (MPI_SUCCESS == (mpi_code = MPI_Query_thread(&provided))) {
-          if (provided == MPI_THREAD_MULTIPLE) {
-            h5fd_hid_flags[7] = (hid_t_f)H5FD_SUBFILING;
-          }
+        if (mpi_initialized) {
+            /* If MPI is initialized, validate that it was initialized with MPI_THREAD_MULTIPLE */
+            if (MPI_SUCCESS == (mpi_code = MPI_Query_thread(&provided))) {
+                if (provided == MPI_THREAD_MULTIPLE) {
+                    h5fd_hid_flags[7] = (hid_t_f)H5FD_SUBFILING;
+                }
+            }
         }
-      }
     }
 #endif
 #ifdef H5_HAVE_SUBFILING_VFD

--- a/fortran/src/H5_f.c
+++ b/fortran/src/H5_f.c
@@ -561,7 +561,29 @@ h5init_flags_c(int_f *h5d_flags, size_t_f *h5d_size_flags, int_f *h5e_flags, hid
     h5fd_hid_flags[4] = (hid_t_f)H5FD_MULTI;
     h5fd_hid_flags[5] = (hid_t_f)H5FD_SEC2;
     h5fd_hid_flags[6] = (hid_t_f)H5FD_STDIO;
-    h5fd_hid_flags[7] = (hid_t_f)H5FD_SUBFILING;
+
+    /* Calling H5FD_subfiling_init here requires the
+       subfiling requirements to be met.  Only set the
+       subfiling if it meets the below conditions */
+
+    h5fd_hid_flags[7] = (hid_t_f)H5I_INVALID_HID;
+
+#ifdef H5_HAVE_PARALLEL
+    int mpi_initialized = 0;
+    int provided        = 0;
+    int mpi_code;
+
+    if (MPI_SUCCESS == (mpi_code = MPI_Initialized(&mpi_initialized))) {
+      if (mpi_initialized) {
+        /* If MPI is initialized, validate that it was initialized with MPI_THREAD_MULTIPLE */
+        if (MPI_SUCCESS == (mpi_code = MPI_Query_thread(&provided))) {
+          if (provided == MPI_THREAD_MULTIPLE) {
+            h5fd_hid_flags[7] = (hid_t_f)H5FD_SUBFILING;
+          }
+        }
+      }
+    }
+#endif
 #ifdef H5_HAVE_SUBFILING_VFD
     h5fd_hid_flags[8] = (hid_t_f)H5FD_SUBFILING_DEFAULT_STRIPE_SIZE;
 #else


### PR DESCRIPTION
If H5FD_subfiling_init is called and the necessary conditions for subfiling are not met, i.e., parallel with mpi_int_thread and MPI_THREAD_MULTIPLE, it will fail with an error and an error message to the stack. To avoid that, H5FD_subfiling_init is called, and H5FD_SUBFILING_F is set, if H5FD_subfiling_init is expected to pass.