### PR TITLE
Hot fix for CVE-2020-10812 / Bug #2257

### DIFF
--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -1380,7 +1380,7 @@ H5F__dest(H5F_t *f, hbool_t flush)
          */
         if (H5AC_prep_for_file_close(f) < 0)
             /* Push error, but keep going */
-            HDONE_ERROR(H5E_FILE, H5E_CANTFLUSH, FAIL, "metadata cache prep for close failed")
+            HDONE_ERROR(H5E_FILE, H5E_CANTFLUSH, ret_value, "metadata cache prep for close failed")
 
         /* Flush at this point since the file will be closed (phase 2).
          * Only try to flush the file if it was opened with write access, and if


### PR DESCRIPTION
CVE-2020-10812 unveils a more fundamental design flaw in H5F__dest(): this function returns FAIL if one of multiple operations fail (in this case H5AC_prep_for_file_close()) while it still proceeds to prepare the close operation, free the 'shared' member in struct H5F_t and ulimately deallocate the structure itself.
When H5F__dest() signals back FAIL to the caller, the caller itself (H5F_try_close() in this case) will fail. This failure is signalled up the stack, thus the file will not be considered closed and another attempt will be made to close it - latest in the exit handler. The next attempt to close will however need the already deallocated H5F_t structure and the H5T_shared_t structure in its 'shared' member, however.
This fix papers over the failure of H5AC_prep_for_file_close() by not changing the return status of H5F__dest() to fail. There are numerous other opportunities where this will happen.
This may call for a more fundamental solution.

Signed-off-by: Egbert Eich <eich@suse.com>