### PR TITLE
Pass compact chunk size info to ensure requested elements are within …

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -172,6 +172,18 @@ Bug Fixes since HDF5-1.13.3 release
 ===================================
     Library
     -------
+    - Fix CVE-2018-11205 / GHSA-8rc4-w39h-mcmg
+
+      Pass compact chunk size info to ensure requested elements are within bounds
+
+      A selection in a malformed hdf5 file may reference data that does not lie
+      within the dataset.
+      To avoid out of bounds reads/writes of elements of a compact chunk, pass
+      size info to the read and write functions and check whether all elements
+      are within size before attempting to read/write them.
+
+      (EFE - 2022/10/01 HDFFV-10479, GH-2250)
+
     - Fix CVE-2018-13867 / GHSA-j8jr-chrh-qfrf
  
       Validate location (offset) of the accumulated metadata when comparing.

--- a/src/H5Dcompact.c
+++ b/src/H5Dcompact.c
@@ -249,6 +249,7 @@ H5D__compact_io_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dinfo)
     FUNC_ENTER_PACKAGE_NOERR
 
     dinfo->store->compact.buf   = dinfo->dset->shared->layout.storage.u.compact.buf;
+    dinfo->store->compact.size  = dinfo->dset->shared->layout.storage.u.compact.size;
     dinfo->store->compact.dirty = &dinfo->dset->shared->layout.storage.u.compact.dirty;
 
     /* Disable selection I/O */
@@ -329,6 +330,9 @@ H5D__compact_readvv(const H5D_io_info_t *io_info, const H5D_dset_io_info_t *dset
 
     HDassert(io_info);
     HDassert(dset_info);
+    if (dset_info->store->compact.size <
+        *(dset_offset_arr + dset_max_nseq - 1) + *(dset_size_arr + dset_max_nseq - 1))
+        HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "source size less than requested data")
 
     /* Check if file driver wishes to do its own memory management */
     if (H5F_SHARED_HAS_FEATURE(io_info->f_sh, H5FD_FEAT_MEMMANAGE)) {
@@ -390,6 +394,9 @@ H5D__compact_writevv(const H5D_io_info_t *io_info, const H5D_dset_io_info_t *dse
 
     HDassert(io_info);
     HDassert(dset_info);
+    if (dset_info->store->compact.size <
+        *(dset_offset_arr + dset_max_nseq - 1) + *(dset_size_arr + dset_max_nseq - 1))
+        HGOTO_ERROR(H5E_IO, H5E_WRITEERROR, FAIL, "source size less than requested data")
 
     /* Check if file driver wishes to do its own memory management */
     if (H5F_SHARED_HAS_FEATURE(io_info->f_sh, H5FD_FEAT_MEMMANAGE)) {

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -190,6 +190,7 @@ typedef struct {
 typedef struct {
     void    *buf;   /* Buffer for compact dataset */
     hbool_t *dirty; /* Pointer to dirty flag to mark */
+    size_t   size;  /* Buffer size for compact dataset */
 } H5D_compact_storage_t;
 
 typedef union H5D_storage_t {


### PR DESCRIPTION
…bounds

Pass compact chunk size info to ensure requested elements are within bounds

A selection in a malformed hdf5 file may reference data that does not lie within the dataset.

To avoid out of bounds reads/writes of elements of a compact chunk, pass size info to the read and write functions and check whether all elements are within size before attempting to read/write them.

This fixes CVE-2018-11205 / HDFFV-10479 / Bug #2250

Signed-off-by: Egbert Eich <eich@suse.com>