### PR TITLE
also build pkgconfig with autotools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -224,3 +224,6 @@ $(top_builddir)/config.status:
 
 # Don't include conclude.am in root Makefile; tests target needs to
 # recurse into reguar subdirs.
+#
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = hdf5.pc

--- a/configure.ac
+++ b/configure.ac
@@ -4203,6 +4203,7 @@ AM_CONDITIONAL([HAVE_SHARED_CONDITIONAL], [test "X$enable_shared" = "Xyes"])
 
 AC_CONFIG_FILES([src/libhdf5.settings
                  Makefile
+                 hdf5.pc
                  doxygen/Doxyfile
                  src/Makefile
                  test/Makefile

--- a/hdf5.pc.in
+++ b/hdf5.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: hdf5
+Description: HDF5 (Hierarchical Data Format 5) Software Library
+Version: @VERSION@
+
+Cflags: -I@includedir@
+Libs: -L@libdir@  -lhdf5


### PR DESCRIPTION
this is a first attempt for closing #8

Since it is the first time that I write a .pc file and the first time that I use autotools, I have no idea how to change

```
Requires: 
Libs.private:
Requires.private:
```

Besides these three entries, the hdf5.pc generated by autotools matches the one generated by CMake.