### PR TITLE
Fix for Autotools --disable-deprecated-symbols

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -278,7 +278,7 @@ jobs:
             mirror_vfd: enable
             direct_vfd: enable
             deprec_sym: disable
-            default_api: v116
+            default_api: default
             toolchain: ""
             generator: "autogen"
             flags: ""

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -261,13 +261,12 @@ jobs:
             generator: "autogen"
             flags: ""
             run_tests: false
-            thread_safety:
-              - enabled: false
-                text: ""
+              enabled: false
+              text: ""
             build_mode:
-              - text: "DBG"
-                cmake: "Debug"
-                autotools: "debug"
+              text: " DBG"
+              cmake: "Debug"
+              autotools: "debug"
 
           - name: "Ubuntu gcc Autotools no deprecated symbols (build only)"
             os: ubuntu-latest

--- a/configure.ac
+++ b/configure.ac
@@ -3751,8 +3751,8 @@ AC_MSG_CHECKING([which version of public symbols to use by default])
 AC_ARG_WITH([default-api-version],
             [AS_HELP_STRING([--with-default-api-version=(v16|v18|v110|v112|v114)],
                             [Specify default release version of public symbols
-                             [default=v114]])],,
-            [withval=v114])
+                             [default=v116]])],,
+            [withval=v116])
 
 if test "X$withval" = "Xv16"; then
     AC_MSG_RESULT([v16])

--- a/configure.ac
+++ b/configure.ac
@@ -3749,11 +3749,13 @@ esac
 AC_SUBST([DEFAULT_API_VERSION])
 AC_MSG_CHECKING([which version of public symbols to use by default])
 AC_ARG_WITH([default-api-version],
-            [AS_HELP_STRING([--with-default-api-version=(v16|v18|v110|v112|v114)],
+            [AS_HELP_STRING([--with-default-api-version=(default|v16|v18|v110|v112|v114|v116)],
                             [Specify default release version of public symbols
                              [default=v116]])],,
             [withval=v116])
 
+## Allowing "default" allows the GitHub CI to check that we didn't forget
+## to change the defaults when creating a new major version
 if test "X$withval" = "Xv16"; then
     AC_MSG_RESULT([v16])
     DEFAULT_API_VERSION=v16
@@ -3779,7 +3781,7 @@ elif test "X$withval" = "Xv114"; then
     DEFAULT_API_VERSION=v114
     AC_DEFINE([USE_114_API_DEFAULT], [1],
               [Define using v1.14 public API symbols by default])
-elif test "X$withval" = "Xv116"; then
+elif test "X$withval" = "Xv116" -o "X$withval" = "Xdefault"; then
     AC_MSG_RESULT([v116])
     DEFAULT_API_VERSION=v116
     AC_DEFINE([USE_116_API_DEFAULT], [1],


### PR DESCRIPTION
When we added v116 as a valid option, we left the default as v114, so using --disable-deprecated-symbols led configure to complain that you can't set a default API that has been eliminated from the build.

The GitHub action didn't catch this because it explicitly specifies v116. I've added a "default" target that gets used by the CI to catch problems like this in the future.

This only affected develop w/ the Autotools when --disable-deprecated-symbols is requested.