### PR TITLE
Only document Fortran functions

### DIFF
--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -901,6 +901,7 @@ EXCLUDE_PATTERNS       = */fortran/test/*
 EXCLUDE_PATTERNS      += */fortran/testpar/*
 EXCLUDE_PATTERNS      += */fortran/examples/*
 EXCLUDE_PATTERNS      += */fortran/src/*.c
+EXCLUDE_PATTERNS      += */fortran/src/*.h
 EXCLUDE_PATTERNS      += */hl/fortran/examples/*
 EXCLUDE_PATTERNS      += */hl/fortran/test/*
 EXCLUDE_PATTERNS      += */hl/fortran/src/*.c

--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -899,6 +899,7 @@ EXCLUDE_SYMLINKS       = NO
 
 EXCLUDE_PATTERNS       = */fortran/test/*
 EXCLUDE_PATTERNS      += */fortran/testpar/*
+EXCLUDE_PATTERNS      += */fortran/examples/*
 EXCLUDE_PATTERNS      += */fortran/src/*.c
 EXCLUDE_PATTERNS      += */hl/fortran/examples/*
 EXCLUDE_PATTERNS      += */hl/fortran/test/*

--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -905,6 +905,7 @@ EXCLUDE_PATTERNS      += */fortran/src/*.h
 EXCLUDE_PATTERNS      += */hl/fortran/examples/*
 EXCLUDE_PATTERNS      += */hl/fortran/test/*
 EXCLUDE_PATTERNS      += */hl/fortran/src/*.c
+EXCLUDE_PATTERNS      += */hl/fortran/src/*.h
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -897,7 +897,12 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = */fortran/test/*
+EXCLUDE_PATTERNS      += */fortran/testpar/*
+EXCLUDE_PATTERNS      += */fortran/src/*.c
+EXCLUDE_PATTERNS      += */hl/fortran/examples/*
+EXCLUDE_PATTERNS      += */hl/fortran/test/*
+EXCLUDE_PATTERNS      += */hl/fortran/src/*.c
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
exclude all FORTRAN related files that are not FORTRAN APIs.