### PR TITLE
Develop ubuntu 20.04

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-* @lrknox @derobins @byrnHDF @fortnern @jhendersonHDF @ChristopherHogan @gnuoyd @qkoziol @vchoi-hdfgroup @bmribler @raylu-hdf
+* @lrknox @derobins @byrnHDF @fortnern @jhendersonHDF @qkoziol @vchoi-hdfgroup @bmribler @raylu-hdf
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -381,6 +381,7 @@ jobs:
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           ${{ matrix.flags }} $GITHUB_WORKSPACE/configure --enable-build-mode=${{ matrix.build_mode.autotools }} --${{ matrix.deprec_sym }}-deprecated-symbols --with-default-api-version=${{ matrix.default_api }} --enable-shared --${{ matrix.parallel }}-parallel --${{ matrix.cpp }}-cxx --${{ matrix.fortran }}-fortran --${{ matrix.java }}-java --${{ matrix.mirror_vfd }}-mirror-vfd --${{ matrix.direct_vfd }}-direct-vfd
+          cat config.log
         shell: bash
         if: (matrix.generator == 'autogen') && (! matrix.thread_safe.enabled)
 
@@ -390,6 +391,7 @@ jobs:
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           ${{ matrix.flags }} $GITHUB_WORKSPACE/configure --enable-build-mode=${{ matrix.build_mode.autotools }} --enable-shared --enable-threadsafe --disable-hl --${{ matrix.parallel }}-parallel --${{ matrix.mirror_vfd }}-mirror-vfd --${{ matrix.direct_vfd }}-direct-vfd
+          cat config.log
         shell: bash
         if: (matrix.generator == 'autogen') && (matrix.thread_safe.enabled)
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -395,6 +395,12 @@ jobs:
         shell: bash
         if: (matrix.generator == 'autogen') && (matrix.thread_safe.enabled)
 
+        name: Autotools config.log output
+        run: |
+          cat config.log
+        shell: bash
+        if: always()
+
       #
       # CMAKE CONFIGURE
       #

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -399,7 +399,7 @@ jobs:
         run: cat config.log
         working-directory: ${{ runner.workspace }}/build
         shell: bash
-        if: ${{ always() }}
+        if: (matrix.generator == 'autogen') && ${{ always() }}
 
       #
       # CMAKE CONFIGURE

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
           # so we catch most issues in daily testing. What we have here is just
           # a compile check to make sure nothing obvious is broken.
           - name: "Ubuntu gcc Autotools parallel (build only)"
-            os: ubuntu-20.04
+            os: ubuntu-latest
             cpp: disable
             fortran: enable
             java: disable

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
           # so we catch most issues in daily testing. What we have here is just
           # a compile check to make sure nothing obvious is broken.
           - name: "Ubuntu gcc Autotools parallel (build only)"
-            os: ubuntu-latest
+            os: ubuntu-20.04
             cpp: disable
             fortran: enable
             java: disable
@@ -381,7 +381,6 @@ jobs:
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           ${{ matrix.flags }} $GITHUB_WORKSPACE/configure --enable-build-mode=${{ matrix.build_mode.autotools }} --${{ matrix.deprec_sym }}-deprecated-symbols --with-default-api-version=${{ matrix.default_api }} --enable-shared --${{ matrix.parallel }}-parallel --${{ matrix.cpp }}-cxx --${{ matrix.fortran }}-fortran --${{ matrix.java }}-java --${{ matrix.mirror_vfd }}-mirror-vfd --${{ matrix.direct_vfd }}-direct-vfd
-          cat config.log
         shell: bash
         if: (matrix.generator == 'autogen') && (! matrix.thread_safe.enabled)
 
@@ -391,15 +390,8 @@ jobs:
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           ${{ matrix.flags }} $GITHUB_WORKSPACE/configure --enable-build-mode=${{ matrix.build_mode.autotools }} --enable-shared --enable-threadsafe --disable-hl --${{ matrix.parallel }}-parallel --${{ matrix.mirror_vfd }}-mirror-vfd --${{ matrix.direct_vfd }}-direct-vfd
-          cat config.log
         shell: bash
         if: (matrix.generator == 'autogen') && (matrix.thread_safe.enabled)
-
-      - name: Config.log output
-        run: cat config.log
-        working-directory: ${{ runner.workspace }}/build
-        shell: bash
-        if: (matrix.generator == 'autogen')
 
       #
       # CMAKE CONFIGURE

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
           # so we catch most issues in daily testing. What we have here is just
           # a compile check to make sure nothing obvious is broken.
           - name: "Ubuntu gcc Autotools parallel (build only)"
-            os: ubuntu-latest
+            os: ubuntu-20.04
             cpp: disable
             fortran: enable
             java: disable

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -399,7 +399,7 @@ jobs:
         run: cat config.log
         working-directory: ${{ runner.workspace }}/build
         shell: bash
-        if: (matrix.generator == 'autogen') && ${{ always() }}
+        if: (matrix.generator == 'autogen')
 
       #
       # CMAKE CONFIGURE

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -396,9 +396,8 @@ jobs:
         if: (matrix.generator == 'autogen') && (matrix.thread_safe.enabled)
 
       - name: Config.log output
-        run: |
-          cd "${{ runner.workspace }}/build"
-          cat config.log
+        run: cat config.log
+        working-directory: ${{ runner.workspace }}/build
         shell: bash
         if: ${{ always() }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -395,11 +395,12 @@ jobs:
         shell: bash
         if: (matrix.generator == 'autogen') && (matrix.thread_safe.enabled)
 
-        name: Autotools config.log output
+      - name: Config.log output
         run: |
+          cd "${{ runner.workspace }}/build"
           cat config.log
         shell: bash
-        if: always()
+        if: ${{ always() }}
 
       #
       # CMAKE CONFIGURE

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
           # so we catch most issues in daily testing. What we have here is just
           # a compile check to make sure nothing obvious is broken.
           - name: "Ubuntu gcc Autotools parallel (build only)"
-            os: ubuntu-20.04
+            os: ubuntu-latest
             cpp: disable
             fortran: enable
             java: disable
@@ -347,7 +347,7 @@ jobs:
         run: |
            sudo apt update
            sudo apt install automake autoconf libtool libtool-bin
-           sudo apt install openmpi-bin openmpi-common
+           sudo apt install openmpi-bin openmpi-common libopenmpi-dev
            echo "CC=mpicc" >> $GITHUB_ENV
            echo "FC=mpif90" >> $GITHUB_ENV
         if: (matrix.generator == 'autogen') && (matrix.parallel == 'enable')


### PR DESCRIPTION
In Ubuntu 20.04, apt install openmpi-bin also installed openmpi-common and libopenmpi-dev as dependencies.  In Ubuntu 22.04, libopenmpi-dev is not installed as a dependency of openmpi-bin, and without it, links such as libmpi.so are not created, resulting in autotools configure failure when trying to compile a basic C program with mpicc.  Specifically adding libopenmpi-dev restores the previous behavior.