### PR TITLE
CVE 2021 46242 develop

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -172,6 +172,18 @@ Bug Fixes since HDF5-1.13.3 release
 ===================================
     Library
     -------
+    - Fix CVE-2021-46242 / GHSA-x9pw-hh7v-wjpf
+
+      When evicting driver info block, NULL the corresponding entry.
+
+      Since H5C_expunge_entry() called (from H5AC_expunge_entry()) sets the  flag
+      H5C__FLUSH_INVALIDATE_FLAG, the driver info block will be freed. NULLing
+      the pointer in f->shared->drvinfo will prevent use-after-free  when it is
+      used in other functions (like  H5F__dest()) - as other places will check
+      whether the pointer is initialized before using its value.
+
+      (EFE - 2022/09/29 GH-2254)
+
     - Fix CVE-2018-13867 / GHSA-j8jr-chrh-qfrf
  
       Validate location (offset) of the accumulated metadata when comparing.

--- a/src/H5Fsuper.c
+++ b/src/H5Fsuper.c
@@ -1060,6 +1060,7 @@ done:
             /* Evict the superblock from the cache */
             if (H5AC_expunge_entry(f, H5AC_SUPERBLOCK, (haddr_t)0, H5AC__NO_FLAGS_SET) < 0)
                 HDONE_ERROR(H5E_FILE, H5E_CANTEXPUNGE, FAIL, "unable to expunge superblock")
+            f->shared->sblock = NULL;
         } /* end if */
     }     /* end if */
 

--- a/src/H5Fsuper.c
+++ b/src/H5Fsuper.c
@@ -1044,8 +1044,11 @@ done:
                 HDONE_ERROR(H5E_FILE, H5E_CANTUNPIN, FAIL, "unable to unpin driver info")
 
             /* Evict the driver info block from the cache */
-            if (sblock && H5AC_expunge_entry(f, H5AC_DRVRINFO, sblock->driver_addr, H5AC__NO_FLAGS_SET) < 0)
-                HDONE_ERROR(H5E_FILE, H5E_CANTEXPUNGE, FAIL, "unable to expunge driver info block")
+            if (sblock) {
+                if (H5AC_expunge_entry(f, H5AC_DRVRINFO, sblock->driver_addr, H5AC__NO_FLAGS_SET) < 0)
+                    HDONE_ERROR(H5E_FILE, H5E_CANTEXPUNGE, FAIL, "unable to expunge driver info block")
+                f->shared->drvinfo = NULL;
+            }
         } /* end if */
 
         /* Unpin & discard superblock */


### PR DESCRIPTION
Fix two potential causes of usr-after-free:

- When evicting the superblock, NULL the corresponding entry
- When evicting driver info block, NULL the corresponding entry (CVE-2021-46242, Bug #2254)

