### PR TITLE
Bug fix: the previous checkin only supported the native connector

### DIFF
--- a/test/vol.c
+++ b/test/vol.c
@@ -2233,8 +2233,20 @@ test_get_vol_name(void)
     hid_t file_id = H5I_INVALID_HID;
     char  filename[NAME_LEN];
     char  vol_name[NAME_LEN];
+    const char  *conn_env_str = NULL;
 
     TESTING("getting connector name");
+
+    conn_env_str = HDgetenv(HDF5_VOL_CONNECTOR);
+    if (NULL == (conn_env_str = HDgetenv("HDF5_VOL_CONNECTOR")))
+        conn_env_str = "native";
+
+    /* Skip the connectors other than the native and pass_through connector */
+    if (HDstrcmp(conn_env_str, "native") && HDstrncmp(conn_env_str, "pass_through", HDstrlen("pass_through"))) {
+        SKIPPED();
+        HDprintf("    only test the native or pass_through connector\n");
+        return SUCCEED;
+    }
 
     /* Retrieve the file access property for testing */
     fapl_id = h5_fileaccess();
@@ -2247,7 +2259,9 @@ test_get_vol_name(void)
     if (H5VLget_connector_name(file_id, vol_name, NAME_LEN) < 0)
         TEST_ERROR;
 
-    if (HDstrcmp(vol_name, "native"))
+    /* When comparing the pass_through connector, ignore the rest information (under_vol=0;under_info={}) */
+    if ((!HDstrcmp(conn_env_str, "native") && HDstrcmp(vol_name, "native")) ||
+        (!HDstrncmp(conn_env_str, "pass_through", HDstrlen("pass_through")) && HDstrcmp(vol_name, "pass_through")))
         TEST_ERROR;
 
     if (H5Fclose(file_id) < 0)

--- a/test/vol.c
+++ b/test/vol.c
@@ -2229,11 +2229,11 @@ error:
 static herr_t
 test_get_vol_name(void)
 {
-    hid_t fapl_id = H5I_INVALID_HID;
-    hid_t file_id = H5I_INVALID_HID;
-    char  filename[NAME_LEN];
-    char  vol_name[NAME_LEN];
-    const char  *conn_env_str = NULL;
+    hid_t       fapl_id = H5I_INVALID_HID;
+    hid_t       file_id = H5I_INVALID_HID;
+    char        filename[NAME_LEN];
+    char        vol_name[NAME_LEN];
+    const char *conn_env_str = NULL;
 
     TESTING("getting connector name");
 
@@ -2242,7 +2242,8 @@ test_get_vol_name(void)
         conn_env_str = "native";
 
     /* Skip the connectors other than the native and pass_through connector */
-    if (HDstrcmp(conn_env_str, "native") && HDstrncmp(conn_env_str, "pass_through", HDstrlen("pass_through"))) {
+    if (HDstrcmp(conn_env_str, "native") &&
+        HDstrncmp(conn_env_str, "pass_through", HDstrlen("pass_through"))) {
         SKIPPED();
         HDprintf("    only test the native or pass_through connector\n");
         return SUCCEED;
@@ -2261,7 +2262,8 @@ test_get_vol_name(void)
 
     /* When comparing the pass_through connector, ignore the rest information (under_vol=0;under_info={}) */
     if ((!HDstrcmp(conn_env_str, "native") && HDstrcmp(vol_name, "native")) ||
-        (!HDstrncmp(conn_env_str, "pass_through", HDstrlen("pass_through")) && HDstrcmp(vol_name, "pass_through")))
+        (!HDstrncmp(conn_env_str, "pass_through", HDstrlen("pass_through")) &&
+         HDstrcmp(vol_name, "pass_through")))
         TEST_ERROR;
 
     if (H5Fclose(file_id) < 0)


### PR DESCRIPTION
Make sure the test case for H5VLget_connector_name() supports the pass_through connector.