### PR TITLE
Remove memory sanity checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,14 +561,6 @@ if (HDF5_ENABLE_USING_MEMCHECKER)
 endif ()
 
 #-----------------------------------------------------------------------------
-# Option to indicate internal memory allocation sanity checks are enabled
-#-----------------------------------------------------------------------------
-option (HDF5_MEMORY_ALLOC_SANITY_CHECK "Indicate that internal memory allocation sanity checks are enabled" OFF)
-if (HDF5_MEMORY_ALLOC_SANITY_CHECK)
-  set (H5_MEMORY_ALLOC_SANITY_CHECK 1)
-endif ()
-
-#-----------------------------------------------------------------------------
 # Option to enable/disable using pread/pwrite for VFDs
 #-----------------------------------------------------------------------------
 option (HDF5_ENABLE_PREADWRITE "Use pread/pwrite in sec2/log/core VFDs in place of read/write (when available)" ON)

--- a/config/cmake/H5pubconf.h.in
+++ b/config/cmake/H5pubconf.h.in
@@ -439,9 +439,6 @@
 /* Define to the sub-directory where libtool stores uninstalled libraries. */
 #cmakedefine H5_LT_OBJDIR @H5_LT_OBJDIR@
 
-/* Define to enable internal memory allocation sanity checking. */
-#cmakedefine H5_MEMORY_ALLOC_SANITY_CHECK @H5_MEMORY_ALLOC_SANITY_CHECK@
-
 /* Define if deprecated public API symbols are disabled */
 #cmakedefine H5_NO_DEPRECATED_SYMBOLS @H5_NO_DEPRECATED_SYMBOLS@
 

--- a/config/cmake/libhdf5.settings.cmake.in
+++ b/config/cmake/libhdf5.settings.cmake.in
@@ -87,7 +87,6 @@ Dimension scales w/ new references: @DIMENSION_SCALES_WITH_NEW_REF@
     Packages w/ extra debug output: @INTERNAL_DEBUG_OUTPUT@
                        API Tracing: @HDF5_ENABLE_TRACE@
               Using memory checker: @HDF5_ENABLE_USING_MEMCHECKER@
-   Memory allocation sanity checks: @HDF5_MEMORY_ALLOC_SANITY_CHECK@
             Function Stack Tracing: @HDF5_ENABLE_CODESTACK@
                   Use file locking: @HDF5_FILE_LOCKING_SETTING@
          Strict File Format Checks: @HDF5_STRICT_FORMAT_CHECKS@

--- a/configure.ac
+++ b/configure.ac
@@ -2689,50 +2689,6 @@ case "X-$USINGMEMCHECKER" in
     ;;
 esac
 
-## ----------------------------------------------------------------------
-## Check if they would like to enable the internal memory allocation sanity
-##     checking code.
-##
-AC_MSG_CHECKING([whether internal memory allocation sanity checking is used])
-AC_ARG_ENABLE([memory-alloc-sanity-check],
-              [AS_HELP_STRING([--enable-memory-alloc-sanity-check],
-                              [Enable this option to turn on internal memory
-                              allocation sanity checking.  This could cause
-                              more memory use and somewhat slower allocation.
-                              This option may also cause issues with HDF5
-                              filter plugins, so should not be enabled if
-                              filters are to be used.  This option is orthogonal
-                              to the --enable-using-memchecker option.
-                               [default=no]
-                              ])],
-              [MEMORYALLOCSANITYCHECK=$enableval])
-
-## Allow this variable to be substituted in
-## other files (src/libhdf5.settings.in, etc.)
-AC_SUBST([MEMORYALLOCSANITYCHECK])
-
-## Set default
-if test "X-$MEMORYALLOCSANITYCHECK" = X- ; then
-# Should consider enabling this option by default for
-# 'developer' builds if that build mode is added in
-# the future
-  MEMORYALLOCSANITYCHECK=no
-fi
-
-case "X-$MEMORYALLOCSANITYCHECK" in
-  X-yes)
-      AC_DEFINE([MEMORY_ALLOC_SANITY_CHECK], [1],
-                [Define to enable internal memory allocation sanity checking.])
-      AC_MSG_RESULT([yes])
-    ;;
-  X-no)
-      AC_MSG_RESULT([no])
-    ;;
-  *)
-      AC_MSG_ERROR([Unrecognized value: $MEMORYALLOCSANITYCHECK])
-    ;;
-esac
-
 ## Checkpoint the cache
 AC_CACHE_SAVE
 

--- a/release_docs/INSTALL_CMake.txt
+++ b/release_docs/INSTALL_CMake.txt
@@ -773,7 +773,6 @@ HDF5_ENABLE_USING_MEMCHECKER   "Indicate that a memory checker is used"         
 HDF5_GENERATE_HEADERS          "Rebuild Generated Files"                                      ON
 HDF5_BUILD_GENERATORS          "Build Test Generators"                                        OFF
 HDF5_JAVA_PACK_JRE             "Package a JRE installer directory"                            OFF
-HDF5_MEMORY_ALLOC_SANITY_CHECK "Indicate that internal memory allocation sanity checks are enabled" OFF
 HDF5_NO_PACKAGES               "Do not include CPack Packaging"                               OFF
 HDF5_PACK_EXAMPLES             "Package the HDF5 Library Examples Compressed File"            OFF
 HDF5_PACK_MACOSX_FRAMEWORK     "Package the HDF5 Library in a Frameworks"                     OFF

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -55,13 +55,29 @@ New Features
 
       (ADB - 2022/08/29, HDFFV-11329)
 
-    -
+    - Removed the --enable-memory-alloc-sanity-check Autotools configure option
+      and the HDF5_MEMORY_ALLOC_SANITY_CHECK CMake option
+
+      The memory allocation sanity checks have been removed from the library.
+
+      (DER - 2022/10/15)
 
 
     Library:
     --------
-    -
+    - Removed the memory allocation sanity checks from the library
 
+      This feature added heap canaries to memory allocated inside the library
+      that were checked on library close. Although potentially helpful, other
+      methods for investigating memory leaks exist (valgrind, -fsanitize, etc.)
+      and the heap canaries caused problems with filters and API calls that
+      return library-allocated memory.
+
+      As a part of this change, the H5get_alloc_stats() API call has been
+      removed from the library. The Autotools and CMake features that
+      enabled this feature have also been removed (see above).
+
+      (DER - 2022/10/15)
 
     Parallel Library:
     -----------------
@@ -75,7 +91,7 @@ New Features
       Added Fortran H5Dfill_f, which is fully equivalent to the C API. It accepts pointers,
       fill value datatype and datatype of dataspace elements.
 
-      (MSB - 2022/10/10, HDFFV-10734.)
+      (MSB - 2022/10/10, HDFFV-10734)
 
     C++ Library:
     ------------

--- a/src/H5.c
+++ b/src/H5.c
@@ -1177,10 +1177,12 @@ H5allocate_memory(size_t size, hbool_t clear)
     FUNC_ENTER_API_NOINIT
     H5TRACE2("*x", "zb", size, clear);
 
-    if (clear)
-        ret_value = H5MM_calloc(size);
-    else
-        ret_value = H5MM_malloc(size);
+    if (size != 0) {
+        if (clear)
+            ret_value = H5MM_calloc(size);
+        else
+            ret_value = H5MM_malloc(size);
+    }
 
     FUNC_LEAVE_API_NOINIT(ret_value)
 } /* end H5allocate_memory() */
@@ -1217,7 +1219,10 @@ H5resize_memory(void *mem, size_t size)
     FUNC_ENTER_API_NOINIT
     H5TRACE2("*x", "*xz", mem, size);
 
-    ret_value = H5MM_realloc(mem, size);
+    if (size != 0)
+        ret_value = H5MM_realloc(mem, size);
+    else if (mem)
+        ret_value = H5MM_xfree(mem);
 
     FUNC_LEAVE_API_NOINIT(ret_value)
 } /* end H5resize_memory() */

--- a/src/H5.c
+++ b/src/H5.c
@@ -541,11 +541,6 @@ H5_term_library(void)
         (void)H5MM_free(tmp_open_stream);
     } /* end while */
 
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-    /* Sanity check memory allocations */
-    H5MM_final_sanity_check();
-#endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
-
     /* Reset flag indicating that the library is being shut down */
     H5_TERM_GLOBAL = FALSE;
 
@@ -715,46 +710,6 @@ H5get_free_list_sizes(size_t *reg_size /*out*/, size_t *arr_size /*out*/, size_t
 done:
     FUNC_LEAVE_API(ret_value)
 } /* end H5get_free_list_sizes() */
-
-/*-------------------------------------------------------------------------
- * Function:    H5get_alloc_stats
- *
- * Purpose:    Gets the memory allocation statistics for the library, if the
- *    --enable-memory-alloc-sanity-check option was given when building the
- *      library.  Applications can check whether this option was enabled by
- *    detecting if the 'H5_MEMORY_ALLOC_SANITY_CHECK' macro is defined.  This
- *    option is enabled by default for debug builds of the library and
- *    disabled by default for non-debug builds.  If the option is not enabled,
- *    all the values returned with be 0.  These statistics are global for the
- *    entire library, but don't include allocations from chunked dataset I/O
- *    filters or non-native VOL connectors.
- *
- * Parameters:
- *  H5_alloc_stats_t *stats;            OUT: Memory allocation statistics
- *
- * Return:    Success:    non-negative
- *        Failure:    negative
- *
- * Programmer:  Quincey Koziol
- *              Saturday, March 7, 2020
- *
- *-------------------------------------------------------------------------
- */
-herr_t
-H5get_alloc_stats(H5_alloc_stats_t *stats /*out*/)
-{
-    herr_t ret_value = SUCCEED; /* Return value */
-
-    FUNC_ENTER_API(FAIL)
-    H5TRACE1("e", "x", stats);
-
-    /* Call the internal allocation stat routine to get the values */
-    if (H5MM_get_alloc_stats(stats) < 0)
-        HGOTO_ERROR(H5E_RESOURCE, H5E_CANTGET, FAIL, "can't get allocation stats")
-
-done:
-    FUNC_LEAVE_API(ret_value)
-} /* end H5get_alloc_stats() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5__debug_mask

--- a/src/H5MM.c
+++ b/src/H5MM.c
@@ -56,110 +56,6 @@
 /*******************/
 
 /*-------------------------------------------------------------------------
- * Function:    H5MM_malloc
- *
- * Purpose:     Similar to the C89 version of malloc().
- *
- *              On size of 0, we return a NULL pointer instead of the
- *              standard-allowed 'special' pointer since that's more
- *              difficult to check as a return value. This is still
- *              considered an error condition since allocations of zero
- *              bytes usually indicate problems.
- *
- * Return:      Success:    Pointer to new memory
- *              Failure:    NULL
- *-------------------------------------------------------------------------
- */
-void *
-H5MM_malloc(size_t size)
-{
-    void *ret_value = NULL;
-
-    /* Use FUNC_ENTER_NOAPI_NOINIT_NOERR here to avoid performance issues */
-    FUNC_ENTER_NOAPI_NOINIT_NOERR
-
-    if (size)
-        ret_value = HDmalloc(size);
-    else
-        ret_value = NULL;
-
-    FUNC_LEAVE_NOAPI(ret_value)
-} /* end H5MM_malloc() */
-
-/*-------------------------------------------------------------------------
- * Function:    H5MM_calloc
- *
- * Purpose:     Similar to the C89 version of calloc(), except this
- *              routine just takes a 'size' parameter.
- *
- *              On size of 0, we return a NULL pointer instead of the
- *              standard-allowed 'special' pointer since that's more
- *              difficult to check as a return value. This is still
- *              considered an error condition since allocations of zero
- *              bytes usually indicate problems.
- *
- *
- * Return:      Success:    Pointer to new memory
- *              Failure:    NULL
- *-------------------------------------------------------------------------
- */
-void *
-H5MM_calloc(size_t size)
-{
-    void *ret_value = NULL;
-
-    /* Use FUNC_ENTER_NOAPI_NOINIT_NOERR here to avoid performance issues */
-    FUNC_ENTER_NOAPI_NOINIT_NOERR
-
-    if (size)
-        ret_value = HDcalloc((size_t)1, size);
-    else
-        ret_value = NULL;
-
-    FUNC_LEAVE_NOAPI(ret_value)
-} /* end H5MM_calloc() */
-
-/*-------------------------------------------------------------------------
- * Function:    H5MM_realloc
- *
- * Purpose:     Similar semantics as C89's realloc(). Specifically, the
- *              following calls are equivalent:
- *
- *              H5MM_realloc(NULL, size)    <==> H5MM_malloc(size)
- *              H5MM_realloc(ptr, 0)        <==> H5MM_xfree(ptr)
- *              H5MM_realloc(NULL, 0)       <==> NULL
- *
- *              Note that the (NULL, 0) combination is undefined behavior
- *              in the C standard.
- *
- * Return:      Success:    Ptr to new memory if size > 0
- *                          NULL if size is zero
- *              Failure:    NULL (input buffer is unchanged on failure)
- *-------------------------------------------------------------------------
- */
-void *
-H5MM_realloc(void *mem, size_t size)
-{
-    void *ret_value = NULL;
-
-    /* Use FUNC_ENTER_NOAPI_NOINIT_NOERR here to avoid performance issues */
-    FUNC_ENTER_NOAPI_NOINIT_NOERR
-
-    if (NULL == mem && 0 == size)
-        /* Not defined in the standard, return NULL */
-        ret_value = NULL;
-    else {
-        ret_value = HDrealloc(mem, size);
-
-        /* Some platforms do not return NULL if size is zero. */
-        if (0 == size)
-            ret_value = NULL;
-    }
-
-    FUNC_LEAVE_NOAPI(ret_value)
-} /* end H5MM_realloc() */
-
-/*-------------------------------------------------------------------------
  * Function:    H5MM_xstrdup
  *
  * Purpose:     Duplicates a string, including memory allocation.
@@ -185,75 +81,12 @@ done:
 } /* end H5MM_xstrdup() */
 
 /*-------------------------------------------------------------------------
- * Function:    H5MM_strdup
- *
- * Purpose:     Duplicates a string, including memory allocation.
- *              NULL is NOT an acceptable value for the input string.
- *
- *              If the string to be duplicated is the NULL pointer, then
- *              an error will be raised.
- *
- * Return:      Success:    Pointer to a new string
- *              Failure:    NULL
- *-------------------------------------------------------------------------
- */
-char *
-H5MM_strdup(const char *s)
-{
-    char *ret_value = NULL;
-
-    FUNC_ENTER_NOAPI(NULL)
-
-    if (!s)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "NULL string not allowed")
-    if (NULL == (ret_value = HDstrdup(s)))
-        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "string duplication failed")
-
-done:
-    FUNC_LEAVE_NOAPI(ret_value)
-} /* end H5MM_strdup() */
-
-/*-------------------------------------------------------------------------
- * Function:    H5MM_strndup
- *
- * Purpose:     Duplicates a string, including memory allocation, but only
- *              copies at most `n` bytes from the string to be duplicated.
- *              If the string to be duplicated is longer than `n`, only `n`
- *              bytes are copied and a terminating null byte is added.
- *              NULL is NOT an acceptable value for the input string.
- *
- *              If the string to be duplicated is the NULL pointer, then
- *              an error will be raised.
- *
- * Return:      Success:    Pointer to a new string
- *              Failure:    NULL
- *-------------------------------------------------------------------------
- */
-char *
-H5MM_strndup(const char *s, size_t n)
-{
-    char *ret_value = NULL;
-
-    FUNC_ENTER_NOAPI(NULL)
-
-    if (!s)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "NULL string not allowed")
-
-    if (NULL == (ret_value = HDstrndup(s, n)))
-        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "string duplication failed")
-
-done:
-    FUNC_LEAVE_NOAPI(ret_value)
-} /* end H5MM_strndup() */
-
-/*-------------------------------------------------------------------------
  * Function:    H5MM_xfree
  *
- * Purpose:     Just like free(3) except null pointers are allowed as
- *              arguments, and the return value (always NULL) can be
- *              assigned to the pointer whose memory was just freed:
+ * Purpose:     Just like free(3) except the return value (always NULL) can
+ *              be assigned to the pointer whose memory was just freed:
  *
- *              thing = H5MM_xfree (thing);
+ *              thing = H5MM_xfree(thing);
  *
  * Return:      Success:    NULL
  *              Failure:    never fails
@@ -293,33 +126,3 @@ H5MM_xfree_const(const void *mem)
 
     FUNC_LEAVE_NOAPI(NULL)
 } /* end H5MM_xfree_const() */
-
-/*-------------------------------------------------------------------------
- * Function:    H5MM_memcpy
- *
- * Purpose:     Like memcpy(3) but with sanity checks on the parameters,
- *              particularly buffer overlap.
- *
- * Return:      Success:    pointer to dest
- *              Failure:    NULL
- *-------------------------------------------------------------------------
- */
-void *
-H5MM_memcpy(void *dest, const void *src, size_t n)
-{
-    void *ret = NULL;
-
-    /* Use FUNC_ENTER_NOAPI_NOINIT_NOERR here to avoid performance issues */
-    FUNC_ENTER_NOAPI_NOINIT_NOERR
-
-    HDassert(dest);
-    HDassert(src);
-
-    /* Check for buffer overlap */
-    HDassert((char *)dest >= (const char *)src + n || (const char *)src >= (char *)dest + n);
-
-    /* Copy */
-    ret = HDmemcpy(dest, src, n);
-
-    FUNC_LEAVE_NOAPI(ret)
-} /* end H5MM_memcpy() */

--- a/src/H5MM.c
+++ b/src/H5MM.c
@@ -14,8 +14,6 @@
 /*-------------------------------------------------------------------------
  *
  * Created:     H5MM.c
- *              Jul 10 1997
- *              Robb Matzke
  *
  * Purpose:     Memory management functions
  *
@@ -36,45 +34,14 @@
 /****************/
 /* Local Macros */
 /****************/
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-#define H5MM_SIG_SIZE        4
-#define H5MM_HEAD_GUARD_SIZE 8
-#define H5MM_TAIL_GUARD_SIZE 8
-#define H5MM_BLOCK_FROM_BUF(mem)                                                                             \
-    ((H5MM_block_t *)((void *)((unsigned char *)mem - (offsetof(H5MM_block_t, b) + H5MM_HEAD_GUARD_SIZE))))
-#endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
 
 /******************/
 /* Local Typedefs */
 /******************/
 
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-/* Memory allocation "block", wrapped around each allocation */
-struct H5MM_block_t; /* Forward declaration for typedef */
-typedef struct H5MM_block_t {
-    unsigned char
-        sig[H5MM_SIG_SIZE]; /* Signature for the block, to indicate it was allocated with H5MM* interface */
-    struct H5MM_block_t *next; /* Pointer to next block in the list of allocated blocks */
-    struct H5MM_block_t *prev; /* Pointer to previous block in the list of allocated blocks */
-    union {
-        struct {
-            size_t  size;   /* Size of allocated block */
-            hbool_t in_use; /* Whether the block is in use or is free */
-        } info;
-        double _align; /* Align following buffer (b) to double boundary (unused) */
-    } u;
-    unsigned char b[]; /* Buffer for caller (includes header and footer) */
-} H5MM_block_t;
-#endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
-
 /********************/
 /* Local Prototypes */
 /********************/
-#if defined    H5_MEMORY_ALLOC_SANITY_CHECK
-static hbool_t H5MM__is_our_block(void *mem);
-static void    H5MM__sanity_check_block(const H5MM_block_t *block);
-static void    H5MM__sanity_check(void *mem);
-#endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
 
 /*********************/
 /* Package Variables */
@@ -87,152 +54,6 @@ static void    H5MM__sanity_check(void *mem);
 /*******************/
 /* Local Variables */
 /*******************/
-
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-/* Constant strings for block signature, head & tail guards */
-static const char H5MM_block_signature_s[H5MM_SIG_SIZE]         = {'H', '5', 'M', 'M'};
-static const char H5MM_block_head_guard_s[H5MM_HEAD_GUARD_SIZE] = {'D', 'E', 'A', 'D', 'B', 'E', 'E', 'F'};
-static const char H5MM_block_tail_guard_s[H5MM_TAIL_GUARD_SIZE] = {'B', 'E', 'E', 'F', 'D', 'E', 'A', 'D'};
-
-/* Flag to indicate the the interface has been initialized */
-static hbool_t H5MM_init_s = FALSE;
-
-/* Head of the list of allocated blocks */
-static H5MM_block_t H5MM_block_head_s;
-
-/* Statistics about block allocations */
-static unsigned long long H5MM_total_alloc_bytes_s        = 0;
-static size_t             H5MM_curr_alloc_bytes_s         = 0;
-static size_t             H5MM_peak_alloc_bytes_s         = 0;
-static size_t             H5MM_max_block_size_s           = 0;
-static size_t             H5MM_total_alloc_blocks_count_s = 0;
-static size_t             H5MM_curr_alloc_blocks_count_s  = 0;
-static size_t             H5MM_peak_alloc_blocks_count_s  = 0;
-#endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
-
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-
-/*-------------------------------------------------------------------------
- * Function:    H5MM__is_our_block
- *
- * Purpose:     Try to determine if a memory buffer has been allocated through
- *              the H5MM* interface, instead of the system's malloc() routines.
- *
- * Return:      Success:    TRUE/FALSE
- *              Failure:    (Can't fail)
- *
- * Programmer:  Quincey Koziol
- *              Dec 30 2015
- *
- *-------------------------------------------------------------------------
- */
-static hbool_t
-H5MM__is_our_block(void *mem)
-{
-    H5MM_block_t *block = H5MM_BLOCK_FROM_BUF(mem);
-
-    return (0 == HDmemcmp(block->sig, H5MM_block_signature_s, H5MM_SIG_SIZE));
-}
-
-/*-------------------------------------------------------------------------
- * Function:    H5MM__sanity_check_block
- *
- * Purpose:     Check a block wrapper around a buffer to validate it.
- *
- * Return:      N/A (void)
- *
- * Programmer:  Quincey Koziol
- *              Dec 30 2015
- *
- *-------------------------------------------------------------------------
- */
-static void
-H5MM__sanity_check_block(const H5MM_block_t *block)
-{
-    HDassert(block->u.info.size > 0);
-    HDassert(block->u.info.in_use);
-    /* Check for head & tail guards, if not head of linked list */
-    if (block->u.info.size != SIZE_MAX) {
-        HDassert(0 == HDmemcmp(block->b, H5MM_block_head_guard_s, H5MM_HEAD_GUARD_SIZE));
-        HDassert(0 == HDmemcmp(block->b + H5MM_HEAD_GUARD_SIZE + block->u.info.size, H5MM_block_tail_guard_s,
-                               H5MM_TAIL_GUARD_SIZE));
-    }
-}
-
-/*-------------------------------------------------------------------------
- * Function:    H5MM__sanity_check
- *
- * Purpose:     Check a buffer to validate it (just calls
- *              H5MM__sanity_check_block after finding block for buffer)
- *
- * Return:      N/A (void)
- *
- * Programmer:  Quincey Koziol
- *              Dec 30 2015
- *
- *-------------------------------------------------------------------------
- */
-static void
-H5MM__sanity_check(void *mem)
-{
-    H5MM_block_t *block = H5MM_BLOCK_FROM_BUF(mem);
-
-    H5MM__sanity_check_block(block);
-}
-
-/*-------------------------------------------------------------------------
- * Function:    H5MM_sanity_check_all
- *
- * Purpose:     Sanity check all current memory allocations.
- *
- * Return:      N/A (void)
- *
- * Programmer:  Quincey Koziol
- *              Jan  5 2016
- *
- *-------------------------------------------------------------------------
- */
-void
-H5MM_sanity_check_all(void)
-{
-    H5MM_block_t *curr = NULL;
-
-    curr = H5MM_block_head_s.next;
-    while (curr != &H5MM_block_head_s) {
-        H5MM__sanity_check_block(curr);
-        curr = curr->next;
-    } /* end while */
-} /* end H5MM_sanity_check_all() */
-
-/*-------------------------------------------------------------------------
- * Function:    H5MM_final_sanity_check
- *
- * Purpose:     Final sanity checks on memory allocation.
- *
- * Return:      N/A (void)
- *
- * Programmer:  Quincey Koziol
- *              Jan  1 2016
- *
- *-------------------------------------------------------------------------
- */
-void
-H5MM_final_sanity_check(void)
-{
-    HDassert(0 == H5MM_curr_alloc_bytes_s);
-    HDassert(0 == H5MM_curr_alloc_blocks_count_s);
-    HDassert(H5MM_block_head_s.next == &H5MM_block_head_s);
-    HDassert(H5MM_block_head_s.prev == &H5MM_block_head_s);
-#ifdef H5MM_PRINT_MEMORY_STATS
-    HDfprintf(stderr, "%s: H5MM_total_alloc_bytes_s = %llu\n", __func__, H5MM_total_alloc_bytes_s);
-    HDfprintf(stderr, "%s: H5MM_peak_alloc_bytes_s = %zu\n", __func__, H5MM_peak_alloc_bytes_s);
-    HDfprintf(stderr, "%s: H5MM_max_block_size_s = %zu\n", __func__, H5MM_max_block_size_s);
-    HDfprintf(stderr, "%s: H5MM_total_alloc_blocks_count_s = %zu\n", __func__,
-              H5MM_total_alloc_blocks_count_s);
-    HDfprintf(stderr, "%s: H5MM_peak_alloc_blocks_count_s = %zu\n", __func__, H5MM_peak_alloc_blocks_count_s);
-#endif /* H5MM_PRINT_MEMORY_STATS */
-}
-#endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
 
 /*-------------------------------------------------------------------------
  * Function:    H5MM_malloc
@@ -247,10 +68,6 @@ H5MM_final_sanity_check(void)
  *
  * Return:      Success:    Pointer to new memory
  *              Failure:    NULL
- *
- * Programmer:  Quincey Koziol
- *              Nov  8 2003
- *
  *-------------------------------------------------------------------------
  */
 void *
@@ -261,58 +78,8 @@ H5MM_malloc(size_t size)
     /* Use FUNC_ENTER_NOAPI_NOINIT_NOERR here to avoid performance issues */
     FUNC_ENTER_NOAPI_NOINIT_NOERR
 
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-    /* Initialize block list head singleton */
-    if (!H5MM_init_s) {
-        H5MM_memcpy(H5MM_block_head_s.sig, H5MM_block_signature_s, H5MM_SIG_SIZE);
-        H5MM_block_head_s.next          = &H5MM_block_head_s;
-        H5MM_block_head_s.prev          = &H5MM_block_head_s;
-        H5MM_block_head_s.u.info.size   = SIZE_MAX;
-        H5MM_block_head_s.u.info.in_use = TRUE;
-
-        H5MM_init_s = TRUE;
-    }  /* end if */
-#endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
-
-    if (size) {
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-        H5MM_block_t *block;
-        size_t        alloc_size = sizeof(H5MM_block_t) + size + H5MM_HEAD_GUARD_SIZE + H5MM_TAIL_GUARD_SIZE;
-
-        if (NULL != (block = (H5MM_block_t *)HDmalloc(alloc_size))) {
-            /* Set up block */
-            H5MM_memcpy(block->sig, H5MM_block_signature_s, H5MM_SIG_SIZE);
-            block->next            = H5MM_block_head_s.next;
-            H5MM_block_head_s.next = block;
-            block->next->prev      = block;
-            block->prev            = &H5MM_block_head_s;
-            block->u.info.size     = size;
-            block->u.info.in_use   = TRUE;
-            H5MM_memcpy(block->b, H5MM_block_head_guard_s, H5MM_HEAD_GUARD_SIZE);
-            H5MM_memcpy(block->b + H5MM_HEAD_GUARD_SIZE + size, H5MM_block_tail_guard_s,
-                        H5MM_TAIL_GUARD_SIZE);
-
-            /* Update statistics */
-            H5MM_total_alloc_bytes_s += size;
-            H5MM_curr_alloc_bytes_s += size;
-            if (H5MM_curr_alloc_bytes_s > H5MM_peak_alloc_bytes_s)
-                H5MM_peak_alloc_bytes_s = H5MM_curr_alloc_bytes_s;
-            if (size > H5MM_max_block_size_s)
-                H5MM_max_block_size_s = size;
-            H5MM_total_alloc_blocks_count_s++;
-            H5MM_curr_alloc_blocks_count_s++;
-            if (H5MM_curr_alloc_blocks_count_s > H5MM_peak_alloc_blocks_count_s)
-                H5MM_peak_alloc_blocks_count_s = H5MM_curr_alloc_blocks_count_s;
-
-            /* Set buffer to return */
-            ret_value = block->b + H5MM_HEAD_GUARD_SIZE;
-        } /* end if */
-        else
-            ret_value = NULL;
-#else  /* H5_MEMORY_ALLOC_SANITY_CHECK */
+    if (size)
         ret_value = HDmalloc(size);
-#endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
-    }  /* end if */
     else
         ret_value = NULL;
 
@@ -334,10 +101,6 @@ H5MM_malloc(size_t size)
  *
  * Return:      Success:    Pointer to new memory
  *              Failure:    NULL
- *
- * Programmer:	Quincey Koziol
- *              Nov  8 2003
- *
  *-------------------------------------------------------------------------
  */
 void *
@@ -348,14 +111,8 @@ H5MM_calloc(size_t size)
     /* Use FUNC_ENTER_NOAPI_NOINIT_NOERR here to avoid performance issues */
     FUNC_ENTER_NOAPI_NOINIT_NOERR
 
-    if (size) {
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-        if (NULL != (ret_value = H5MM_malloc(size)))
-            HDmemset(ret_value, 0, size);
-#else  /* H5_MEMORY_ALLOC_SANITY_CHECK */
+    if (size)
         ret_value = HDcalloc((size_t)1, size);
-#endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
-    }  /* end if */
     else
         ret_value = NULL;
 
@@ -378,10 +135,6 @@ H5MM_calloc(size_t size)
  * Return:      Success:    Ptr to new memory if size > 0
  *                          NULL if size is zero
  *              Failure:    NULL (input buffer is unchanged on failure)
- *
- * Programmer:  Robb Matzke
- *              Jul 10 1997
- *
  *-------------------------------------------------------------------------
  */
 void *
@@ -396,35 +149,12 @@ H5MM_realloc(void *mem, size_t size)
         /* Not defined in the standard, return NULL */
         ret_value = NULL;
     else {
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-        if (size > 0) {
-            if (mem) {
-                if (H5MM__is_our_block(mem)) {
-                    H5MM_block_t *block    = H5MM_BLOCK_FROM_BUF(mem);
-                    size_t        old_size = block->u.info.size;
-
-                    H5MM__sanity_check(mem);
-
-                    ret_value = H5MM_malloc(size);
-                    H5MM_memcpy(ret_value, mem, MIN(size, old_size));
-                    H5MM_xfree(mem);
-                } /* end if */
-                else
-                    ret_value = HDrealloc(mem, size);
-            }
-            else
-                ret_value = H5MM_malloc(size);
-        }
-        else
-            ret_value = H5MM_xfree(mem);
-#else  /* H5_MEMORY_ALLOC_SANITY_CHECK */
         ret_value = HDrealloc(mem, size);
 
         /* Some platforms do not return NULL if size is zero. */
         if (0 == size)
             ret_value = NULL;
-#endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
-    }  /* end else */
+    }
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5MM_realloc() */
@@ -437,9 +167,6 @@ H5MM_realloc(void *mem, size_t size)
  *
  * Return:      Success:    Pointer to a new string (NULL if s is NULL).
  *              Failure:    NULL
- *
- * Programmer:  Robb Matzke
- *              Jul 10 1997
  *-------------------------------------------------------------------------
  */
 char *
@@ -449,17 +176,9 @@ H5MM_xstrdup(const char *s)
 
     FUNC_ENTER_NOAPI(NULL)
 
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-    if (s) {
-        if (NULL == (ret_value = (char *)H5MM_malloc(HDstrlen(s) + 1)))
-            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed")
-        HDstrcpy(ret_value, s);
-    }
-#else
     if (s)
         if (NULL == (ret_value = HDstrdup(s)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "string duplication failed")
-#endif
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -476,9 +195,6 @@ done:
  *
  * Return:      Success:    Pointer to a new string
  *              Failure:    NULL
- *
- * Programmer:  Robb Matzke
- *              Jul 10 1997
  *-------------------------------------------------------------------------
  */
 char *
@@ -490,14 +206,8 @@ H5MM_strdup(const char *s)
 
     if (!s)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "NULL string not allowed")
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-    if (NULL == (ret_value = (char *)H5MM_malloc(HDstrlen(s) + 1)))
-        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed")
-    HDstrcpy(ret_value, s);
-#else
     if (NULL == (ret_value = HDstrdup(s)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "string duplication failed")
-#endif
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -522,9 +232,6 @@ done:
 char *
 H5MM_strndup(const char *s, size_t n)
 {
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-    size_t len;
-#endif
     char *ret_value = NULL;
 
     FUNC_ENTER_NOAPI(NULL)
@@ -532,19 +239,8 @@ H5MM_strndup(const char *s, size_t n)
     if (!s)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "NULL string not allowed")
 
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-    for (len = 0; len < n && s[len] != '\0'; len++)
-        ;
-
-    if (NULL == (ret_value = H5MM_malloc(len + 1)))
-        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed")
-
-    H5MM_memcpy(ret_value, s, len);
-    ret_value[len] = '\0';
-#else
     if (NULL == (ret_value = HDstrndup(s, n)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "string duplication failed")
-#endif
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -561,10 +257,6 @@ done:
  *
  * Return:      Success:    NULL
  *              Failure:    never fails
- *
- * Programmer:  Robb Matzke
- *              Jul 10 1997
- *
  *-------------------------------------------------------------------------
  */
 void *
@@ -573,37 +265,8 @@ H5MM_xfree(void *mem)
     /* Use FUNC_ENTER_NOAPI_NOINIT_NOERR here to avoid performance issues */
     FUNC_ENTER_NOAPI_NOINIT_NOERR
 
-    if (mem) {
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-        if (H5MM__is_our_block(mem)) {
-            H5MM_block_t *block = H5MM_BLOCK_FROM_BUF(mem);
-
-            /* Run sanity checks on this block and its neighbors */
-            H5MM__sanity_check(mem);
-            H5MM__sanity_check_block(block->next);
-            H5MM__sanity_check_block(block->prev);
-
-            /* Update statistics */
-            H5MM_curr_alloc_bytes_s -= block->u.info.size;
-            H5MM_curr_alloc_blocks_count_s--;
-
-            /* Reset block info */
-            HDmemset(block->sig, 0, H5MM_SIG_SIZE);
-            block->next->prev    = block->prev;
-            block->prev->next    = block->next;
-            block->next          = NULL;
-            block->prev          = NULL;
-            block->u.info.in_use = FALSE;
-
-            /* Free the block (finally!) */
-            HDfree(block);
-        }
-        else
-            HDfree(mem);
-#else  /* H5_MEMORY_ALLOC_SANITY_CHECK */
+    if (mem)
         HDfree(mem);
-#endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
-    }  /* end if */
 
     FUNC_LEAVE_NOAPI(NULL)
 } /* end H5MM_xfree() */
@@ -617,7 +280,6 @@ H5MM_xfree(void *mem)
  *
  * Return:      Success:    NULL
  *              Failure:    never fails
- *
  *-------------------------------------------------------------------------
  */
 void *
@@ -640,10 +302,6 @@ H5MM_xfree_const(const void *mem)
  *
  * Return:      Success:    pointer to dest
  *              Failure:    NULL
- *
- * Programmer:  Dana Robinson
- *              Spring 2019
- *
  *-------------------------------------------------------------------------
  */
 void *
@@ -664,47 +322,4 @@ H5MM_memcpy(void *dest, const void *src, size_t n)
     ret = HDmemcpy(dest, src, n);
 
     FUNC_LEAVE_NOAPI(ret)
-
 } /* end H5MM_memcpy() */
-
-/*-------------------------------------------------------------------------
- * Function:	H5MM_get_alloc_stats
- *
- * Purpose:	Gets the memory allocation statistics for the library, if the
- *	H5_MEMORY_ALLOC_SANITY_CHECK macro is defined.  If the macro is not
- *	defined, zeros are returned.  These statistics are global for the
- *	entire library.
- *
- * Parameters:
- *  H5_alloc_stats_t *stats;            OUT: Memory allocation statistics
- *
- * Return:	Success:	non-negative
- *		Failure:	negative
- *
- * Programmer:  Quincey Koziol
- *              Saturday, March 7, 2020
- *
- *-------------------------------------------------------------------------
- */
-herr_t
-H5MM_get_alloc_stats(H5_alloc_stats_t *stats)
-{
-    FUNC_ENTER_NOAPI_NOERR
-
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-    if (stats) {
-        stats->total_alloc_bytes        = H5MM_total_alloc_bytes_s;
-        stats->curr_alloc_bytes         = H5MM_curr_alloc_bytes_s;
-        stats->peak_alloc_bytes         = H5MM_peak_alloc_bytes_s;
-        stats->max_block_size           = H5MM_max_block_size_s;
-        stats->total_alloc_blocks_count = H5MM_total_alloc_blocks_count_s;
-        stats->curr_alloc_blocks_count  = H5MM_curr_alloc_blocks_count_s;
-        stats->peak_alloc_blocks_count  = H5MM_peak_alloc_blocks_count_s;
-    }  /* end if */
-#else  /* H5_MEMORY_ALLOC_SANITY_CHECK */
-    if (stats)
-        HDmemset(stats, 0, sizeof(H5_alloc_stats_t));
-#endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
-
-    FUNC_LEAVE_NOAPI(SUCCEED)
-} /* end H5MM_get_alloc_stats() */

--- a/src/H5MMprivate.h
+++ b/src/H5MMprivate.h
@@ -27,19 +27,19 @@
 /* Private headers needed by this file */
 #include "H5private.h"
 
-#define H5MM_free(Z) HDfree(Z)
+#define H5MM_malloc(size)        HDmalloc(size)
+#define H5MM_calloc(size)        HDcalloc(1, size)
+#define H5MM_realloc(ptr, size)  HDrealloc(ptr, size)
+#define H5MM_free(ptr)           HDfree(ptr)
+#define H5MM_strdup(s)           HDstrdup(s)
+#define H5MM_strndup(s, n)       HDstrndup(s, n)
+#define H5MM_memcpy(dst, src, n) HDmemcpy(dst, src, n)
 
 /*
  * Library prototypes...
  */
-H5_DLL void  *H5MM_malloc(size_t size) H5_ATTR_MALLOC;
-H5_DLL void  *H5MM_calloc(size_t size) H5_ATTR_MALLOC;
-H5_DLL void  *H5MM_realloc(void *mem, size_t size);
 H5_DLL char  *H5MM_xstrdup(const char *s);
-H5_DLL char  *H5MM_strdup(const char *s);
-H5_DLL char  *H5MM_strndup(const char *s, size_t n);
 H5_DLL void  *H5MM_xfree(void *mem);
 H5_DLL void  *H5MM_xfree_const(const void *mem);
-H5_DLL void  *H5MM_memcpy(void *dest, const void *src, size_t n);
 
 #endif /* H5MMprivate_H */

--- a/src/H5MMprivate.h
+++ b/src/H5MMprivate.h
@@ -38,8 +38,8 @@
 /*
  * Library prototypes...
  */
-H5_DLL char  *H5MM_xstrdup(const char *s);
-H5_DLL void  *H5MM_xfree(void *mem);
-H5_DLL void  *H5MM_xfree_const(const void *mem);
+H5_DLL char *H5MM_xstrdup(const char *s);
+H5_DLL void *H5MM_xfree(void *mem);
+H5_DLL void *H5MM_xfree_const(const void *mem);
 
 #endif /* H5MMprivate_H */

--- a/src/H5MMprivate.h
+++ b/src/H5MMprivate.h
@@ -14,10 +14,8 @@
 /*-------------------------------------------------------------------------
  *
  * Created:             H5MMprivate.h
- *                      Jul 10 1997
- *                      Robb Matzke
  *
- * Purpose:             Private header for memory management.
+ * Purpose:             Private header for memory management
  *
  *-------------------------------------------------------------------------
  */
@@ -29,12 +27,7 @@
 /* Private headers needed by this file */
 #include "H5private.h"
 
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-/*#define H5MM_PRINT_MEMORY_STATS */
-#define H5MM_free(Z) H5MM_xfree(Z)
-#else /* H5_MEMORY_ALLOC_SANITY_CHECK */
 #define H5MM_free(Z) HDfree(Z)
-#endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
 
 /*
  * Library prototypes...
@@ -48,10 +41,5 @@ H5_DLL char  *H5MM_strndup(const char *s, size_t n);
 H5_DLL void  *H5MM_xfree(void *mem);
 H5_DLL void  *H5MM_xfree_const(const void *mem);
 H5_DLL void  *H5MM_memcpy(void *dest, const void *src, size_t n);
-H5_DLL herr_t H5MM_get_alloc_stats(H5_alloc_stats_t *stats);
-#if defined   H5_MEMORY_ALLOC_SANITY_CHECK
-H5_DLL void   H5MM_sanity_check_all(void);
-H5_DLL void   H5MM_final_sanity_check(void);
-#endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
 
 #endif /* H5MMprivate_H */

--- a/src/H5Zdevelop.h
+++ b/src/H5Zdevelop.h
@@ -353,15 +353,6 @@ extern "C" {
  *          release builds. Static links to the MSVC CRT can also introduce
  *          new memory allocator state.
  *
- *          Note that the HDF5 library enabled memory sanity checks by default
- *          in debug builds for many years. The heap canaries introduced to
- *          buffers by this mechanism would cause problems when filters
- *          attempted to reallocate these buffers. The sanity checks are no
- *          longer enabled by default in any configuration. When in doubt,
- *          memory sanity checking can be disabled explicitly by configuring
- *          with `--disable-memory-alloc-sanity-check` in the Autotools or
- *          setting `HDF5_MEMORY_ALLOC_SANITY_CHECK` to `OFF` in CMake.
- *
  *          The library does provide H5allocate_memory() and H5free_memory()
  *          functions that will use the library's allocation and free functions,
  *          however using these functions will require linking your filter to

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -592,27 +592,6 @@ H5_DLL herr_t H5set_free_list_limits(int reg_global_lim, int reg_list_lim, int a
 H5_DLL herr_t H5get_free_list_sizes(size_t *reg_size, size_t *arr_size, size_t *blk_size, size_t *fac_size);
 /**
  * \ingroup H5
- * \brief Gets the memory allocation statistics for the library
- *
- * \param[out] stats Memory allocation statistics
- * \return \herr_t
- *
- * \details H5get_alloc_stats() gets the memory allocation statistics for the
- *          library, if the \c --enable-memory-alloc-sanity-check option was
- *          given when building the library. Applications can check whether
- *          this option was enabled detecting if the
- *          \c H5_MEMORY_ALLOC_SANITY_CHECK macro is defined. This option is
- *          enabled by default for debug builds of the library and disabled by
- *          default for non-debug builds. If the option is not enabled, all the
- *          values returned with be 0. These statistics are global for the
- *          entire library, but do not include allocations from chunked dataset
- *          I/O filters or non-native VOL connectors.
- *
- * \since 1.10.7
- */
-H5_DLL herr_t H5get_alloc_stats(H5_alloc_stats_t *stats);
-/**
- * \ingroup H5
  * \brief Returns the HDF library release number
  *
  * \param[out] majnum The major version number of the library

--- a/src/libhdf5.settings.in
+++ b/src/libhdf5.settings.in
@@ -90,7 +90,6 @@ Dimension scales w/ new references: @DIMENSION_SCALES_WITH_NEW_REF@
     Packages w/ extra debug output: @INTERNAL_DEBUG_OUTPUT@
                        API tracing: @TRACE_API@
               Using memory checker: @USINGMEMCHECKER@
-   Memory allocation sanity checks: @MEMORYALLOCSANITYCHECK@
             Function stack tracing: @CODESTACK@
                   Use file locking: @DESIRED_FILE_LOCKING@
          Strict file format checks: @STRICT_FORMAT_CHECKS@

--- a/test/tmisc.c
+++ b/test/tmisc.c
@@ -5809,64 +5809,6 @@ test_misc33(void)
 
 /****************************************************************
 **
-**  test_misc34(): Ensure zero-size memory allocations work
-**
-****************************************************************/
-static void
-test_misc34(void)
-{
-    void  *mem = NULL; /* allocated buffer     */
-    char  *dup = NULL; /* 'duplicated' string  */
-    size_t sz  = 0;    /* buffer size          */
-
-    /* Output message about test being performed */
-    MESSAGE(5, ("Testing O and NULL behavior in H5MM API calls"));
-
-    /* H5MM_xfree(): Ensure that passing NULL is allowed and returns NULL */
-    mem = H5MM_xfree(mem);
-    CHECK_PTR_NULL(mem, "H5MM_xfree");
-
-    /* H5MM_malloc(): Ensure that size 0 returns NULL */
-    mem = H5MM_malloc(sz);
-    CHECK_PTR_NULL(mem, "H5MM_malloc");
-    mem = H5MM_xfree(mem);
-
-    /* H5MM_calloc(): Ensure that size 0 returns NULL */
-    mem = H5MM_calloc(sz);
-    CHECK_PTR_NULL(mem, "H5MM_calloc");
-    mem = H5MM_xfree(mem);
-
-    /* H5MM_realloc(): Check behavior:
-     *
-     *  H5MM_realloc(NULL, size)    <==> H5MM_malloc(size)
-     *  H5MM_realloc(ptr, 0)        <==> H5MM_xfree(ptr)
-     *  H5MM_realloc(NULL, 0)       <==> NULL
-     */
-    mem = H5MM_xfree(mem);
-
-    sz  = 1024;
-    mem = H5MM_realloc(mem, sz);
-    CHECK_PTR(mem, "H5MM_realloc (case 1)");
-    /* Don't free mem here! */
-
-    sz  = 0;
-    mem = H5MM_realloc(mem, sz);
-    CHECK_PTR_NULL(mem, "H5MM_realloc (case 2)");
-    mem = H5MM_xfree(mem);
-
-    mem = H5MM_realloc(mem, sz);
-    CHECK_PTR_NULL(mem, "H5MM_realloc (case 3)");
-    mem = H5MM_xfree(mem);
-
-    /* H5MM_xstrdup(): Ensure NULL returns NULL */
-    dup = H5MM_xstrdup((const char *)mem);
-    CHECK_PTR_NULL(dup, "H5MM_xstrdup");
-    dup = (char *)H5MM_xfree((void *)dup);
-
-} /* end test_misc34() */
-
-/****************************************************************
-**
 **  test_misc35(): Check operation of free-list routines
 **
 ****************************************************************/
@@ -6119,7 +6061,6 @@ test_misc(void)
 
     test_misc32(); /* Test filter memory allocation functions */
     test_misc33(); /* Test to verify that H5HL_offset_into() returns error if offset exceeds heap block */
-    test_misc34(); /* Test behavior of 0 and NULL in H5MM API calls */
     test_misc35(); /* Test behavior of free-list & allocation statistics API calls */
     test_misc36(); /* Exercise H5atclose and H5is_library_terminating */
 

--- a/test/tmisc.c
+++ b/test/tmisc.c
@@ -5886,7 +5886,6 @@ test_misc35(void)
     size_t           arr_size_final; /* Final amount of array memory allocated */
     size_t           blk_size_final; /* Final amount of block memory allocated */
     size_t           fac_size_final; /* Final amount of factory memory allocated */
-    H5_alloc_stats_t alloc_stats;    /* Memory stats */
     herr_t           ret;            /* Return value */
 
     /* Output message about test being performed */
@@ -5915,13 +5914,13 @@ test_misc35(void)
     CHECK(arr_size_start, 0, "H5get_free_list_sizes");
     CHECK(blk_size_start, 0, "H5get_free_list_sizes");
     CHECK(fac_size_start, 0, "H5get_free_list_sizes");
-#else  /* H5_MEMORY_ALLOC_SANITY_CHECK */
+#else
     /* All the values should be == 0 */
     VERIFY(reg_size_start, 0, "H5get_free_list_sizes");
     VERIFY(arr_size_start, 0, "H5get_free_list_sizes");
     VERIFY(blk_size_start, 0, "H5get_free_list_sizes");
     VERIFY(fac_size_start, 0, "H5get_free_list_sizes");
-#endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
+#endif
 
     /* Garbage collect the free lists */
     ret = H5garbage_collect();
@@ -5940,30 +5939,6 @@ test_misc35(void)
         ERROR("blk_size_final > blk_size_start");
     if (fac_size_final > fac_size_start)
         ERROR("fac_size_final > fac_size_start");
-
-    /* Retrieve memory allocation statistics */
-    ret = H5get_alloc_stats(&alloc_stats);
-    CHECK(ret, FAIL, "H5get_alloc_stats");
-
-#if defined H5_MEMORY_ALLOC_SANITY_CHECK
-    /* All the values should be >0 */
-    CHECK(alloc_stats.total_alloc_bytes, 0, "H5get_alloc_stats");
-    CHECK(alloc_stats.curr_alloc_bytes, 0, "H5get_alloc_stats");
-    CHECK(alloc_stats.peak_alloc_bytes, 0, "H5get_alloc_stats");
-    CHECK(alloc_stats.max_block_size, 0, "H5get_alloc_stats");
-    CHECK(alloc_stats.total_alloc_blocks_count, 0, "H5get_alloc_stats");
-    CHECK(alloc_stats.curr_alloc_blocks_count, 0, "H5get_alloc_stats");
-    CHECK(alloc_stats.peak_alloc_blocks_count, 0, "H5get_alloc_stats");
-#else  /* H5_MEMORY_ALLOC_SANITY_CHECK */
-    /* All the values should be == 0 */
-    VERIFY(alloc_stats.total_alloc_bytes, 0, "H5get_alloc_stats");
-    VERIFY(alloc_stats.curr_alloc_bytes, 0, "H5get_alloc_stats");
-    VERIFY(alloc_stats.peak_alloc_bytes, 0, "H5get_alloc_stats");
-    VERIFY(alloc_stats.max_block_size, 0, "H5get_alloc_stats");
-    VERIFY(alloc_stats.total_alloc_blocks_count, 0, "H5get_alloc_stats");
-    VERIFY(alloc_stats.curr_alloc_blocks_count, 0, "H5get_alloc_stats");
-    VERIFY(alloc_stats.peak_alloc_blocks_count, 0, "H5get_alloc_stats");
-#endif /* H5_MEMORY_ALLOC_SANITY_CHECK */
 
 } /* end test_misc35() */
 

--- a/test/tmisc.c
+++ b/test/tmisc.c
@@ -5820,15 +5820,15 @@ test_misc35(void)
     hsize_t coord[MISC35_NPOINTS][MISC35_SPACE_RANK] = /* Coordinates for point selection */
         {{0, 10, 5}, {1, 2, 7},  {2, 4, 9}, {0, 6, 11}, {1, 8, 13},
          {2, 12, 0}, {0, 14, 2}, {1, 0, 4}, {2, 1, 6},  {0, 3, 8}};
-    size_t           reg_size_start; /* Initial amount of regular memory allocated */
-    size_t           arr_size_start; /* Initial amount of array memory allocated */
-    size_t           blk_size_start; /* Initial amount of block memory allocated */
-    size_t           fac_size_start; /* Initial amount of factory memory allocated */
-    size_t           reg_size_final; /* Final amount of regular memory allocated */
-    size_t           arr_size_final; /* Final amount of array memory allocated */
-    size_t           blk_size_final; /* Final amount of block memory allocated */
-    size_t           fac_size_final; /* Final amount of factory memory allocated */
-    herr_t           ret;            /* Return value */
+    size_t reg_size_start; /* Initial amount of regular memory allocated */
+    size_t arr_size_start; /* Initial amount of array memory allocated */
+    size_t blk_size_start; /* Initial amount of block memory allocated */
+    size_t fac_size_start; /* Initial amount of factory memory allocated */
+    size_t reg_size_final; /* Final amount of regular memory allocated */
+    size_t arr_size_final; /* Final amount of array memory allocated */
+    size_t blk_size_final; /* Final amount of block memory allocated */
+    size_t fac_size_final; /* Final amount of factory memory allocated */
+    herr_t ret;            /* Return value */
 
     /* Output message about test being performed */
     MESSAGE(5, ("Free-list API calls"));


### PR DESCRIPTION
Also simplifies the H5MM package, replacing most H5MM replacement functions with defines to C standard library functions