### PR TITLE
Removes MPE instrumentation support.

### DIFF
--- a/bin/checkposix
+++ b/bin/checkposix
@@ -143,7 +143,7 @@ foreach $arg (@ARGV) {
             next if $name =~ /^(_beginthread|(Initialize|Enter|Leave)CriticalSection|TlsAlloc)$/;
 
             # These are MPI function calls. Ignore them.
-            next if $name =~ /^(MPI_|MPE_)/;
+            next if $name =~ /^(MPI_)/;
 
             # These are POSIX threads function calls. Ignore them.
             next if $name =~ /^pthread_/;

--- a/bin/output_filter.sh
+++ b/bin/output_filter.sh
@@ -61,26 +61,21 @@ STDOUT_FILTER() {
 # Remove them from the stderr result file.
 # $1 is the file name of the file to be filtered.
 # Cases of filter needed:
-# 1. MPE:
-# In parallel mode and if MPE library is used, it prints the following
-# two message lines whether the MPE tracing is used or not.
-#    Writing logfile.
-#    Finished writing logfile.
-# 2. LANL MPI:
+# * LANL MPI:
 # The LANL MPI will print some messages like the following,
 #    LA-MPI: *** mpirun (1.5.10)
 #    LA-MPI: *** 3 process(es) on 2 host(s): 2*fln21 1*fln22
 #    LA-MPI: *** libmpi (1.5.10)
 #    LA-MPI: *** Copyright 2001-2004, ACL, Los Alamos National Laboratory
-# 3. h5diff debug output:
+# * h5diff debug output:
 #    Debug output all have prefix "h5diff debug: ".
-# 4. AIX system prints messages like these when it is aborting:
+# * AIX system prints messages like these when it is aborting:
 #    ERROR: 0031-300  Forcing all remote tasks to exit due to exit code 1 in task 0
 #    ERROR: 0031-250  task 4: Terminated
 #    ERROR: 0031-250  task 3: Terminated
 #    ERROR: 0031-250  task 2: Terminated
 #    ERROR: 0031-250  task 1: Terminated
-# 5. LLNL Blue-Gene mpirun prints messages like there when it exit non-zero:
+# * LLNL Blue-Gene mpirun prints messages like there when it exit non-zero:
 #    <Apr 12 15:01:49.075658> BE_MPI (ERROR): The error message in the job record is as follows:
 #    <Apr 12 15:01:49.075736> BE_MPI (ERROR):   "killed by exit(1) on node 0"
 STDERR_FILTER() {
@@ -91,12 +86,6 @@ STDERR_FILTER() {
     cp $result_file $tmp_file
     sed -e '/ BE_MPI (ERROR): /d' \
 	< $tmp_file > $result_file
-    # Filter MPE messages
-    if test -n "$pmode"; then
-	cp $result_file $tmp_file
-	sed -e '/^Writing logfile./d' -e '/^Finished writing logfile./d' \
-	    < $tmp_file > $result_file
-    fi
     # Filter LANL MPI messages
     # and LLNL srun messages
     # and AIX error messages

--- a/config/cmake/H5pubconf.h.in
+++ b/config/cmake/H5pubconf.h.in
@@ -198,9 +198,6 @@
 /* Define to 1 if you have the `m' library (-lm). */
 #cmakedefine H5_HAVE_LIBM @H5_HAVE_LIBM@
 
-/* Define to 1 if you have the `mpe' library (-lmpe). */
-#cmakedefine H5_HAVE_LIBMPE @H5_HAVE_LIBMPE@
-
 /* Define to 1 if you have the `pthread' library (-lpthread). */
 #cmakedefine H5_HAVE_LIBPTHREAD @H5_HAVE_LIBPTHREAD@
 
@@ -224,12 +221,6 @@
 
 /* Define whether the Mirror virtual file driver (VFD) will be compiled */
 #cmakedefine H5_HAVE_MIRROR_VFD @H5_HAVE_MIRROR_VFD@
-
-/* Define if we have MPE support */
-#cmakedefine H5_HAVE_MPE @H5_HAVE_MPE@
-
-/* Define to 1 if you have the <mpe.h> header file. */
-#cmakedefine H5_HAVE_MPE_H @H5_HAVE_MPE_H@
 
 /* Define if MPI_Comm_c2f and MPI_Comm_f2c exist */
 #cmakedefine H5_HAVE_MPI_MULTI_LANG_Comm @H5_HAVE_MPI_MULTI_LANG_Comm@

--- a/config/cmake/libhdf5.settings.cmake.in
+++ b/config/cmake/libhdf5.settings.cmake.in
@@ -77,7 +77,6 @@ Dimension scales w/ new references: @DIMENSION_SCALES_WITH_NEW_REF@
                Default API mapping: @DEFAULT_API_VERSION@
     With deprecated public symbols: @HDF5_ENABLE_DEPRECATED_SYMBOLS@
             I/O filters (external): @EXTERNAL_FILTERS@
-                               MPE: @H5_HAVE_LIBLMPE@
                         Direct VFD: @H5_HAVE_DIRECT@
                         Mirror VFD: @H5_HAVE_MIRROR_VFD@
                      Subfiling VFD: @H5_HAVE_SUBFILING_VFD@

--- a/config/commence.am
+++ b/config/commence.am
@@ -87,8 +87,7 @@ F9XMODFLAG=@F9XMODFLAG@
 
 # .chkexe files are used to mark tests that have run successfully.
 # .chklog files are output from those tests.
-# *.clog and *.clog2 are from the MPE option.
-CHECK_CLEANFILES=*.chkexe *.chklog *.clog *.clog2
+CHECK_CLEANFILES=*.chkexe *.chklog
 
 # List all build rules defined by HDF5 Makefiles as "PHONY" targets here.
 # This tells the Makefiles that these targets are not files to be built but

--- a/configure.ac
+++ b/configure.ac
@@ -2682,7 +2682,6 @@ esac
 ## build also needs to have values defined.
 ##
 AC_SUBST([ADD_PARALLEL_FILES]) ADD_PARALLEL_FILES="no"
-AC_SUBST([MPE]) MPE=no
 AC_SUBST([INSTRUMENT_LIBRARY]) INSTRUMENT_LIBRARY=no
 AC_SUBST([PARALLEL_FILTERED_WRITES])
 AC_SUBST([LARGE_PARALLEL_IO])
@@ -2780,69 +2779,6 @@ if test -n "$PARALLEL"; then
       AC_MSG_ERROR([Unrecognized value: $INSTRUMENT_LIBRARY])
       ;;
   esac
-
-  ## --------------------------------------------------------------------
-  ## Do we want MPE instrumentation feature on?
-  ##
-  ## This must be done after enable-parallel is checked since it depends
-  ## on a mpich compiler.
-  ##
-  MPE=yes
-  AC_ARG_WITH([mpe],
-              [AS_HELP_STRING([--with-mpe=DIR],
-                              [Use MPE instrumentation [default=no]])],,
-              [withval=no])
-
-  case "X-$withval" in
-    X-|X-no|X-none)
-      AC_MSG_CHECKING([for MPE])
-      AC_MSG_RESULT([suppressed])
-      unset MPE
-      ;;
-    X-yes)
-      AC_CHECK_HEADERS([mpe.h],, [unset MPE])
-      AC_CHECK_LIB([mpe], [MPE_Init_log],, [unset MPE])
-      ;;
-    *)
-      case "$withval" in
-        *,*)
-          mpe_inc="`echo $withval | cut -f1 -d,`"
-          mpe_lib="`echo $withval | cut -f2 -d, -s`"
-          ;;
-        *)
-          if test -n "$withval"; then
-            mpe_inc="$withval/include"
-            mpe_lib="$withval/lib"
-          fi
-          ;;
-      esac
-
-      if test -n "$mpe_inc"; then
-        saved_CPPFLAGS="$CPPFLAGS"
-        saved_AM_CPPFLAGS="$AM_CPPFLAGS"
-        CPPFLAGS="$CPPFLAGS -I$mpe_inc"
-        AM_CPPFLAGS="$AM_CPPFLAGS -I$mpe_inc"
-        AC_CHECK_HEADERS([mpe.h],, [CPPFLAGS="$saved_CPPFLAGS"; AM_CPPFLAGS="$saved_AM_CPPFLAGS"; unset MPE])
-      else
-        AC_CHECK_HEADERS([mpe.h],, [unset MPE])
-      fi
-
-      if test -n "$mpe_lib"; then
-        saved_LDFLAGS="$LDFLAGS"
-        saved_AM_LDFLAGS="$AM_LDFLAGS"
-        LDFLAGS="$LDFLAGS -L$mpe_lib"
-        AM_LDFLAGS="$AM_LDFLAGS -L$mpe_lib"
-        AC_CHECK_LIB([mpe], [MPE_Init_log],,
-                     [LDFLAGS="$saved_LDFLAGS"; AM_LDFLAGS="$saved_AM_LDFLAGS"; unset MPE])
-      else
-        AC_CHECK_LIB([mpe], [MPE_Init_log],, [unset MPE])
-      fi
-      ;;
-  esac
-
-  if test "X-$MPE" = "X-yes"; then
-    AC_DEFINE([HAVE_MPE], [1], [Define if we have MPE support])
-  fi
 
   ## ----------------------------------------------------------------------
   ## Check for the MPI functions necessary for the Parallel Compression

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -47,7 +47,19 @@ New Features
 
     Configuration:
     -------------
-    - Removal of dmalloc support
+    - Removal of MPE support
+
+      The ability to build with MPE instrumentation has been removed along with
+      the following configure options:
+
+      Autotools:
+          --with-mpe=
+
+      CMake has never supported building with MPE support.
+
+      (DER - 2022/11/08)
+
+     - Removal of dmalloc support
 
       The ability to build with dmalloc support has been removed along with
       the following configure options:

--- a/src/H5.c
+++ b/src/H5.c
@@ -84,10 +84,6 @@ hbool_t H5_libterm_g = FALSE; /* Library isn't being shutdown */
 
 hbool_t H5_use_selection_io_g = FALSE;
 
-#ifdef H5_HAVE_MPE
-hbool_t H5_MPEinit_g = FALSE; /* MPE Library hasn't been initialized */
-#endif
-
 char           H5_lib_vers_info_g[] = H5_VERS_INFO;
 static hbool_t H5_dont_atexit_g     = FALSE;
 H5_debug_t     H5_debug_g; /* debugging info */
@@ -167,18 +163,6 @@ H5_init_library(void)
 
         MPI_Initialized(&mpi_initialized);
         MPI_Finalized(&mpi_finalized);
-
-#ifdef H5_HAVE_MPE
-        /* Initialize MPE instrumentation library. */
-        if (!H5_MPEinit_g) {
-            int mpe_code;
-            if (mpi_initialized && !mpi_finalized) {
-                mpe_code = MPE_Init_log();
-                HDassert(mpe_code >= 0);
-                H5_MPEinit_g = TRUE;
-            }
-        }
-#endif /*H5_HAVE_MPE*/
 
         /* add an attribute on MPI_COMM_SELF to call H5_term_library
            when it is destroyed, i.e. on MPI_Finalize */
@@ -509,26 +493,6 @@ H5_term_library(void)
 #endif    /* NDEBUG */
         } /* end if */
     }     /* end if */
-
-#ifdef H5_HAVE_MPE
-    /* Close MPE instrumentation library.  May need to move this
-     * down if any of the below code involves using the instrumentation code.
-     */
-    if (H5_MPEinit_g) {
-        int mpi_initialized;
-        int mpi_finalized;
-        int mpe_code;
-
-        MPI_Initialized(&mpi_initialized);
-        MPI_Finalized(&mpi_finalized);
-
-        if (mpi_initialized && !mpi_finalized) {
-            mpe_code = MPE_Finish_log("h5log");
-            HDassert(mpe_code >= 0);
-        }                     /* end if */
-        H5_MPEinit_g = FALSE; /* turn it off no matter what */
-    }                         /* end if */
-#endif
 
     /* Free open debugging streams */
     while (H5_debug_g.open_stream) {

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -2023,8 +2023,7 @@ H5_DLL herr_t H5CX_pop(hbool_t update_dxpl_props);
     H5_API_LOCK
 
 /* Local variables for API routines */
-#define FUNC_ENTER_API_VARS                                                                                  \
-    H5TRACE_DECL
+#define FUNC_ENTER_API_VARS H5TRACE_DECL
 
 #define FUNC_ENTER_API_COMMON                                                                                \
     FUNC_ENTER_API_VARS                                                                                      \
@@ -2298,8 +2297,7 @@ H5_DLL herr_t H5CX_pop(hbool_t update_dxpl_props);
     H5_API_UNLOCK                                                                                            \
     H5_API_SET_CANCEL
 
-#define FUNC_LEAVE_API_COMMON(ret_value)                                                                     \
-    H5TRACE_RETURN(ret_value);
+#define FUNC_LEAVE_API_COMMON(ret_value) H5TRACE_RETURN(ret_value);
 
 #define FUNC_LEAVE_API(ret_value)                                                                            \
     ;                                                                                                        \

--- a/src/libhdf5.settings.in
+++ b/src/libhdf5.settings.in
@@ -79,7 +79,6 @@ Dimension scales w/ new references: @DIMENSION_SCALES_WITH_NEW_REF@
                Default API mapping: @DEFAULT_API_VERSION@
     With deprecated public symbols: @DEPRECATED_SYMBOLS@
             I/O filters (external): @EXTERNAL_FILTERS@
-                               MPE: @MPE@
                      Map (H5M) API: @MAP_API@
                         Direct VFD: @DIRECT_VFD@
                         Mirror VFD: @MIRROR_VFD@

--- a/testpar/t_cache.c
+++ b/testpar/t_cache.c
@@ -209,10 +209,6 @@ struct datum *data = NULL;
 
 #define STD_VIRT_NUM_DATA_ENTRIES     NUM_DATA_ENTRIES
 #define EXPRESS_VIRT_NUM_DATA_ENTRIES (NUM_DATA_ENTRIES / 10)
-/* Use a smaller test size to avoid creating huge MPE logfiles. */
-#ifdef H5_HAVE_MPE
-#define MPE_VIRT_NUM_DATA_ENTIES (NUM_DATA_ENTRIES / 100)
-#endif
 
 int virt_num_data_entries = NUM_DATA_ENTRIES;
 
@@ -6918,12 +6914,6 @@ main(int argc, char **argv)
         virt_num_data_entries = EXPRESS_VIRT_NUM_DATA_ENTRIES;
     else
         virt_num_data_entries = STD_VIRT_NUM_DATA_ENTRIES;
-
-#ifdef H5_HAVE_MPE
-    if (MAINPROCESS)
-        HDprintf("    Tests compiled for MPE.\n");
-    virt_num_data_entries = MPE_VIRT_NUM_DATA_ENTIES;
-#endif /* H5_HAVE_MPE */
 
     if (MAINPROCESS) {
         HDprintf("===================================\n");


### PR DESCRIPTION
The Autotools will no longer accept --with-mpe= and the logging commands have been removed from the FUNC_ENTER macros. CMake has never supported instrumenting for MPE.