### PR TITLE
moved quad precision checks

### DIFF
--- a/config/cmake/ConfigureChecks.cmake
+++ b/config/cmake/ConfigureChecks.cmake
@@ -750,24 +750,26 @@ if (HDF5_ENABLE_MIRROR_VFD)
 endif()
 
 #-----------------------------------------------------------------------------
-# Check if C has __float128 extension
+# Check if C has __float128 extension (used for Fortran only)
 #-----------------------------------------------------------------------------
 
-HDF_CHECK_TYPE_SIZE(__float128 _SIZEOF___FLOAT128)
-if (${_SIZEOF___FLOAT128})
-  set (${HDF_PREFIX}_HAVE_FLOAT128 1)
-  set (${HDF_PREFIX}_SIZEOF___FLOAT128 ${_SIZEOF___FLOAT128})
-else ()
-  set (${HDF_PREFIX}_HAVE_FLOAT128 0)
-  set (${HDF_PREFIX}_SIZEOF___FLOAT128 0)
-endif ()
+if (HDF5_BUILD_FORTRAN)
+  HDF_CHECK_TYPE_SIZE(__float128 _SIZEOF___FLOAT128)
+  if (${_SIZEOF___FLOAT128})
+    set (${HDF_PREFIX}_HAVE_FLOAT128 1)
+    set (${HDF_PREFIX}_SIZEOF___FLOAT128 ${_SIZEOF___FLOAT128})
+  else ()
+    set (${HDF_PREFIX}_HAVE_FLOAT128 0)
+    set (${HDF_PREFIX}_SIZEOF___FLOAT128 0)
+  endif ()
 
-HDF_CHECK_TYPE_SIZE(_Quad _SIZEOF__QUAD)
-if (NOT ${_SIZEOF__QUAD})
-  set (${HDF_PREFIX}_SIZEOF__QUAD 0)
-else ()
-  set (${HDF_PREFIX}_SIZEOF__QUAD ${_SIZEOF__QUAD})
-endif ()
+  HDF_CHECK_TYPE_SIZE(_Quad _SIZEOF__QUAD)
+  if (NOT ${_SIZEOF__QUAD})
+    set (${HDF_PREFIX}_SIZEOF__QUAD 0)
+  else ()
+    set (${HDF_PREFIX}_SIZEOF__QUAD ${_SIZEOF__QUAD})
+  endif ()
+endif()
 
 #-----------------------------------------------------------------------------
 # The provided CMake C macros don't provide a general compile/run function

--- a/config/cmake/ConfigureChecks.cmake
+++ b/config/cmake/ConfigureChecks.cmake
@@ -769,58 +769,57 @@ if (HDF5_BUILD_FORTRAN)
   else ()
     set (${HDF_PREFIX}_SIZEOF__QUAD ${_SIZEOF__QUAD})
   endif ()
-endif()
 
 #-----------------------------------------------------------------------------
 # The provided CMake C macros don't provide a general compile/run function
 # so this one is used.
 #-----------------------------------------------------------------------------
-set (RUN_OUTPUT_PATH_DEFAULT ${CMAKE_BINARY_DIR})
-macro (C_RUN FUNCTION_NAME SOURCE_CODE RETURN_VAR RETURN_OUTPUT_VAR)
-    message (VERBOSE "Detecting C ${FUNCTION_NAME}")
-    file (WRITE
-        ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/testCCompiler1.c
-        ${SOURCE_CODE}
-    )
-    TRY_RUN (RUN_RESULT_VAR COMPILE_RESULT_VAR
-        ${CMAKE_BINARY_DIR}
-        ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/testCCompiler1.c
-        COMPILE_DEFINITIONS "-D_SIZEOF___FLOAT128=${H5_SIZEOF___FLOAT128};-D_HAVE_QUADMATH_H=${H5_HAVE_QUADMATH_H}"
-        COMPILE_OUTPUT_VARIABLE COMPILEOUT
-        RUN_OUTPUT_VARIABLE OUTPUT_VAR
-    )
+  set (RUN_OUTPUT_PATH_DEFAULT ${CMAKE_BINARY_DIR})
+  macro (C_RUN FUNCTION_NAME SOURCE_CODE RETURN_VAR RETURN_OUTPUT_VAR)
+      message (VERBOSE "Detecting C ${FUNCTION_NAME}")
+      file (WRITE
+          ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/testCCompiler1.c
+          ${SOURCE_CODE}
+      )
+      TRY_RUN (RUN_RESULT_VAR COMPILE_RESULT_VAR
+          ${CMAKE_BINARY_DIR}
+          ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/testCCompiler1.c
+          COMPILE_DEFINITIONS "-D_SIZEOF___FLOAT128=${H5_SIZEOF___FLOAT128};-D_HAVE_QUADMATH_H=${H5_HAVE_QUADMATH_H}"
+          COMPILE_OUTPUT_VARIABLE COMPILEOUT
+          RUN_OUTPUT_VARIABLE OUTPUT_VAR
+      )
 
-    set (${RETURN_OUTPUT_VAR} ${OUTPUT_VAR})
+      set (${RETURN_OUTPUT_VAR} ${OUTPUT_VAR})
 
-    message (VERBOSE "* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * ")
-    message (VERBOSE "Test COMPILE_RESULT_VAR ${COMPILE_RESULT_VAR} ")
-    message (VERBOSE "Test COMPILE_OUTPUT ${COMPILEOUT} ")
-    message (VERBOSE "* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * ")
-    message (VERBOSE "Test RUN_RESULT_VAR ${RUN_RESULT_VAR} ")
-    message (VERBOSE "* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * ")
+      message (VERBOSE "* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * ")
+      message (VERBOSE "Test COMPILE_RESULT_VAR ${COMPILE_RESULT_VAR} ")
+      message (VERBOSE "Test COMPILE_OUTPUT ${COMPILEOUT} ")
+      message (VERBOSE "* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * ")
+      message (VERBOSE "Test RUN_RESULT_VAR ${RUN_RESULT_VAR} ")
+      message (VERBOSE "* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * ")
 
-    if (COMPILE_RESULT_VAR)
-      if (RUN_RESULT_VAR EQUAL "0")
-        set (${RETURN_VAR} 1 CACHE INTERNAL "Have C function ${FUNCTION_NAME}")
-        message (VERBOSE "Testing C ${FUNCTION_NAME} - OK")
-        file (APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
-            "Determining if the C ${FUNCTION_NAME} exists passed with the following output:\n"
-            "${OUTPUT_VAR}\n\n"
-        )
+      if (COMPILE_RESULT_VAR)
+        if (RUN_RESULT_VAR EQUAL "0")
+          set (${RETURN_VAR} 1 CACHE INTERNAL "Have C function ${FUNCTION_NAME}")
+          message (VERBOSE "Testing C ${FUNCTION_NAME} - OK")
+          file (APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
+              "Determining if the C ${FUNCTION_NAME} exists passed with the following output:\n"
+              "${OUTPUT_VAR}\n\n"
+          )
+        else ()
+          message (VERBOSE "Testing C ${FUNCTION_NAME} - Fail")
+          set (${RETURN_VAR} 0 CACHE INTERNAL "Have C function ${FUNCTION_NAME}")
+          file (APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+              "Determining if the C ${FUNCTION_NAME} exists failed with the following output:\n"
+              "${OUTPUT_VAR}\n\n")
+        endif ()
       else ()
-        message (VERBOSE "Testing C ${FUNCTION_NAME} - Fail")
-        set (${RETURN_VAR} 0 CACHE INTERNAL "Have C function ${FUNCTION_NAME}")
-        file (APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
-            "Determining if the C ${FUNCTION_NAME} exists failed with the following output:\n"
-            "${OUTPUT_VAR}\n\n")
+          message (FATAL_ERROR "Compilation of C ${FUNCTION_NAME} - Failed")
       endif ()
-    else ()
-        message (FATAL_ERROR "Compilation of C ${FUNCTION_NAME} - Failed")
-    endif ()
-endmacro ()
+  endmacro ()
 
-set (PROG_SRC
-    "
+  set (PROG_SRC
+      "
 #include <float.h>\n\
 #include <stdio.h>\n\
 #define CHECK_FLOAT128 _SIZEOF___FLOAT128\n\
@@ -841,31 +840,33 @@ set (PROG_SRC
 #else\n\
 #define C_LDBL_DIG LDBL_DIG\n\
 #endif\n\nint main() {\nprintf(\"\\%d\\\;\\%d\\\;\", C_LDBL_DIG, C_FLT128_DIG)\\\;\n\nreturn 0\\\;\n}\n
-     "
-)
+       "
+  )
 
-C_RUN ("maximum decimal precision for C" ${PROG_SRC} PROG_RES PROG_OUTPUT4)
-message (STATUS "Testing maximum decimal precision for C - ${PROG_OUTPUT4}")
+  C_RUN ("maximum decimal precision for C" ${PROG_SRC} PROG_RES PROG_OUTPUT4)
+  message (STATUS "Testing maximum decimal precision for C - ${PROG_OUTPUT4}")
 
-# dnl The output from the above program will be:
-# dnl  -- long double decimal precision  --  __float128 decimal precision
+  # dnl The output from the above program will be:
+  # dnl  -- long double decimal precision  --  __float128 decimal precision
 
-list (GET PROG_OUTPUT4 0 H5_LDBL_DIG)
-list (GET PROG_OUTPUT4 1 H5_FLT128_DIG)
+  list (GET PROG_OUTPUT4 0 H5_LDBL_DIG)
+  list (GET PROG_OUTPUT4 1 H5_FLT128_DIG)
 
-if (${HDF_PREFIX}_SIZEOF___FLOAT128 EQUAL "0" OR FLT128_DIG EQUAL "0")
-  set (${HDF_PREFIX}_HAVE_FLOAT128 0)
-  set (${HDF_PREFIX}_SIZEOF___FLOAT128 0)
-  set (_PAC_C_MAX_REAL_PRECISION ${H5_LDBL_DIG})
-else ()
-  set (_PAC_C_MAX_REAL_PRECISION ${H5_FLT128_DIG})
-endif ()
-if (NOT ${_PAC_C_MAX_REAL_PRECISION})
-  set (${HDF_PREFIX}_PAC_C_MAX_REAL_PRECISION 0)
-else ()
-  set (${HDF_PREFIX}_PAC_C_MAX_REAL_PRECISION ${_PAC_C_MAX_REAL_PRECISION})
-endif ()
-message (STATUS "maximum decimal precision for C var - ${${HDF_PREFIX}_PAC_C_MAX_REAL_PRECISION}")
+  if (${HDF_PREFIX}_SIZEOF___FLOAT128 EQUAL "0" OR FLT128_DIG EQUAL "0")
+    set (${HDF_PREFIX}_HAVE_FLOAT128 0)
+    set (${HDF_PREFIX}_SIZEOF___FLOAT128 0)
+    set (_PAC_C_MAX_REAL_PRECISION ${H5_LDBL_DIG})
+  else ()
+    set (_PAC_C_MAX_REAL_PRECISION ${H5_FLT128_DIG})
+  endif ()
+  if (NOT ${_PAC_C_MAX_REAL_PRECISION})
+    set (${HDF_PREFIX}_PAC_C_MAX_REAL_PRECISION 0)
+  else ()
+    set (${HDF_PREFIX}_PAC_C_MAX_REAL_PRECISION ${_PAC_C_MAX_REAL_PRECISION})
+  endif ()
+  message (STATUS "maximum decimal precision for C var - ${${HDF_PREFIX}_PAC_C_MAX_REAL_PRECISION}")
+
+endif()
 
 #-----------------------------------------------------------------------------
 # Macro to determine the various conversion capabilities

--- a/configure.ac
+++ b/configure.ac
@@ -536,31 +536,7 @@ AC_CHECK_SIZEOF([double])
 AC_CHECK_SIZEOF([long double])
 
 ## ----------------------------------------------------------------------
-## Check for non-standard extension __FLOAT128
-##
-HAVE_FLOAT128=0
-HAVE_QUADMATH=0
-FLT128_DIG=0
-LDBL_DIG=0
-
-AC_CHECK_SIZEOF([__float128])
-AC_CHECK_SIZEOF([_Quad])
-AC_CHECK_HEADERS([quadmath.h], [HAVE_QUADMATH=1], [])
-PAC_FC_LDBL_DIG
-
-AC_SUBST([PAC_C_MAX_REAL_PRECISION])
-
-if test "$ac_cv_sizeof___float128" != 0 && test "$FLT128_DIG" != 0 ; then
-  AC_DEFINE([HAVE_FLOAT128], [1], [Determine if __float128 is available])
-  PAC_C_MAX_REAL_PRECISION=$FLT128_DIG
-else
-  PAC_C_MAX_REAL_PRECISION=$LDBL_DIG
-fi
-AC_DEFINE_UNQUOTED([PAC_C_MAX_REAL_PRECISION], $PAC_C_MAX_REAL_PRECISION, [Determine the maximum decimal precision in C])
-AC_MSG_RESULT([$PAC_C_MAX_REAL_PRECISION])
-
-## ----------------------------------------------------------------------
-## Check if they would like the Fortran interface compiled
+## Check if the Fortran interface should be enabled
 ##
 
 ## This needs to be exposed for the library info file even if Fortran is disabled.
@@ -579,6 +555,30 @@ AC_ARG_ENABLE([fortran],
 AC_MSG_RESULT([$HDF_FORTRAN])
 
 if test "X$HDF_FORTRAN" = "Xyes"; then
+
+## ----------------------------------------------------------------------
+## Check for non-standard extension __FLOAT128
+##
+  HAVE_FLOAT128=0
+  HAVE_QUADMATH=0
+  FLT128_DIG=0
+  LDBL_DIG=0
+
+  AC_CHECK_SIZEOF([__float128])
+  AC_CHECK_SIZEOF([_Quad])
+  AC_CHECK_HEADERS([quadmath.h], [HAVE_QUADMATH=1], [])
+  PAC_FC_LDBL_DIG
+
+  AC_SUBST([PAC_C_MAX_REAL_PRECISION])
+
+  if test "$ac_cv_sizeof___float128" != 0 && test "$FLT128_DIG" != 0 ; then
+    AC_DEFINE([HAVE_FLOAT128], [1], [Determine if __float128 is available])
+    PAC_C_MAX_REAL_PRECISION=$FLT128_DIG
+  else
+    PAC_C_MAX_REAL_PRECISION=$LDBL_DIG
+  fi
+  AC_DEFINE_UNQUOTED([PAC_C_MAX_REAL_PRECISION], $PAC_C_MAX_REAL_PRECISION, [Determine the maximum decimal precision in C])
+  AC_MSG_RESULT([$PAC_C_MAX_REAL_PRECISION])
 
 ## We will output an include file for Fortran, H5config_f.inc which
 ## contains various configure definitions used by the Fortran Library.


### PR DESCRIPTION
Quad precision checks only happen if FORTRAN is enabled since the information is only used for FORTRAN.