### PR TITLE
Fix H5Dchunk_iter doxygen example, add doxygen example to tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1089,6 +1089,7 @@ if (EXISTS "${HDF5_SOURCE_DIR}/examples" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/ex
   option (HDF5_BUILD_EXAMPLES  "Build HDF5 Library Examples" ON)
   if (HDF5_BUILD_EXAMPLES)
     add_subdirectory (examples)
+    add_subdirectory (doxygen/examples)
   endif ()
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1089,7 +1089,7 @@ if (EXISTS "${HDF5_SOURCE_DIR}/examples" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/ex
   option (HDF5_BUILD_EXAMPLES  "Build HDF5 Library Examples" ON)
   if (HDF5_BUILD_EXAMPLES)
     add_subdirectory (examples)
-    if (EXISTS "${HDF5_SOURCE_DIR}/doxygen/examples" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/doxygen/examples")
+    if (EXISTS "${HDF5_SOURCE_DIR}/doxygen/examples" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/doxygen/examples" AND NOT MSVC)
       add_subdirectory (doxygen/examples)
     endif ()
   endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1089,7 +1089,7 @@ if (EXISTS "${HDF5_SOURCE_DIR}/examples" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/ex
   option (HDF5_BUILD_EXAMPLES  "Build HDF5 Library Examples" ON)
   if (HDF5_BUILD_EXAMPLES)
     add_subdirectory (examples)
-    if (EXISTS "${HDF5_SOURCE_DIR}/doxygen/examples" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/doxygen/examples" AND NOT MSVC)
+    if (EXISTS "${HDF5_SOURCE_DIR}/doxygen/examples" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/doxygen/examples")
       add_subdirectory (doxygen/examples)
     endif ()
   endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1089,7 +1089,9 @@ if (EXISTS "${HDF5_SOURCE_DIR}/examples" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/ex
   option (HDF5_BUILD_EXAMPLES  "Build HDF5 Library Examples" ON)
   if (HDF5_BUILD_EXAMPLES)
     add_subdirectory (examples)
-    add_subdirectory (doxygen/examples)
+    if (EXISTS "${HDF5_SOURCE_DIR}/doxygen/examples" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/doxygen/examples")
+      add_subdirectory (doxygen/examples)
+    endif ()
   endif ()
 endif ()
 

--- a/doxygen/examples/CMakeLists.txt
+++ b/doxygen/examples/CMakeLists.txt
@@ -5,7 +5,32 @@ project (HDF5_EXAMPLES C)
 # Define Sources
 #-----------------------------------------------------------------------------
 set (examples
+    H5A_examples
     H5D_examples
+    H5DO_examples
+    H5E_examples
+    H5_examples
+    H5Fclose
+    H5Fcreate
+    H5F_examples
+    H5G_examples
+    H5I_examples
+    H5LDget_dset_elmts
+    H5O_examples
+    H5P_examples
+    H5Pget_metadata_read_attempts.1
+    H5Pget_metadata_read_attempts.2
+    H5Pget_metadata_read_attempts.3
+    H5Pget_object_flush_cb
+    H5PL_examples
+    H5Pset_metadata_read_attempts
+    H5Pset_object_flush_cb
+    H5R_examples
+    H5S_examples
+    H5TBAget_fill
+    H5T_examples
+    H5Z_examples
+    hello_hdf5
 )
 
 foreach (example ${examples})

--- a/doxygen/examples/CMakeLists.txt
+++ b/doxygen/examples/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required (VERSION 3.18)
+project (HDF5_EXAMPLES C)
+
+#-----------------------------------------------------------------------------
+# Define Sources
+#-----------------------------------------------------------------------------
+set (examples
+    H5D_examples
+)
+
+if (H5_HAVE_PARALLEL)
+  set (parallel_examples
+  )
+
+  if (HDF5_ENABLE_SUBFILING_VFD)
+    list (APPEND parallel_examples ph5_subfiling)
+  endif ()
+endif ()
+
+foreach (example ${examples})
+  add_executable (${example} ${HDF5_DOXYGEN_DIR}/examples/${example}.c)
+  target_include_directories (${example} PRIVATE "${HDF5_SRC_INCLUDE_DIRS};${HDF5_SRC_BINARY_DIR};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:${MPI_C_INCLUDE_DIRS}>")
+  if (NOT BUILD_SHARED_LIBS)
+    TARGET_C_PROPERTIES (${example} STATIC)
+    target_link_libraries (${example} PRIVATE ${HDF5_LIB_TARGET})
+  else ()
+    TARGET_C_PROPERTIES (${example} SHARED)
+    target_link_libraries (${example} PRIVATE ${HDF5_LIBSH_TARGET})
+  endif ()
+  set_target_properties (${example} PROPERTIES FOLDER examples)
+
+  #-----------------------------------------------------------------------------
+  # Add Target to clang-format
+  #-----------------------------------------------------------------------------
+  if (HDF5_ENABLE_FORMATTERS)
+    clang_format (HDF5_EXAMPLES_${example}_FORMAT ${example})
+  endif ()
+endforeach ()
+
+if (H5_HAVE_PARALLEL)
+  foreach (parallel_example ${parallel_examples})
+    add_executable (${parallel_example} ${HDF5_DOXYGEN_DIR}/examples/${parallel_example}.c)
+    target_include_directories (${parallel_example} PRIVATE "${HDF5_SRC_INCLUDE_DIRS};${HDF5_SRC_BINARY_DIR};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:${MPI_C_INCLUDE_DIRS}>")
+    if (NOT BUILD_SHARED_LIBS)
+      TARGET_C_PROPERTIES (${parallel_example} STATIC)
+      target_link_libraries (${parallel_example} PRIVATE ${HDF5_LIB_TARGET} MPI::MPI_C)
+    else ()
+      TARGET_C_PROPERTIES (${parallel_example} SHARED)
+      target_link_libraries (${parallel_example} PRIVATE ${HDF5_LIBSH_TARGET} MPI::MPI_C)
+    endif ()
+    set_target_properties (${parallel_example} PROPERTIES FOLDER examples)
+
+    #-----------------------------------------------------------------------------
+    # Add Target to clang-format
+    #-----------------------------------------------------------------------------
+    if (HDF5_ENABLE_FORMATTERS)
+      clang_format (HDF5_EXAMPLES_${parallel_example}_FORMAT ${parallel_example})
+    endif ()
+  endforeach ()
+endif ()
+
+if (BUILD_TESTING AND HDF5_TEST_EXAMPLES)
+  include (CMakeTests.cmake)
+endif ()

--- a/doxygen/examples/CMakeLists.txt
+++ b/doxygen/examples/CMakeLists.txt
@@ -8,15 +8,6 @@ set (examples
     H5D_examples
 )
 
-if (H5_HAVE_PARALLEL)
-  set (parallel_examples
-  )
-
-  if (HDF5_ENABLE_SUBFILING_VFD)
-    list (APPEND parallel_examples ph5_subfiling)
-  endif ()
-endif ()
-
 foreach (example ${examples})
   add_executable (${example} ${HDF5_DOXYGEN_DIR}/examples/${example}.c)
   target_include_directories (${example} PRIVATE "${HDF5_SRC_INCLUDE_DIRS};${HDF5_SRC_BINARY_DIR};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:${MPI_C_INCLUDE_DIRS}>")
@@ -36,28 +27,6 @@ foreach (example ${examples})
     clang_format (HDF5_EXAMPLES_${example}_FORMAT ${example})
   endif ()
 endforeach ()
-
-if (H5_HAVE_PARALLEL)
-  foreach (parallel_example ${parallel_examples})
-    add_executable (${parallel_example} ${HDF5_DOXYGEN_DIR}/examples/${parallel_example}.c)
-    target_include_directories (${parallel_example} PRIVATE "${HDF5_SRC_INCLUDE_DIRS};${HDF5_SRC_BINARY_DIR};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:${MPI_C_INCLUDE_DIRS}>")
-    if (NOT BUILD_SHARED_LIBS)
-      TARGET_C_PROPERTIES (${parallel_example} STATIC)
-      target_link_libraries (${parallel_example} PRIVATE ${HDF5_LIB_TARGET} MPI::MPI_C)
-    else ()
-      TARGET_C_PROPERTIES (${parallel_example} SHARED)
-      target_link_libraries (${parallel_example} PRIVATE ${HDF5_LIBSH_TARGET} MPI::MPI_C)
-    endif ()
-    set_target_properties (${parallel_example} PROPERTIES FOLDER examples)
-
-    #-----------------------------------------------------------------------------
-    # Add Target to clang-format
-    #-----------------------------------------------------------------------------
-    if (HDF5_ENABLE_FORMATTERS)
-      clang_format (HDF5_EXAMPLES_${parallel_example}_FORMAT ${parallel_example})
-    endif ()
-  endforeach ()
-endif ()
 
 if (BUILD_TESTING AND HDF5_TEST_EXAMPLES)
   include (CMakeTests.cmake)

--- a/doxygen/examples/CMakeTests.cmake
+++ b/doxygen/examples/CMakeTests.cmake
@@ -15,8 +15,6 @@
 ###           T E S T I N G                                                ###
 ##############################################################################
 ##############################################################################
-file (MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/red ${PROJECT_BINARY_DIR}/blue ${PROJECT_BINARY_DIR}/u2w)
-
 set (text_dox_ex_CLEANFILES
     d1.h5
 )
@@ -56,9 +54,6 @@ if (HDF5_TEST_SERIAL)
       )
     endif ()
     set_tests_properties (DOXYGEN-EXAMPLES-${example} PROPERTIES FIXTURES_REQUIRED clear_DOXYGEN_EXAMPLES)
-    if (last_test)
-      set_tests_properties (DOXYGEN-EXAMPLES-${example} PROPERTIES DEPENDS ${last_test})
-    endif ()
     set (last_test "DOXYGEN-EXAMPLES-${example}")
   endforeach ()
 endif ()

--- a/doxygen/examples/CMakeTests.cmake
+++ b/doxygen/examples/CMakeTests.cmake
@@ -1,0 +1,92 @@
+#
+# Copyright by The HDF Group.
+# All rights reserved.
+#
+# This file is part of HDF5.  The full HDF5 copyright notice, including
+# terms governing use, modification, and redistribution, is contained in
+# the COPYING file, which can be found at the root of the source code
+# distribution tree, or in https://www.hdfgroup.org/licenses.
+# If you do not have access to either file, you may request a copy from
+# help@hdfgroup.org.
+#
+
+##############################################################################
+##############################################################################
+###           T E S T I N G                                                ###
+##############################################################################
+##############################################################################
+file (MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/red ${PROJECT_BINARY_DIR}/blue ${PROJECT_BINARY_DIR}/u2w)
+
+set (text_dox_ex_CLEANFILES
+    d1.h5
+)
+
+if (HDF5_TEST_SERIAL)
+  # Remove any output file left over from previous test run
+  add_test (
+      NAME DOXYGEN-EXAMPLES-clear-objects
+      COMMAND    ${CMAKE_COMMAND} -E remove ${text_dox_ex_CLEANFILES}
+  )
+  set_tests_properties (DOXYGEN-EXAMPLES-clear-objects PROPERTIES
+      FIXTURES_SETUP clear_DOXYGEN_EXAMPLES
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+  )
+  add_test (
+      NAME DOXYGEN-EXAMPLES-clean-objects
+      COMMAND    ${CMAKE_COMMAND} -E remove ${text_dox_ex_CLEANFILES}
+  )
+  set_tests_properties (DOXYGEN-EXAMPLES-clean-objects PROPERTIES
+      FIXTURES_CLEANUP clear_DOXYGEN_EXAMPLES
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+  )
+
+  foreach (example ${examples})
+    if (HDF5_ENABLE_USING_MEMCHECKER)
+      add_test (NAME DOXYGEN-EXAMPLES-${example} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:${example}>)
+    else ()
+      add_test (NAME DOXYGEN-EXAMPLES-${example} COMMAND "${CMAKE_COMMAND}"
+          -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
+          -D "TEST_PROGRAM=$<TARGET_FILE:${example}>"
+          -D "TEST_ARGS:STRING="
+          -D "TEST_EXPECT=0"
+          -D "TEST_SKIP_COMPARE=TRUE"
+          -D "TEST_OUTPUT=${example}.txt"
+          -D "TEST_FOLDER=${PROJECT_BINARY_DIR}"
+          -P "${HDF_RESOURCES_DIR}/runTest.cmake"
+      )
+    endif ()
+    set_tests_properties (DOXYGEN-EXAMPLES-${example} PROPERTIES FIXTURES_REQUIRED clear_DOXYGEN_EXAMPLES)
+    if (last_test)
+      set_tests_properties (DOXYGEN-EXAMPLES-${example} PROPERTIES DEPENDS ${last_test})
+    endif ()
+    set (last_test "DOXYGEN-EXAMPLES-${example}")
+  endforeach ()
+endif ()
+
+### Windows pops up a modal permission dialog on this test
+if (H5_HAVE_PARALLEL AND HDF5_TEST_PARALLEL AND NOT WIN32)
+  # Ensure that 24 is a multiple of the number of processes.
+  # The number 24 corresponds to SPACE1_DIM1 and SPACE1_DIM2 defined in ph5example.c
+  math(EXPR NUMPROCS "24 / ((24 + ${MPIEXEC_MAX_NUMPROCS} - 1) / ${MPIEXEC_MAX_NUMPROCS})")
+
+  foreach (parallel_example ${parallel_examples})
+    if (HDF5_ENABLE_USING_MEMCHECKER)
+      add_test (NAME MPI_TEST_EXAMPLES-${parallel_example} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${parallel_example}> ${MPIEXEC_POSTFLAGS})
+    else ()
+      add_test (NAME MPI_TEST_EXAMPLES-${parallel_example} COMMAND "${CMAKE_COMMAND}"
+          -D "TEST_PROGRAM=${MPIEXEC_EXECUTABLE};${MPIEXEC_NUMPROC_FLAG};${NUMPROCS};${MPIEXEC_PREFLAGS};$<TARGET_FILE:${parallel_example}>;${MPIEXEC_POSTFLAGS}"
+          -D "TEST_ARGS:STRING="
+          -D "TEST_EXPECT=0"
+          -D "TEST_SKIP_COMPARE=TRUE"
+          -D "TEST_OUTPUT=${parallel_example}.out"
+          -D "TEST_REFERENCE:STRING=PHDF5 example finished with no errors"
+          -D "TEST_FOLDER=${PROJECT_BINARY_DIR}"
+          -P "${HDF_RESOURCES_DIR}/grepTest.cmake"
+      )
+    endif ()
+    if (last_test)
+      set_tests_properties (MPI_TEST_EXAMPLES-${parallel_example} PROPERTIES DEPENDS ${last_test})
+    endif ()
+    set (last_test "MPI_TEST_EXAMPLES-${parallel_example}")
+  endforeach ()
+endif ()

--- a/doxygen/examples/CMakeTests.cmake
+++ b/doxygen/examples/CMakeTests.cmake
@@ -62,31 +62,3 @@ if (HDF5_TEST_SERIAL)
     set (last_test "DOXYGEN-EXAMPLES-${example}")
   endforeach ()
 endif ()
-
-### Windows pops up a modal permission dialog on this test
-if (H5_HAVE_PARALLEL AND HDF5_TEST_PARALLEL AND NOT WIN32)
-  # Ensure that 24 is a multiple of the number of processes.
-  # The number 24 corresponds to SPACE1_DIM1 and SPACE1_DIM2 defined in ph5example.c
-  math(EXPR NUMPROCS "24 / ((24 + ${MPIEXEC_MAX_NUMPROCS} - 1) / ${MPIEXEC_MAX_NUMPROCS})")
-
-  foreach (parallel_example ${parallel_examples})
-    if (HDF5_ENABLE_USING_MEMCHECKER)
-      add_test (NAME MPI_TEST_EXAMPLES-${parallel_example} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${parallel_example}> ${MPIEXEC_POSTFLAGS})
-    else ()
-      add_test (NAME MPI_TEST_EXAMPLES-${parallel_example} COMMAND "${CMAKE_COMMAND}"
-          -D "TEST_PROGRAM=${MPIEXEC_EXECUTABLE};${MPIEXEC_NUMPROC_FLAG};${NUMPROCS};${MPIEXEC_PREFLAGS};$<TARGET_FILE:${parallel_example}>;${MPIEXEC_POSTFLAGS}"
-          -D "TEST_ARGS:STRING="
-          -D "TEST_EXPECT=0"
-          -D "TEST_SKIP_COMPARE=TRUE"
-          -D "TEST_OUTPUT=${parallel_example}.out"
-          -D "TEST_REFERENCE:STRING=PHDF5 example finished with no errors"
-          -D "TEST_FOLDER=${PROJECT_BINARY_DIR}"
-          -P "${HDF_RESOURCES_DIR}/grepTest.cmake"
-      )
-    endif ()
-    if (last_test)
-      set_tests_properties (MPI_TEST_EXAMPLES-${parallel_example} PROPERTIES DEPENDS ${last_test})
-    endif ()
-    set (last_test "MPI_TEST_EXAMPLES-${parallel_example}")
-  endforeach ()
-endif ()

--- a/doxygen/examples/H5D_examples.c
+++ b/doxygen/examples/H5D_examples.c
@@ -7,10 +7,10 @@
 
 //! <!-- [H5Dchunk_iter_cb] -->
 int
-chunk_cb(const hsize_t *offset, uint32_t filter_mask, haddr_t addr, uint32_t nbytes, void *op_data)
+chunk_cb(const hsize_t *offset, unsigned filter_mask, haddr_t addr, hsize_t size, void *op_data)
 {
     // only print the allocated chunk size only
-    printf("%d\n", nbytes);
+    printf("%ld\n", size);
     return EXIT_SUCCESS;
 }
 //! <!-- [H5Dchunk_iter_cb] -->
@@ -67,7 +67,7 @@ H5Ovisit_cb(hid_t obj, const char *name, const H5O_info2_t *info, void *op_data)
                 retval = -1;
                 goto fail_fig;
             }
-
+fail_fig:
 fail_shape:
             H5Sclose(dspace);
 fail_dspace:


### PR DESCRIPTION
This updates the doxygen example for `H5Dchunk_iter` following changes made in #2074 .

The primary goal is to change the `chunk_cb` function to the following signature:
```
chunk_cb(const hsize_t *offset, unsigned filter_mask, haddr_t addr, hsize_t size, void *op_data)
```

To ensure the doxygen examples can be compiled, the cmake infrastructure is extended in a limited way to now cover `doxygen/examples/H5D_examples.c`. I anticipate another pull request may extend this further to cover other files in `doxygen/examples`.