### PR TITLE
Update testh5cc.sh.in for new major version 1.14.

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -52,7 +52,7 @@ for compressing the resulting tar archive (if none are given then
                    information is available in the README_HPC file.
     doc         -- produce the latest doc tree in addition to the archive.
 
-An sha256 checksum is produced for each archive created and stored in the sha256 file.
+A sha256 checksum is produced for each archive created and stored in the sha256 file.
 
 Examples:
 
@@ -537,37 +537,37 @@ for comp in $methods; do
     case $comp in
         tar)
             cp -p $tmpdir/$HDF5_VERS.tar $DEST/$HDF5_VERS.tar
-            (cd $DEST; sha256 $HDF5_VERS.tar >> $SHA256)
+            (cd $DEST; sha256sum $HDF5_VERS.tar >> $SHA256)
             ;;
         gzip)
             test "$verbose" && echo "   Running gzip..." 1>&2
             gzip -9 <$tmpdir/$HDF5_VERS.tar >$DEST/$HDF5_VERS.tar.gz
-            (cd $DEST; sha256 $HDF5_VERS.tar.gz >> $SHA256)
+            (cd $DEST; sha256sum $HDF5_VERS.tar.gz >> $SHA256)
             ;;
         cmake-tgz)
             test "$verbose" && echo "   Creating CMake tar.gz file..." 1>&2
             tar2cmaketgz $HDF5_VERS $tmpdir/$HDF5_VERS.tar $DEST/CMake-$HDF5_VERS.tar.gz 1>&2
-            (cd $DEST; sha256 CMake-$HDF5_VERS.tar.gz >> $SHA256)
+            (cd $DEST; sha256sum CMake-$HDF5_VERS.tar.gz >> $SHA256)
             ;;
         hpc-cmake-tgz)
             test "$verbose" && echo "   Creating HPC-CMake tar.gz file..." 1>&2
             tar2hpccmaketgz $HDF5_VERS $tmpdir/$HDF5_VERS.tar $DEST/HPC-CMake-$HDF5_VERS.tar.gz 1>&2
-            (cd $DEST; sha256 HPC-CMake-$HDF5_VERS.tar.gz >> $SHA256)
+            (cd $DEST; sha256sum HPC-CMake-$HDF5_VERS.tar.gz >> $SHA256)
             ;;
         bzip2)
             test "$verbose" && echo "   Running bzip2..." 1>&2
             bzip2 -9 <$tmpdir/$HDF5_VERS.tar >$DEST/$HDF5_VERS.tar.bz2
-            (cd $DEST; sha256 $HDF5_VERS.tar.bz2 >> $SHA256)
+            (cd $DEST; sha256sum $HDF5_VERS.tar.bz2 >> $SHA256)
             ;;
         zip)
             test "$verbose" && echo "   Creating zip ball..." 1>&2
             tar2zip $HDF5_VERS $tmpdir/$HDF5_VERS.tar $DEST/$HDF5_VERS.zip 1>&2
-            (cd $DEST; sha256 $HDF5_VERS.zip >> $SHA256)
+            (cd $DEST; sha256sum $HDF5_VERS.zip >> $SHA256)
             ;;
         cmake-zip)
             test "$verbose" && echo "   Creating CMake-zip ball..." 1>&2
             tar2cmakezip $HDF5_VERS $tmpdir/$HDF5_VERS.tar $DEST/CMake-$HDF5_VERS.zip 1>&2
-            (cd $DEST; sha256 CMake-$HDF5_VERS.zip >> $SHA256)
+            (cd $DEST; sha256sum CMake-$HDF5_VERS.zip >> $SHA256)
             ;;
         doc)
             if [ "${DOCVERSION}" = "" ]; then

--- a/examples/testh5cc.sh.in
+++ b/examples/testh5cc.sh.in
@@ -69,6 +69,8 @@ v110main=${H5TOOL}_v110main.$suffix
 v110main_o=${H5TOOL}_v110main.o
 v112main=${H5TOOL}_v112main.$suffix
 v112main_o=${H5TOOL}_v112main.o
+v114main=${H5TOOL}_v114main.$suffix
+v114main_o=${H5TOOL}_v114main.o
 appmain=${H5TOOL}_appmain.$suffix
 appmain_o=${H5TOOL}_appmain.o
 prog1=${H5TOOL}_prog1.$suffix
@@ -82,7 +84,7 @@ applib=libapp${H5TOOL}.a
 # Don't use the wildcard form of *.h5 as it will wipe out even *.h5 generated
 # by other test programs. This will cause a racing condition error when
 # parallel make (e.g., gmake -j 4) is used.
-temp_SRC="$hdf5main $v16main $v18main $v110main $v112main $appmain $prog1 $prog2"
+temp_SRC="$hdf5main $v16main $v18main $v110main $v112main $v114main $appmain $prog1 $prog2"
 temp_OBJ=`echo $temp_SRC | sed -e "s/\.${suffix}/.o/g"`
 temp_FILES="a.out $applib"
 
@@ -286,6 +288,53 @@ main (void)
 }
 EOF
 
+# Generate HDF5 v1.14 Main Program:
+# This makes unique V1.14 API calls.
+cat > $v114main <<EOF
+/* This is a V1.14 API calls example Program. */
+#include "hdf5.h"
+#define H5FILE_NAME        "tmp.h5"
+#define SPACE1_RANK    3
+int
+main (void)
+{
+    hid_t       sid;                  /* Dataspace ID */
+    hid_t       fapl = -1;            /* File access property list ID */
+    int         rank;                 /* Logical rank of dataspace    */
+    hsize_t     dims[] = {3, 3, 15};
+    size_t      sbuf_size=0;
+    herr_t      ret;                  /* Generic return value        */
+    hsize_t             start[] = {0, 0, 0};
+    hsize_t             stride[] = {2, 5, 3};
+    hsize_t             count[] = {2, 2, 2};
+    hsize_t             block[] = {1, 3, 1};
+
+    /* Create the file access property list */
+    fapl = H5Pcreate(H5P_FILE_ACCESS);
+
+    /* Set low/high bounds in the fapl */
+    ret = H5Pset_libver_bounds(fapl, H5F_LIBVER_EARLIEST,
+                               H5F_LIBVER_LATEST);
+
+    /* Create the dataspace */
+    sid = H5Screate_simple(SPACE1_RANK, dims, NULL);
+
+    /* Set the hyperslab selection */
+    ret = H5Sselect_hyperslab(sid, H5S_SELECT_SET, start, stride, count, block);
+
+    /* Encode simple dataspace in a buffer with the fapl setting */
+    ret = H5Sencode(sid, NULL, &sbuf_size, fapl);
+
+    /* Encode simple dataspace in a buffer with the fapl setting */
+    ret = H5Sencode2(sid, NULL, &sbuf_size, fapl);
+
+    printf("HDF5 C program created with V1.14 API ran successfully. ");
+/*       "File %s generated.\n", H5FILE_NAME);
+      remove(H5FILE_NAME); */
+    return 0;
+}
+EOF
+
 
 # Parse option
 #   None
@@ -432,6 +481,7 @@ if [ -n "$H5_NO_DEPRECATED_SYMBOLS" ]; then
     TOOLTEST $v18main
     TOOLTEST $v110main
     TOOLTEST $v112main
+    TOOLTEST $v114main
 elif [ -n "$H5_USE_16_API_DEFAULT" ]; then
     echo "Testing HDF5  with 16_API_DEFAULT"
     TOOLTEST $v16main


### PR DESCRIPTION
Fixes test failure in make installcheck for autotools builds.
Not needed for HDF5 1.14.