### PR TITLE
1.14: Converts the YAML build mode arrays to objects in special runs (#2308)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,12 +174,12 @@ jobs:
             flags: ""
             run_tests: false
             thread_safety:
-              - enabled: false
-                text: ""
+              enabled: false
+              text: ""
             build_mode:
-              - text: " DBG"
-                cmake: "Debug"
-                autotools: "debug"
+              text: " DBG"
+              cmake: "Debug"
+              autotools: "debug"
 
           - name: "Ubuntu gcc Autotools v1.8 default API (build only)"
             os: ubuntu-latest
@@ -196,12 +196,12 @@ jobs:
             flags: ""
             run_tests: false
             thread_safety:
-              - enabled: false
-                text: ""
+              enabled: false
+              text: ""
             build_mode:
-              - text: " DBG"
-                cmake: "Debug"
-                autotools: "debug"
+              text: " DBG"
+              cmake: "Debug"
+              autotools: "debug"
 
           - name: "Ubuntu gcc Autotools v1.10 default API (build only)"
             os: ubuntu-latest
@@ -218,12 +218,12 @@ jobs:
             flags: ""
             run_tests: false
             thread_safety:
-              - enabled: false
-                text: ""
+              enabled: false
+              text: ""
             build_mode:
-              - text: " DBG"
-                cmake: "Debug"
-                autotools: "debug"
+              text: " DBG"
+              cmake: "Debug"
+              autotools: "debug"
 
           - name: "Ubuntu gcc Autotools v1.12 default API (build only)"
             os: ubuntu-latest
@@ -240,12 +240,12 @@ jobs:
             flags: ""
             run_tests: false
             thread_safety:
-              - enabled: false
-                text: ""
+              enabled: false
+              text: ""
             build_mode:
-              - text: " DBG"
-                cmake: "Debug"
-                autotools: "debug"
+              text: " DBG"
+              cmake: "Debug"
+              autotools: "debug"
 
           - name: "Ubuntu gcc Autotools no deprecated symbols (build only)"
             os: ubuntu-latest
@@ -262,12 +262,12 @@ jobs:
             flags: ""
             run_tests: false
             thread_safety:
-              - enabled: false
-                text: ""
+              enabled: false
+              text: ""
             build_mode:
-              - text: " DBG"
-                cmake: "Debug"
-                autotools: "debug"
+              text: " DBG"
+              cmake: "Debug"
+              autotools: "debug"
 
           - name: "Ubuntu gcc Autotools -Werror (build only) DBG"
             os: ubuntu-latest
@@ -275,7 +275,7 @@ jobs:
             fortran: disable
             java: disable
             parallel: disable
-            mirror_vfd: enable
+            mirror_vfd: disable
             direct_vfd: enable
             deprec_sym: enable
             default_api: v114
@@ -284,12 +284,12 @@ jobs:
             flags: "CFLAGS=-Werror"
             run_tests: false
             thread_safety:
-              - enabled: false
-                text: ""
+              enabled: false
+              text: ""
             build_mode:
-              - text: " DBG"
-                cmake: "Debug"
-                autotools: "debug"
+              text: " DBG"
+              cmake: "Debug"
+              autotools: "debug"
 
           - name: "Ubuntu gcc Autotools -Werror (build only) REL"
             os: ubuntu-latest
@@ -297,7 +297,7 @@ jobs:
             fortran: disable
             java: disable
             parallel: disable
-            mirror_vfd: enable
+            mirror_vfd: disable
             direct_vfd: enable
             deprec_sym: enable
             default_api: v114
@@ -306,12 +306,12 @@ jobs:
             flags: "CFLAGS=-Werror"
             run_tests: false
             thread_safety:
-              - enabled: false
-                text: ""
+              enabled: false
+              text: ""
             build_mode:
-              - text: " REL"
-                cmake: "Release"
-                autotools: "production"
+              text: " REL"
+              cmake: "Release"
+              autotools: "production"
 
     # Sets the job's name from the properties
     name: "${{ matrix.name }}${{ matrix.build_mode.text }}${{ matrix.thread_safety.text }}"
@@ -328,6 +328,10 @@ jobs:
       #
       # SETUP
       #
+
+      #Useful for debugging
+      - name: Dump matrix context
+        run: echo '${{ toJSON(matrix) }}'
 
       - name: Install CMake Dependencies (Linux)
         run: sudo apt-get install ninja-build


### PR DESCRIPTION
* Converts the YAML build mode arrays to objects in special runs

* Adds a dump of the matrix context for each test

This would have made it a LOT easier to debug the build_mode issues...

* Disable the mirror VFD in the -Werror checks

We can re-enable this after we fix the warnings, but I don't want to conflate code and GitHub changes, so this is a better way to get the CI to pass for now.