### PR TITLE
WIP: Improved const usage in dataset write calls

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -172,6 +172,15 @@ Bug Fixes since HDF5-1.13.3 release
 ===================================
     Library
     -------
+    - Change data array parameter type in H5FDwrite_selection()
+
+      The data array type of H5FDwrite_selection() and related was changed from
+      `const void *` to `const void * const` which is safer and probably what
+      was intended. This also affects the write_selection callback in the
+      H5FD_class_t struct.
+
+      (DER - 2022/12/06)
+
     - Fix CVE-2021-46242 / GHSA-x9pw-hh7v-wjpf
 
       When evicting driver info block, NULL the corresponding entry.

--- a/src/H5FD.c
+++ b/src/H5FD.c
@@ -1785,7 +1785,7 @@ done:
  */
 herr_t
 H5FDwrite_selection(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, uint32_t count, hid_t mem_space_ids[],
-                    hid_t file_space_ids[], haddr_t offsets[], size_t element_sizes[], const void *bufs[])
+                    hid_t file_space_ids[], haddr_t offsets[], size_t element_sizes[], const void * const bufs[])
 {
     herr_t ret_value = SUCCEED; /* Return value             */
 

--- a/src/H5FD.c
+++ b/src/H5FD.c
@@ -1785,7 +1785,8 @@ done:
  */
 herr_t
 H5FDwrite_selection(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, uint32_t count, hid_t mem_space_ids[],
-                    hid_t file_space_ids[], haddr_t offsets[], size_t element_sizes[], const void * const bufs[])
+                    hid_t file_space_ids[], haddr_t offsets[], size_t element_sizes[],
+                    const void *const bufs[])
 {
     herr_t ret_value = SUCCEED; /* Return value             */
 

--- a/src/H5FDdevelop.h
+++ b/src/H5FDdevelop.h
@@ -201,7 +201,7 @@ typedef struct H5FD_class_t {
                              void *bufs[] /*out*/);
     herr_t (*write_selection)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, size_t count, hid_t mem_spaces[],
                               hid_t file_spaces[], haddr_t offsets[], size_t element_sizes[],
-                              const void *bufs[] /*in*/);
+                              const void * const bufs[] /*in*/);
     herr_t (*flush)(H5FD_t *file, hid_t dxpl_id, hbool_t closing);
     herr_t (*truncate)(H5FD_t *file, hid_t dxpl_id, hbool_t closing);
     herr_t (*lock)(H5FD_t *file, hbool_t rw);
@@ -280,7 +280,7 @@ H5_DLL herr_t  H5FDread_selection(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, 
                                   size_t element_sizes[], void *bufs[] /* out */);
 H5_DLL herr_t  H5FDwrite_selection(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, uint32_t count,
                                    hid_t mem_spaces[], hid_t file_spaces[], haddr_t offsets[],
-                                   size_t element_sizes[], const void *bufs[]);
+                                   size_t element_sizes[], const void * const bufs[]);
 H5_DLL herr_t  H5FDflush(H5FD_t *file, hid_t dxpl_id, hbool_t closing);
 H5_DLL herr_t  H5FDtruncate(H5FD_t *file, hid_t dxpl_id, hbool_t closing);
 H5_DLL herr_t  H5FDlock(H5FD_t *file, hbool_t rw);

--- a/src/H5FDdevelop.h
+++ b/src/H5FDdevelop.h
@@ -201,7 +201,7 @@ typedef struct H5FD_class_t {
                              void *bufs[] /*out*/);
     herr_t (*write_selection)(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, size_t count, hid_t mem_spaces[],
                               hid_t file_spaces[], haddr_t offsets[], size_t element_sizes[],
-                              const void * const bufs[] /*in*/);
+                              const void *const bufs[] /*in*/);
     herr_t (*flush)(H5FD_t *file, hid_t dxpl_id, hbool_t closing);
     herr_t (*truncate)(H5FD_t *file, hid_t dxpl_id, hbool_t closing);
     herr_t (*lock)(H5FD_t *file, hbool_t rw);
@@ -280,7 +280,7 @@ H5_DLL herr_t  H5FDread_selection(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, 
                                   size_t element_sizes[], void *bufs[] /* out */);
 H5_DLL herr_t  H5FDwrite_selection(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, uint32_t count,
                                    hid_t mem_spaces[], hid_t file_spaces[], haddr_t offsets[],
-                                   size_t element_sizes[], const void * const bufs[]);
+                                   size_t element_sizes[], const void *const bufs[]);
 H5_DLL herr_t  H5FDflush(H5FD_t *file, hid_t dxpl_id, hbool_t closing);
 H5_DLL herr_t  H5FDtruncate(H5FD_t *file, hid_t dxpl_id, hbool_t closing);
 H5_DLL herr_t  H5FDlock(H5FD_t *file, hbool_t rw);

--- a/src/H5FDint.c
+++ b/src/H5FDint.c
@@ -113,7 +113,7 @@ static herr_t H5FD__read_selection_translate(H5FD_t *file, H5FD_mem_t type, hid_
                                              size_t element_sizes[], void *bufs[] /* out */);
 static herr_t H5FD__write_selection_translate(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, uint32_t count,
                                               H5S_t **mem_spaces, H5S_t **file_spaces, haddr_t offsets[],
-                                              size_t element_sizes[], const void * const bufs[]);
+                                              size_t element_sizes[], const void *const bufs[]);
 
 /*********************/
 /* Package Variables */
@@ -1394,7 +1394,7 @@ done:
 static herr_t
 H5FD__write_selection_translate(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, uint32_t count,
                                 H5S_t **mem_spaces, H5S_t **file_spaces, haddr_t offsets[],
-                                size_t element_sizes[], const void * const bufs[])
+                                size_t element_sizes[], const void *const bufs[])
 {
     hbool_t         extend_sizes = FALSE;
     hbool_t         extend_bufs  = FALSE;
@@ -1715,7 +1715,7 @@ done:
  */
 herr_t
 H5FD_write_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t **mem_spaces, H5S_t **file_spaces,
-                     haddr_t offsets[], size_t element_sizes[], const void * const bufs[])
+                     haddr_t offsets[], size_t element_sizes[], const void *const bufs[])
 {
     hbool_t  offsets_cooked = FALSE;
     hid_t    mem_space_ids_local[H5FD_LOCAL_SEL_ARR_LEN];
@@ -1873,7 +1873,8 @@ done:
  */
 herr_t
 H5FD_write_selection_id(H5FD_t *file, H5FD_mem_t type, uint32_t count, hid_t mem_space_ids[],
-                        hid_t file_space_ids[], haddr_t offsets[], size_t element_sizes[], const void * const bufs[])
+                        hid_t file_space_ids[], haddr_t offsets[], size_t element_sizes[],
+                        const void *const bufs[])
 {
     hbool_t  offsets_cooked = FALSE;
     H5S_t   *mem_spaces_local[H5FD_LOCAL_SEL_ARR_LEN];

--- a/src/H5FDint.c
+++ b/src/H5FDint.c
@@ -113,7 +113,7 @@ static herr_t H5FD__read_selection_translate(H5FD_t *file, H5FD_mem_t type, hid_
                                              size_t element_sizes[], void *bufs[] /* out */);
 static herr_t H5FD__write_selection_translate(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, uint32_t count,
                                               H5S_t **mem_spaces, H5S_t **file_spaces, haddr_t offsets[],
-                                              size_t element_sizes[], const void *bufs[]);
+                                              size_t element_sizes[], const void * const bufs[]);
 
 /*********************/
 /* Package Variables */
@@ -1394,7 +1394,7 @@ done:
 static herr_t
 H5FD__write_selection_translate(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, uint32_t count,
                                 H5S_t **mem_spaces, H5S_t **file_spaces, haddr_t offsets[],
-                                size_t element_sizes[], const void *bufs[])
+                                size_t element_sizes[], const void * const bufs[])
 {
     hbool_t         extend_sizes = FALSE;
     hbool_t         extend_bufs  = FALSE;
@@ -1715,7 +1715,7 @@ done:
  */
 herr_t
 H5FD_write_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t **mem_spaces, H5S_t **file_spaces,
-                     haddr_t offsets[], size_t element_sizes[], const void *bufs[])
+                     haddr_t offsets[], size_t element_sizes[], const void * const bufs[])
 {
     hbool_t  offsets_cooked = FALSE;
     hid_t    mem_space_ids_local[H5FD_LOCAL_SEL_ARR_LEN];
@@ -1873,7 +1873,7 @@ done:
  */
 herr_t
 H5FD_write_selection_id(H5FD_t *file, H5FD_mem_t type, uint32_t count, hid_t mem_space_ids[],
-                        hid_t file_space_ids[], haddr_t offsets[], size_t element_sizes[], const void *bufs[])
+                        hid_t file_space_ids[], haddr_t offsets[], size_t element_sizes[], const void * const bufs[])
 {
     hbool_t  offsets_cooked = FALSE;
     H5S_t   *mem_spaces_local[H5FD_LOCAL_SEL_ARR_LEN];

--- a/src/H5FDprivate.h
+++ b/src/H5FDprivate.h
@@ -152,13 +152,13 @@ H5_DLL herr_t  H5FD_read_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count
                                    void *bufs[] /* out */);
 H5_DLL herr_t  H5FD_write_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, struct H5S_t **mem_spaces,
                                     struct H5S_t **file_spaces, haddr_t offsets[], size_t element_sizes[],
-                                    const void *bufs[]);
+                                    const void * const bufs[]);
 H5_DLL herr_t  H5FD_read_selection_id(H5FD_t *file, H5FD_mem_t type, uint32_t count, hid_t mem_space_ids[],
                                       hid_t file_space_ids[], haddr_t offsets[], size_t element_sizes[],
                                       void *bufs[] /* out */);
 H5_DLL herr_t  H5FD_write_selection_id(H5FD_t *file, H5FD_mem_t type, uint32_t count, hid_t mem_space_ids[],
                                        hid_t file_space_ids[], haddr_t offsets[], size_t element_sizes[],
-                                       const void *bufs[]);
+                                       const void * const bufs[]);
 H5_DLL herr_t  H5FD_flush(H5FD_t *file, hbool_t closing);
 H5_DLL herr_t  H5FD_truncate(H5FD_t *file, hbool_t closing);
 H5_DLL herr_t  H5FD_lock(H5FD_t *file, hbool_t rw);

--- a/src/H5FDprivate.h
+++ b/src/H5FDprivate.h
@@ -152,13 +152,13 @@ H5_DLL herr_t  H5FD_read_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count
                                    void *bufs[] /* out */);
 H5_DLL herr_t  H5FD_write_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, struct H5S_t **mem_spaces,
                                     struct H5S_t **file_spaces, haddr_t offsets[], size_t element_sizes[],
-                                    const void * const bufs[]);
+                                    const void *const bufs[]);
 H5_DLL herr_t  H5FD_read_selection_id(H5FD_t *file, H5FD_mem_t type, uint32_t count, hid_t mem_space_ids[],
                                       hid_t file_space_ids[], haddr_t offsets[], size_t element_sizes[],
                                       void *bufs[] /* out */);
 H5_DLL herr_t  H5FD_write_selection_id(H5FD_t *file, H5FD_mem_t type, uint32_t count, hid_t mem_space_ids[],
                                        hid_t file_space_ids[], haddr_t offsets[], size_t element_sizes[],
-                                       const void * const bufs[]);
+                                       const void *const bufs[]);
 H5_DLL herr_t  H5FD_flush(H5FD_t *file, hbool_t closing);
 H5_DLL herr_t  H5FD_truncate(H5FD_t *file, hbool_t closing);
 H5_DLL herr_t  H5FD_lock(H5FD_t *file, hbool_t rw);

--- a/src/H5Fio.c
+++ b/src/H5Fio.c
@@ -299,7 +299,8 @@ done:
  */
 herr_t
 H5F_shared_select_write(H5F_shared_t *f_sh, H5FD_mem_t type, uint32_t count, H5S_t **mem_spaces,
-                        H5S_t **file_spaces, haddr_t offsets[], size_t element_sizes[], const void * const bufs[])
+                        H5S_t **file_spaces, haddr_t offsets[], size_t element_sizes[],
+                        const void *const bufs[])
 {
     H5FD_mem_t map_type;            /* Mapped memory type */
     herr_t     ret_value = SUCCEED; /* Return value */

--- a/src/H5Fio.c
+++ b/src/H5Fio.c
@@ -299,7 +299,7 @@ done:
  */
 herr_t
 H5F_shared_select_write(H5F_shared_t *f_sh, H5FD_mem_t type, uint32_t count, H5S_t **mem_spaces,
-                        H5S_t **file_spaces, haddr_t offsets[], size_t element_sizes[], const void *bufs[])
+                        H5S_t **file_spaces, haddr_t offsets[], size_t element_sizes[], const void * const bufs[])
 {
     H5FD_mem_t map_type;            /* Mapped memory type */
     herr_t     ret_value = SUCCEED; /* Return value */

--- a/src/H5Fprivate.h
+++ b/src/H5Fprivate.h
@@ -929,7 +929,7 @@ H5_DLL herr_t H5F_shared_select_read(H5F_shared_t *f_sh, H5FD_mem_t type, uint32
                                      size_t element_sizes[], void *bufs[] /* out */);
 H5_DLL herr_t H5F_shared_select_write(H5F_shared_t *f_sh, H5FD_mem_t type, uint32_t count,
                                       struct H5S_t **mem_spaces, struct H5S_t **file_spaces,
-                                      haddr_t offsets[], size_t element_sizes[], const void * const bufs[]);
+                                      haddr_t offsets[], size_t element_sizes[], const void *const bufs[]);
 
 /* Functions that operate on I/O vectors */
 H5_DLL herr_t H5F_shared_vector_read(H5F_shared_t *f_sh, uint32_t count, H5FD_mem_t types[], haddr_t addrs[],

--- a/src/H5Fprivate.h
+++ b/src/H5Fprivate.h
@@ -929,7 +929,7 @@ H5_DLL herr_t H5F_shared_select_read(H5F_shared_t *f_sh, H5FD_mem_t type, uint32
                                      size_t element_sizes[], void *bufs[] /* out */);
 H5_DLL herr_t H5F_shared_select_write(H5F_shared_t *f_sh, H5FD_mem_t type, uint32_t count,
                                       struct H5S_t **mem_spaces, struct H5S_t **file_spaces,
-                                      haddr_t offsets[], size_t element_sizes[], const void *bufs[]);
+                                      haddr_t offsets[], size_t element_sizes[], const void * const bufs[]);
 
 /* Functions that operate on I/O vectors */
 H5_DLL herr_t H5F_shared_vector_read(H5F_shared_t *f_sh, uint32_t count, H5FD_mem_t types[], haddr_t addrs[],

--- a/test/vfd.c
+++ b/test/vfd.c
@@ -5007,7 +5007,7 @@ test_selection_io_write(H5FD_t *lf, H5FD_mem_t type, uint32_t count, hid_t mem_s
 
     /* Issue write call */
     if (H5FDwrite_selection(lf, type, H5P_DEFAULT, count, mem_spaces, file_spaces, offsets, element_sizes,
-                            (const void * const *)wbufs) < 0)
+                            (const void *const *)wbufs) < 0)
         TEST_ERROR;
 
     return 0;

--- a/test/vfd.c
+++ b/test/vfd.c
@@ -5007,7 +5007,7 @@ test_selection_io_write(H5FD_t *lf, H5FD_mem_t type, uint32_t count, hid_t mem_s
 
     /* Issue write call */
     if (H5FDwrite_selection(lf, type, H5P_DEFAULT, count, mem_spaces, file_spaces, offsets, element_sizes,
-                            (const void **)wbufs) < 0)
+                            (const void * const *)wbufs) < 0)
         TEST_ERROR;
 
     return 0;


### PR DESCRIPTION
The data array parameter in dataset write calls should be `const void * const buf[]` instead of `const void * buf[]` as the latter allows for the const-ness to be subverted.  This affects both the VOL and VFD layers.