### PR TITLE
WIP: Remove file "post open" VOL callback

### DIFF
--- a/src/H5ES.c
+++ b/src/H5ES.c
@@ -143,7 +143,8 @@ H5ESinsert_request(hid_t es_id, hid_t connector_id, void *request)
         HGOTO_ERROR(H5E_EVENTSET, H5E_CANTINSERT, FAIL, "can't insert request into event set")
 
 done:
-    /* Release our reference to the newly created connector (the request, if created, keeps another reference) */
+    /* Release our reference to the newly created connector (the request, if created, keeps another reference)
+     */
     if (connector && H5VL_conn_dec_rc(connector) < 0)
         HDONE_ERROR(H5E_EVENTSET, H5E_CANTDEC, FAIL, "unable to decrement ref count on VOL connector")
 

--- a/src/H5ES.c
+++ b/src/H5ES.c
@@ -143,11 +143,9 @@ H5ESinsert_request(hid_t es_id, hid_t connector_id, void *request)
         HGOTO_ERROR(H5E_EVENTSET, H5E_CANTINSERT, FAIL, "can't insert request into event set")
 
 done:
-    /* Clean up on error */
-    if (ret_value < 0)
-        /* Release newly created connector */
-        if (connector && H5VL_conn_dec_rc(connector) < 0)
-            HDONE_ERROR(H5E_EVENTSET, H5E_CANTDEC, FAIL, "unable to decrement ref count on VOL connector")
+    /* Release our reference to the newly created connector (the request, if created, keeps another reference) */
+    if (connector && H5VL_conn_dec_rc(connector) < 0)
+        HDONE_ERROR(H5E_EVENTSET, H5E_CANTDEC, FAIL, "unable to decrement ref count on VOL connector")
 
     FUNC_LEAVE_API(ret_value)
 } /* end H5ESinsert_request() */

--- a/src/H5F.c
+++ b/src/H5F.c
@@ -616,7 +616,7 @@ done:
 hid_t
 H5Fcreate(const char *filename, unsigned flags, hid_t fcpl_id, hid_t fapl_id)
 {
-    hid_t          ret_value = H5I_INVALID_HID; /* Return value */
+    hid_t ret_value = H5I_INVALID_HID; /* Return value */
 
     FUNC_ENTER_API(H5I_INVALID_HID)
     H5TRACE4("i", "*sIuii", filename, flags, fcpl_id, fapl_id);
@@ -772,7 +772,7 @@ done:
 hid_t
 H5Fopen(const char *filename, unsigned flags, hid_t fapl_id)
 {
-    hid_t          ret_value = H5I_INVALID_HID; /* Return value */
+    hid_t ret_value = H5I_INVALID_HID; /* Return value */
 
     FUNC_ENTER_API(H5I_INVALID_HID)
     H5TRACE3("i", "*sIui", filename, flags, fapl_id);
@@ -1383,7 +1383,7 @@ done:
 hid_t
 H5Freopen(hid_t file_id)
 {
-    hid_t          ret_value = H5I_INVALID_HID; /* Return value */
+    hid_t ret_value = H5I_INVALID_HID; /* Return value */
 
     FUNC_ENTER_API(H5I_INVALID_HID)
     H5TRACE1("i", "i", file_id);

--- a/src/H5Fefc.c
+++ b/src/H5Fefc.c
@@ -175,10 +175,6 @@ H5F__efc_open(H5F_t *parent, const char *name, unsigned flags, hid_t fcpl_id, hi
         if (NULL == (ret_value = H5F_open(name, flags, fcpl_id, fapl_id)))
             HGOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, NULL, "can't open file")
 
-        /* Make file post open call */
-        if (H5F__post_open(ret_value) < 0)
-            HGOTO_ERROR(H5E_FILE, H5E_CANTINIT, NULL, "can't finish opening file")
-
         /* Increment the number of open objects to prevent the file from being
          * closed out from under us - "simulate" having an open file id.  Note
          * that this behaviour replaces the calls to H5F_incr_nopen_objs() and
@@ -252,10 +248,6 @@ H5F__efc_open(H5F_t *parent, const char *name, unsigned flags, hid_t fcpl_id, hi
                 if (NULL == (ret_value = H5F_open(name, flags, fcpl_id, fapl_id)))
                     HGOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, NULL, "can't open file")
 
-                /* Make file post open call */
-                if (H5F__post_open(ret_value) < 0)
-                    HGOTO_ERROR(H5E_FILE, H5E_CANTINIT, NULL, "can't finish opening file")
-
                 /* Increment the number of open objects to prevent the file from
                  * being closed out from under us - "simulate" having an open
                  * file id */
@@ -277,10 +269,6 @@ H5F__efc_open(H5F_t *parent, const char *name, unsigned flags, hid_t fcpl_id, hi
         if (NULL == (ent->file = H5F_open(name, flags, fcpl_id, fapl_id)))
             HGOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, NULL, "can't open file")
         open_file = TRUE;
-
-        /* Make file post open call */
-        if (H5F__post_open(ent->file) < 0)
-            HGOTO_ERROR(H5E_FILE, H5E_CANTINIT, NULL, "can't finish opening file")
 
         /* Increment the number of open objects to prevent the file from being
          * closed out from under us - "simulate" having an open file id */

--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -1306,6 +1306,10 @@ H5F__new(H5F_shared_t *shared, unsigned flags, hid_t fcpl_id, hid_t fapl_id, H5F
             HGOTO_ERROR(H5E_FILE, H5E_CANTINIT, NULL, "unable to append to list of open files")
     } /* end else */
 
+    /* Create VOL object for file */
+    if (NULL == (f->vol_obj = H5VL_create_object_using_vol_id(H5I_FILE, f, f->shared->vol_id)))
+        HGOTO_ERROR(H5E_FILE, H5E_CANTINIT, NULL, "can't create VOL object")
+
     f->shared->nrefs++;
 
     /* Create the file's "top open object" information */
@@ -2086,34 +2090,6 @@ done:
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5F_open() */
-
-/*-------------------------------------------------------------------------
- * Function:    H5F__post_open
- *
- * Purpose:     Finishes file open after wrapper context for file has been
- *              set.
- *
- * Return:      SUCCEED/FAIL
- *
- *-------------------------------------------------------------------------
- */
-herr_t
-H5F__post_open(H5F_t *f)
-{
-    herr_t ret_value = SUCCEED; /* Return value */
-
-    FUNC_ENTER_PACKAGE
-
-    /* Sanity check arguments */
-    HDassert(f);
-
-    /* Store a vol object in the file struct */
-    if (NULL == (f->vol_obj = H5VL_create_object_using_vol_id(H5I_FILE, f, f->shared->vol_id)))
-        HGOTO_ERROR(H5E_FILE, H5E_CANTINIT, FAIL, "can't create VOL object")
-
-done:
-    FUNC_LEAVE_NOAPI(ret_value)
-} /* end H5F__post_open() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5F_flush_phase1

--- a/src/H5Fpkg.h
+++ b/src/H5Fpkg.h
@@ -403,7 +403,6 @@ H5_DLLVAR htri_t use_locks_env_g;
 /******************************/
 
 /* General routines */
-H5_DLL herr_t H5F__post_open(H5F_t *f);
 H5_DLL H5F_t *H5F__reopen(H5F_t *f);
 H5_DLL herr_t H5F__flush(H5F_t *f);
 H5_DLL htri_t H5F__is_hdf5(const char *name, hid_t fapl_id);

--- a/src/H5Rint.c
+++ b/src/H5Rint.c
@@ -459,9 +459,9 @@ H5R__get_loc_id(const H5R_ref_priv_t *ref)
 hid_t
 H5R__reopen_file(H5R_ref_priv_t *ref, hid_t fapl_id)
 {
-    H5P_genplist_t       *plist;           /* Property list for FAPL */
-    void                 *new_file = NULL; /* File object opened */
-    H5VL_connector_prop_t connector_prop;  /* Property for VOL connector ID & info     */
+    H5P_genplist_t       *plist;            /* Property list for FAPL */
+    void                 *new_file = NULL;  /* File object opened */
+    H5VL_connector_prop_t connector_prop;   /* Property for VOL connector ID & info     */
     H5VL_t               *connector = NULL; /* VOL connector struct */
     hid_t                 ret_value = H5I_INVALID_HID;
 
@@ -488,8 +488,8 @@ H5R__reopen_file(H5R_ref_priv_t *ref, hid_t fapl_id)
 
     /* Open the file */
     /* (Must open file read-write to allow for object modifications) */
-    if (NULL == (new_file = H5VL_file_open(&connector, &connector_prop, H5R_REF_FILENAME(ref), H5F_ACC_RDWR, fapl_id,
-                                           H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL)))
+    if (NULL == (new_file = H5VL_file_open(&connector, &connector_prop, H5R_REF_FILENAME(ref), H5F_ACC_RDWR,
+                                           fapl_id, H5P_DATASET_XFER_DEFAULT, H5_REQUEST_NULL)))
         HGOTO_ERROR(H5E_REFERENCE, H5E_CANTOPENFILE, H5I_INVALID_HID, "unable to open file")
 
     /* Get an ID for the file */
@@ -504,7 +504,8 @@ H5R__reopen_file(H5R_ref_priv_t *ref, hid_t fapl_id)
     }
 
 done:
-    /* Release our reference to the newly created connector (the file ID, if created, keeps another reference) */
+    /* Release our reference to the newly created connector (the file ID, if created, keeps another reference)
+     */
     if (connector && H5VL_conn_dec_rc(connector) < 0)
         HDONE_ERROR(H5E_FILE, H5E_CANTDEC, H5I_INVALID_HID, "unable to decrement ref count on VOL connector")
 

--- a/src/H5VLcallback.c
+++ b/src/H5VLcallback.c
@@ -791,7 +791,8 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5VL_get_wrap_ctx_pre_open(const H5VL_class_t *cls, const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id, void **wrap_ctx)
+H5VL_get_wrap_ctx_pre_open(const H5VL_class_t *cls, const char *name, unsigned flags, hid_t fcpl_id,
+                           hid_t fapl_id, hid_t dxpl_id, void **wrap_ctx)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
@@ -829,12 +830,13 @@ done:
  *---------------------------------------------------------------------------
  */
 herr_t
-H5VLget_wrap_ctx_pre_open(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id, void **wrap_ctx /*out*/)
+H5VLget_wrap_ctx_pre_open(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id,
+                          void **wrap_ctx /*out*/)
 {
-    H5P_genplist_t       *plist;            /* Property list pointer */
-    H5VL_connector_prop_t connector_prop;   /* Property for VOL connector ID & info */
-    H5VL_class_t         *cls;              /* VOL connector's class struct */
-    herr_t        ret_value = SUCCEED; /* Return value */
+    H5P_genplist_t       *plist;               /* Property list pointer */
+    H5VL_connector_prop_t connector_prop;      /* Property for VOL connector ID & info */
+    H5VL_class_t         *cls;                 /* VOL connector's class struct */
+    herr_t                ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
     H5TRACE6("e", "*sIuiiix", name, flags, fcpl_id, fapl_id, dxpl_id, wrap_ctx);
@@ -852,7 +854,6 @@ H5VLget_wrap_ctx_pre_open(const char *name, unsigned flags, hid_t fcpl_id, hid_t
     /* Get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_prop.connector_id, H5I_VOL)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a VOL connector ID")
-
 
     /* Get the VOL connector's object wrapper */
     if (H5VL_get_wrap_ctx_pre_open(cls, name, flags, fcpl_id, fapl_id, dxpl_id, wrap_ctx) < 0)
@@ -3652,7 +3653,8 @@ H5VL__file_create(const H5VL_class_t *cls, const char *name, unsigned flags, hid
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, NULL, "VOL connector has no 'file create' method")
 
     /* Call the corresponding VOL callback */
-    if (NULL == (ret_value = (cls->file_cls.create)(name, flags, fcpl_id, fapl_id, dxpl_id, obj_wrap_ctx, req)))
+    if (NULL ==
+        (ret_value = (cls->file_cls.create)(name, flags, fcpl_id, fapl_id, dxpl_id, obj_wrap_ctx, req)))
         HGOTO_ERROR(H5E_VOL, H5E_CANTCREATE, NULL, "file create failed")
 
 done:
@@ -3673,13 +3675,13 @@ done:
  *-------------------------------------------------------------------------
  */
 void *
-H5VL_file_create(H5VL_t **connector, const H5VL_connector_prop_t *connector_prop, const char *name, unsigned flags, hid_t fcpl_id,
-                 hid_t fapl_id, hid_t dxpl_id, void **req)
+H5VL_file_create(H5VL_t **connector, const H5VL_connector_prop_t *connector_prop, const char *name,
+                 unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id, void **req)
 {
-    H5VL_class_t *cls;              /* VOL Class structure for callback info    */
-    void *obj_wrap_ctx = NULL; /* Object wrapping context */
-    hbool_t vol_wrapper_set = FALSE;   /* Whether the VOL object wrapping context was set up */
-    void         *ret_value = NULL; /* Return value */
+    H5VL_class_t *cls;                     /* VOL Class structure for callback info    */
+    void         *obj_wrap_ctx    = NULL;  /* Object wrapping context */
+    hbool_t       vol_wrapper_set = FALSE; /* Whether the VOL object wrapping context was set up */
+    void         *ret_value       = NULL;  /* Return value */
 
     FUNC_ENTER_NOAPI(NULL)
 
@@ -3697,7 +3699,8 @@ H5VL_file_create(H5VL_t **connector, const H5VL_connector_prop_t *connector_prop
     vol_wrapper_set = TRUE;
 
     /* Call the corresponding internal VOL routine */
-    if (NULL == (ret_value = H5VL__file_create(cls, name, flags, fcpl_id, fapl_id, dxpl_id, obj_wrap_ctx, req)))
+    if (NULL ==
+        (ret_value = H5VL__file_create(cls, name, flags, fcpl_id, fapl_id, dxpl_id, obj_wrap_ctx, req)))
         HGOTO_ERROR(H5E_VOL, H5E_CANTCREATE, NULL, "file create failed")
 
 done:
@@ -3915,13 +3918,13 @@ done:
  *-------------------------------------------------------------------------
  */
 void *
-H5VL_file_open(H5VL_t **connector, H5VL_connector_prop_t *connector_prop, const char *name, unsigned flags, hid_t fapl_id,
-               hid_t dxpl_id, void **req)
+H5VL_file_open(H5VL_t **connector, H5VL_connector_prop_t *connector_prop, const char *name, unsigned flags,
+               hid_t fapl_id, hid_t dxpl_id, void **req)
 {
-    H5VL_class_t *cls;              /* VOL Class structure for callback info    */
-    void *obj_wrap_ctx = NULL; /* Object wrapping context */
-    hbool_t vol_wrapper_set = FALSE;   /* Whether the VOL object wrapping context was set up */
-    void         *ret_value = NULL; /* Return value */
+    H5VL_class_t *cls;                     /* VOL Class structure for callback info    */
+    void         *obj_wrap_ctx    = NULL;  /* Object wrapping context */
+    hbool_t       vol_wrapper_set = FALSE; /* Whether the VOL object wrapping context was set up */
+    void         *ret_value       = NULL;  /* Return value */
 
     FUNC_ENTER_NOAPI(NULL)
 
@@ -3934,7 +3937,8 @@ H5VL_file_open(H5VL_t **connector, H5VL_connector_prop_t *connector_prop, const 
         HGOTO_ERROR(H5E_FILE, H5E_CANTINIT, NULL, "can't create VOL connector")
 
     /* Set wrapper info in API context */
-    if (H5VL_set_vol_wrapper_pre_open(*connector, name, flags, H5I_INVALID_HID, fapl_id, dxpl_id, &obj_wrap_ctx) < 0)
+    if (H5VL_set_vol_wrapper_pre_open(*connector, name, flags, H5I_INVALID_HID, fapl_id, dxpl_id,
+                                      &obj_wrap_ctx) < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTSET, NULL, "can't set VOL wrapper info")
     vol_wrapper_set = TRUE;
 
@@ -3989,12 +3993,14 @@ H5VL_file_open(H5VL_t **connector, H5VL_connector_prop_t *connector_prop, const 
                     HGOTO_ERROR(H5E_FILE, H5E_CANTINIT, NULL, "can't create VOL connector")
 
                 /* Set new wrapper info in API context */
-                if (H5VL_set_vol_wrapper_pre_open(*connector, name, flags, H5I_INVALID_HID, fapl_id, dxpl_id, &obj_wrap_ctx) < 0)
+                if (H5VL_set_vol_wrapper_pre_open(*connector, name, flags, H5I_INVALID_HID, fapl_id, dxpl_id,
+                                                  &obj_wrap_ctx) < 0)
                     HGOTO_ERROR(H5E_VOL, H5E_CANTSET, NULL, "can't set VOL wrapper info")
                 vol_wrapper_set = TRUE;
 
-                if (NULL == (ret_value = H5VL__file_open(find_connector_ud.cls, name, flags,
-                                                         find_connector_ud.fapl_id, dxpl_id, obj_wrap_ctx, req)))
+                if (NULL ==
+                    (ret_value = H5VL__file_open(find_connector_ud.cls, name, flags,
+                                                 find_connector_ud.fapl_id, dxpl_id, obj_wrap_ctx, req)))
                     HGOTO_ERROR(H5E_VOL, H5E_CANTOPENOBJ, NULL,
                                 "can't open file '%s' with VOL connector '%s'", name,
                                 find_connector_ud.cls->name)

--- a/src/H5VLconnector.h
+++ b/src/H5VLconnector.h
@@ -851,9 +851,10 @@ typedef struct H5VL_wrap_class_t {
     herr_t (*get_wrap_ctx)(
         const void *obj,
         void      **wrap_ctx); /* Callback to retrieve the object wrapping context for the connector */
-    herr_t (*get_wrap_ctx_pre_open)(
-        const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id,
-        void      **wrap_ctx); /* Callback to retrieve the object wrapping context for the connector before file create/open */
+    herr_t (*get_wrap_ctx_pre_open)(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id,
+                                    hid_t  dxpl_id,
+                                    void **wrap_ctx); /* Callback to retrieve the object wrapping context for
+                                                         the connector before file create/open */
     void *(*wrap_object)(void *obj, H5I_type_t obj_type,
                          void *wrap_ctx); /* Callback to wrap a library object */
     void *(*unwrap_object)(void *obj);    /* Callback to unwrap a library object */

--- a/src/H5VLconnector.h
+++ b/src/H5VLconnector.h
@@ -851,6 +851,9 @@ typedef struct H5VL_wrap_class_t {
     herr_t (*get_wrap_ctx)(
         const void *obj,
         void      **wrap_ctx); /* Callback to retrieve the object wrapping context for the connector */
+    herr_t (*get_wrap_ctx_pre_open)(
+        const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id,
+        void      **wrap_ctx); /* Callback to retrieve the object wrapping context for the connector before file create/open */
     void *(*wrap_object)(void *obj, H5I_type_t obj_type,
                          void *wrap_ctx); /* Callback to wrap a library object */
     void *(*unwrap_object)(void *obj);    /* Callback to unwrap a library object */
@@ -904,8 +907,8 @@ typedef struct H5VL_datatype_class_t {
 /* H5F routines */
 typedef struct H5VL_file_class_t {
     void *(*create)(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id,
-                    void **req);
-    void *(*open)(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, void **req);
+                    void *wrap_ctx, void **req);
+    void *(*open)(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, void *wrap_ctx, void **req);
     herr_t (*get)(void *obj, H5VL_file_get_args_t *args, hid_t dxpl_id, void **req);
     herr_t (*specific)(void *obj, H5VL_file_specific_args_t *args, hid_t dxpl_id, void **req);
     herr_t (*optional)(void *obj, H5VL_optional_args_t *args, hid_t dxpl_id, void **req);

--- a/src/H5VLconnector_passthru.h
+++ b/src/H5VLconnector_passthru.h
@@ -90,7 +90,8 @@ H5_DLL herr_t H5VLfree_lib_state(void *state);
 /* Pass-through callbacks */
 H5_DLL void  *H5VLget_object(void *obj, hid_t connector_id);
 H5_DLL herr_t H5VLget_wrap_ctx(void *obj, hid_t connector_id, void **wrap_ctx);
-H5_DLL herr_t H5VLget_wrap_ctx_pre_open(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id, void **wrap_ctx);
+H5_DLL herr_t H5VLget_wrap_ctx_pre_open(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id,
+                                        hid_t dxpl_id, void **wrap_ctx);
 H5_DLL void  *H5VLwrap_object(void *obj, H5I_type_t obj_type, hid_t connector_id, void *wrap_ctx);
 H5_DLL void  *H5VLunwrap_object(void *obj, hid_t connector_id);
 H5_DLL herr_t H5VLfree_wrap_ctx(void *wrap_ctx, hid_t connector_id);

--- a/src/H5VLconnector_passthru.h
+++ b/src/H5VLconnector_passthru.h
@@ -90,6 +90,7 @@ H5_DLL herr_t H5VLfree_lib_state(void *state);
 /* Pass-through callbacks */
 H5_DLL void  *H5VLget_object(void *obj, hid_t connector_id);
 H5_DLL herr_t H5VLget_wrap_ctx(void *obj, hid_t connector_id, void **wrap_ctx);
+H5_DLL herr_t H5VLget_wrap_ctx_pre_open(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id, void **wrap_ctx);
 H5_DLL void  *H5VLwrap_object(void *obj, H5I_type_t obj_type, hid_t connector_id, void *wrap_ctx);
 H5_DLL void  *H5VLunwrap_object(void *obj, hid_t connector_id);
 H5_DLL herr_t H5VLfree_wrap_ctx(void *wrap_ctx, hid_t connector_id);

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -780,9 +780,9 @@ H5VL_new_connector(hid_t connector_id)
     /* Setup VOL info struct */
     if (NULL == (connector = H5FL_CALLOC(H5VL_t)))
         HGOTO_ERROR(H5E_VOL, H5E_CANTALLOC, NULL, "can't allocate VOL connector struct")
-    connector->cls = cls;
+    connector->cls   = cls;
     connector->nrefs = 1;
-    connector->id  = connector_id;
+    connector->id    = connector_id;
     if (H5I_inc_ref(connector->id, FALSE) < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTINC, NULL, "unable to increment ref count on VOL connector")
     conn_id_incr = TRUE;
@@ -836,8 +836,7 @@ H5VL_register_using_vol_id(H5I_type_t type, void *obj, hid_t connector_id, hbool
 done:
     /* Release our reference to the newly created connector (the ID, if created, keeps another reference) */
     if (connector && H5VL_conn_dec_rc(connector) < 0)
-        HDONE_ERROR(H5E_VOL, H5E_CANTDEC, H5I_INVALID_HID,
-                    "unable to decrement ref count on VOL connector")
+        HDONE_ERROR(H5E_VOL, H5E_CANTDEC, H5I_INVALID_HID, "unable to decrement ref count on VOL connector")
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5VL_register_using_vol_id() */
@@ -2336,7 +2335,7 @@ done:
  */
 herr_t
 H5VL_set_vol_wrapper_pre_open(H5VL_t *connector, const char *name, unsigned flags, hid_t fcpl_id,
-                 hid_t fapl_id, hid_t dxpl_id, void **obj_wrap_ctx_out)
+                              hid_t fapl_id, hid_t dxpl_id, void **obj_wrap_ctx_out)
 {
     H5VL_wrap_ctx_t *vol_wrap_ctx = NULL;    /* Object wrapping context */
     herr_t           ret_value    = SUCCEED; /* Return value */
@@ -2360,7 +2359,8 @@ H5VL_set_vol_wrapper_pre_open(H5VL_t *connector, const char *name, unsigned flag
             HDassert(connector->cls->wrap_cls.free_wrap_ctx);
 
             /* Get the wrap context from the connector */
-            if ((connector->cls->wrap_cls.get_wrap_ctx_pre_open)(name, flags, fcpl_id, fapl_id, dxpl_id, &obj_wrap_ctx) < 0)
+            if ((connector->cls->wrap_cls.get_wrap_ctx_pre_open)(name, flags, fcpl_id, fapl_id, dxpl_id,
+                                                                 &obj_wrap_ctx) < 0)
                 HGOTO_ERROR(H5E_VOL, H5E_CANTGET, FAIL, "can't retrieve VOL connector's object wrap context")
         } /* end if */
 

--- a/src/H5VLnative.c
+++ b/src/H5VLnative.c
@@ -80,6 +80,7 @@ static const H5VL_class_t H5VL_native_cls_g = {
         /* wrap_cls */
         NULL, /* get_object   */
         NULL, /* get_wrap_ctx */
+        NULL, /* get_wrap_ctx_pre_open */
         NULL, /* wrap_object  */
         NULL, /* unwrap_object */
         NULL  /* free_wrap_ctx */

--- a/src/H5VLnative.h
+++ b/src/H5VLnative.h
@@ -209,7 +209,6 @@ typedef union H5VL_native_dataset_optional_args_t {
 #define H5VL_NATIVE_FILE_GET_MPI_ATOMICITY 26 /* H5Fget_mpi_atomicity                 */
 #define H5VL_NATIVE_FILE_SET_MPI_ATOMICITY 27 /* H5Fset_mpi_atomicity                 */
 #endif
-#define H5VL_NATIVE_FILE_POST_OPEN 28 /* Adjust file after open, with wrapping context */
 /* NOTE: If values over 1023 are added, the H5VL_RESERVED_NATIVE_OPTIONAL macro
  *      must be updated.
  */
@@ -390,9 +389,6 @@ typedef union H5VL_native_file_optional_args_t {
         hbool_t flag; /* Flag whether to set MPI atomicity for files */
     } set_mpi_atomicity;
 #endif /* H5_HAVE_PARALLEL */
-
-    /* H5VL_NATIVE_FILE_POST_OPEN */
-    /* No args */
 } H5VL_native_file_optional_args_t;
 
 /* Values for native VOL connector group optional VOL operations */

--- a/src/H5VLnative_file.c
+++ b/src/H5VLnative_file.c
@@ -74,7 +74,8 @@
  */
 void *
 H5VL__native_file_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id,
-                         hid_t H5_ATTR_UNUSED dxpl_id, void H5_ATTR_UNUSED * obj_wrap_ctx, void H5_ATTR_UNUSED **req)
+                         hid_t H5_ATTR_UNUSED dxpl_id, void H5_ATTR_UNUSED *obj_wrap_ctx,
+                         void H5_ATTR_UNUSED **req)
 {
     H5F_t *new_file  = NULL;
     void  *ret_value = NULL;
@@ -116,7 +117,7 @@ done:
  */
 void *
 H5VL__native_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t H5_ATTR_UNUSED dxpl_id,
-                       void H5_ATTR_UNUSED * obj_wrap_ctx, void H5_ATTR_UNUSED **req)
+                       void H5_ATTR_UNUSED *obj_wrap_ctx, void H5_ATTR_UNUSED **req)
 {
     H5F_t *new_file  = NULL;
     void  *ret_value = NULL;

--- a/src/H5VLnative_file.c
+++ b/src/H5VLnative_file.c
@@ -74,7 +74,7 @@
  */
 void *
 H5VL__native_file_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id,
-                         hid_t H5_ATTR_UNUSED dxpl_id, void H5_ATTR_UNUSED **req)
+                         hid_t H5_ATTR_UNUSED dxpl_id, void H5_ATTR_UNUSED * obj_wrap_ctx, void H5_ATTR_UNUSED **req)
 {
     H5F_t *new_file  = NULL;
     void  *ret_value = NULL;
@@ -116,7 +116,7 @@ done:
  */
 void *
 H5VL__native_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t H5_ATTR_UNUSED dxpl_id,
-                       void H5_ATTR_UNUSED **req)
+                       void H5_ATTR_UNUSED * obj_wrap_ctx, void H5_ATTR_UNUSED **req)
 {
     H5F_t *new_file  = NULL;
     void  *ret_value = NULL;
@@ -715,14 +715,6 @@ H5VL__native_file_optional(void *obj, H5VL_optional_args_t *args, hid_t H5_ATTR_
             break;
         }
 #endif /* H5_HAVE_PARALLEL */
-
-        /* Finalize H5Fopen */
-        case H5VL_NATIVE_FILE_POST_OPEN: {
-            /* Call package routine */
-            if (H5F__post_open(f) < 0)
-                HGOTO_ERROR(H5E_FILE, H5E_CANTINIT, FAIL, "can't finish opening file")
-            break;
-        }
 
         default:
             HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "invalid optional operation")

--- a/src/H5VLnative_introspect.c
+++ b/src/H5VLnative_introspect.c
@@ -186,7 +186,6 @@ H5VL__native_introspect_opt_query(void H5_ATTR_UNUSED *obj, H5VL_subclass_t subc
                 case H5VL_NATIVE_FILE_GET_MPI_ATOMICITY:
                 case H5VL_NATIVE_FILE_SET_MPI_ATOMICITY:
 #endif /* H5_HAVE_PARALLEL */
-                case H5VL_NATIVE_FILE_POST_OPEN:
                     break;
 
                 default:

--- a/src/H5VLnative_private.h
+++ b/src/H5VLnative_private.h
@@ -85,9 +85,9 @@ H5_DLL herr_t H5VL__native_datatype_close(void *dt, hid_t dxpl_id, void **req);
 
 /* File callbacks */
 H5_DLL void  *H5VL__native_file_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id,
-                                       hid_t dxpl_id, void **req);
+                                       hid_t dxpl_id, void *obj_wrap_ctx, void **req);
 H5_DLL void  *H5VL__native_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id,
-                                     void **req);
+                                     void *obj_wrap_ctx, void **req);
 H5_DLL herr_t H5VL__native_file_get(void *file, H5VL_file_get_args_t *args, hid_t dxpl_id, void **req);
 H5_DLL herr_t H5VL__native_file_specific(void *file, H5VL_file_specific_args_t *args, hid_t dxpl_id,
                                          void **req);

--- a/src/H5VLpassthru.c
+++ b/src/H5VLpassthru.c
@@ -94,7 +94,8 @@ static herr_t H5VL_pass_through_str_to_info(const char *str, void **info);
 /* VOL object wrap / retrieval callbacks */
 static void  *H5VL_pass_through_get_object(const void *obj);
 static herr_t H5VL_pass_through_get_wrap_ctx(const void *obj, void **wrap_ctx);
-static herr_t H5VL_pass_through_get_wrap_ctx_pre_open(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id, void **wrap_ctx);
+static herr_t H5VL_pass_through_get_wrap_ctx_pre_open(const char *name, unsigned flags, hid_t fcpl_id,
+                                                      hid_t fapl_id, hid_t dxpl_id, void **wrap_ctx);
 static void  *H5VL_pass_through_wrap_object(void *obj, H5I_type_t obj_type, void *wrap_ctx);
 static void  *H5VL_pass_through_unwrap_object(void *obj);
 static herr_t H5VL_pass_through_free_wrap_ctx(void *obj);
@@ -262,12 +263,12 @@ static const H5VL_class_t H5VL_pass_through_g = {
     },
     {
         /* wrap_cls */
-        H5VL_pass_through_get_object,    /* get_object   */
-        H5VL_pass_through_get_wrap_ctx,  /* get_wrap_ctx */
+        H5VL_pass_through_get_object,            /* get_object   */
+        H5VL_pass_through_get_wrap_ctx,          /* get_wrap_ctx */
         H5VL_pass_through_get_wrap_ctx_pre_open, /* get_wrap_ctx_pre_open */
-        H5VL_pass_through_wrap_object,   /* wrap_object  */
-        H5VL_pass_through_unwrap_object, /* unwrap_object */
-        H5VL_pass_through_free_wrap_ctx  /* free_wrap_ctx */
+        H5VL_pass_through_wrap_object,           /* wrap_object  */
+        H5VL_pass_through_unwrap_object,         /* unwrap_object */
+        H5VL_pass_through_free_wrap_ctx          /* free_wrap_ctx */
     },
     {
         /* attribute_cls */
@@ -775,10 +776,11 @@ H5VL_pass_through_get_wrap_ctx(const void *obj, void **wrap_ctx)
  *---------------------------------------------------------------------------
  */
 static herr_t
-H5VL_pass_through_get_wrap_ctx_pre_open(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id, void **wrap_ctx)
+H5VL_pass_through_get_wrap_ctx_pre_open(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id,
+                                        hid_t dxpl_id, void **wrap_ctx)
 {
-    H5VL_pass_through_info_t *info;
-    hid_t                     under_fapl_id;
+    H5VL_pass_through_info_t     *info;
+    hid_t                         under_fapl_id;
     H5VL_pass_through_wrap_ctx_t *new_wrap_ctx;
 
 #ifdef ENABLE_PASSTHRU_LOGGING
@@ -1746,7 +1748,8 @@ H5VL_pass_through_file_create(const char *name, unsigned flags, hid_t fcpl_id, h
  *-------------------------------------------------------------------------
  */
 static void *
-H5VL_pass_through_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, void *obj_wrap_ctx, void **req)
+H5VL_pass_through_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id,
+                            void *obj_wrap_ctx, void **req)
 {
     H5VL_pass_through_info_t *info;
     H5VL_pass_through_t      *file;

--- a/src/H5VLprivate.h
+++ b/src/H5VLprivate.h
@@ -106,10 +106,13 @@ H5_DLL herr_t         H5VL_file_is_same(const H5VL_object_t *vol_obj1, const H5V
 
 /* Functions that wrap / unwrap VOL objects */
 H5_DLL herr_t H5VL_get_wrap_ctx(const H5VL_class_t *connector, void *obj, void **wrap_ctx);
+H5_DLL herr_t H5VL_get_wrap_ctx_pre_open(const H5VL_class_t *cls, const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id, void **wrap_ctx);
 H5_DLL void  *H5VL_wrap_object(const H5VL_class_t *connector, void *wrap_ctx, void *obj, H5I_type_t obj_type);
 H5_DLL void  *H5VL_unwrap_object(const H5VL_class_t *connector, void *obj);
 H5_DLL herr_t H5VL_free_wrap_ctx(const H5VL_class_t *connector, void *wrap_ctx);
 H5_DLL herr_t H5VL_set_vol_wrapper(const H5VL_object_t *vol_obj);
+H5_DLL herr_t H5VL_set_vol_wrapper_pre_open(H5VL_t *connector, const char *name, unsigned flags, hid_t fcpl_id,
+                 hid_t fapl_id, hid_t dxpl_id, void **obj_wrap_ctx_out);
 H5_DLL herr_t H5VL_inc_vol_wrapper(void *vol_wrap_ctx);
 H5_DLL herr_t H5VL_dec_vol_wrapper(void *vol_wrap_ctx);
 H5_DLL herr_t H5VL_reset_vol_wrapper(void);
@@ -214,9 +217,9 @@ H5_DLL herr_t H5VL_datatype_optional_op(H5VL_object_t *vol_obj, H5VL_optional_ar
 H5_DLL herr_t H5VL_datatype_close(const H5VL_object_t *vol_obj, hid_t dxpl_id, void **req);
 
 /* File functions */
-H5_DLL void  *H5VL_file_create(const H5VL_connector_prop_t *connector_prop, const char *name, unsigned flags,
+H5_DLL void  *H5VL_file_create(H5VL_t **connector, const H5VL_connector_prop_t *connector_prop, const char *name, unsigned flags,
                                hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id, void **req);
-H5_DLL void  *H5VL_file_open(H5VL_connector_prop_t *connector_prop, const char *name, unsigned flags,
+H5_DLL void  *H5VL_file_open(H5VL_t **connector, H5VL_connector_prop_t *connector_prop, const char *name, unsigned flags,
                              hid_t fapl_id, hid_t dxpl_id, void **req);
 H5_DLL herr_t H5VL_file_get(const H5VL_object_t *vol_obj, H5VL_file_get_args_t *args, hid_t dxpl_id,
                             void **req);

--- a/src/H5VLprivate.h
+++ b/src/H5VLprivate.h
@@ -106,13 +106,15 @@ H5_DLL herr_t         H5VL_file_is_same(const H5VL_object_t *vol_obj1, const H5V
 
 /* Functions that wrap / unwrap VOL objects */
 H5_DLL herr_t H5VL_get_wrap_ctx(const H5VL_class_t *connector, void *obj, void **wrap_ctx);
-H5_DLL herr_t H5VL_get_wrap_ctx_pre_open(const H5VL_class_t *cls, const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id, void **wrap_ctx);
+H5_DLL herr_t H5VL_get_wrap_ctx_pre_open(const H5VL_class_t *cls, const char *name, unsigned flags,
+                                         hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id, void **wrap_ctx);
 H5_DLL void  *H5VL_wrap_object(const H5VL_class_t *connector, void *wrap_ctx, void *obj, H5I_type_t obj_type);
 H5_DLL void  *H5VL_unwrap_object(const H5VL_class_t *connector, void *obj);
 H5_DLL herr_t H5VL_free_wrap_ctx(const H5VL_class_t *connector, void *wrap_ctx);
 H5_DLL herr_t H5VL_set_vol_wrapper(const H5VL_object_t *vol_obj);
-H5_DLL herr_t H5VL_set_vol_wrapper_pre_open(H5VL_t *connector, const char *name, unsigned flags, hid_t fcpl_id,
-                 hid_t fapl_id, hid_t dxpl_id, void **obj_wrap_ctx_out);
+H5_DLL herr_t H5VL_set_vol_wrapper_pre_open(H5VL_t *connector, const char *name, unsigned flags,
+                                            hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id,
+                                            void **obj_wrap_ctx_out);
 H5_DLL herr_t H5VL_inc_vol_wrapper(void *vol_wrap_ctx);
 H5_DLL herr_t H5VL_dec_vol_wrapper(void *vol_wrap_ctx);
 H5_DLL herr_t H5VL_reset_vol_wrapper(void);
@@ -217,10 +219,11 @@ H5_DLL herr_t H5VL_datatype_optional_op(H5VL_object_t *vol_obj, H5VL_optional_ar
 H5_DLL herr_t H5VL_datatype_close(const H5VL_object_t *vol_obj, hid_t dxpl_id, void **req);
 
 /* File functions */
-H5_DLL void  *H5VL_file_create(H5VL_t **connector, const H5VL_connector_prop_t *connector_prop, const char *name, unsigned flags,
-                               hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id, void **req);
-H5_DLL void  *H5VL_file_open(H5VL_t **connector, H5VL_connector_prop_t *connector_prop, const char *name, unsigned flags,
-                             hid_t fapl_id, hid_t dxpl_id, void **req);
+H5_DLL void  *H5VL_file_create(H5VL_t **connector, const H5VL_connector_prop_t *connector_prop,
+                               const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id,
+                               void **req);
+H5_DLL void  *H5VL_file_open(H5VL_t **connector, H5VL_connector_prop_t *connector_prop, const char *name,
+                             unsigned flags, hid_t fapl_id, hid_t dxpl_id, void **req);
 H5_DLL herr_t H5VL_file_get(const H5VL_object_t *vol_obj, H5VL_file_get_args_t *args, hid_t dxpl_id,
                             void **req);
 H5_DLL herr_t H5VL_file_specific(const H5VL_object_t *vol_obj, H5VL_file_specific_args_t *args, hid_t dxpl_id,

--- a/src/H5trace.c
+++ b/src/H5trace.c
@@ -3688,10 +3688,6 @@ H5_trace_args(H5RS_str_t *rs, const char *type, va_list ap)
                                     break;
 #endif /* H5_HAVE_PARALLEL */
 
-                                case H5VL_NATIVE_FILE_POST_OPEN:
-                                    H5RS_acat(rs, "H5VL_NATIVE_FILE_POST_OPEN");
-                                    break;
-
                                 default:
                                     H5RS_asprintf_cat(rs, "%ld", (long)optional);
                                     break;

--- a/test/event_set.c
+++ b/test/event_set.c
@@ -50,11 +50,12 @@ static const H5VL_class_t fake_wait_vol_g = {
     },
     {
         /* wrap_cls */
-        NULL, /* get_object   */
-        NULL, /* get_wrap_ctx */
-        NULL, /* wrap_object  */
-        NULL, /* unwrap_object */
-        NULL, /* free_wrap_ctx */
+        NULL, /* get_object            */
+        NULL, /* get_wrap_ctx          */
+        NULL, /* get_wrap_ctx_pre_open */
+        NULL, /* wrap_object           */
+        NULL, /* unwrap_object         */
+        NULL, /* free_wrap_ctx         */
     },
     {
         /* attribute_cls */

--- a/test/null_vol_connector.c
+++ b/test/null_vol_connector.c
@@ -41,11 +41,12 @@ static const H5VL_class_t null_vol_g = {
     },
     {
         /* wrap_cls */
-        NULL, /* get_object       */
-        NULL, /* get_wrap_ctx     */
-        NULL, /* wrap_object      */
-        NULL, /* unwrap_object    */
-        NULL, /* free_wrap_ctx    */
+        NULL, /* get_object            */
+        NULL, /* get_wrap_ctx          */
+        NULL, /* get_wrap_ctx_pre_open */
+        NULL, /* wrap_object           */
+        NULL, /* unwrap_object         */
+        NULL, /* free_wrap_ctx         */
     },
     {
         /* attribute_cls */

--- a/test/vol.c
+++ b/test/vol.c
@@ -70,11 +70,12 @@ static const H5VL_class_t reg_opt_vol_g = {
     },
     {
         /* wrap_cls */
-        NULL, /* get_object   */
-        NULL, /* get_wrap_ctx */
-        NULL, /* wrap_object  */
-        NULL, /* unwrap_object */
-        NULL, /* free_wrap_ctx */
+        NULL, /* get_object            */
+        NULL, /* get_wrap_ctx          */
+        NULL, /* get_wrap_ctx_pre_open */
+        NULL, /* wrap_object           */
+        NULL, /* unwrap_object         */
+        NULL, /* free_wrap_ctx         */
     },
     {
         /* attribute_cls */
@@ -202,11 +203,12 @@ static const H5VL_class_t fake_vol_g = {
     },
     {
         /* wrap_cls */
-        NULL, /* get_object   */
-        NULL, /* get_wrap_ctx */
-        NULL, /* wrap_object  */
-        NULL, /* unwrap_object */
-        NULL, /* free_wrap_ctx */
+        NULL, /* get_object            */
+        NULL, /* get_wrap_ctx          */
+        NULL, /* get_wrap_ctx_pre_open */
+        NULL, /* wrap_object           */
+        NULL, /* unwrap_object         */
+        NULL, /* free_wrap_ctx         */
     },
     {
         /* attribute_cls */
@@ -332,11 +334,12 @@ static const H5VL_class_t fake_async_vol_g = {
     },
     {
         /* wrap_cls */
-        NULL, /* get_object   */
-        NULL, /* get_wrap_ctx */
-        NULL, /* wrap_object  */
-        NULL, /* unwrap_object */
-        NULL, /* free_wrap_ctx */
+        NULL, /* get_object            */
+        NULL, /* get_wrap_ctx          */
+        NULL, /* get_wrap_ctx_pre_open */
+        NULL, /* wrap_object           */
+        NULL, /* unwrap_object         */
+        NULL, /* free_wrap_ctx         */
     },
     {
         /* attribute_cls */


### PR DESCRIPTION
Also add "get_wrap_ctx_pre_open" VOL callback and add "wrap_ctx" parameter to file create and file open VOL
callbacks to allow this to work.

The main aim of these changes is to set a valid wrap context *before* making the file open/create VOL callback. This removes the need for post open since we can do everything inside the main open/create calls. This should also allow more flexibility for VOL connector authors to do things in the open/create calls that were previously precluded due to not having a wrap context.

Passthrough authors need to implement the "get_wrap_ctx_pre_open" callback, but they can ignore the "wrap_ctx" parameter to file create/open unless they want to use the same wrap context for all objects in a file.