### PR TITLE
JNI: Improve varlen datatype handling in H5A/H5D read/write functions

### DIFF
--- a/java/src/jni/h5aImp.c
+++ b/java/src/jni/h5aImp.c
@@ -156,44 +156,60 @@ JNIEXPORT jint JNICALL
 Java_hdf_hdf5lib_H5_H5Aread(JNIEnv *env, jclass clss, jlong attr_id, jlong mem_type_id, jbyteArray buf,
                             jboolean isCriticalPinning)
 {
-    jboolean readBufIsCopy;
-    jbyte   *readBuf = NULL;
-    hsize_t  dims[H5S_MAX_RANK];
-    hid_t    sid = H5I_INVALID_HID;
-    jsize    n;
-    htri_t   vl_data_class;
-    herr_t   status = FAIL;
+    jboolean    readBufIsCopy;
+    jbyte      *readBuf = NULL;
+    hsize_t     dims[H5S_MAX_RANK];
+    hid_t       sid = H5I_INVALID_HID;
+    size_t      typeSize;
+    H5T_class_t type_class;
+    jsize       n;
+    htri_t      vl_data_class;
+    herr_t      status = FAIL;
 
     UNUSED(clss);
 
     if (NULL == buf)
         H5_NULL_ARGUMENT_ERROR(ENVONLY, "H5Aread: read buffer is NULL");
 
+    /* Get size of data array */
+    if ((n = ENVPTR->GetArrayLength(ENVONLY, buf)) < 0) {
+        CHECK_JNI_EXCEPTION(ENVONLY, JNI_TRUE);
+        H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5Aread: readBuf length < 0");
+    }
+
     if ((vl_data_class = h5str_detect_vlen(mem_type_id)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
 
     if (vl_data_class) {
-        /* Get size of data array */
-        if ((n = ENVPTR->GetArrayLength(ENVONLY, buf)) < 0) {
-            CHECK_JNI_EXCEPTION(ENVONLY, JNI_TRUE);
-            H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5Aread: readBuf length < 0");
-        }
-
         dims[0] = (hsize_t)n;
         if ((sid = H5Screate_simple(1, dims, NULL)) < 0)
             H5_LIBRARY_ERROR(ENVONLY);
     }
 
-    if (isCriticalPinning) {
-        PIN_BYTE_ARRAY_CRITICAL(ENVONLY, buf, readBuf, &readBufIsCopy,
-                                "H5Aread: read buffer not critically pinned");
+    if (!(typeSize = H5Tget_size(mem_type_id)))
+        H5_LIBRARY_ERROR(ENVONLY);
+
+    if ((type_class = H5Tget_class((hid_t)mem_type_id)) < 0)
+        H5_LIBRARY_ERROR(ENVONLY);
+    if (vl_data_class) {
+        if (NULL == (readBuf = HDcalloc((size_t)n, typeSize)))
+            H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5Aread: failed to allocate raw VL read buffer");
     }
     else {
-        PIN_BYTE_ARRAY(ENVONLY, buf, readBuf, &readBufIsCopy, "H5Aread: read buffer not pinned");
+        if (isCriticalPinning) {
+            PIN_BYTE_ARRAY_CRITICAL(ENVONLY, buf, readBuf, &readBufIsCopy,
+                                    "H5Aread: read buffer not critically pinned");
+        }
+        else {
+            PIN_BYTE_ARRAY(ENVONLY, buf, readBuf, &readBufIsCopy, "H5Aread: read buffer not pinned");
+        }
     }
 
     if ((status = H5Aread((hid_t)attr_id, (hid_t)mem_type_id, (void *)readBuf)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
+
+    if (vl_data_class)
+        translate_rbuf(env, buf, mem_type_id, type_class, n, (jsize)typeSize, (jobjectArray)readBuf);
 
 done:
     if (readBuf) {
@@ -203,11 +219,16 @@ done:
                 H5Sclose(sid);
         }
 
-        if (isCriticalPinning) {
-            UNPIN_ARRAY_CRITICAL(ENVONLY, buf, readBuf, (status < 0) ? JNI_ABORT : 0);
+        if (vl_data_class) {
+            HDfree(readBuf);
         }
         else {
-            UNPIN_BYTE_ARRAY(ENVONLY, buf, readBuf, (status < 0) ? JNI_ABORT : 0);
+            if (isCriticalPinning) {
+                UNPIN_ARRAY_CRITICAL(ENVONLY, buf, readBuf, (status < 0) ? JNI_ABORT : 0);
+            }
+            else {
+                UNPIN_BYTE_ARRAY(ENVONLY, buf, readBuf, (status < 0) ? JNI_ABORT : 0);
+            }
         }
     }
 
@@ -223,13 +244,15 @@ JNIEXPORT jint JNICALL
 Java_hdf_hdf5lib_H5_H5Awrite(JNIEnv *env, jclass clss, jlong attr_id, jlong mem_type_id, jbyteArray buf,
                              jboolean isCriticalPinning)
 {
-    jboolean writeBufIsCopy;
-    jbyte   *writeBuf = NULL;
-    hsize_t  dims[H5S_MAX_RANK];
-    hid_t    sid = H5I_INVALID_HID;
-    jsize    n;
-    htri_t   vl_data_class;
-    herr_t   status = FAIL;
+    jboolean    writeBufIsCopy;
+    jbyte      *writeBuf = NULL;
+    hsize_t     dims[H5S_MAX_RANK];
+    hid_t       sid = H5I_INVALID_HID;
+    size_t      typeSize;
+    H5T_class_t type_class;
+    jsize       n;
+    htri_t      vl_data_class;
+    herr_t      status = FAIL;
 
     UNUSED(clss);
 
@@ -239,7 +262,7 @@ Java_hdf_hdf5lib_H5_H5Awrite(JNIEnv *env, jclass clss, jlong attr_id, jlong mem_
     /* Get size of data array */
     if ((n = ENVPTR->GetArrayLength(ENVONLY, buf)) < 0) {
         CHECK_JNI_EXCEPTION(ENVONLY, JNI_TRUE);
-        H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5Aread: readBuf length < 0");
+        H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5Awrite: write buffer length < 0");
     }
 
     dims[0] = (hsize_t)n;
@@ -249,13 +272,27 @@ Java_hdf_hdf5lib_H5_H5Awrite(JNIEnv *env, jclass clss, jlong attr_id, jlong mem_
     if ((vl_data_class = h5str_detect_vlen(mem_type_id)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
 
-    if (isCriticalPinning) {
-        PIN_BYTE_ARRAY_CRITICAL(ENVONLY, buf, writeBuf, &writeBufIsCopy,
-                                "H5Awrite: write buffer not critically pinned");
+    if (!(typeSize = H5Tget_size(mem_type_id)))
+        H5_LIBRARY_ERROR(ENVONLY);
+
+    if ((type_class = H5Tget_class((hid_t)mem_type_id)) < 0)
+        H5_LIBRARY_ERROR(ENVONLY);
+    if (vl_data_class) {
+        if (NULL == (writeBuf = HDcalloc((size_t)n, typeSize)))
+            H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5Awrite: failed to allocate raw VL write buffer");
     }
     else {
-        PIN_BYTE_ARRAY(ENVONLY, buf, writeBuf, &writeBufIsCopy, "H5Awrite: write buffer not pinned");
+        if (isCriticalPinning) {
+            PIN_BYTE_ARRAY_CRITICAL(ENVONLY, buf, writeBuf, &writeBufIsCopy,
+                                    "H5Awrite: write buffer not critically pinned");
+        }
+        else {
+            PIN_BYTE_ARRAY(ENVONLY, buf, writeBuf, &writeBufIsCopy, "H5Awrite: write buffer not pinned");
+        }
     }
+
+    if (vl_data_class)
+        translate_wbuf(ENVONLY, buf, mem_type_id, type_class, n, (jsize)typeSize, (jobjectArray)writeBuf);
 
     if ((status = H5Awrite((hid_t)attr_id, (hid_t)mem_type_id, writeBuf)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
@@ -265,11 +302,16 @@ done:
         if ((status >= 0) && vl_data_class)
             H5Treclaim(attr_id, sid, H5P_DEFAULT, writeBuf);
 
-        if (isCriticalPinning) {
-            UNPIN_ARRAY_CRITICAL(ENVONLY, buf, writeBuf, (status < 0) ? JNI_ABORT : 0);
+        if (vl_data_class) {
+            HDfree(writeBuf);
         }
         else {
-            UNPIN_BYTE_ARRAY(ENVONLY, buf, writeBuf, (status < 0) ? JNI_ABORT : 0);
+            if (isCriticalPinning) {
+                UNPIN_ARRAY_CRITICAL(ENVONLY, buf, writeBuf, (status < 0) ? JNI_ABORT : 0);
+            }
+            else {
+                UNPIN_BYTE_ARRAY(ENVONLY, buf, writeBuf, (status < 0) ? JNI_ABORT : 0);
+            }
         }
     }
 
@@ -1064,244 +1106,9 @@ done:
 JNIEXPORT jint JNICALL
 Java_hdf_hdf5lib_H5_H5AreadVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem_type_id, jobjectArray buf)
 {
-    H5T_class_t type_class;
-    hsize_t     dims[H5S_MAX_RANK];
-    hid_t       sid = H5I_INVALID_HID;
-    jsize       n   = 0;
-    htri_t      vl_data_class;
     herr_t      status  = FAIL;
-    jbyteArray *readBuf = NULL;
 
-    UNUSED(clss);
-
-    if (NULL == buf)
-        H5_NULL_ARGUMENT_ERROR(ENVONLY, "H5AreadVL: read buffer is NULL");
-
-    if ((vl_data_class = h5str_detect_vlen(mem_type_id)) < 0)
-        H5_LIBRARY_ERROR(ENVONLY);
-
-    if (vl_data_class) {
-        /* Get size of data array */
-        if ((n = ENVPTR->GetArrayLength(ENVONLY, buf)) < 0) {
-            CHECK_JNI_EXCEPTION(ENVONLY, JNI_TRUE);
-            H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5AreadVL: readBuf length < 0");
-        }
-
-        dims[0] = (hsize_t)n;
-        if ((sid = H5Screate_simple(1, dims, NULL)) < 0)
-            H5_LIBRARY_ERROR(ENVONLY);
-    }
-
-    if ((type_class = H5Tget_class((hid_t)mem_type_id)) < 0)
-        H5_LIBRARY_ERROR(ENVONLY);
-    if (type_class == H5T_VLEN) {
-        size_t       typeSize;
-        hid_t        memb = H5I_INVALID_HID;
-        H5T_class_t  vlClass;
-        size_t       vlSize;
-        void        *rawBuf = NULL;
-        jobjectArray jList  = NULL;
-
-        size_t i, j, x;
-
-        if (!(typeSize = H5Tget_size(mem_type_id)))
-            H5_LIBRARY_ERROR(ENVONLY);
-
-        if (!(memb = H5Tget_super(mem_type_id)))
-            H5_LIBRARY_ERROR(ENVONLY);
-        if ((vlClass = H5Tget_class((hid_t)memb)) < 0)
-            H5_LIBRARY_ERROR(ENVONLY);
-        if (!(vlSize = H5Tget_size(memb)))
-            H5_LIBRARY_ERROR(ENVONLY);
-
-        if (NULL == (rawBuf = HDcalloc((size_t)n, typeSize)))
-            H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5AreadVL: failed to allocate raw VL read buffer");
-
-        if ((status = H5Aread((hid_t)attr_id, (hid_t)mem_type_id, (void *)rawBuf)) < 0)
-            H5_LIBRARY_ERROR(ENVONLY);
-
-        /* Cache class types */
-        /* jclass cBool   = ENVPTR->FindClass(ENVONLY, "java/lang/Boolean"); */
-        jclass cByte   = ENVPTR->FindClass(ENVONLY, "java/lang/Byte");
-        jclass cShort  = ENVPTR->FindClass(ENVONLY, "java/lang/Short");
-        jclass cInt    = ENVPTR->FindClass(ENVONLY, "java/lang/Integer");
-        jclass cLong   = ENVPTR->FindClass(ENVONLY, "java/lang/Long");
-        jclass cFloat  = ENVPTR->FindClass(ENVONLY, "java/lang/Float");
-        jclass cDouble = ENVPTR->FindClass(ENVONLY, "java/lang/Double");
-
-        /*
-        jmethodID boolValueMid =
-            ENVPTR->GetStaticMethodID(ENVONLY, cBool, "valueOf", "(Z)Ljava/lang/Boolean;");
-        */
-        jmethodID byteValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cByte, "valueOf", "(B)Ljava/lang/Byte;");
-        jmethodID shortValueMid =
-            ENVPTR->GetStaticMethodID(ENVONLY, cShort, "valueOf", "(S)Ljava/lang/Short;");
-        jmethodID intValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cInt, "valueOf", "(I)Ljava/lang/Integer;");
-        jmethodID longValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cLong, "valueOf", "(J)Ljava/lang/Long;");
-        jmethodID floatValueMid =
-            ENVPTR->GetStaticMethodID(ENVONLY, cFloat, "valueOf", "(F)Ljava/lang/Float;");
-        jmethodID doubleValueMid =
-            ENVPTR->GetStaticMethodID(ENVONLY, cDouble, "valueOf", "(D)Ljava/lang/Double;");
-
-        // retrieve the java.util.List interface class
-        jclass    cList     = ENVPTR->FindClass(ENVONLY, "java/util/List");
-        jmethodID addMethod = ENVPTR->GetMethodID(ENVONLY, cList, "add", "(Ljava/lang/Object;)Z");
-
-        /* Convert each element to a list */
-        for (i = 0; i < (size_t)n; i++) {
-            hvl_t vl_elem;
-
-            // The list we're going to return:
-            if (NULL == (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)buf, (jsize)i)))
-                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-
-            /* Get the number of sequence elements */
-            HDmemcpy(&vl_elem, (char *)rawBuf + i * typeSize, sizeof(hvl_t));
-
-            jsize nelmts = (jsize)vl_elem.len;
-            if (vl_elem.len != (size_t)nelmts)
-                H5_JNI_FATAL_ERROR(ENVONLY, "H5AreadVL: overflow of number of VL elements");
-            if (nelmts < 0)
-                H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5AreadVL: number of VL elements < 0");
-
-            jobject jobj = NULL;
-            for (j = 0; j < (size_t)nelmts; j++) {
-                switch (vlClass) {
-                    /* case H5T_BOOL: {
-                        jboolean boolValue;
-                        for (x = 0; x < vlSize; x++) {
-                            ((char *)&boolValue)[x] = ((char *)vl_elem.p)[j*vlSize+x];
-                        }
-
-                        jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cBool, boolValueMid, boolValue);
-                        CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                        break;
-                    } */
-                    case H5T_INTEGER: {
-                        switch (vlSize) {
-                            case sizeof(jbyte): {
-                                jbyte byteValue;
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)&byteValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
-                                }
-
-                                jobj =
-                                    ENVPTR->CallStaticObjectMethod(ENVONLY, cByte, byteValueMid, byteValue);
-                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                                break;
-                            }
-                            case sizeof(jshort): {
-                                jshort shortValue;
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)&shortValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
-                                }
-
-                                jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cShort, shortValueMid,
-                                                                      shortValue);
-                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                                break;
-                            }
-                            case sizeof(jint): {
-                                jint intValue;
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)&intValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
-                                }
-
-                                jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cInt, intValueMid, intValue);
-                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                                break;
-                            }
-                            case sizeof(jlong): {
-                                jlong longValue;
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)&longValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
-                                }
-
-                                jobj =
-                                    ENVPTR->CallStaticObjectMethod(ENVONLY, cLong, longValueMid, longValue);
-                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                                break;
-                            }
-                        }
-                        break;
-                    }
-                    case H5T_FLOAT: {
-                        switch (vlSize) {
-                            case sizeof(jfloat): {
-                                jfloat floatValue;
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)&floatValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
-                                }
-
-                                jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cFloat, floatValueMid,
-                                                                      (double)floatValue);
-                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                                break;
-                            }
-                            case sizeof(jdouble): {
-                                jdouble doubleValue;
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)&doubleValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
-                                }
-
-                                jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cDouble, doubleValueMid,
-                                                                      doubleValue);
-                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                                break;
-                            }
-                        }
-                        break;
-                    }
-                    case H5T_REFERENCE: {
-                        jboolean bb;
-                        jbyte   *barray = NULL;
-
-                        jsize byteArraySize = (jsize)vlSize;
-                        if (vlSize != (size_t)byteArraySize)
-                            H5_JNI_FATAL_ERROR(ENVONLY, "H5AreadVL: overflow of byteArraySize");
-
-                        if (NULL == (jobj = ENVPTR->NewByteArray(ENVONLY, byteArraySize)))
-                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-
-                        PIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, &bb,
-                                       "readVL reference: byte array not pinned");
-
-                        for (x = 0; x < vlSize; x++) {
-                            barray[x] = ((jbyte *)vl_elem.p)[j * vlSize + x];
-                        }
-                        if (barray)
-                            UNPIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, jobj ? 0 : JNI_ABORT);
-                        break;
-                    }
-                    default:
-                        H5_UNIMPLEMENTED(ENVONLY, "H5AreadVL: invalid class type");
-                        break;
-                }
-
-                // Add it to the list
-                ENVPTR->CallBooleanMethod(ENVONLY, jList, addMethod, jobj);
-                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-            }
-        } /* end for */
-
-        if (rawBuf)
-            HDfree(rawBuf);
-    }
-    else {
-        if ((status = H5Aread((hid_t)attr_id, (hid_t)mem_type_id, (void *)readBuf)) < 0)
-            H5_LIBRARY_ERROR(ENVONLY);
-    }
-
-done:
-    if (readBuf) {
-        if ((status >= 0) && vl_data_class) {
-            H5Treclaim(attr_id, sid, H5P_DEFAULT, readBuf);
-            if (sid >= 0)
-                H5Sclose(sid);
-        }
-
-        UNPIN_BYTE_ARRAY(ENVONLY, buf, readBuf, (status < 0) ? JNI_ABORT : 0);
-    }
+    status = Java_hdf_hdf5lib_H5_H5Aread(env, clss, attr_id, mem_type_id, (jbyteArray)buf, JNI_TRUE);
 
     return (jint)status;
 } /* end Java_hdf_hdf5lib_H5_H5AreadVL */
@@ -1314,206 +1121,9 @@ done:
 JNIEXPORT jint JNICALL
 Java_hdf_hdf5lib_H5_H5AwriteVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem_type_id, jobjectArray buf)
 {
-    H5T_class_t type_class;
-    hsize_t     dims[H5S_MAX_RANK];
-    hid_t       sid = H5I_INVALID_HID;
-    jsize       n;
-    htri_t      vl_data_class;
     herr_t      status = FAIL;
-    jboolean    writeBufIsCopy;
-    jbyteArray  writeBuf = NULL;
 
-    UNUSED(clss);
-
-    if (NULL == buf)
-        H5_NULL_ARGUMENT_ERROR(ENVONLY, "H5AwriteVL: write buffer is NULL");
-
-    /* Get size of data array */
-    if ((n = ENVPTR->GetArrayLength(ENVONLY, buf)) < 0) {
-        CHECK_JNI_EXCEPTION(ENVONLY, JNI_TRUE);
-        H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5AwriteVL: readBuf length < 0");
-    }
-
-    dims[0] = (hsize_t)n;
-    if ((sid = H5Screate_simple(1, dims, NULL)) < 0)
-        H5_LIBRARY_ERROR(ENVONLY);
-
-    if ((vl_data_class = h5str_detect_vlen(mem_type_id)) < 0)
-        H5_LIBRARY_ERROR(ENVONLY);
-
-    if ((type_class = H5Tget_class((hid_t)mem_type_id)) < 0)
-        H5_LIBRARY_ERROR(ENVONLY);
-    if (type_class == H5T_VLEN) {
-        size_t       typeSize;
-        hid_t        memb = H5I_INVALID_HID;
-        H5T_class_t  vlClass;
-        size_t       vlSize;
-        void        *rawBuf = NULL;
-        jobjectArray jList  = NULL;
-
-        size_t i, j, x;
-
-        if (!(typeSize = H5Tget_size(mem_type_id)))
-            H5_LIBRARY_ERROR(ENVONLY);
-
-        if (!(memb = H5Tget_super(mem_type_id)))
-            H5_LIBRARY_ERROR(ENVONLY);
-        if ((vlClass = H5Tget_class((hid_t)memb)) < 0)
-            H5_LIBRARY_ERROR(ENVONLY);
-        if (!(vlSize = H5Tget_size(memb)))
-            H5_LIBRARY_ERROR(ENVONLY);
-
-        if (NULL == (rawBuf = HDcalloc((size_t)n, typeSize)))
-            H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5AwriteVL: failed to allocate raw VL write buffer");
-
-        /* Cache class types */
-        /* jclass cBool   = ENVPTR->FindClass(ENVONLY, "java/lang/Boolean"); */
-        jclass cByte   = ENVPTR->FindClass(ENVONLY, "java/lang/Byte");
-        jclass cShort  = ENVPTR->FindClass(ENVONLY, "java/lang/Short");
-        jclass cInt    = ENVPTR->FindClass(ENVONLY, "java/lang/Integer");
-        jclass cLong   = ENVPTR->FindClass(ENVONLY, "java/lang/Long");
-        jclass cFloat  = ENVPTR->FindClass(ENVONLY, "java/lang/Float");
-        jclass cDouble = ENVPTR->FindClass(ENVONLY, "java/lang/Double");
-
-        /* jmethodID boolValueMid   = ENVPTR->GetMethodID(ENVONLY, cBool, "booleanValue", "()Z"); */
-        jmethodID byteValueMid   = ENVPTR->GetMethodID(ENVONLY, cByte, "byteValue", "()B");
-        jmethodID shortValueMid  = ENVPTR->GetMethodID(ENVONLY, cShort, "shortValue", "()S");
-        jmethodID intValueMid    = ENVPTR->GetMethodID(ENVONLY, cInt, "intValue", "()I");
-        jmethodID longValueMid   = ENVPTR->GetMethodID(ENVONLY, cLong, "longValue", "()J");
-        jmethodID floatValueMid  = ENVPTR->GetMethodID(ENVONLY, cFloat, "floatValue", "()F");
-        jmethodID doubleValueMid = ENVPTR->GetMethodID(ENVONLY, cDouble, "doubleValue", "()D");
-
-        /* Convert each list to a vlen element */
-        for (i = 0; i < (size_t)n; i++) {
-            hvl_t vl_elem;
-
-            if (NULL == (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)buf, (jsize)i)))
-                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-
-            // retrieve the java.util.List interface class
-            jclass cList = ENVPTR->FindClass(ENVONLY, "java/util/List");
-
-            // retrieve the toArray method and invoke it
-            jmethodID mToArray = ENVPTR->GetMethodID(ENVONLY, cList, "toArray", "()[Ljava/lang/Object;");
-            if (mToArray == NULL)
-                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-            jobjectArray array   = (jobjectArray)ENVPTR->CallObjectMethod(ENVONLY, jList, mToArray);
-            jsize        jnelmts = ENVPTR->GetArrayLength(ENVONLY, array);
-
-            if (jnelmts < 0)
-                H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5AwriteVL: number of VL elements < 0");
-
-            HDmemcpy(&vl_elem, (char *)rawBuf + i * typeSize, sizeof(hvl_t));
-            vl_elem.len = (size_t)jnelmts;
-
-            if (NULL == (vl_elem.p = HDmalloc((size_t)jnelmts * vlSize)))
-                H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5AwriteVL: failed to allocate vlen ptr buffer");
-
-            jobject jobj = NULL;
-            for (j = 0; j < (size_t)jnelmts; j++) {
-                if (NULL == (jobj = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)array, (jsize)j)))
-                    CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-
-                switch (vlClass) {
-                    /* case H5T_BOOL: {
-                            jboolean boolValue = ENVPTR->CallBooleanMethod(ENVONLY, jobj, boolValueMid);
-                            for (x = 0; x < vlSize; x++) {
-                                ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&boolValue)[x];
-                            }
-                            break;
-                    } */
-                    case H5T_INTEGER: {
-                        switch (vlSize) {
-                            case sizeof(jbyte): {
-                                jbyte byteValue = ENVPTR->CallByteMethod(ENVONLY, jobj, byteValueMid);
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&byteValue)[x];
-                                }
-                                break;
-                            }
-                            case sizeof(jshort): {
-                                jshort shortValue = ENVPTR->CallShortMethod(ENVONLY, jobj, shortValueMid);
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&shortValue)[x];
-                                }
-                                break;
-                            }
-                            case sizeof(jint): {
-                                jint intValue = ENVPTR->CallIntMethod(ENVONLY, jobj, intValueMid);
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&intValue)[x];
-                                }
-                                break;
-                            }
-                            case sizeof(jlong): {
-                                jlong longValue = ENVPTR->CallLongMethod(ENVONLY, jobj, longValueMid);
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&longValue)[x];
-                                }
-                                break;
-                            }
-                        }
-                        break;
-                    }
-                    case H5T_FLOAT: {
-                        switch (vlSize) {
-                            case sizeof(jfloat): {
-                                jfloat floatValue = ENVPTR->CallFloatMethod(ENVONLY, jobj, floatValueMid);
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&floatValue)[x];
-                                }
-                                break;
-                            }
-                            case sizeof(jdouble): {
-                                jdouble doubleValue = ENVPTR->CallDoubleMethod(ENVONLY, jobj, doubleValueMid);
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&doubleValue)[x];
-                                }
-                                break;
-                            }
-                        }
-                        break;
-                    }
-                    case H5T_REFERENCE: {
-                        jbyte *barray = (jbyte *)ENVPTR->GetByteArrayElements(ENVONLY, jobj, 0);
-                        for (x = 0; x < vlSize; x++) {
-                            ((char *)vl_elem.p)[j * vlSize + x] = ((char *)barray)[x];
-                        }
-                        ENVPTR->ReleaseByteArrayElements(ENVONLY, jobj, barray, 0);
-                        break;
-                    }
-                    default:
-                        H5_UNIMPLEMENTED(ENVONLY, "H5AwriteVL: invalid class type");
-                        break;
-                }
-                ENVPTR->DeleteLocalRef(ENVONLY, jobj);
-            }
-
-            HDmemcpy((char *)rawBuf + i * typeSize, &vl_elem, sizeof(hvl_t));
-
-            ENVPTR->DeleteLocalRef(ENVONLY, jList);
-        } /* end for (i = 0; i < n; i++) */
-
-        if ((status = H5Awrite((hid_t)attr_id, (hid_t)mem_type_id, rawBuf)) < 0)
-            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-
-        if (rawBuf)
-            HDfree(rawBuf);
-    }
-    else {
-        PIN_BYTE_ARRAY(ENVONLY, buf, writeBuf, &writeBufIsCopy, "H5AwriteVL: write buffer not pinned");
-        if ((status = H5Awrite((hid_t)attr_id, (hid_t)mem_type_id, writeBuf)) < 0)
-            H5_LIBRARY_ERROR(ENVONLY);
-    }
-
-done:
-    if (writeBuf) {
-        if ((status >= 0) && vl_data_class)
-            H5Treclaim(attr_id, sid, H5P_DEFAULT, writeBuf);
-
-        if (type_class != H5T_VLEN)
-            UNPIN_BYTE_ARRAY(ENVONLY, buf, writeBuf, (status < 0) ? JNI_ABORT : 0);
-    }
+    status = Java_hdf_hdf5lib_H5_H5Awrite(env, clss, attr_id, mem_type_id, (jbyteArray)buf, JNI_TRUE);
 
     return (jint)status;
 } /* end Java_hdf_hdf5lib_H5_H5AwriteVL */

--- a/java/src/jni/h5aImp.c
+++ b/java/src/jni/h5aImp.c
@@ -209,7 +209,7 @@ Java_hdf_hdf5lib_H5_H5Aread(JNIEnv *env, jclass clss, jlong attr_id, jlong mem_t
         H5_LIBRARY_ERROR(ENVONLY);
 
     if (vl_data_class)
-        translate_rbuf(env, buf, mem_type_id, type_class, n, (jsize)typeSize, (jobjectArray)readBuf);
+        translate_rbuf(env, buf, mem_type_id, type_class, n, (jobjectArray)readBuf);
 
 done:
     if (readBuf) {
@@ -292,7 +292,7 @@ Java_hdf_hdf5lib_H5_H5Awrite(JNIEnv *env, jclass clss, jlong attr_id, jlong mem_
     }
 
     if (vl_data_class)
-        translate_wbuf(ENVONLY, buf, mem_type_id, type_class, n, (jsize)typeSize, (jobjectArray)writeBuf);
+        translate_wbuf(ENVONLY, buf, mem_type_id, type_class, n, (jobjectArray)writeBuf);
 
     if ((status = H5Awrite((hid_t)attr_id, (hid_t)mem_type_id, writeBuf)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);

--- a/java/src/jni/h5aImp.c
+++ b/java/src/jni/h5aImp.c
@@ -1106,7 +1106,7 @@ done:
 JNIEXPORT jint JNICALL
 Java_hdf_hdf5lib_H5_H5AreadVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem_type_id, jobjectArray buf)
 {
-    herr_t      status  = FAIL;
+    herr_t status  = FAIL;
 
     status = Java_hdf_hdf5lib_H5_H5Aread(env, clss, attr_id, mem_type_id, (jbyteArray)buf, JNI_TRUE);
 
@@ -1121,7 +1121,7 @@ Java_hdf_hdf5lib_H5_H5AreadVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem
 JNIEXPORT jint JNICALL
 Java_hdf_hdf5lib_H5_H5AwriteVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem_type_id, jobjectArray buf)
 {
-    herr_t      status = FAIL;
+    herr_t status = FAIL;
 
     status = Java_hdf_hdf5lib_H5_H5Awrite(env, clss, attr_id, mem_type_id, (jbyteArray)buf, JNI_TRUE);
 

--- a/java/src/jni/h5aImp.c
+++ b/java/src/jni/h5aImp.c
@@ -1106,7 +1106,7 @@ done:
 JNIEXPORT jint JNICALL
 Java_hdf_hdf5lib_H5_H5AreadVL(JNIEnv *env, jclass clss, jlong attr_id, jlong mem_type_id, jobjectArray buf)
 {
-    herr_t status  = FAIL;
+    herr_t status = FAIL;
 
     status = Java_hdf_hdf5lib_H5_H5Aread(env, clss, attr_id, mem_type_id, (jbyteArray)buf, JNI_TRUE);
 

--- a/java/src/jni/h5aImp.c
+++ b/java/src/jni/h5aImp.c
@@ -213,9 +213,9 @@ done:
             dims[0] = (hsize_t)vl_array_len;
             if ((sid = H5Screate_simple(1, dims, NULL)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
-                
+
             H5Treclaim(attr_id, sid, H5P_DEFAULT, readBuf);
-            
+
             if (sid >= 0)
                 H5Sclose(sid);
         }

--- a/java/src/jni/h5dImp.c
+++ b/java/src/jni/h5dImp.c
@@ -1131,10 +1131,10 @@ JNIEXPORT jint JNICALL
 Java_hdf_hdf5lib_H5_H5DreadVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong mem_type_id,
                               jlong mem_space_id, jlong file_space_id, jlong xfer_plist_id, jobjectArray buf)
 {
-    herr_t      status  = FAIL;
+    herr_t status = FAIL;
 
-    status = Java_hdf_hdf5lib_H5_H5Dread(env, clss, dataset_id, mem_type_id, mem_space_id,
-                                         file_space_id, xfer_plist_id, (jbyteArray)buf, JNI_TRUE);
+    status = Java_hdf_hdf5lib_H5_H5Dread(env, clss, dataset_id, mem_type_id, mem_space_id, file_space_id,
+                                         xfer_plist_id, (jbyteArray)buf, JNI_TRUE);
 
     return (jint)status;
 } /* end Java_hdf_hdf5lib_H5_H5DreadVL */
@@ -1148,10 +1148,10 @@ JNIEXPORT jint JNICALL
 Java_hdf_hdf5lib_H5_H5DwriteVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong mem_type_id,
                                jlong mem_space_id, jlong file_space_id, jlong xfer_plist_id, jobjectArray buf)
 {
-    herr_t      status = FAIL;
+    herr_t status = FAIL;
 
-    status = Java_hdf_hdf5lib_H5_H5Dwrite(env, clss, dataset_id, mem_type_id, mem_space_id,
-                                          file_space_id, xfer_plist_id, (jbyteArray)buf, JNI_TRUE);
+    status = Java_hdf_hdf5lib_H5_H5Dwrite(env, clss, dataset_id, mem_type_id, mem_space_id, file_space_id,
+                                          xfer_plist_id, (jbyteArray)buf, JNI_TRUE);
 
     return (jint)status;
 } /* end Java_hdf_hdf5lib_H5_H5DwriteVL */

--- a/java/src/jni/h5dImp.c
+++ b/java/src/jni/h5dImp.c
@@ -182,10 +182,13 @@ Java_hdf_hdf5lib_H5_H5Dread(JNIEnv *env, jclass clss, jlong dataset_id, jlong me
                             jlong file_space_id, jlong xfer_plist_id, jbyteArray buf,
                             jboolean isCriticalPinning)
 {
-    jboolean readBufIsCopy;
-    jbyte   *readBuf = NULL;
-    htri_t   vl_data_class;
-    herr_t   status = FAIL;
+    jboolean    readBufIsCopy;
+    jbyte      *readBuf = NULL;
+    size_t      typeSize;
+    H5T_class_t type_class;
+    jsize       n;
+    htri_t      vl_data_class;
+    herr_t      status = FAIL;
 
     UNUSED(clss);
 
@@ -193,7 +196,7 @@ Java_hdf_hdf5lib_H5_H5Dread(JNIEnv *env, jclass clss, jlong dataset_id, jlong me
         H5_NULL_ARGUMENT_ERROR(ENVONLY, "H5Dread: read buffer is NULL");
 
     /* Get size of data array */
-    if (ENVPTR->GetArrayLength(ENVONLY, buf) < 0) {
+    if ((n = ENVPTR->GetArrayLength(ENVONLY, buf)) < 0) {
         CHECK_JNI_EXCEPTION(ENVONLY, JNI_TRUE);
         H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5Dread: readBuf length < 0");
     }
@@ -201,28 +204,47 @@ Java_hdf_hdf5lib_H5_H5Dread(JNIEnv *env, jclass clss, jlong dataset_id, jlong me
     if ((vl_data_class = h5str_detect_vlen(mem_type_id)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
 
-    if (isCriticalPinning) {
-        PIN_BYTE_ARRAY_CRITICAL(ENVONLY, buf, readBuf, &readBufIsCopy,
-                                "H5Dread: read buffer not critically pinned");
+    if (!(typeSize = H5Tget_size(mem_type_id)))
+        H5_LIBRARY_ERROR(ENVONLY);
+
+    if ((type_class = H5Tget_class((hid_t)mem_type_id)) < 0)
+        H5_LIBRARY_ERROR(ENVONLY);
+    if (vl_data_class) {
+        if (NULL == (readBuf = HDcalloc((size_t)n, typeSize)))
+            H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5Dread: failed to allocate raw VL read buffer");
     }
     else {
-        PIN_BYTE_ARRAY(ENVONLY, buf, readBuf, &readBufIsCopy, "H5Dread: read buffer not pinned");
+        if (isCriticalPinning) {
+            PIN_BYTE_ARRAY_CRITICAL(ENVONLY, buf, readBuf, &readBufIsCopy,
+                                    "H5Dread: read buffer not critically pinned");
+        }
+        else {
+            PIN_BYTE_ARRAY(ENVONLY, buf, readBuf, &readBufIsCopy, "H5Dread: read buffer not pinned");
+        }
     }
 
     if ((status = H5Dread((hid_t)dataset_id, (hid_t)mem_type_id, (hid_t)mem_space_id, (hid_t)file_space_id,
-                          (hid_t)xfer_plist_id, readBuf)) < 0)
+                          (hid_t)xfer_plist_id, (void *)readBuf)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
+
+    if (vl_data_class)
+        translate_rbuf(env, buf, mem_type_id, type_class, n, (jsize)typeSize, (jobjectArray)readBuf);
 
 done:
     if (readBuf) {
         if ((status >= 0) && vl_data_class)
             H5Treclaim(dataset_id, mem_space_id, H5P_DEFAULT, readBuf);
 
-        if (isCriticalPinning) {
-            UNPIN_ARRAY_CRITICAL(ENVONLY, buf, readBuf, (status < 0) ? JNI_ABORT : 0);
+        if (vl_data_class) {
+            HDfree(readBuf);
         }
         else {
-            UNPIN_BYTE_ARRAY(ENVONLY, buf, readBuf, (status < 0) ? JNI_ABORT : 0);
+            if (isCriticalPinning) {
+                UNPIN_ARRAY_CRITICAL(ENVONLY, buf, readBuf, (status < 0) ? JNI_ABORT : 0);
+            }
+            else {
+                UNPIN_BYTE_ARRAY(ENVONLY, buf, readBuf, (status < 0) ? JNI_ABORT : 0);
+            }
         }
     }
 
@@ -239,10 +261,13 @@ Java_hdf_hdf5lib_H5_H5Dwrite(JNIEnv *env, jclass clss, jlong dataset_id, jlong m
                              jlong mem_space_id, jlong file_space_id, jlong xfer_plist_id, jbyteArray buf,
                              jboolean isCriticalPinning)
 {
-    jboolean writeBufIsCopy;
-    jbyte   *writeBuf = NULL;
-    htri_t   vl_data_class;
-    herr_t   status = FAIL;
+    jboolean    writeBufIsCopy;
+    jbyte      *writeBuf = NULL;
+    size_t      typeSize;
+    H5T_class_t type_class;
+    jsize       n;
+    htri_t      vl_data_class;
+    herr_t      status = FAIL;
 
     UNUSED(clss);
 
@@ -250,21 +275,35 @@ Java_hdf_hdf5lib_H5_H5Dwrite(JNIEnv *env, jclass clss, jlong dataset_id, jlong m
         H5_NULL_ARGUMENT_ERROR(ENVONLY, "H5Dwrite: write buffer is NULL");
 
     /* Get size of data array */
-    if (ENVPTR->GetArrayLength(ENVONLY, buf) < 0) {
+    if ((n = ENVPTR->GetArrayLength(ENVONLY, buf)) < 0) {
         CHECK_JNI_EXCEPTION(ENVONLY, JNI_TRUE);
-        H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5Dread: readBuf length < 0");
+        H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5Dwrite: write buffer length < 0");
     }
 
     if ((vl_data_class = h5str_detect_vlen(mem_type_id)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
 
-    if (isCriticalPinning) {
-        PIN_BYTE_ARRAY_CRITICAL(ENVONLY, buf, writeBuf, &writeBufIsCopy,
-                                "H5Dwrite: write buffer not critically pinned");
+    if (!(typeSize = H5Tget_size(mem_type_id)))
+        H5_LIBRARY_ERROR(ENVONLY);
+
+    if ((type_class = H5Tget_class((hid_t)mem_type_id)) < 0)
+        H5_LIBRARY_ERROR(ENVONLY);
+    if (vl_data_class) {
+        if (NULL == (writeBuf = HDcalloc((size_t)n, typeSize)))
+            H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5Dwrite: failed to allocate raw VL write buffer");
     }
     else {
-        PIN_BYTE_ARRAY(ENVONLY, buf, writeBuf, &writeBufIsCopy, "H5Dwrite: write buffer not pinned");
+        if (isCriticalPinning) {
+            PIN_BYTE_ARRAY_CRITICAL(ENVONLY, buf, writeBuf, &writeBufIsCopy,
+                                    "H5Dwrite: write buffer not critically pinned");
+        }
+        else {
+            PIN_BYTE_ARRAY(ENVONLY, buf, writeBuf, &writeBufIsCopy, "H5Dwrite: write buffer not pinned");
+        }
     }
+
+    if (vl_data_class)
+        translate_wbuf(ENVONLY, buf, mem_type_id, type_class, n, (jsize)typeSize, (jobjectArray)writeBuf);
 
     if ((status = H5Dwrite((hid_t)dataset_id, (hid_t)mem_type_id, (hid_t)mem_space_id, (hid_t)file_space_id,
                            (hid_t)xfer_plist_id, writeBuf)) < 0)
@@ -275,11 +314,16 @@ done:
         if ((status >= 0) && vl_data_class)
             H5Treclaim(dataset_id, mem_space_id, H5P_DEFAULT, writeBuf);
 
-        if (isCriticalPinning) {
-            UNPIN_ARRAY_CRITICAL(ENVONLY, buf, writeBuf, (status < 0) ? JNI_ABORT : 0);
+        if (vl_data_class) {
+            HDfree(writeBuf);
         }
         else {
-            UNPIN_BYTE_ARRAY(ENVONLY, buf, writeBuf, (status < 0) ? JNI_ABORT : 0);
+            if (isCriticalPinning) {
+                UNPIN_ARRAY_CRITICAL(ENVONLY, buf, writeBuf, (status < 0) ? JNI_ABORT : 0);
+            }
+            else {
+                UNPIN_BYTE_ARRAY(ENVONLY, buf, writeBuf, (status < 0) ? JNI_ABORT : 0);
+            }
         }
     }
 
@@ -1087,235 +1131,10 @@ JNIEXPORT jint JNICALL
 Java_hdf_hdf5lib_H5_H5DreadVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong mem_type_id,
                               jlong mem_space_id, jlong file_space_id, jlong xfer_plist_id, jobjectArray buf)
 {
-    H5T_class_t type_class;
-    jsize       n;
-    htri_t      vl_data_class;
     herr_t      status  = FAIL;
-    jbyteArray *readBuf = NULL;
 
-    UNUSED(clss);
-
-    if (NULL == buf)
-        H5_NULL_ARGUMENT_ERROR(ENVONLY, "H5DreadVL: read buffer is NULL");
-
-    /* Get size of data array */
-    if ((n = ENVPTR->GetArrayLength(ENVONLY, buf)) < 0) {
-        CHECK_JNI_EXCEPTION(ENVONLY, JNI_TRUE);
-        H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5DreadVL: readBuf length < 0");
-    }
-
-    if ((vl_data_class = h5str_detect_vlen(mem_type_id)) < 0)
-        H5_LIBRARY_ERROR(ENVONLY);
-
-    if ((type_class = H5Tget_class((hid_t)mem_type_id)) < 0)
-        H5_LIBRARY_ERROR(ENVONLY);
-    if (type_class == H5T_VLEN) {
-        size_t       typeSize;
-        hid_t        memb = H5I_INVALID_HID;
-        H5T_class_t  vlClass;
-        size_t       vlSize;
-        void        *rawBuf = NULL;
-        jobjectArray jList  = NULL;
-
-        size_t i, j, x;
-
-        if (!(typeSize = H5Tget_size(mem_type_id)))
-            H5_LIBRARY_ERROR(ENVONLY);
-
-        if (!(memb = H5Tget_super(mem_type_id)))
-            H5_LIBRARY_ERROR(ENVONLY);
-        if ((vlClass = H5Tget_class((hid_t)memb)) < 0)
-            H5_LIBRARY_ERROR(ENVONLY);
-        if (!(vlSize = H5Tget_size(memb)))
-            H5_LIBRARY_ERROR(ENVONLY);
-
-        if (NULL == (rawBuf = HDcalloc((size_t)n, typeSize)))
-            H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5DreadVL: failed to allocate raw VL read buffer");
-
-        if ((status = H5Dread((hid_t)dataset_id, (hid_t)mem_type_id, (hid_t)mem_space_id,
-                              (hid_t)file_space_id, (hid_t)xfer_plist_id, (void *)rawBuf)) < 0)
-            H5_LIBRARY_ERROR(ENVONLY);
-
-        /* Cache class types */
-        /* jclass cBool   = ENVPTR->FindClass(ENVONLY, "java/lang/Boolean"); */
-        jclass cByte   = ENVPTR->FindClass(ENVONLY, "java/lang/Byte");
-        jclass cShort  = ENVPTR->FindClass(ENVONLY, "java/lang/Short");
-        jclass cInt    = ENVPTR->FindClass(ENVONLY, "java/lang/Integer");
-        jclass cLong   = ENVPTR->FindClass(ENVONLY, "java/lang/Long");
-        jclass cFloat  = ENVPTR->FindClass(ENVONLY, "java/lang/Float");
-        jclass cDouble = ENVPTR->FindClass(ENVONLY, "java/lang/Double");
-
-        /*
-        jmethodID boolValueMid =
-            ENVPTR->GetStaticMethodID(ENVONLY, cBool, "valueOf", "(Z)Ljava/lang/Boolean;");
-        */
-        jmethodID byteValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cByte, "valueOf", "(B)Ljava/lang/Byte;");
-        jmethodID shortValueMid =
-            ENVPTR->GetStaticMethodID(ENVONLY, cShort, "valueOf", "(S)Ljava/lang/Short;");
-        jmethodID intValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cInt, "valueOf", "(I)Ljava/lang/Integer;");
-        jmethodID longValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cLong, "valueOf", "(J)Ljava/lang/Long;");
-        jmethodID floatValueMid =
-            ENVPTR->GetStaticMethodID(ENVONLY, cFloat, "valueOf", "(F)Ljava/lang/Float;");
-        jmethodID doubleValueMid =
-            ENVPTR->GetStaticMethodID(ENVONLY, cDouble, "valueOf", "(D)Ljava/lang/Double;");
-
-        // retrieve the java.util.List interface class
-        jclass    cList     = ENVPTR->FindClass(ENVONLY, "java/util/List");
-        jmethodID addMethod = ENVPTR->GetMethodID(ENVONLY, cList, "add", "(Ljava/lang/Object;)Z");
-
-        /* Convert each element to a list */
-        for (i = 0; i < (size_t)n; i++) {
-            hvl_t vl_elem;
-
-            // The list we're going to return:
-            if (NULL == (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)buf, (jsize)i)))
-                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-
-            /* Get the number of sequence elements */
-            HDmemcpy(&vl_elem, (char *)rawBuf + i * typeSize, sizeof(hvl_t));
-
-            jsize nelmts = (jsize)vl_elem.len;
-            if (vl_elem.len != (size_t)nelmts)
-                H5_JNI_FATAL_ERROR(ENVONLY, "H5DreadVL: overflow of number of VL elements");
-            if (nelmts < 0)
-                H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5DreadVL: number of VL elements < 0");
-
-            jobject jobj = NULL;
-            for (j = 0; j < (size_t)nelmts; j++) {
-                switch (vlClass) {
-                    /*case H5T_BOOL: {
-                        jboolean boolValue;
-                        for (x = 0; x < vlSize; x++) {
-                            ((char *)&boolValue)[x] = ((char *)vl_elem.p)[j*vlSize+x];
-                        }
-
-                        jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cBool, boolValueMid, boolValue);
-                        CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                        break;
-                    } */
-                    case H5T_INTEGER: {
-                        switch (vlSize) {
-                            case sizeof(jbyte): {
-                                jbyte byteValue;
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)&byteValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
-                                }
-
-                                jobj =
-                                    ENVPTR->CallStaticObjectMethod(ENVONLY, cByte, byteValueMid, byteValue);
-                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                                break;
-                            }
-                            case sizeof(jshort): {
-                                jshort shortValue;
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)&shortValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
-                                }
-
-                                jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cShort, shortValueMid,
-                                                                      shortValue);
-                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                                break;
-                            }
-                            case sizeof(jint): {
-                                jint intValue;
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)&intValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
-                                }
-
-                                jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cInt, intValueMid, intValue);
-                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                                break;
-                            }
-                            case sizeof(jlong): {
-                                jlong longValue;
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)&longValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
-                                }
-
-                                jobj =
-                                    ENVPTR->CallStaticObjectMethod(ENVONLY, cLong, longValueMid, longValue);
-                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                                break;
-                            }
-                        }
-                        break;
-                    }
-                    case H5T_FLOAT: {
-                        switch (vlSize) {
-                            case sizeof(jfloat): {
-                                jfloat floatValue;
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)&floatValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
-                                }
-
-                                jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cFloat, floatValueMid,
-                                                                      (double)floatValue);
-                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                                break;
-                            }
-                            case sizeof(jdouble): {
-                                jdouble doubleValue;
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)&doubleValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
-                                }
-
-                                jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cDouble, doubleValueMid,
-                                                                      doubleValue);
-                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                                break;
-                            }
-                        }
-                        break;
-                    }
-                    case H5T_REFERENCE: {
-                        jboolean bb;
-                        jbyte   *barray = NULL;
-
-                        jsize byteArraySize = (jsize)vlSize;
-                        if (vlSize != (size_t)byteArraySize)
-                            H5_JNI_FATAL_ERROR(ENVONLY, "H5DreadVL: overflow of byteArraySize");
-
-                        if (NULL == (jobj = ENVPTR->NewByteArray(ENVONLY, byteArraySize)))
-                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-
-                        PIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, &bb,
-                                       "readVL reference: byte array not pinned");
-
-                        for (x = 0; x < vlSize; x++) {
-                            barray[x] = ((jbyte *)vl_elem.p)[j * vlSize + x];
-                        }
-                        if (barray)
-                            UNPIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, jobj ? 0 : JNI_ABORT);
-                        break;
-                    }
-                    default:
-                        H5_UNIMPLEMENTED(ENVONLY, "H5DreadVL: invalid class type");
-                        break;
-                }
-
-                // Add it to the list
-                ENVPTR->CallBooleanMethod(ENVONLY, jList, addMethod, jobj);
-                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-            }
-        } /* end for */
-
-        if (rawBuf)
-            HDfree(rawBuf);
-    }
-    else {
-        if ((status = H5Dread((hid_t)dataset_id, (hid_t)mem_type_id, (hid_t)mem_space_id,
-                              (hid_t)file_space_id, (hid_t)xfer_plist_id, (void *)readBuf)) < 0)
-            H5_LIBRARY_ERROR(ENVONLY);
-    }
-
-done:
-    if (readBuf) {
-        if ((status >= 0) && vl_data_class)
-            H5Treclaim(dataset_id, mem_space_id, H5P_DEFAULT, readBuf);
-
-        UNPIN_BYTE_ARRAY(ENVONLY, buf, readBuf, (status < 0) ? JNI_ABORT : 0);
-    }
+    status = Java_hdf_hdf5lib_H5_H5Dread(env, clss, dataset_id, mem_type_id, mem_space_id,
+                                         file_space_id, xfer_plist_id, (jbyteArray)buf, JNI_TRUE);
 
     return (jint)status;
 } /* end Java_hdf_hdf5lib_H5_H5DreadVL */
@@ -1329,202 +1148,10 @@ JNIEXPORT jint JNICALL
 Java_hdf_hdf5lib_H5_H5DwriteVL(JNIEnv *env, jclass clss, jlong dataset_id, jlong mem_type_id,
                                jlong mem_space_id, jlong file_space_id, jlong xfer_plist_id, jobjectArray buf)
 {
-    H5T_class_t type_class;
-    jsize       n;
-    htri_t      vl_data_class;
     herr_t      status = FAIL;
-    jboolean    writeBufIsCopy;
-    jbyteArray  writeBuf = NULL;
 
-    UNUSED(clss);
-
-    if (NULL == buf)
-        H5_NULL_ARGUMENT_ERROR(ENVONLY, "H5DwriteVL: write buffer is NULL");
-
-    /* Get size of data array */
-    if ((n = ENVPTR->GetArrayLength(ENVONLY, buf)) < 0) {
-        CHECK_JNI_EXCEPTION(ENVONLY, JNI_TRUE);
-        H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5DwriteVL: readBuf length < 0");
-    }
-
-    if ((vl_data_class = h5str_detect_vlen(mem_type_id)) < 0)
-        H5_LIBRARY_ERROR(ENVONLY);
-
-    if ((type_class = H5Tget_class((hid_t)mem_type_id)) < 0)
-        H5_LIBRARY_ERROR(ENVONLY);
-    if (type_class == H5T_VLEN) {
-        size_t       typeSize;
-        hid_t        memb = H5I_INVALID_HID;
-        H5T_class_t  vlClass;
-        size_t       vlSize;
-        void        *rawBuf = NULL;
-        jobjectArray jList  = NULL;
-
-        size_t i, j, x;
-
-        if (!(typeSize = H5Tget_size(mem_type_id)))
-            H5_LIBRARY_ERROR(ENVONLY);
-
-        if (!(memb = H5Tget_super(mem_type_id)))
-            H5_LIBRARY_ERROR(ENVONLY);
-        if ((vlClass = H5Tget_class((hid_t)memb)) < 0)
-            H5_LIBRARY_ERROR(ENVONLY);
-        if (!(vlSize = H5Tget_size(memb)))
-            H5_LIBRARY_ERROR(ENVONLY);
-
-        if (NULL == (rawBuf = HDcalloc((size_t)n, typeSize)))
-            H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5DwriteVL: failed to allocate raw VL write buffer");
-
-        /* Cache class types */
-        /* jclass cBool   = ENVPTR->FindClass(ENVONLY, "java/lang/Boolean"); */
-        jclass cByte   = ENVPTR->FindClass(ENVONLY, "java/lang/Byte");
-        jclass cShort  = ENVPTR->FindClass(ENVONLY, "java/lang/Short");
-        jclass cInt    = ENVPTR->FindClass(ENVONLY, "java/lang/Integer");
-        jclass cLong   = ENVPTR->FindClass(ENVONLY, "java/lang/Long");
-        jclass cFloat  = ENVPTR->FindClass(ENVONLY, "java/lang/Float");
-        jclass cDouble = ENVPTR->FindClass(ENVONLY, "java/lang/Double");
-
-        /* jmethodID boolValueMid   = ENVPTR->GetMethodID(ENVONLY, cBool, "booleanValue", "()Z"); */
-        jmethodID byteValueMid   = ENVPTR->GetMethodID(ENVONLY, cByte, "byteValue", "()B");
-        jmethodID shortValueMid  = ENVPTR->GetMethodID(ENVONLY, cShort, "shortValue", "()S");
-        jmethodID intValueMid    = ENVPTR->GetMethodID(ENVONLY, cInt, "intValue", "()I");
-        jmethodID longValueMid   = ENVPTR->GetMethodID(ENVONLY, cLong, "longValue", "()J");
-        jmethodID floatValueMid  = ENVPTR->GetMethodID(ENVONLY, cFloat, "floatValue", "()F");
-        jmethodID doubleValueMid = ENVPTR->GetMethodID(ENVONLY, cDouble, "doubleValue", "()D");
-
-        /* Convert each list to a vlen element */
-        for (i = 0; i < (size_t)n; i++) {
-            hvl_t vl_elem;
-
-            if (NULL == (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)buf, (jsize)i)))
-                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-
-            // retrieve the java.util.List interface class
-            jclass cList = ENVPTR->FindClass(ENVONLY, "java/util/List");
-
-            // retrieve the toArray method and invoke it
-            jmethodID mToArray = ENVPTR->GetMethodID(ENVONLY, cList, "toArray", "()[Ljava/lang/Object;");
-            if (mToArray == NULL)
-                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-            jobjectArray array   = (jobjectArray)ENVPTR->CallObjectMethod(ENVONLY, jList, mToArray);
-            jsize        jnelmts = ENVPTR->GetArrayLength(ENVONLY, array);
-
-            if (jnelmts < 0)
-                H5_BAD_ARGUMENT_ERROR(ENVONLY, "H5DwriteVL: number of VL elements < 0");
-
-            HDmemcpy(&vl_elem, (char *)rawBuf + i * typeSize, sizeof(hvl_t));
-            vl_elem.len = (size_t)jnelmts;
-
-            if (NULL == (vl_elem.p = HDmalloc((size_t)jnelmts * vlSize)))
-                H5_OUT_OF_MEMORY_ERROR(ENVONLY, "H5DwriteVL: failed to allocate vlen ptr buffer");
-
-            jobject jobj = NULL;
-            for (j = 0; j < (size_t)jnelmts; j++) {
-                if (NULL == (jobj = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)array, (jsize)j)))
-                    CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-
-                switch (vlClass) {
-                    /* case H5T_BOOL: {
-                            jboolean boolValue = ENVPTR->CallBooleanMethod(ENVONLY, jobj, boolValueMid);
-                            for (x = 0; x < vlSize; x++) {
-                                ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&boolValue)[x];
-                            }
-                            break;
-                    } */
-                    case H5T_INTEGER: {
-                        switch (vlSize) {
-                            case sizeof(jbyte): {
-                                jbyte byteValue = ENVPTR->CallByteMethod(ENVONLY, jobj, byteValueMid);
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&byteValue)[x];
-                                }
-                                break;
-                            }
-                            case sizeof(jshort): {
-                                jshort shortValue = ENVPTR->CallShortMethod(ENVONLY, jobj, shortValueMid);
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&shortValue)[x];
-                                }
-                                break;
-                            }
-                            case sizeof(jint): {
-                                jint intValue = ENVPTR->CallIntMethod(ENVONLY, jobj, intValueMid);
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&intValue)[x];
-                                }
-                                break;
-                            }
-                            case sizeof(jlong): {
-                                jlong longValue = ENVPTR->CallLongMethod(ENVONLY, jobj, longValueMid);
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&longValue)[x];
-                                }
-                                break;
-                            }
-                        }
-                        break;
-                    }
-                    case H5T_FLOAT: {
-                        switch (vlSize) {
-                            case sizeof(jfloat): {
-                                jfloat floatValue = ENVPTR->CallFloatMethod(ENVONLY, jobj, floatValueMid);
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&floatValue)[x];
-                                }
-                                break;
-                            }
-                            case sizeof(jdouble): {
-                                jdouble doubleValue = ENVPTR->CallDoubleMethod(ENVONLY, jobj, doubleValueMid);
-                                for (x = 0; x < vlSize; x++) {
-                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&doubleValue)[x];
-                                }
-                                break;
-                            }
-                        }
-                        break;
-                    }
-                    case H5T_REFERENCE: {
-                        jbyte *barray = (jbyte *)ENVPTR->GetByteArrayElements(ENVONLY, jobj, 0);
-                        for (x = 0; x < vlSize; x++) {
-                            ((char *)vl_elem.p)[j * vlSize + x] = ((char *)barray)[x];
-                        }
-                        ENVPTR->ReleaseByteArrayElements(ENVONLY, jobj, barray, 0);
-                        break;
-                    }
-                    default:
-                        H5_UNIMPLEMENTED(ENVONLY, "H5DwriteVL: invalid class type");
-                        break;
-                }
-                ENVPTR->DeleteLocalRef(ENVONLY, jobj);
-            }
-
-            HDmemcpy((char *)rawBuf + i * typeSize, &vl_elem, sizeof(hvl_t));
-
-            ENVPTR->DeleteLocalRef(ENVONLY, jList);
-        } /* end for (i = 0; i < n; i++) */
-
-        if ((status = H5Dwrite((hid_t)dataset_id, (hid_t)mem_type_id, (hid_t)mem_space_id,
-                               (hid_t)file_space_id, (hid_t)xfer_plist_id, rawBuf)) < 0)
-            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-
-        if (rawBuf)
-            HDfree(rawBuf);
-    }
-    else {
-        PIN_BYTE_ARRAY(ENVONLY, buf, writeBuf, &writeBufIsCopy, "H5DwriteVL: write buffer not pinned");
-        if ((status = H5Dwrite((hid_t)dataset_id, (hid_t)mem_type_id, (hid_t)mem_space_id,
-                               (hid_t)file_space_id, (hid_t)xfer_plist_id, writeBuf)) < 0)
-            H5_LIBRARY_ERROR(ENVONLY);
-    }
-
-done:
-    if (writeBuf) {
-        if ((status >= 0) && vl_data_class)
-            H5Treclaim(dataset_id, mem_space_id, H5P_DEFAULT, writeBuf);
-
-        if (type_class != H5T_VLEN)
-            UNPIN_BYTE_ARRAY(ENVONLY, buf, writeBuf, (status < 0) ? JNI_ABORT : 0);
-    }
+    status = Java_hdf_hdf5lib_H5_H5Dwrite(env, clss, dataset_id, mem_type_id, mem_space_id,
+                                          file_space_id, xfer_plist_id, (jbyteArray)buf, JNI_TRUE);
 
     return (jint)status;
 } /* end Java_hdf_hdf5lib_H5_H5DwriteVL */

--- a/java/src/jni/h5dImp.c
+++ b/java/src/jni/h5dImp.c
@@ -228,7 +228,7 @@ Java_hdf_hdf5lib_H5_H5Dread(JNIEnv *env, jclass clss, jlong dataset_id, jlong me
         H5_LIBRARY_ERROR(ENVONLY);
 
     if (vl_data_class)
-        translate_rbuf(env, buf, mem_type_id, type_class, n, (jsize)typeSize, (jobjectArray)readBuf);
+        translate_rbuf(env, buf, mem_type_id, type_class, n, (jobjectArray)readBuf);
 
 done:
     if (readBuf) {
@@ -303,7 +303,7 @@ Java_hdf_hdf5lib_H5_H5Dwrite(JNIEnv *env, jclass clss, jlong dataset_id, jlong m
     }
 
     if (vl_data_class)
-        translate_wbuf(ENVONLY, buf, mem_type_id, type_class, n, (jsize)typeSize, (jobjectArray)writeBuf);
+        translate_wbuf(ENVONLY, buf, mem_type_id, type_class, n, (jobjectArray)writeBuf);
 
     if ((status = H5Dwrite((hid_t)dataset_id, (hid_t)mem_type_id, (hid_t)mem_space_id, (hid_t)file_space_id,
                            (hid_t)xfer_plist_id, writeBuf)) < 0)

--- a/java/src/jni/h5fImp.c
+++ b/java/src/jni/h5fImp.c
@@ -742,7 +742,7 @@ Java_hdf_hdf5lib_H5_H5Fset_1dset_1no_1attrs_1hint(JNIEnv *env, jclass clss, jlon
 
 done:
     return;
-}
+} /* end Java_hdf_hdf5lib_H5_H5Fset_1dset_1no_1attrs_1hint */
 
 /*
  * Class:     hdf_hdf5lib_H5
@@ -765,7 +765,7 @@ Java_hdf_hdf5lib_H5_H5Fget_1dset_1no_1attrs_1hint(JNIEnv *env, jclass clss, jlon
 
 done:
     return bval;
-}
+} /* end Java_hdf_hdf5lib_H5_H5Fget_1dset_1no_1attrs_1hint */
 
 /*
  * Class:     hdf_hdf5lib_H5

--- a/java/src/jni/h5tImp.c
+++ b/java/src/jni/h5tImp.c
@@ -1688,7 +1688,7 @@ Java_hdf_hdf5lib_H5_H5Tflush(JNIEnv *env, jclass clss, jlong loc_id)
 
 done:
     return;
-}
+} /* end Java_hdf_hdf5lib_H5_H5Tflush */
 
 /*
  * Class:     hdf_hdf5lib_H5
@@ -1705,7 +1705,7 @@ Java_hdf_hdf5lib_H5_H5Trefresh(JNIEnv *env, jclass clss, jlong loc_id)
 
 done:
     return;
-}
+} /* end Java_hdf_hdf5lib_H5_H5Trefresh */
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/java/src/jni/h5util.c
+++ b/java/src/jni/h5util.c
@@ -4044,37 +4044,41 @@ done:
 } /* end Java_hdf_hdf5lib_H5_H5export_1attribute */
 
 
-herr_t translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t type_class, jsize count, jobjectArray raw_buf) {
-    herr_t       status  = FAIL;
-    hid_t        memb    = H5I_INVALID_HID;
+herr_t
+translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t type_class, jsize count,
+               jobjectArray raw_buf)
+{
+    herr_t       status = FAIL;
+    hid_t        memb   = H5I_INVALID_HID;
     H5T_class_t  vlClass;
     size_t       vlSize;
     jobjectArray jList = NULL;
     size_t       i, j, x;
 
     /* retrieve the java.util.ArrayList interface class */
-    jclass arrCList = ENVPTR->FindClass(ENVONLY, "java/util/ArrayList");
+    jclass arrCList         = ENVPTR->FindClass(ENVONLY, "java/util/ArrayList");
     jmethodID arrListMethod = ENVPTR->GetMethodID(ENVONLY, arrCList, "<init>", "(I)V");
-    jmethodID arrAddMethod = ENVPTR->GetMethodID(ENVONLY, arrCList, "add", "(Ljava/lang/Object;)Z");
+    jmethodID arrAddMethod  = ENVPTR->GetMethodID(ENVONLY, arrCList, "add", "(Ljava/lang/Object;)Z");
 
     /* Cache class types */
     /* jclass cBool   = ENVPTR->FindClass(ENVONLY, "java/lang/Boolean"); */
-    jclass cByte = ENVPTR->FindClass(ENVONLY, "java/lang/Byte");
-    jclass cShort = ENVPTR->FindClass(ENVONLY, "java/lang/Short");
-    jclass cInt = ENVPTR->FindClass(ENVONLY, "java/lang/Integer");
-    jclass cLong = ENVPTR->FindClass(ENVONLY, "java/lang/Long");
-    jclass cFloat = ENVPTR->FindClass(ENVONLY, "java/lang/Float");
+    jclass cByte   = ENVPTR->FindClass(ENVONLY, "java/lang/Byte");
+    jclass cShort  = ENVPTR->FindClass(ENVONLY, "java/lang/Short");
+    jclass cInt    = ENVPTR->FindClass(ENVONLY, "java/lang/Integer");
+    jclass cLong   = ENVPTR->FindClass(ENVONLY, "java/lang/Long");
+    jclass cFloat  = ENVPTR->FindClass(ENVONLY, "java/lang/Float");
     jclass cDouble = ENVPTR->FindClass(ENVONLY, "java/lang/Double");
     /*
      jmethodID boolValueMid =
      ENVPTR->GetStaticMethodID(ENVONLY, cBool, "valueOf", "(Z)Ljava/lang/Boolean;");
      */
-    jmethodID byteValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cByte, "valueOf", "(B)Ljava/lang/Byte;");
-    jmethodID shortValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cShort, "valueOf", "(S)Ljava/lang/Short;");
-    jmethodID intValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cInt, "valueOf", "(I)Ljava/lang/Integer;");
-    jmethodID longValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cLong, "valueOf", "(J)Ljava/lang/Long;");
-    jmethodID floatValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cFloat, "valueOf", "(F)Ljava/lang/Float;");
-    jmethodID doubleValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cDouble, "valueOf", "(D)Ljava/lang/Double;");
+    jmethodID byteValueMid   = ENVPTR->GetStaticMethodID(ENVONLY, cByte, "valueOf", "(B)Ljava/lang/Byte;");
+    jmethodID shortValueMid  = ENVPTR->GetStaticMethodID(ENVONLY, cShort, "valueOf", "(S)Ljava/lang/Short;");
+    jmethodID intValueMid    = ENVPTR->GetStaticMethodID(ENVONLY, cInt, "valueOf", "(I)Ljava/lang/Integer;");
+    jmethodID longValueMid   = ENVPTR->GetStaticMethodID(ENVONLY, cLong, "valueOf", "(J)Ljava/lang/Long;");
+    jmethodID floatValueMid  = ENVPTR->GetStaticMethodID(ENVONLY, cFloat, "valueOf", "(F)Ljava/lang/Float;");
+    jmethodID doubleValueMid =
+        ENVPTR->GetStaticMethodID(ENVONLY, cDouble, "valueOf", "(D)Ljava/lang/Double;");
 
     if (type_class == H5T_VLEN) {
         if (!(memb = H5Tget_super(mem_type_id)))
@@ -4085,14 +4089,14 @@ herr_t translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_
             H5_LIBRARY_ERROR(ENVONLY);
 
         /* Convert each element to a list */
-        for (i = 0; i < (size_t) count; i++) {
-            hvl_t vl_elem;
+        for (i = 0; i < (size_t)count; i++) {
+            hvl_t    vl_elem;
             jboolean found_jList = JNI_TRUE;
 
             /* Get the number of sequence elements */
-            HDmemcpy(&vl_elem, (char* )raw_buf + i * sizeof(hvl_t), sizeof(hvl_t));
-            jsize nelmts = (jsize) vl_elem.len;
-            if (vl_elem.len != (size_t) nelmts)
+            HDmemcpy(&vl_elem, (char *)raw_buf + i * sizeof(hvl_t), sizeof(hvl_t));
+            jsize nelmts = (jsize)vl_elem.len;
+            if (vl_elem.len != (size_t)nelmts)
                 H5_JNI_FATAL_ERROR(ENVONLY, "translate_rbuf: overflow of number of VL elements");
 
             if (nelmts < 0)
@@ -4109,104 +4113,110 @@ herr_t translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_
                 translate_rbuf(ENVONLY, jList, memb, vlClass, (jsize)nelmts, vl_elem.p);
             else {
                 jobject jobj = NULL;
-                for (j = 0; j < (size_t) nelmts; j++) {
+                for (j = 0; j < (size_t)nelmts; j++) {
                     switch (vlClass) {
-                    /*case H5T_BOOL: {
-                     jboolean boolValue;
-                     for (x = 0; x < vlSize; x++) {
-                     ((char *)&boolValue)[x] = ((char *)vl_elem.p)[j*vlSize+x];
-                     }
+                        /*case H5T_BOOL: {
+                         jboolean boolValue;
+                         for (x = 0; x < vlSize; x++) {
+                         ((char *)&boolValue)[x] = ((char *)vl_elem.p)[j*vlSize+x];
+                         }
 
-                     jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cBool, boolValueMid, boolValue);
-                     CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                     break;
-                     } */
-                    case H5T_INTEGER: {
-                        switch (vlSize) {
-                        case sizeof(jbyte): {
-                            jbyte byteValue;
-                            for (x = 0; x < vlSize; x++) {
-                                ((char*) &byteValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                         jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cBool, boolValueMid, boolValue);
+                         CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                         break;
+                         } */
+                        case H5T_INTEGER: {
+                            switch (vlSize) {
+                                case sizeof(jbyte): {
+                                    jbyte byteValue;
+                                    for (x = 0; x < vlSize; x++) {
+                                        ((char*) &byteValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                                    }
+                                    jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cByte, byteValueMid,
+                                                                          byteValue);
+                                    CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                                    break;
+                                }
+                                case sizeof(jshort): {
+                                    jshort shortValue;
+                                    for (x = 0; x < vlSize; x++) {
+                                        ((char*) &shortValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                                    }
+                                    jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cShort, shortValueMid,
+                                                                          shortValue);
+                                    CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                                    break;
+                                }
+                                case sizeof(jint): {
+                                    jint intValue;
+                                    for (x = 0; x < vlSize; x++) {
+                                        ((char*) &intValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                                    }
+                                    jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cInt, intValueMid, intValue);
+                                    CHECK_JNI_EXCEPTION(ENVONLY, JNI_TRUE);
+                                    break;
+                                }
+                                case sizeof(jlong): {
+                                    jlong longValue;
+                                    for (x = 0; x < vlSize; x++) {
+                                        ((char*) &longValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                                    }
+                                    jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cLong, longValueMid,
+                                                                          longValue);
+                                    CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                                    break;
+                                }
                             }
-                            jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cByte, byteValueMid, byteValue);
-                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
                             break;
                         }
-                        case sizeof(jshort): {
-                            jshort shortValue;
-                            for (x = 0; x < vlSize; x++) {
-                                ((char*) &shortValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                        case H5T_FLOAT: {
+                            switch (vlSize) {
+                                case sizeof(jfloat): {
+                                    jfloat floatValue;
+                                    for (x = 0; x < vlSize; x++) {
+                                        ((char*) &floatValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                                    }
+                                    jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cFloat, floatValueMid,
+                                                                          (double) floatValue);
+                                    CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                                    break;
+                                }
+                                case sizeof(jdouble): {
+                                    jdouble doubleValue;
+                                    for (x = 0; x < vlSize; x++) {
+                                        ((char*) &doubleValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                                    }
+                                    jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cDouble, doubleValueMid,
+                                                                          doubleValue);
+                                    CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                                    break;
+                                }
                             }
-                            jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cShort, shortValueMid, shortValue);
-                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
                             break;
                         }
-                        case sizeof(jint): {
-                            jint intValue;
-                            for (x = 0; x < vlSize; x++) {
-                                ((char*) &intValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
-                            }
-                            jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cInt, intValueMid, intValue);
-                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_TRUE);
-                            break;
-                        }
-                        case sizeof(jlong): {
-                            jlong longValue;
-                            for (x = 0; x < vlSize; x++) {
-                                ((char*) &longValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
-                            }
-                            jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cLong, longValueMid, longValue);
-                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                            break;
-                        }
-                        }
-                        break;
-                    }
-                    case H5T_FLOAT: {
-                        switch (vlSize) {
-                        case sizeof(jfloat): {
-                            jfloat floatValue;
-                            for (x = 0; x < vlSize; x++) {
-                                ((char*) &floatValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
-                            }
-                            jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cFloat, floatValueMid, (double) floatValue);
-                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                            break;
-                        }
-                        case sizeof(jdouble): {
-                            jdouble doubleValue;
-                            for (x = 0; x < vlSize; x++) {
-                                ((char*) &doubleValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
-                            }
-                            jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cDouble, doubleValueMid, doubleValue);
-                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                            break;
-                        }
-                        }
-                        break;
-                    }
-                    case H5T_REFERENCE: {
-                        jboolean bb;
-                        jbyte *barray = NULL;
-                        jsize byteArraySize = (jsize) vlSize;
-                        if (vlSize != (size_t) byteArraySize)
-                            H5_JNI_FATAL_ERROR(ENVONLY, "translate_rbuf: overflow of byteArraySize");
+                        case H5T_REFERENCE: {
+                            jboolean bb;
+                            jbyte *barray = NULL;
+                            jsize byteArraySize = (jsize) vlSize;
+                            if (vlSize != (size_t) byteArraySize)
+                                H5_JNI_FATAL_ERROR(ENVONLY, "translate_rbuf: overflow of byteArraySize");
 
-                        if (NULL == (jobj = ENVPTR->NewByteArray(ENVONLY, byteArraySize)))
-                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                            if (NULL == (jobj = ENVPTR->NewByteArray(ENVONLY, byteArraySize)))
+                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
-                        PIN_BYTE_ARRAY(ENVONLY, (jbyteArray )jobj, barray, &bb, "read(translate_buf) reference: byte array not pinned");
-                        for (x = 0; x < vlSize; x++) {
-                            barray[x] = ((jbyte*) vl_elem.p)[j * vlSize + x];
+                            PIN_BYTE_ARRAY(ENVONLY, (jbyteArray )jobj, barray, &bb,
+                                           "read(translate_buf) reference: byte array not pinned");
+                            for (x = 0; x < vlSize; x++) {
+                                barray[x] = ((jbyte *) vl_elem.p)[j * vlSize + x];
+                            }
+                            if (barray)
+                                UNPIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, jobj ? 0 : JNI_ABORT);
+
+                            break;
                         }
-                        if (barray)
-                            UNPIN_BYTE_ARRAY(ENVONLY, (jbyteArray )jobj, barray, jobj ? 0 : JNI_ABORT);
-
-                        break;
-                    }
-                    default:
-                        H5_UNIMPLEMENTED(ENVONLY, "translate_rbuf: invalid class type");
-                        break;
+                        default:
+                            H5_UNIMPLEMENTED(ENVONLY, "translate_rbuf: invalid class type");
+                            break;
                     }
                     /* Add it to the list */
                     if (jobj) {
@@ -4224,7 +4234,7 @@ herr_t translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_
             }
         }
     }
-    else  if (type_class == H5T_COMPOUND) {
+    else if (type_class == H5T_COMPOUND) {
         int    nmembs = H5Tget_nmembers(mem_type_id);
         void  *objBuf = NULL;
         size_t offset;
@@ -4234,6 +4244,8 @@ herr_t translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_
 
         /* Convert each element to a list */
         for (i = 0; i < (size_t)nmembs; i++) {
+            jboolean found_jList = JNI_TRUE;
+
             if ((memb = H5Tget_member_type(mem_type_id, (unsigned int)i)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
             offset = H5Tget_member_offset(mem_type_id, (unsigned int)i);
@@ -4243,134 +4255,144 @@ herr_t translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_
             if (!(vlSize = H5Tget_size(memb)))
                 H5_LIBRARY_ERROR(ENVONLY);
 
-            /* The list we're going to return: */
-            if (NULL == (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)ret_buf, (jsize)i)))
-                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-
             /* Get the object element */
             HDmemcpy(&objBuf, (char *)raw_buf + offset, vlSize);
 
-            jobject jobj = NULL;
-            switch (vlClass) {
-            case H5T_ARRAY:
-            case H5T_COMPOUND:
-            case H5T_VLEN:
-                translate_rbuf(ENVONLY, ret_buf, memb, vlClass, (jsize)1, objBuf);
-                break;
-                /*case H5T_BOOL: {
-                    jboolean boolValue;
-                    for (x = 0; x < vlSize; x++) {
-                        ((char *)&boolValue)[x] = ((char *)vl_elem.p)[j*vlSize+x];
-                    }
-
-                    jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cBool, boolValueMid, boolValue);
-                    CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                    break;
-                } */
-                case H5T_INTEGER: {
-                    switch (vlSize) {
-                        case sizeof(jbyte): {
-                            jbyte byteValue;
-                            for (x = 0; x < vlSize; x++) {
-                                ((char *)&byteValue)[x] = ((char *)objBuf)[vlSize + x];
-                            }
-
-                            jobj =
-                                ENVPTR->CallStaticObjectMethod(ENVONLY, cByte, byteValueMid, byteValue);
-                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                            break;
-                        }
-                        case sizeof(jshort): {
-                            jshort shortValue;
-                            for (x = 0; x < vlSize; x++) {
-                                ((char *)&shortValue)[x] = ((char *)objBuf)[vlSize + x];
-                            }
-
-                            jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cShort, shortValueMid,
-                                                                  shortValue);
-                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                            break;
-                        }
-                        case sizeof(jint): {
-                            jint intValue;
-                            for (x = 0; x < vlSize; x++) {
-                                ((char *)&intValue)[x] = ((char *)objBuf)[vlSize + x];
-                            }
-
-                            jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cInt, intValueMid, intValue);
-                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                            break;
-                        }
-                        case sizeof(jlong): {
-                            jlong longValue;
-                            for (x = 0; x < vlSize; x++) {
-                                ((char *)&longValue)[x] = ((char *)objBuf)[vlSize + x];
-                            }
-
-                            jobj =
-                                ENVPTR->CallStaticObjectMethod(ENVONLY, cLong, longValueMid, longValue);
-                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                            break;
-                        }
-                    }
-                    break;
-                }
-                case H5T_FLOAT: {
-                    switch (vlSize) {
-                        case sizeof(jfloat): {
-                            jfloat floatValue;
-                            for (x = 0; x < vlSize; x++) {
-                                ((char *)&floatValue)[x] = ((char *)objBuf)[vlSize + x];
-                            }
-
-                            jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cFloat, floatValueMid,
-                                                                  (double)floatValue);
-                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                            break;
-                        }
-                        case sizeof(jdouble): {
-                            jdouble doubleValue;
-                            for (x = 0; x < vlSize; x++) {
-                                ((char *)&doubleValue)[x] = ((char *)objBuf)[vlSize + x];
-                            }
-
-                            jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cDouble, doubleValueMid,
-                                                                  doubleValue);
-                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-                            break;
-                        }
-                    }
-                    break;
-                }
-                case H5T_REFERENCE: {
-                    jboolean bb;
-                    jbyte   *barray = NULL;
-
-                    jsize byteArraySize = (jsize)vlSize;
-                    if (vlSize != (size_t)byteArraySize)
-                        H5_JNI_FATAL_ERROR(ENVONLY, "translate_rbuf: overflow of byteArraySize");
-
-                    if (NULL == (jobj = ENVPTR->NewByteArray(ENVONLY, byteArraySize)))
-                        CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
-
-                    PIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, &bb,
-                                   "translate_rbuf reference: byte array not pinned");
-
-                    for (x = 0; x < vlSize; x++) {
-                        barray[x] = ((jbyte *)objBuf)[vlSize + x];
-                    }
-                    if (barray)
-                        UNPIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, jobj ? 0 : JNI_ABORT);
-                    break;
-                }
-                default:
-                    H5_UNIMPLEMENTED(ENVONLY, "translate_rbuf: invalid class type");
-                    break;
+            /* The list we're going to return: */
+            if (NULL == (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)ret_buf, (jsize)i))) {
+                found_jList = JNI_FALSE;
+                if (NULL == (jList = (jobjectArray)ENVPTR->NewObject(ENVONLY, arrCList, arrListMethod, 0)))
+                    H5_OUT_OF_MEMORY_ERROR(ENVONLY, "translate_rbuf: failed to allocate list read buffer");
             }
 
-            /* Add it to the list */
-            ENVPTR->CallBooleanMethod(ENVONLY, jList, arrAddMethod, jobj);
-            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+            if ((vlClass == H5T_ARRAY) || (vlClass == H5T_COMPOUND) || (vlClass == H5T_VLEN))
+                translate_rbuf(ENVONLY, jList, memb, vlClass, (jsize)1, objBuf);
+            else {
+                jobject jobj = NULL;
+                switch (vlClass) {
+                    /*case H5T_BOOL: {
+                        jboolean boolValue;
+                        for (x = 0; x < vlSize; x++) {
+                            ((char *)&boolValue)[x] = ((char *)vl_elem.p)[j*vlSize+x];
+                        }
+
+                        jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cBool, boolValueMid, boolValue);
+                        CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                        break;
+                    } */
+                    case H5T_INTEGER: {
+                        switch (vlSize) {
+                            case sizeof(jbyte): {
+                                jbyte byteValue;
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&byteValue)[x] = ((char *)objBuf)[vlSize + x];
+                                }
+
+                                jobj =
+                                    ENVPTR->CallStaticObjectMethod(ENVONLY, cByte, byteValueMid, byteValue);
+                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                                break;
+                            }
+                            case sizeof(jshort): {
+                                jshort shortValue;
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&shortValue)[x] = ((char *)objBuf)[vlSize + x];
+                                }
+
+                                jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cShort, shortValueMid,
+                                                                      shortValue);
+                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                                break;
+                            }
+                            case sizeof(jint): {
+                                jint intValue;
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&intValue)[x] = ((char *)objBuf)[vlSize + x];
+                                }
+
+                                jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cInt, intValueMid, intValue);
+                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                                break;
+                            }
+                            case sizeof(jlong): {
+                                jlong longValue;
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&longValue)[x] = ((char *)objBuf)[vlSize + x];
+                                }
+
+                                jobj =
+                                    ENVPTR->CallStaticObjectMethod(ENVONLY, cLong, longValueMid, longValue);
+                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                    case H5T_FLOAT: {
+                        switch (vlSize) {
+                            case sizeof(jfloat): {
+                                jfloat floatValue;
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&floatValue)[x] = ((char *)objBuf)[vlSize + x];
+                                }
+
+                                jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cFloat, floatValueMid,
+                                                                      (double)floatValue);
+                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                                break;
+                            }
+                            case sizeof(jdouble): {
+                                jdouble doubleValue;
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)&doubleValue)[x] = ((char *)objBuf)[vlSize + x];
+                                }
+
+                                jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cDouble, doubleValueMid,
+                                                                      doubleValue);
+                                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                    case H5T_REFERENCE: {
+                        jboolean bb;
+                        jbyte   *barray = NULL;
+
+                        jsize byteArraySize = (jsize)vlSize;
+                        if (vlSize != (size_t)byteArraySize)
+                            H5_JNI_FATAL_ERROR(ENVONLY, "translate_rbuf: overflow of byteArraySize");
+
+                        if (NULL == (jobj = ENVPTR->NewByteArray(ENVONLY, byteArraySize)))
+                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+
+                        PIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, &bb,
+                                       "translate_rbuf reference: byte array not pinned");
+
+                        for (x = 0; x < vlSize; x++) {
+                            barray[x] = ((jbyte *)objBuf)[vlSize + x];
+                        }
+                        if (barray)
+                            UNPIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, jobj ? 0 : JNI_ABORT);
+                        break;
+                    }
+                    default:
+                        H5_UNIMPLEMENTED(ENVONLY, "translate_rbuf: invalid class type");
+                        break;
+                }
+                /* Add it to the list */
+                if (jobj) {
+                    ENVPTR->CallBooleanMethod(ENVONLY, jList, arrAddMethod, jobj);
+                    CHECK_JNI_EXCEPTION(ENVONLY, JNI_TRUE);
+
+                    ENVPTR->DeleteLocalRef(ENVONLY, jobj);
+                }
+            }
+            if (!found_jList) {
+                ENVPTR->CallBooleanMethod(ENVONLY, ret_buf, arrAddMethod, jList);
+                CHECK_JNI_EXCEPTION(ENVONLY, JNI_TRUE);
+                ENVPTR->DeleteLocalRef(ENVONLY, jList);
+            }
         }
         H5Tclose(memb);
     }
@@ -4382,7 +4404,7 @@ herr_t translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_
         if (!(vlSize = H5Tget_size(memb)))
             H5_LIBRARY_ERROR(ENVONLY);
 
-        //TODO
+        // TODO
         H5_UNIMPLEMENTED(ENVONLY, "translate_rbuf: invalid H5T_ARRAY type");
     }
 
@@ -4391,7 +4413,10 @@ done:
     return (jint)status;
 }
 
-herr_t translate_wbuf(JNIEnv *env, jobjectArray in_buf, jlong mem_type_id, H5T_class_t type_class, jsize count, jobjectArray raw_buf) {
+herr_t
+translate_wbuf(JNIEnv *env, jobjectArray in_buf, jlong mem_type_id, H5T_class_t type_class, jsize count,
+               jobjectArray raw_buf)
+{
     herr_t       status  = FAIL;
     hid_t        memb    = H5I_INVALID_HID;
     H5T_class_t  vlClass;
@@ -4400,18 +4425,17 @@ herr_t translate_wbuf(JNIEnv *env, jobjectArray in_buf, jlong mem_type_id, H5T_c
     size_t       i, j, x;
 
     /* retrieve the java.util.ArrayList interface class */
-    jclass arrCList = ENVPTR->FindClass(ENVONLY, "java/util/ArrayList");
-    jmethodID arrAddMethod = ENVPTR->GetMethodID(ENVONLY, arrCList, "add", "(Ljava/lang/Object;)Z");
+    jclass    arrCList     = ENVPTR->FindClass(ENVONLY, "java/util/ArrayList");
     /* retrieve the toArray method */
     jmethodID mToArray = ENVPTR->GetMethodID(ENVONLY, arrCList, "toArray", "()[Ljava/lang/Object;");
 
     /* Cache class types */
     /* jclass cBool   = ENVPTR->FindClass(ENVONLY, "java/lang/Boolean"); */
-    jclass cByte = ENVPTR->FindClass(ENVONLY, "java/lang/Byte");
-    jclass cShort = ENVPTR->FindClass(ENVONLY, "java/lang/Short");
-    jclass cInt = ENVPTR->FindClass(ENVONLY, "java/lang/Integer");
-    jclass cLong = ENVPTR->FindClass(ENVONLY, "java/lang/Long");
-    jclass cFloat = ENVPTR->FindClass(ENVONLY, "java/lang/Float");
+    jclass cByte   = ENVPTR->FindClass(ENVONLY, "java/lang/Byte");
+    jclass cShort  = ENVPTR->FindClass(ENVONLY, "java/lang/Short");
+    jclass cInt    = ENVPTR->FindClass(ENVONLY, "java/lang/Integer");
+    jclass cLong   = ENVPTR->FindClass(ENVONLY, "java/lang/Long");
+    jclass cFloat  = ENVPTR->FindClass(ENVONLY, "java/lang/Float");
     jclass cDouble = ENVPTR->FindClass(ENVONLY, "java/lang/Double");
 
     /* jmethodID boolValueMid   = ENVPTR->GetMethodID(ENVONLY, cBool, "booleanValue", "()Z"); */
@@ -4434,7 +4458,8 @@ herr_t translate_wbuf(JNIEnv *env, jobjectArray in_buf, jlong mem_type_id, H5T_c
         for (i = 0; i < (size_t)count; i++) {
             hvl_t vl_elem;
 
-            if (NULL == (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)in_buf, (jsize)i)))
+            if (NULL ==
+                (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)in_buf, (jsize)i)))
                 CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
             /* invoke the toArray method */
@@ -4510,7 +4535,8 @@ herr_t translate_wbuf(JNIEnv *env, jobjectArray in_buf, jlong mem_type_id, H5T_c
                                     break;
                                 }
                                 case sizeof(jdouble): {
-                                    jdouble doubleValue = ENVPTR->CallDoubleMethod(ENVONLY, jobj, doubleValueMid);
+                                    jdouble doubleValue =
+                                        ENVPTR->CallDoubleMethod(ENVONLY, jobj, doubleValueMid);
                                     for (x = 0; x < vlSize; x++) {
                                         ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&doubleValue)[x];
                                     }
@@ -4540,11 +4566,11 @@ herr_t translate_wbuf(JNIEnv *env, jobjectArray in_buf, jlong mem_type_id, H5T_c
             ENVPTR->DeleteLocalRef(ENVONLY, jList);
         } /* end for (i = 0; i < count; i++) */
     }
-    else  if (type_class == H5T_COMPOUND) {
-        //TODO
+    else if (type_class == H5T_COMPOUND) {
+        // TODO
         H5_UNIMPLEMENTED(ENVONLY, "translate_wbuf: invalid H5T_COMPOUND type");
     }
-    else  if (type_class == H5T_ARRAY) {
+    else if (type_class == H5T_ARRAY) {
         if (!(memb = H5Tget_super(mem_type_id)))
             H5_LIBRARY_ERROR(ENVONLY);
         if ((vlClass = H5Tget_class(memb)) < 0)
@@ -4552,7 +4578,7 @@ herr_t translate_wbuf(JNIEnv *env, jobjectArray in_buf, jlong mem_type_id, H5T_c
         if (!(vlSize = H5Tget_size(memb)))
             H5_LIBRARY_ERROR(ENVONLY);
 
-        //TODO
+        // TODO
         H5_UNIMPLEMENTED(ENVONLY, "translate_wbuf: invalid H5T_ARRAY type");
     }
 

--- a/java/src/jni/h5util.c
+++ b/java/src/jni/h5util.c
@@ -4045,7 +4045,7 @@ done:
 
 herr_t
 translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t type_class, jsize count,
-               jobjectArray raw_buf)
+               jbyte *raw_buf)
 {
     herr_t       status = FAIL;
     hid_t        memb   = H5I_INVALID_HID;
@@ -4067,7 +4067,7 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
     jclass cLong   = ENVPTR->FindClass(ENVONLY, "java/lang/Long");
     jclass cFloat  = ENVPTR->FindClass(ENVONLY, "java/lang/Float");
     jclass cDouble = ENVPTR->FindClass(ENVONLY, "java/lang/Double");
-    /*
+    /*jobjectArray
      jmethodID boolValueMid =
      ENVPTR->GetStaticMethodID(ENVONLY, cBool, "valueOf", "(Z)Ljava/lang/Boolean;");
      */
@@ -4416,7 +4416,7 @@ done:
 
 herr_t
 translate_wbuf(JNIEnv *env, jobjectArray in_buf, jlong mem_type_id, H5T_class_t type_class, jsize count,
-               jobjectArray raw_buf)
+               jbyte *raw_buf)
 {
     herr_t       status = FAIL;
     hid_t        memb   = H5I_INVALID_HID;

--- a/java/src/jni/h5util.c
+++ b/java/src/jni/h5util.c
@@ -4043,7 +4043,6 @@ done:
         H5Aclose(attr_id);
 } /* end Java_hdf_hdf5lib_H5_H5export_1attribute */
 
-
 herr_t
 translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t type_class, jsize count,
                jobjectArray raw_buf)
@@ -4200,7 +4199,7 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
                             jbyte   *barray        = NULL;
                             jsize    byteArraySize = (jsize)vlSize;
 
-                            if (vlSize != (size_t) byteArraySize)
+                            if (vlSize != (size_t)byteArraySize)
                                 H5_JNI_FATAL_ERROR(ENVONLY, "translate_rbuf: overflow of byteArraySize");
 
                             if (NULL == (jobj = ENVPTR->NewByteArray(ENVONLY, byteArraySize)))

--- a/java/src/jni/h5util.c
+++ b/java/src/jni/h5util.c
@@ -4056,7 +4056,7 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
     size_t       i, j, x;
 
     /* retrieve the java.util.ArrayList interface class */
-    jclass arrCList         = ENVPTR->FindClass(ENVONLY, "java/util/ArrayList");
+    jclass    arrCList      = ENVPTR->FindClass(ENVONLY, "java/util/ArrayList");
     jmethodID arrListMethod = ENVPTR->GetMethodID(ENVONLY, arrCList, "<init>", "(I)V");
     jmethodID arrAddMethod  = ENVPTR->GetMethodID(ENVONLY, arrCList, "add", "(Ljava/lang/Object;)Z");
 
@@ -4072,11 +4072,11 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
      jmethodID boolValueMid =
      ENVPTR->GetStaticMethodID(ENVONLY, cBool, "valueOf", "(Z)Ljava/lang/Boolean;");
      */
-    jmethodID byteValueMid   = ENVPTR->GetStaticMethodID(ENVONLY, cByte, "valueOf", "(B)Ljava/lang/Byte;");
-    jmethodID shortValueMid  = ENVPTR->GetStaticMethodID(ENVONLY, cShort, "valueOf", "(S)Ljava/lang/Short;");
-    jmethodID intValueMid    = ENVPTR->GetStaticMethodID(ENVONLY, cInt, "valueOf", "(I)Ljava/lang/Integer;");
-    jmethodID longValueMid   = ENVPTR->GetStaticMethodID(ENVONLY, cLong, "valueOf", "(J)Ljava/lang/Long;");
-    jmethodID floatValueMid  = ENVPTR->GetStaticMethodID(ENVONLY, cFloat, "valueOf", "(F)Ljava/lang/Float;");
+    jmethodID byteValueMid  = ENVPTR->GetStaticMethodID(ENVONLY, cByte, "valueOf", "(B)Ljava/lang/Byte;");
+    jmethodID shortValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cShort, "valueOf", "(S)Ljava/lang/Short;");
+    jmethodID intValueMid   = ENVPTR->GetStaticMethodID(ENVONLY, cInt, "valueOf", "(I)Ljava/lang/Integer;");
+    jmethodID longValueMid  = ENVPTR->GetStaticMethodID(ENVONLY, cLong, "valueOf", "(J)Ljava/lang/Long;");
+    jmethodID floatValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cFloat, "valueOf", "(F)Ljava/lang/Float;");
     jmethodID doubleValueMid =
         ENVPTR->GetStaticMethodID(ENVONLY, cDouble, "valueOf", "(D)Ljava/lang/Double;");
 
@@ -4130,7 +4130,7 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
                                 case sizeof(jbyte): {
                                     jbyte byteValue;
                                     for (x = 0; x < vlSize; x++) {
-                                        ((char*) &byteValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                                        ((char *)&byteValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                     }
                                     jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cByte, byteValueMid,
                                                                           byteValue);
@@ -4140,7 +4140,7 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
                                 case sizeof(jshort): {
                                     jshort shortValue;
                                     for (x = 0; x < vlSize; x++) {
-                                        ((char*) &shortValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                                        ((char *)&shortValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                     }
                                     jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cShort, shortValueMid,
                                                                           shortValue);
@@ -4150,7 +4150,7 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
                                 case sizeof(jint): {
                                     jint intValue;
                                     for (x = 0; x < vlSize; x++) {
-                                        ((char*) &intValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                                        ((char *)&intValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                     }
                                     jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cInt, intValueMid, intValue);
                                     CHECK_JNI_EXCEPTION(ENVONLY, JNI_TRUE);
@@ -4159,7 +4159,7 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
                                 case sizeof(jlong): {
                                     jlong longValue;
                                     for (x = 0; x < vlSize; x++) {
-                                        ((char*) &longValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                                        ((char *)&longValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                     }
                                     jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cLong, longValueMid,
                                                                           longValue);
@@ -4174,7 +4174,7 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
                                 case sizeof(jfloat): {
                                     jfloat floatValue;
                                     for (x = 0; x < vlSize; x++) {
-                                        ((char*) &floatValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                                        ((char *)&floatValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                     }
                                     jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cFloat, floatValueMid,
                                                                           (double) floatValue);
@@ -4184,7 +4184,7 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
                                 case sizeof(jdouble): {
                                     jdouble doubleValue;
                                     for (x = 0; x < vlSize; x++) {
-                                        ((char*) &doubleValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                                        ((char *)&doubleValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                     }
                                     jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cDouble, doubleValueMid,
                                                                           doubleValue);
@@ -4196,18 +4196,19 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
                         }
                         case H5T_REFERENCE: {
                             jboolean bb;
-                            jbyte *barray = NULL;
-                            jsize byteArraySize = (jsize) vlSize;
+                            jbyte   *barray        = NULL;
+                            jsize    byteArraySize = (jsize) vlSize;
+
                             if (vlSize != (size_t) byteArraySize)
                                 H5_JNI_FATAL_ERROR(ENVONLY, "translate_rbuf: overflow of byteArraySize");
 
                             if (NULL == (jobj = ENVPTR->NewByteArray(ENVONLY, byteArraySize)))
                                 CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
-                            PIN_BYTE_ARRAY(ENVONLY, (jbyteArray )jobj, barray, &bb,
+                            PIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, &bb,
                                            "read(translate_buf) reference: byte array not pinned");
                             for (x = 0; x < vlSize; x++) {
-                                barray[x] = ((jbyte *) vl_elem.p)[j * vlSize + x];
+                                barray[x] = ((jbyte *)vl_elem.p)[j * vlSize + x];
                             }
                             if (barray)
                                 UNPIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, jobj ? 0 : JNI_ABORT);
@@ -4396,7 +4397,7 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
         }
         H5Tclose(memb);
     }
-    else  if (type_class == H5T_ARRAY) {
+    else if (type_class == H5T_ARRAY) {
         if (!(memb = H5Tget_super(mem_type_id)))
             H5_LIBRARY_ERROR(ENVONLY);
         if ((vlClass = H5Tget_class(memb)) < 0)
@@ -4417,15 +4418,15 @@ herr_t
 translate_wbuf(JNIEnv *env, jobjectArray in_buf, jlong mem_type_id, H5T_class_t type_class, jsize count,
                jobjectArray raw_buf)
 {
-    herr_t       status  = FAIL;
-    hid_t        memb    = H5I_INVALID_HID;
+    herr_t       status = FAIL;
+    hid_t        memb   = H5I_INVALID_HID;
     H5T_class_t  vlClass;
     size_t       vlSize;
     jobjectArray jList = NULL;
     size_t       i, j, x;
 
     /* retrieve the java.util.ArrayList interface class */
-    jclass    arrCList     = ENVPTR->FindClass(ENVONLY, "java/util/ArrayList");
+    jclass arrCList = ENVPTR->FindClass(ENVONLY, "java/util/ArrayList");
     /* retrieve the toArray method */
     jmethodID mToArray = ENVPTR->GetMethodID(ENVONLY, arrCList, "toArray", "()[Ljava/lang/Object;");
 
@@ -4458,8 +4459,7 @@ translate_wbuf(JNIEnv *env, jobjectArray in_buf, jlong mem_type_id, H5T_class_t 
         for (i = 0; i < (size_t)count; i++) {
             hvl_t vl_elem;
 
-            if (NULL ==
-                (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)in_buf, (jsize)i)))
+            if (NULL == (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)in_buf, (jsize)i)))
                 CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
             /* invoke the toArray method */
@@ -4481,7 +4481,8 @@ translate_wbuf(JNIEnv *env, jobjectArray in_buf, jlong mem_type_id, H5T_class_t 
             else {
                 jobject jobj = NULL;
                 for (j = 0; j < (size_t)jnelmts; j++) {
-                    if (NULL == (jobj = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)array, (jsize)j)))
+                    if (NULL ==
+                        (jobj = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)array, (jsize)j)))
                         CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
 
                     switch (vlClass) {

--- a/java/src/jni/h5util.c
+++ b/java/src/jni/h5util.c
@@ -4043,6 +4043,511 @@ done:
         H5Aclose(attr_id);
 } /* end Java_hdf_hdf5lib_H5_H5export_1attribute */
 
+
+herr_t translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t type_class, jsize count, jsize count_size, jobjectArray raw_buf) {
+    herr_t       status  = FAIL;
+    hid_t        memb    = H5I_INVALID_HID;
+    H5T_class_t  vlClass;
+    size_t       vlSize;
+    jobjectArray jList = NULL;
+    size_t       i, j, x;
+
+    /* retrieve the java.util.List interface class */
+    jclass cList = ENVPTR->FindClass(ENVONLY, "java/util/List");
+    jmethodID addMethod = ENVPTR->GetMethodID(ENVONLY, cList, "add", "(Ljava/lang/Object;)Z");
+
+    /* Cache class types */
+    /* jclass cBool   = ENVPTR->FindClass(ENVONLY, "java/lang/Boolean"); */
+    jclass cByte = ENVPTR->FindClass(ENVONLY, "java/lang/Byte");
+    jclass cShort = ENVPTR->FindClass(ENVONLY, "java/lang/Short");
+    jclass cInt = ENVPTR->FindClass(ENVONLY, "java/lang/Integer");
+    jclass cLong = ENVPTR->FindClass(ENVONLY, "java/lang/Long");
+    jclass cFloat = ENVPTR->FindClass(ENVONLY, "java/lang/Float");
+    jclass cDouble = ENVPTR->FindClass(ENVONLY, "java/lang/Double");
+    /*
+     jmethodID boolValueMid =
+     ENVPTR->GetStaticMethodID(ENVONLY, cBool, "valueOf", "(Z)Ljava/lang/Boolean;");
+     */
+    jmethodID byteValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cByte, "valueOf", "(B)Ljava/lang/Byte;");
+    jmethodID shortValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cShort, "valueOf", "(S)Ljava/lang/Short;");
+    jmethodID intValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cInt, "valueOf", "(I)Ljava/lang/Integer;");
+    jmethodID longValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cLong, "valueOf", "(J)Ljava/lang/Long;");
+    jmethodID floatValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cFloat, "valueOf", "(F)Ljava/lang/Float;");
+    jmethodID doubleValueMid = ENVPTR->GetStaticMethodID(ENVONLY, cDouble, "valueOf", "(D)Ljava/lang/Double;");
+
+    if (type_class == H5T_VLEN) {
+        if (!(memb = H5Tget_super(mem_type_id)))
+            H5_LIBRARY_ERROR(ENVONLY);
+        if ((vlClass = H5Tget_class(memb)) < 0)
+            H5_LIBRARY_ERROR(ENVONLY);
+        if (!(vlSize = H5Tget_size(memb)))
+            H5_LIBRARY_ERROR(ENVONLY);
+
+        /* Convert each element to a list */
+        for (i = 0; i < (size_t) count; i++) {
+            hvl_t vl_elem;
+            /* The list we're going to return: */
+            if (NULL == (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)ret_buf, (jsize)i)))
+                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+
+            /* Get the number of sequence elements */
+            HDmemcpy(&vl_elem, (char* )raw_buf + i * (size_t)count_size, sizeof(hvl_t));
+            jsize nelmts = (jsize) vl_elem.len;
+            if (vl_elem.len != (size_t) nelmts)
+                H5_JNI_FATAL_ERROR(ENVONLY, "translate_rbuf: overflow of number of VL elements");
+
+            if (nelmts < 0)
+                H5_BAD_ARGUMENT_ERROR(ENVONLY, "translate_rbuf: number of VL elements < 0");
+
+            jobject jobj = NULL;
+            for (j = 0; j < (size_t) nelmts; j++) {
+                switch (vlClass) {
+                case H5T_ARRAY:
+                case H5T_COMPOUND:
+                case H5T_VLEN:
+                    translate_rbuf(ENVONLY, ret_buf, memb, vlClass, (jsize)i, (jsize)vlSize, vl_elem.p);
+                    break;
+                /*case H5T_BOOL: {
+                 jboolean boolValue;
+                 for (x = 0; x < vlSize; x++) {
+                 ((char *)&boolValue)[x] = ((char *)vl_elem.p)[j*vlSize+x];
+                 }
+
+                 jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cBool, boolValueMid, boolValue);
+                 CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                 break;
+                 } */
+                case H5T_INTEGER: {
+                    switch (vlSize) {
+                    case sizeof(jbyte): {
+                        jbyte byteValue;
+                        for (x = 0; x < vlSize; x++) {
+                            ((char*) &byteValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                        }
+                        jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cByte, byteValueMid, byteValue);
+                        CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                        break;
+                    }
+                    case sizeof(jshort): {
+                        jshort shortValue;
+                        for (x = 0; x < vlSize; x++) {
+                            ((char*) &shortValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                        }
+                        jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cShort, shortValueMid, shortValue);
+                        CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                        break;
+                    }
+                    case sizeof(jint): {
+                        jint intValue;
+                        for (x = 0; x < vlSize; x++) {
+                            ((char*) &intValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                        }
+                        jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cInt, intValueMid, intValue);
+                        CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                        break;
+                    }
+                    case sizeof(jlong): {
+                        jlong longValue;
+                        for (x = 0; x < vlSize; x++) {
+                            ((char*) &longValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                        }
+                        jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cLong, longValueMid, longValue);
+                        CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                        break;
+                    }
+                    }
+                    break;
+                }
+                case H5T_FLOAT: {
+                    switch (vlSize) {
+                    case sizeof(jfloat): {
+                        jfloat floatValue;
+                        for (x = 0; x < vlSize; x++) {
+                            ((char*) &floatValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                        }
+                        jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cFloat, floatValueMid, (double) floatValue);
+                        CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                        break;
+                    }
+                    case sizeof(jdouble): {
+                        jdouble doubleValue;
+                        for (x = 0; x < vlSize; x++) {
+                            ((char*) &doubleValue)[x] = ((char*) vl_elem.p)[j * vlSize + x];
+                        }
+                        jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cDouble, doubleValueMid, doubleValue);
+                        CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                        break;
+                    }
+                    }
+                    break;
+                }
+                case H5T_REFERENCE: {
+                    jboolean bb;
+                    jbyte *barray = NULL;
+                    jsize byteArraySize = (jsize) vlSize;
+                    if (vlSize != (size_t) byteArraySize)
+                        H5_JNI_FATAL_ERROR(ENVONLY, "translate_rbuf: overflow of byteArraySize");
+
+                    if (NULL == (jobj = ENVPTR->NewByteArray(ENVONLY, byteArraySize)))
+                        CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+
+                    PIN_BYTE_ARRAY(ENVONLY, (jbyteArray )jobj, barray, &bb, "read(translate_buf) reference: byte array not pinned");
+                    for (x = 0; x < vlSize; x++) {
+                        barray[x] = ((jbyte*) vl_elem.p)[j * vlSize + x];
+                    }
+                    if (barray)
+                        UNPIN_BYTE_ARRAY(ENVONLY, (jbyteArray )jobj, barray, jobj ? 0 : JNI_ABORT);
+
+                    break;
+                }
+                default:
+                    H5_UNIMPLEMENTED(ENVONLY, "translate_rbuf: invalid class type");
+                    break;
+                }
+                /* Add it to the list */
+                ENVPTR->CallBooleanMethod(ENVONLY, jList, addMethod, jobj);
+                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+            }
+        }
+    }
+    else  if (type_class == H5T_COMPOUND) {
+        int    nmembs = H5Tget_nmembers(mem_type_id);
+        void  *objBuf = NULL;
+        size_t offset;
+
+        if (nmembs < 0)
+            goto done;
+
+        /* Convert each element to a list */
+        for (i = 0; i < (size_t)nmembs; i++) {
+            if ((memb = H5Tget_member_type(mem_type_id, (unsigned int)i)) < 0)
+                H5_LIBRARY_ERROR(ENVONLY);
+            offset = H5Tget_member_offset(mem_type_id, (unsigned int)i);
+
+            if ((vlClass = H5Tget_class(memb)) < 0)
+                H5_LIBRARY_ERROR(ENVONLY);
+            if (!(vlSize = H5Tget_size(memb)))
+                H5_LIBRARY_ERROR(ENVONLY);
+
+            /* The list we're going to return: */
+            if (NULL == (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)ret_buf, (jsize)i)))
+                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+
+            /* Get the object element */
+            HDmemcpy(&objBuf, (char *)raw_buf + offset, vlSize);
+
+            jobject jobj = NULL;
+            switch (vlClass) {
+            case H5T_ARRAY:
+            case H5T_COMPOUND:
+            case H5T_VLEN:
+                translate_rbuf(ENVONLY, ret_buf, memb, vlClass, (jsize)i, (jsize)vlSize, objBuf);
+                break;
+                /*case H5T_BOOL: {
+                    jboolean boolValue;
+                    for (x = 0; x < vlSize; x++) {
+                        ((char *)&boolValue)[x] = ((char *)vl_elem.p)[j*vlSize+x];
+                    }
+
+                    jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cBool, boolValueMid, boolValue);
+                    CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                    break;
+                } */
+                case H5T_INTEGER: {
+                    switch (vlSize) {
+                        case sizeof(jbyte): {
+                            jbyte byteValue;
+                            for (x = 0; x < vlSize; x++) {
+                                ((char *)&byteValue)[x] = ((char *)objBuf)[vlSize + x];
+                            }
+
+                            jobj =
+                                ENVPTR->CallStaticObjectMethod(ENVONLY, cByte, byteValueMid, byteValue);
+                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                            break;
+                        }
+                        case sizeof(jshort): {
+                            jshort shortValue;
+                            for (x = 0; x < vlSize; x++) {
+                                ((char *)&shortValue)[x] = ((char *)objBuf)[vlSize + x];
+                            }
+
+                            jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cShort, shortValueMid,
+                                                                  shortValue);
+                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                            break;
+                        }
+                        case sizeof(jint): {
+                            jint intValue;
+                            for (x = 0; x < vlSize; x++) {
+                                ((char *)&intValue)[x] = ((char *)objBuf)[vlSize + x];
+                            }
+
+                            jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cInt, intValueMid, intValue);
+                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                            break;
+                        }
+                        case sizeof(jlong): {
+                            jlong longValue;
+                            for (x = 0; x < vlSize; x++) {
+                                ((char *)&longValue)[x] = ((char *)objBuf)[vlSize + x];
+                            }
+
+                            jobj =
+                                ENVPTR->CallStaticObjectMethod(ENVONLY, cLong, longValueMid, longValue);
+                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                            break;
+                        }
+                    }
+                    break;
+                }
+                case H5T_FLOAT: {
+                    switch (vlSize) {
+                        case sizeof(jfloat): {
+                            jfloat floatValue;
+                            for (x = 0; x < vlSize; x++) {
+                                ((char *)&floatValue)[x] = ((char *)objBuf)[vlSize + x];
+                            }
+
+                            jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cFloat, floatValueMid,
+                                                                  (double)floatValue);
+                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                            break;
+                        }
+                        case sizeof(jdouble): {
+                            jdouble doubleValue;
+                            for (x = 0; x < vlSize; x++) {
+                                ((char *)&doubleValue)[x] = ((char *)objBuf)[vlSize + x];
+                            }
+
+                            jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cDouble, doubleValueMid,
+                                                                  doubleValue);
+                            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+                            break;
+                        }
+                    }
+                    break;
+                }
+                case H5T_REFERENCE: {
+                    jboolean bb;
+                    jbyte   *barray = NULL;
+
+                    jsize byteArraySize = (jsize)vlSize;
+                    if (vlSize != (size_t)byteArraySize)
+                        H5_JNI_FATAL_ERROR(ENVONLY, "translate_rbuf: overflow of byteArraySize");
+
+                    if (NULL == (jobj = ENVPTR->NewByteArray(ENVONLY, byteArraySize)))
+                        CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+
+                    PIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, &bb,
+                                   "translate_rbuf reference: byte array not pinned");
+
+                    for (x = 0; x < vlSize; x++) {
+                        barray[x] = ((jbyte *)objBuf)[vlSize + x];
+                    }
+                    if (barray)
+                        UNPIN_BYTE_ARRAY(ENVONLY, (jbyteArray)jobj, barray, jobj ? 0 : JNI_ABORT);
+                    break;
+                }
+                default:
+                    H5_UNIMPLEMENTED(ENVONLY, "translate_rbuf: invalid class type");
+                    break;
+            }
+
+            /* Add it to the list */
+            ENVPTR->CallBooleanMethod(ENVONLY, jList, addMethod, jobj);
+            CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+        }
+        H5Tclose(memb);
+    }
+    else  if (type_class == H5T_ARRAY) {
+        if (!(memb = H5Tget_super(mem_type_id)))
+            H5_LIBRARY_ERROR(ENVONLY);
+        if ((vlClass = H5Tget_class(memb)) < 0)
+            H5_LIBRARY_ERROR(ENVONLY);
+        if (!(vlSize = H5Tget_size(memb)))
+            H5_LIBRARY_ERROR(ENVONLY);
+
+        //TODO
+        H5_UNIMPLEMENTED(ENVONLY, "translate_rbuf: invalid H5T_ARRAY type");
+    }
+
+done:
+
+    return (jint)status;
+}
+
+herr_t translate_wbuf(JNIEnv *env, jobjectArray in_buf, jlong mem_type_id, H5T_class_t type_class, jsize count, jsize count_size, jobjectArray raw_buf) {
+    herr_t       status  = FAIL;
+    hid_t        memb    = H5I_INVALID_HID;
+    H5T_class_t  vlClass;
+    size_t       vlSize;
+    jobjectArray jList = NULL;
+    size_t       i, j, x;
+
+    /* retrieve the java.util.List interface class */
+    jclass cList = ENVPTR->FindClass(ENVONLY, "java/util/List");
+
+    /* Cache class types */
+    /* jclass cBool   = ENVPTR->FindClass(ENVONLY, "java/lang/Boolean"); */
+    jclass cByte = ENVPTR->FindClass(ENVONLY, "java/lang/Byte");
+    jclass cShort = ENVPTR->FindClass(ENVONLY, "java/lang/Short");
+    jclass cInt = ENVPTR->FindClass(ENVONLY, "java/lang/Integer");
+    jclass cLong = ENVPTR->FindClass(ENVONLY, "java/lang/Long");
+    jclass cFloat = ENVPTR->FindClass(ENVONLY, "java/lang/Float");
+    jclass cDouble = ENVPTR->FindClass(ENVONLY, "java/lang/Double");
+
+    /* jmethodID boolValueMid   = ENVPTR->GetMethodID(ENVONLY, cBool, "booleanValue", "()Z"); */
+    jmethodID byteValueMid   = ENVPTR->GetMethodID(ENVONLY, cByte, "byteValue", "()B");
+    jmethodID shortValueMid  = ENVPTR->GetMethodID(ENVONLY, cShort, "shortValue", "()S");
+    jmethodID intValueMid    = ENVPTR->GetMethodID(ENVONLY, cInt, "intValue", "()I");
+    jmethodID longValueMid   = ENVPTR->GetMethodID(ENVONLY, cLong, "longValue", "()J");
+    jmethodID floatValueMid  = ENVPTR->GetMethodID(ENVONLY, cFloat, "floatValue", "()F");
+    jmethodID doubleValueMid = ENVPTR->GetMethodID(ENVONLY, cDouble, "doubleValue", "()D");
+
+    if (type_class == H5T_VLEN) {
+        if (!(memb = H5Tget_super(mem_type_id)))
+            H5_LIBRARY_ERROR(ENVONLY);
+        if ((vlClass = H5Tget_class((hid_t)memb)) < 0)
+            H5_LIBRARY_ERROR(ENVONLY);
+        if (!(vlSize = H5Tget_size(memb)))
+            H5_LIBRARY_ERROR(ENVONLY);
+
+        /* Convert each list to a vlen element */
+        for (i = 0; i < (size_t)count; i++) {
+            hvl_t vl_elem;
+
+            if (NULL == (jList = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)in_buf, (jsize)i)))
+                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+
+            /* retrieve the toArray method and invoke it */
+            jmethodID mToArray = ENVPTR->GetMethodID(ENVONLY, cList, "toArray", "()[Ljava/lang/Object;");
+            if (mToArray == NULL)
+                CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+            jobjectArray array   = (jobjectArray)ENVPTR->CallObjectMethod(ENVONLY, jList, mToArray);
+            jsize        jnelmts = ENVPTR->GetArrayLength(ENVONLY, array);
+
+            if (jnelmts < 0)
+                H5_BAD_ARGUMENT_ERROR(ENVONLY, "translate_wbuf: number of VL elements < 0");
+
+            HDmemcpy(&vl_elem, (char *)raw_buf + i * (size_t)count_size, sizeof(hvl_t));
+            vl_elem.len = (size_t)jnelmts;
+
+            if (NULL == (vl_elem.p = HDmalloc((size_t)jnelmts * vlSize)))
+                H5_OUT_OF_MEMORY_ERROR(ENVONLY, "translate_wbuf: failed to allocate vlen ptr buffer");
+
+            jobject jobj = NULL;
+            for (j = 0; j < (size_t)jnelmts; j++) {
+                if (NULL == (jobj = ENVPTR->GetObjectArrayElement(ENVONLY, (jobjectArray)array, (jsize)j)))
+                    CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
+
+                switch (vlClass) {
+                case H5T_ARRAY:
+                case H5T_COMPOUND:
+                case H5T_VLEN:
+                    translate_wbuf(ENVONLY, in_buf, memb, vlClass, (jsize)i, (jsize)vlSize, vl_elem.p);
+                    break;
+                    /* case H5T_BOOL: {
+                            jboolean boolValue = ENVPTR->CallBooleanMethod(ENVONLY, jobj, boolValueMid);
+                            for (x = 0; x < vlSize; x++) {
+                                ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&boolValue)[x];
+                            }
+                            break;
+                    } */
+                    case H5T_INTEGER: {
+                        switch (vlSize) {
+                            case sizeof(jbyte): {
+                                jbyte byteValue = ENVPTR->CallByteMethod(ENVONLY, jobj, byteValueMid);
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&byteValue)[x];
+                                }
+                                break;
+                            }
+                            case sizeof(jshort): {
+                                jshort shortValue = ENVPTR->CallShortMethod(ENVONLY, jobj, shortValueMid);
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&shortValue)[x];
+                                }
+                                break;
+                            }
+                            case sizeof(jint): {
+                                jint intValue = ENVPTR->CallIntMethod(ENVONLY, jobj, intValueMid);
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&intValue)[x];
+                                }
+                                break;
+                            }
+                            case sizeof(jlong): {
+                                jlong longValue = ENVPTR->CallLongMethod(ENVONLY, jobj, longValueMid);
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&longValue)[x];
+                                }
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                    case H5T_FLOAT: {
+                        switch (vlSize) {
+                            case sizeof(jfloat): {
+                                jfloat floatValue = ENVPTR->CallFloatMethod(ENVONLY, jobj, floatValueMid);
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&floatValue)[x];
+                                }
+                                break;
+                            }
+                            case sizeof(jdouble): {
+                                jdouble doubleValue = ENVPTR->CallDoubleMethod(ENVONLY, jobj, doubleValueMid);
+                                for (x = 0; x < vlSize; x++) {
+                                    ((char *)vl_elem.p)[j * vlSize + x] = ((char *)&doubleValue)[x];
+                                }
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                    case H5T_REFERENCE: {
+                        jbyte *barray = (jbyte *)ENVPTR->GetByteArrayElements(ENVONLY, jobj, 0);
+                        for (x = 0; x < vlSize; x++) {
+                            ((char *)vl_elem.p)[j * vlSize + x] = ((char *)barray)[x];
+                        }
+                        ENVPTR->ReleaseByteArrayElements(ENVONLY, jobj, barray, 0);
+                        break;
+                    }
+                    default:
+                        H5_UNIMPLEMENTED(ENVONLY, "translate_wbuf: invalid class type");
+                        break;
+                }
+                ENVPTR->DeleteLocalRef(ENVONLY, jobj);
+            }
+
+            HDmemcpy((char *)raw_buf + i * (size_t)count_size, &vl_elem, sizeof(hvl_t));
+
+            ENVPTR->DeleteLocalRef(ENVONLY, jList);
+        } /* end for (i = 0; i < count; i++) */
+    }
+    else  if (type_class == H5T_COMPOUND) {
+
+        //TODO
+        H5_UNIMPLEMENTED(ENVONLY, "translate_wbuf: invalid H5T_COMPOUND type");
+    }
+    else  if (type_class == H5T_ARRAY) {
+        if (!(memb = H5Tget_super(mem_type_id)))
+            H5_LIBRARY_ERROR(ENVONLY);
+        if ((vlClass = H5Tget_class(memb)) < 0)
+            H5_LIBRARY_ERROR(ENVONLY);
+        if (!(vlSize = H5Tget_size(memb)))
+            H5_LIBRARY_ERROR(ENVONLY);
+
+        //TODO
+        H5_UNIMPLEMENTED(ENVONLY, "translate_wbuf: invalid H5T_ARRAY type");
+    }
+
+done:
+
+    return (jint)status;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/java/src/jni/h5util.c
+++ b/java/src/jni/h5util.c
@@ -4152,7 +4152,8 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
                                     for (x = 0; x < vlSize; x++) {
                                         ((char *)&intValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                     }
-                                    jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cInt, intValueMid, intValue);
+                                    jobj =
+                                        ENVPTR->CallStaticObjectMethod(ENVONLY, cInt, intValueMid, intValue);
                                     CHECK_JNI_EXCEPTION(ENVONLY, JNI_TRUE);
                                     break;
                                 }
@@ -4177,7 +4178,7 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
                                         ((char *)&floatValue)[x] = ((char *)vl_elem.p)[j * vlSize + x];
                                     }
                                     jobj = ENVPTR->CallStaticObjectMethod(ENVONLY, cFloat, floatValueMid,
-                                                                          (double) floatValue);
+                                                                          (double)floatValue);
                                     CHECK_JNI_EXCEPTION(ENVONLY, JNI_FALSE);
                                     break;
                                 }
@@ -4197,7 +4198,7 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
                         case H5T_REFERENCE: {
                             jboolean bb;
                             jbyte   *barray        = NULL;
-                            jsize    byteArraySize = (jsize) vlSize;
+                            jsize    byteArraySize = (jsize)vlSize;
 
                             if (vlSize != (size_t) byteArraySize)
                                 H5_JNI_FATAL_ERROR(ENVONLY, "translate_rbuf: overflow of byteArraySize");

--- a/java/src/jni/h5util.h
+++ b/java/src/jni/h5util.h
@@ -52,6 +52,11 @@ extern int    h5str_dump_simple_mem(JNIEnv *env, FILE *stream, hid_t attr, int b
 
 extern htri_t H5Tdetect_variable_str(hid_t tid);
 
+extern herr_t translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t type_class,
+                     jsize count, jsize count_size, jobjectArray raw_buf);
+extern herr_t translate_wbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t type_class,
+                     jsize count, jsize count_size, jobjectArray raw_buf);
+
 /*
  * Symbols used to format the output of h5str_sprintf and
  * to interpret the input to h5str_convert.

--- a/java/src/jni/h5util.h
+++ b/java/src/jni/h5util.h
@@ -53,9 +53,9 @@ extern int    h5str_dump_simple_mem(JNIEnv *env, FILE *stream, hid_t attr, int b
 extern htri_t H5Tdetect_variable_str(hid_t tid);
 
 extern herr_t translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t type_class,
-                     jsize count, jsize count_size, jobjectArray raw_buf);
+                     jsize count, jobjectArray raw_buf);
 extern herr_t translate_wbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t type_class,
-                     jsize count, jsize count_size, jobjectArray raw_buf);
+                     jsize count, jobjectArray raw_buf);
 
 /*
  * Symbols used to format the output of h5str_sprintf and

--- a/java/src/jni/h5util.h
+++ b/java/src/jni/h5util.h
@@ -53,9 +53,9 @@ extern int    h5str_dump_simple_mem(JNIEnv *env, FILE *stream, hid_t attr, int b
 extern htri_t H5Tdetect_variable_str(hid_t tid);
 
 extern herr_t translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t type_class,
-                             jsize count, jobjectArray raw_buf);
+                             jsize count, jbyte *raw_buf);
 extern herr_t translate_wbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t type_class,
-                             jsize count, jobjectArray raw_buf);
+                             jsize count, jbyte *raw_buf);
 
 /*
  * Symbols used to format the output of h5str_sprintf and

--- a/java/src/jni/h5util.h
+++ b/java/src/jni/h5util.h
@@ -53,9 +53,9 @@ extern int    h5str_dump_simple_mem(JNIEnv *env, FILE *stream, hid_t attr, int b
 extern htri_t H5Tdetect_variable_str(hid_t tid);
 
 extern herr_t translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t type_class,
-                     jsize count, jobjectArray raw_buf);
+                             jsize count, jobjectArray raw_buf);
 extern herr_t translate_wbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t type_class,
-                     jsize count, jobjectArray raw_buf);
+                             jsize count, jobjectArray raw_buf);
 
 /*
  * Symbols used to format the output of h5str_sprintf and

--- a/java/test/TestH5A.java
+++ b/java/test/TestH5A.java
@@ -1415,7 +1415,7 @@ public class TestH5A {
                                            HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
                 assertTrue("testH5AVLwr: ", attr_int_id >= 0);
 
-                H5.H5AwriteVL(attr_int_id, atype_int_id, vl_int_data);
+                H5.H5Awrite(attr_int_id, atype_int_id, vl_int_data);
             }
             catch (Exception err) {
                 if (attr_int_id > 0)
@@ -1472,7 +1472,7 @@ public class TestH5A {
                                            HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
                 assertTrue("testH5AVLwr: ", attr_dbl_id >= 0);
 
-                H5.H5AwriteVL(attr_dbl_id, atype_dbl_id, vl_dbl_data);
+                H5.H5Awrite(attr_dbl_id, atype_dbl_id, vl_dbl_data);
             }
             catch (Exception err) {
                 if (attr_dbl_id > 0)
@@ -1511,7 +1511,7 @@ public class TestH5A {
                 vl_readbuf[j] = new ArrayList<Integer>();
 
             try {
-                H5.H5AreadVL(attr_int_id, atype_int_id, vl_readbuf);
+                H5.H5Aread(attr_int_id, atype_int_id, vl_readbuf);
             }
             catch (Exception ex) {
                 ex.printStackTrace();
@@ -1531,7 +1531,7 @@ public class TestH5A {
                 vl_readbuf[j] = new ArrayList<Double>();
 
             try {
-                H5.H5AreadVL(attr_dbl_id, atype_dbl_id, vl_readbuf);
+                H5.H5Aread(attr_dbl_id, atype_dbl_id, vl_readbuf);
             }
             catch (Exception ex) {
                 ex.printStackTrace();

--- a/java/test/TestH5A.java
+++ b/java/test/TestH5A.java
@@ -1580,13 +1580,13 @@ public class TestH5A {
     @Test
     public void testH5AVLwrVL()
     {
-        String attr_int_name = "VLIntdata";
-        long attr_int_id     = HDF5Constants.H5I_INVALID_HID;
-        long atype_int_id    = HDF5Constants.H5I_INVALID_HID;
-        long base_atype_int_id    = HDF5Constants.H5I_INVALID_HID;
-        long aspace_id       = HDF5Constants.H5I_INVALID_HID;
-        long[] dims          = {4};
-        long lsize           = 1;
+        String attr_int_name   = "VLIntdata";
+        long attr_int_id       = HDF5Constants.H5I_INVALID_HID;
+        long atype_int_id      = HDF5Constants.H5I_INVALID_HID;
+        long base_atype_int_id = HDF5Constants.H5I_INVALID_HID;
+        long aspace_id         = HDF5Constants.H5I_INVALID_HID;
+        long[] dims            = {4};
+        long lsize             = 1;
 
         ArrayList[] base_vl_int_data = new ArrayList[4];
         ArrayList[] vl_int_data      = new ArrayList[4];

--- a/java/test/TestH5D.java
+++ b/java/test/TestH5D.java
@@ -1064,7 +1064,7 @@ public class TestH5D {
                                  HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
                 assertTrue("testH5DVLwr: ", dset_int_id >= 0);
 
-                H5.H5DwriteVL(dset_int_id, dtype_int_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
+                H5.H5Dwrite(dset_int_id, dtype_int_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
                               HDF5Constants.H5P_DEFAULT, vl_int_data);
             }
             catch (Exception err) {
@@ -1123,7 +1123,7 @@ public class TestH5D {
                                  HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
                 assertTrue("testH5DVLwr: ", dset_dbl_id >= 0);
 
-                H5.H5DwriteVL(dset_dbl_id, dtype_dbl_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
+                H5.H5Dwrite(dset_dbl_id, dtype_dbl_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
                               HDF5Constants.H5P_DEFAULT, vl_dbl_data);
             }
             catch (Exception err) {
@@ -1163,7 +1163,7 @@ public class TestH5D {
                 vl_readbuf[j] = new ArrayList<Integer>();
 
             try {
-                H5.H5DreadVL(dset_int_id, dtype_int_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
+                H5.H5Dread(dset_int_id, dtype_int_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
                              HDF5Constants.H5P_DEFAULT, vl_readbuf);
             }
             catch (Exception ex) {
@@ -1184,7 +1184,7 @@ public class TestH5D {
                 vl_readbuf[j] = new ArrayList<Double>();
 
             try {
-                H5.H5DreadVL(dset_dbl_id, dtype_dbl_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
+                H5.H5Dread(dset_dbl_id, dtype_dbl_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
                              HDF5Constants.H5P_DEFAULT, vl_readbuf);
             }
             catch (Exception ex) {

--- a/java/test/TestH5D.java
+++ b/java/test/TestH5D.java
@@ -1065,7 +1065,7 @@ public class TestH5D {
                 assertTrue("testH5DVLwr: ", dset_int_id >= 0);
 
                 H5.H5Dwrite(dset_int_id, dtype_int_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
-                              HDF5Constants.H5P_DEFAULT, vl_int_data);
+                            HDF5Constants.H5P_DEFAULT, vl_int_data);
             }
             catch (Exception err) {
                 if (dset_int_id > 0)
@@ -1124,7 +1124,7 @@ public class TestH5D {
                 assertTrue("testH5DVLwr: ", dset_dbl_id >= 0);
 
                 H5.H5Dwrite(dset_dbl_id, dtype_dbl_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
-                              HDF5Constants.H5P_DEFAULT, vl_dbl_data);
+                            HDF5Constants.H5P_DEFAULT, vl_dbl_data);
             }
             catch (Exception err) {
                 if (dset_dbl_id > 0)
@@ -1153,9 +1153,8 @@ public class TestH5D {
 
             H5.H5Fflush(H5fid, HDF5Constants.H5F_SCOPE_LOCAL);
 
-            for (int j = 0; j < dims.length; j++) {
+            for (int j = 0; j < dims.length; j++)
                 lsize *= dims[j];
-            }
 
             // Read Integer data
             ArrayList[] vl_readbuf = new ArrayList[4];
@@ -1164,7 +1163,7 @@ public class TestH5D {
 
             try {
                 H5.H5Dread(dset_int_id, dtype_int_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
-                             HDF5Constants.H5P_DEFAULT, vl_readbuf);
+                           HDF5Constants.H5P_DEFAULT, vl_readbuf);
             }
             catch (Exception ex) {
                 ex.printStackTrace();
@@ -1185,7 +1184,7 @@ public class TestH5D {
 
             try {
                 H5.H5Dread(dset_dbl_id, dtype_dbl_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
-                             HDF5Constants.H5P_DEFAULT, vl_readbuf);
+                           HDF5Constants.H5P_DEFAULT, vl_readbuf);
             }
             catch (Exception ex) {
                 ex.printStackTrace();
@@ -1243,7 +1242,7 @@ public class TestH5D {
         long lsize             = 1;
 
         ArrayList[] base_vl_int_data = new ArrayList[4];
-        ArrayList[] vl_int_data = new ArrayList[4];
+        ArrayList[] vl_int_data      = new ArrayList[4];
         try {
             // Write Integer data
             vl_int_data[0]  = new ArrayList<Integer>(Arrays.asList(1));
@@ -1252,18 +1251,18 @@ public class TestH5D {
             vl_int_data[3]  = new ArrayList<Integer>(Arrays.asList(7, 8, 9, 10));
             Class dataClass = vl_int_data.getClass();
             assertTrue("testH5DVLwrVL.getClass: " + dataClass, dataClass.isArray());
-            
+
             // Write VL data
-            base_vl_int_data[0]  = new ArrayList<ArrayList<Integer>>();
+            base_vl_int_data[0] = new ArrayList<ArrayList<Integer>>();
             base_vl_int_data[0].add(vl_int_data[0]);
-            base_vl_int_data[1]  = new ArrayList<ArrayList<Integer>>();
+            base_vl_int_data[1] = new ArrayList<ArrayList<Integer>>();
             base_vl_int_data[1].add(vl_int_data[0]);
             base_vl_int_data[1].add(vl_int_data[1]);
-            base_vl_int_data[2]  = new ArrayList<ArrayList<Integer>>();
+            base_vl_int_data[2] = new ArrayList<ArrayList<Integer>>();
             base_vl_int_data[2].add(vl_int_data[0]);
             base_vl_int_data[2].add(vl_int_data[1]);
             base_vl_int_data[2].add(vl_int_data[2]);
-            base_vl_int_data[3]  = new ArrayList<ArrayList<Integer>>();
+            base_vl_int_data[3] = new ArrayList<ArrayList<Integer>>();
             base_vl_int_data[3].add(vl_int_data[0]);
             base_vl_int_data[3].add(vl_int_data[1]);
             base_vl_int_data[3].add(vl_int_data[2]);
@@ -1295,13 +1294,13 @@ public class TestH5D {
             try {
                 dspace_id = H5.H5Screate_simple(1, dims, null);
                 assertTrue(dspace_id > 0);
-                dset_int_id =
-                    H5.H5Dcreate(H5fid, dset_int_name, base_dtype_int_id, dspace_id, HDF5Constants.H5P_DEFAULT,
-                                 HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
+                dset_int_id = H5.H5Dcreate(H5fid, dset_int_name, base_dtype_int_id, dspace_id,
+                                           HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT,
+                                           HDF5Constants.H5P_DEFAULT);
                 assertTrue("testH5DVLwrVL: ", dset_int_id >= 0);
 
                 H5.H5Dwrite(dset_int_id, base_dtype_int_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
-                              HDF5Constants.H5P_DEFAULT, base_vl_int_data);
+                            HDF5Constants.H5P_DEFAULT, base_vl_int_data);
             }
             catch (Exception err) {
                 if (dset_int_id > 0)
@@ -1330,19 +1329,17 @@ public class TestH5D {
 
             H5.H5Fflush(H5fid, HDF5Constants.H5F_SCOPE_LOCAL);
 
-            for (int j = 0; j < dims.length; j++) {
+            for (int j = 0; j < dims.length; j++)
                 lsize *= dims[j];
-            }
 
             // Read Integer data
             ArrayList[] base_vl_readbuf = new ArrayList[4];
-            for (int j = 0; j < lsize; j++) {
-                base_vl_readbuf[j]  = new ArrayList<ArrayList<Integer>>();
-            }
-            
+            for (int j = 0; j < lsize; j++)
+                base_vl_readbuf[j] = new ArrayList<ArrayList<Integer>>();
+
             try {
                 H5.H5Dread(dset_int_id, base_dtype_int_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
-                             HDF5Constants.H5P_DEFAULT, base_vl_readbuf);
+                           HDF5Constants.H5P_DEFAULT, base_vl_readbuf);
             }
             catch (Exception ex) {
                 ex.printStackTrace();
@@ -1353,15 +1350,18 @@ public class TestH5D {
             ArrayList vl_readbuf_int = (ArrayList)vl_readbuf.get(0);
             assertTrue("testH5DVLwrVL:" + vl_readbuf_int.get(0),
                        vl_int_data[0].get(0).equals(vl_readbuf_int.get(0)));
-            vl_readbuf = (ArrayList)base_vl_readbuf[1];
+
+            vl_readbuf     = (ArrayList)base_vl_readbuf[1];
             vl_readbuf_int = (ArrayList)vl_readbuf.get(1);
             assertTrue("testH5DVLwrVL:" + vl_readbuf_int.get(0),
                        vl_int_data[1].get(0).equals(vl_readbuf_int.get(0)));
-            vl_readbuf = (ArrayList)base_vl_readbuf[2];
+
+            vl_readbuf     = (ArrayList)base_vl_readbuf[2];
             vl_readbuf_int = (ArrayList)vl_readbuf.get(2);
             assertTrue("testH5DVLwrVL:" + vl_readbuf_int.get(0),
                        vl_int_data[2].get(0).equals(vl_readbuf_int.get(0)));
-            vl_readbuf = (ArrayList)base_vl_readbuf[3];
+
+            vl_readbuf     = (ArrayList)base_vl_readbuf[3];
             vl_readbuf_int = (ArrayList)vl_readbuf.get(3);
             assertTrue("testH5DVLwrVL:" + vl_readbuf_int.get(0),
                        vl_int_data[3].get(0).equals(vl_readbuf_int.get(0)));

--- a/java/test/TestH5D.java
+++ b/java/test/TestH5D.java
@@ -1230,4 +1230,165 @@ public class TestH5D {
                 }
         }
     }
+
+    @Test
+    public void testH5DVLwrVL()
+    {
+        String dset_int_name   = "VLIntdata";
+        long dset_int_id       = HDF5Constants.H5I_INVALID_HID;
+        long dtype_int_id      = HDF5Constants.H5I_INVALID_HID;
+        long base_dtype_int_id = HDF5Constants.H5I_INVALID_HID;
+        long dspace_id         = HDF5Constants.H5I_INVALID_HID;
+        long[] dims            = {4};
+        long lsize             = 1;
+
+        ArrayList[] base_vl_int_data = new ArrayList[4];
+        ArrayList[] vl_int_data = new ArrayList[4];
+        try {
+            // Write Integer data
+            vl_int_data[0]  = new ArrayList<Integer>(Arrays.asList(1));
+            vl_int_data[1]  = new ArrayList<Integer>(Arrays.asList(2, 3));
+            vl_int_data[2]  = new ArrayList<Integer>(Arrays.asList(4, 5, 6));
+            vl_int_data[3]  = new ArrayList<Integer>(Arrays.asList(7, 8, 9, 10));
+            Class dataClass = vl_int_data.getClass();
+            assertTrue("testH5DVLwrVL.getClass: " + dataClass, dataClass.isArray());
+            
+            // Write VL data
+            base_vl_int_data[0]  = new ArrayList<ArrayList<Integer>>();
+            base_vl_int_data[0].add(vl_int_data[0]);
+            base_vl_int_data[1]  = new ArrayList<ArrayList<Integer>>();
+            base_vl_int_data[1].add(vl_int_data[0]);
+            base_vl_int_data[1].add(vl_int_data[1]);
+            base_vl_int_data[2]  = new ArrayList<ArrayList<Integer>>();
+            base_vl_int_data[2].add(vl_int_data[0]);
+            base_vl_int_data[2].add(vl_int_data[1]);
+            base_vl_int_data[2].add(vl_int_data[2]);
+            base_vl_int_data[3]  = new ArrayList<ArrayList<Integer>>();
+            base_vl_int_data[3].add(vl_int_data[0]);
+            base_vl_int_data[3].add(vl_int_data[1]);
+            base_vl_int_data[3].add(vl_int_data[2]);
+            base_vl_int_data[3].add(vl_int_data[3]);
+
+            try {
+                dtype_int_id = H5.H5Tvlen_create(HDF5Constants.H5T_STD_U32LE);
+                assertTrue("testH5DVLwrVL.H5Tvlen_create: ", dtype_int_id >= 0);
+                base_dtype_int_id = H5.H5Tvlen_create(dtype_int_id);
+                assertTrue("testH5DVLwrVL.H5Tvlen_create: ", base_dtype_int_id >= 0);
+            }
+            catch (Exception err) {
+                if (base_dtype_int_id > 0)
+                    try {
+                        H5.H5Tclose(base_dtype_int_id);
+                    }
+                    catch (Exception ex) {
+                    }
+                if (dtype_int_id > 0)
+                    try {
+                        H5.H5Tclose(dtype_int_id);
+                    }
+                    catch (Exception ex) {
+                    }
+                err.printStackTrace();
+                fail("H5.testH5DVLwrVL: " + err);
+            }
+
+            try {
+                dspace_id = H5.H5Screate_simple(1, dims, null);
+                assertTrue(dspace_id > 0);
+                dset_int_id =
+                    H5.H5Dcreate(H5fid, dset_int_name, base_dtype_int_id, dspace_id, HDF5Constants.H5P_DEFAULT,
+                                 HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
+                assertTrue("testH5DVLwrVL: ", dset_int_id >= 0);
+
+                H5.H5Dwrite(dset_int_id, base_dtype_int_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
+                              HDF5Constants.H5P_DEFAULT, base_vl_int_data);
+            }
+            catch (Exception err) {
+                if (dset_int_id > 0)
+                    try {
+                        H5.H5Dclose(dset_int_id);
+                    }
+                    catch (Exception ex) {
+                    }
+                if (dtype_int_id > 0)
+                    try {
+                        H5.H5Tclose(dtype_int_id);
+                    }
+                    catch (Exception ex) {
+                    }
+                err.printStackTrace();
+                fail("H5.testH5DVLwrVL: " + err);
+            }
+            finally {
+                if (dspace_id > 0)
+                    try {
+                        H5.H5Sclose(dspace_id);
+                    }
+                    catch (Exception ex) {
+                    }
+            }
+
+            H5.H5Fflush(H5fid, HDF5Constants.H5F_SCOPE_LOCAL);
+
+            for (int j = 0; j < dims.length; j++) {
+                lsize *= dims[j];
+            }
+
+            // Read Integer data
+            ArrayList[] base_vl_readbuf = new ArrayList[4];
+            for (int j = 0; j < lsize; j++) {
+                base_vl_readbuf[j]  = new ArrayList<ArrayList<Integer>>();
+            }
+            
+            try {
+                H5.H5Dread(dset_int_id, base_dtype_int_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
+                             HDF5Constants.H5P_DEFAULT, base_vl_readbuf);
+            }
+            catch (Exception ex) {
+                ex.printStackTrace();
+            }
+            ArrayList vl_readbuf = (ArrayList)base_vl_readbuf[0];
+            assertTrue("vl_readbuf exists", vl_readbuf != null);
+            assertTrue("vl_readbuf has size " + vl_readbuf.size(), vl_readbuf.size() > 0);
+            ArrayList vl_readbuf_int = (ArrayList)vl_readbuf.get(0);
+            assertTrue("testH5DVLwrVL:" + vl_readbuf_int.get(0),
+                       vl_int_data[0].get(0).equals(vl_readbuf_int.get(0)));
+            vl_readbuf = (ArrayList)base_vl_readbuf[1];
+            vl_readbuf_int = (ArrayList)vl_readbuf.get(1);
+            assertTrue("testH5DVLwrVL:" + vl_readbuf_int.get(0),
+                       vl_int_data[1].get(0).equals(vl_readbuf_int.get(0)));
+            vl_readbuf = (ArrayList)base_vl_readbuf[2];
+            vl_readbuf_int = (ArrayList)vl_readbuf.get(2);
+            assertTrue("testH5DVLwrVL:" + vl_readbuf_int.get(0),
+                       vl_int_data[2].get(0).equals(vl_readbuf_int.get(0)));
+            vl_readbuf = (ArrayList)base_vl_readbuf[3];
+            vl_readbuf_int = (ArrayList)vl_readbuf.get(3);
+            assertTrue("testH5DVLwrVL:" + vl_readbuf_int.get(0),
+                       vl_int_data[3].get(0).equals(vl_readbuf_int.get(0)));
+        }
+        catch (Throwable err) {
+            err.printStackTrace();
+            fail("H5.testH5DVLwrVL: " + err);
+        }
+        finally {
+            if (dset_int_id > 0)
+                try {
+                    H5.H5Dclose(dset_int_id);
+                }
+                catch (Exception ex) {
+                }
+            if (dtype_int_id > 0)
+                try {
+                    H5.H5Tclose(dtype_int_id);
+                }
+                catch (Exception ex) {
+                }
+            if (base_dtype_int_id > 0)
+                try {
+                    H5.H5Tclose(base_dtype_int_id);
+                }
+                catch (Exception ex) {
+                }
+        }
+    }
 }

--- a/java/test/TestH5R.java
+++ b/java/test/TestH5R.java
@@ -832,7 +832,7 @@ public class TestH5R {
                 assertTrue("testH5RVLdset_ref: ", dset_obj_id >= 0);
 
                 H5.H5Dwrite(dset_obj_id, dtype_obj_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
-                              HDF5Constants.H5P_DEFAULT, vl_obj_data);
+                            HDF5Constants.H5P_DEFAULT, vl_obj_data);
             }
             catch (Exception err) {
                 if (dset_obj_id > 0)
@@ -891,7 +891,7 @@ public class TestH5R {
                 assertTrue("testH5RVLdset_ref: ", dset_reg_id >= 0);
 
                 H5.H5Dwrite(dset_reg_id, dtype_reg_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
-                              HDF5Constants.H5P_DEFAULT, vl_reg_data);
+                            HDF5Constants.H5P_DEFAULT, vl_reg_data);
             }
             catch (Exception err) {
                 if (dset_reg_id > 0)
@@ -931,7 +931,7 @@ public class TestH5R {
 
             try {
                 H5.H5Dread(dset_obj_id, dtype_obj_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
-                             HDF5Constants.H5P_DEFAULT, vl_readbuf);
+                           HDF5Constants.H5P_DEFAULT, vl_readbuf);
             }
             catch (Exception ex) {
                 ex.printStackTrace();
@@ -952,7 +952,7 @@ public class TestH5R {
 
             try {
                 H5.H5Dread(dset_reg_id, dtype_reg_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
-                             HDF5Constants.H5P_DEFAULT, vl_readbuf);
+                           HDF5Constants.H5P_DEFAULT, vl_readbuf);
             }
             catch (Exception ex) {
                 ex.printStackTrace();

--- a/java/test/TestH5R.java
+++ b/java/test/TestH5R.java
@@ -600,7 +600,7 @@ public class TestH5R {
                                            HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
                 assertTrue("testH5RVLattr_ref: ", attr_obj_id >= 0);
 
-                H5.H5AwriteVL(attr_obj_id, atype_obj_id, vl_obj_data);
+                H5.H5Awrite(attr_obj_id, atype_obj_id, vl_obj_data);
             }
             catch (Exception err) {
                 if (attr_obj_id > 0)
@@ -657,7 +657,7 @@ public class TestH5R {
                                            HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
                 assertTrue("testH5RVLattr_ref: ", attr_reg_id >= 0);
 
-                H5.H5AwriteVL(attr_reg_id, atype_reg_id, vl_reg_data);
+                H5.H5Awrite(attr_reg_id, atype_reg_id, vl_reg_data);
             }
             catch (Exception err) {
                 if (attr_reg_id > 0)
@@ -696,7 +696,7 @@ public class TestH5R {
                 vl_readbuf[j] = new ArrayList<byte[]>();
 
             try {
-                H5.H5AreadVL(attr_obj_id, atype_obj_id, vl_readbuf);
+                H5.H5Aread(attr_obj_id, atype_obj_id, vl_readbuf);
             }
             catch (Exception ex) {
                 ex.printStackTrace();
@@ -716,7 +716,7 @@ public class TestH5R {
                 vl_readbuf[j] = new ArrayList<byte[]>();
 
             try {
-                H5.H5AreadVL(attr_reg_id, atype_reg_id, vl_readbuf);
+                H5.H5Aread(attr_reg_id, atype_reg_id, vl_readbuf);
             }
             catch (Exception ex) {
                 ex.printStackTrace();
@@ -831,7 +831,7 @@ public class TestH5R {
                                  HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
                 assertTrue("testH5RVLdset_ref: ", dset_obj_id >= 0);
 
-                H5.H5DwriteVL(dset_obj_id, dtype_obj_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
+                H5.H5Dwrite(dset_obj_id, dtype_obj_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
                               HDF5Constants.H5P_DEFAULT, vl_obj_data);
             }
             catch (Exception err) {
@@ -890,7 +890,7 @@ public class TestH5R {
                                  HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
                 assertTrue("testH5RVLdset_ref: ", dset_reg_id >= 0);
 
-                H5.H5DwriteVL(dset_reg_id, dtype_reg_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
+                H5.H5Dwrite(dset_reg_id, dtype_reg_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
                               HDF5Constants.H5P_DEFAULT, vl_reg_data);
             }
             catch (Exception err) {
@@ -930,7 +930,7 @@ public class TestH5R {
                 vl_readbuf[j] = new ArrayList<byte[]>();
 
             try {
-                H5.H5DreadVL(dset_obj_id, dtype_obj_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
+                H5.H5Dread(dset_obj_id, dtype_obj_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
                              HDF5Constants.H5P_DEFAULT, vl_readbuf);
             }
             catch (Exception ex) {
@@ -951,7 +951,7 @@ public class TestH5R {
                 vl_readbuf[j] = new ArrayList<byte[]>();
 
             try {
-                H5.H5DreadVL(dset_reg_id, dtype_reg_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
+                H5.H5Dread(dset_reg_id, dtype_reg_id, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL,
                              HDF5Constants.H5P_DEFAULT, vl_readbuf);
             }
             catch (Exception ex) {

--- a/java/test/testfiles/JUnit-TestH5A.txt
+++ b/java/test/testfiles/JUnit-TestH5A.txt
@@ -11,6 +11,7 @@ JUnit version 4.11
 .testH5Aget_info_by_name
 .testH5Aget_create_plist
 .testH5Adelete_by_name
+.testH5AVLwrVL
 .testH5Aopen_by_name
 .testH5Aget_info
 .testH5Aget_name
@@ -31,5 +32,5 @@ JUnit version 4.11
 
 Time:  XXXX
 
-OK (29 tests)
+OK (30 tests)
 

--- a/java/test/testfiles/JUnit-TestH5D.txt
+++ b/java/test/testfiles/JUnit-TestH5D.txt
@@ -1,4 +1,5 @@
 JUnit version 4.11
+.testH5DVLwrVL
 .testH5Dget_storage_size
 .testH5Diterate_write
 .testH5Dcreate
@@ -22,5 +23,5 @@ JUnit version 4.11
 
 Time:  XXXX
 
-OK (20 tests)
+OK (21 tests)
 

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -144,7 +144,14 @@ Bug Fixes since HDF5-1.13.2 release
 
     Java Library
     ------------
-    -
+    - Improve variable-length datatype handling in JNI.
+
+      The existing JNI read-write functions could handle variable-length datatypes
+      that were simple variable-length datatype with an atomic sub-datatype. More
+      complex combinations could not be handled. Reworked the JNI read-write functions
+      to recursively inspect datatypes for variable-length sub-datatypes.
+
+      (ADB - 2022/10/12, HDFFV-8701,10375)
 
 
     Configuration


### PR DESCRIPTION
Existing code works if VL datatype is top level datatype.
This change moves the read/write to a separate function so it can be called recursively for VL types in container datatpyes (VL, Compound, Array). Java passes in an ArrayList of Arrays for the data buffer. This needs to be translated to C structures.

Tests need to be written for the other types (see the tvldtypes.h5 files generated by h5dumpgentest.c).