### PR TITLE
1.8 Fix for HDFFV-10840: Instead of using fill->buf for datatype conversi…

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -364,6 +364,19 @@ Bug Fixes since HDF5-1.8.22
 
       (NAF - 2022/10/24)
 
+    - Memory leak 
+    
+      A memory leak was observed with variable-length fill value in 
+      H5O_fill_convert() function in H5Ofill.c. The leak is
+      manifested by running valgrind on test/set_extent.c.
+
+      Previously, fill->buf is used for datatype conversion 
+      if it is large enough and the variable-length information 
+      is therefore lost.  A buffer is now allocated regardless 
+      so that the element in fill->buf can later be reclaimed.
+
+      (VC - 2022/10/10, HDFFV-10840)
+
     - Fixed an issue with attribute type conversion with compound datatypes
 
       Previously, when performing type conversion for attribute I/O with a


### PR DESCRIPTION
…on (#2153)

* Fix for HDFFV-10840: Instead of using fill->buf for datatype conversion if it is large enough, a buffer is allocated regardless so that the element in fill->buf can later be reclaimed.
Valgrind is run on test/set_extent.c and there is no memory leak.

* Add information of this fix to release notes.

Co-authored-by: vchoi <vchoi@jelly.ad.hdfgroup.org>