### PR TITLE
H5E_ERR_CLS_g symbol missing when compiling C++ plugins

### DIFF
--- a/src/H5Epublic.h
+++ b/src/H5Epublic.h
@@ -64,7 +64,6 @@ typedef struct H5E_error2_t {
  * can miss the symbol at linking time (for instance with Visual Studio)
  *
  */
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/H5Epublic.h
+++ b/src/H5Epublic.h
@@ -59,8 +59,20 @@ typedef struct H5E_error2_t {
 #endif /* H5private_H */
 
 /* HDF5 error class */
+/* 
+ * If this extern "C" block is not added, filter plugins compiled with C++ (ex. SZ3)
+ * can miss the symbol at linking time (for instance with Visual Studio)
+ *
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 #define H5E_ERR_CLS (H5OPEN H5E_ERR_CLS_g)
 H5_DLLVAR hid_t H5E_ERR_CLS_g;
+#ifdef __cplusplus
+}
+#endif
 
 /* Include the automatically generated public header information */
 /* (This includes the list of major and minor error codes for the library) */

--- a/src/H5Epublic.h
+++ b/src/H5Epublic.h
@@ -59,11 +59,7 @@ typedef struct H5E_error2_t {
 #endif /* H5private_H */
 
 /* HDF5 error class */
-/* 
- * If this extern "C" block is not added, filter plugins compiled with C++ (ex. SZ3)
- * can miss the symbol at linking time (for instance with Visual Studio)
- *
- */
+/* Extern "C" block needed to compile C++ filter plugins with some compilers */
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
C++ HDF5 filter plugin SZ3 fails to build under windows with failure at linking time unless that extern "C" block is added.

![image](https://user-images.githubusercontent.com/5636251/204863383-8d35e8b2-5d81-4a6c-ad5f-54a0a8eac596.png)
