### PR TITLE
Restore line 264 of main.yml:  "thread_safety:"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -261,6 +261,7 @@ jobs:
             generator: "autogen"
             flags: ""
             run_tests: false
+            thread_safety:
               enabled: false
               text: ""
             build_mode:


### PR DESCRIPTION
This was removed in #2363 causing an error in CI workflow;  apparently the line was unintentionally removed.