### PR TITLE
Adds -Warray-temporaries to the gfortran developer warnings

### DIFF
--- a/config/cmake/HDFFortranCompilerFlags.cmake
+++ b/config/cmake/HDFFortranCompilerFlags.cmake
@@ -79,6 +79,11 @@ if (NOT MSVC AND NOT MINGW)
     # Append more extra warning flags that only gcc 4.8+ knows about
     if (NOT CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 4.8)
       ADD_H5_FLAGS (HDF5_CMAKE_Fortran_FLAGS "${HDF5_SOURCE_DIR}/config/gnu-warnings/gfort-4.8")
+      if (HDF5_ENABLE_DEV_WARNINGS)
+        ADD_H5_FLAGS (HDF5_CMAKE_Fortran_FLAGS "${HDF5_SOURCE_DIR}/config/gnu-warnings/gfort-developer-4.8")
+      else ()
+        ADD_H5_FLAGS (HDF5_CMAKE_Fortran_FLAGS "${HDF5_SOURCE_DIR}/config/gnu-warnings/gfort-no-developer-4.8")
+      endif ()
     endif ()
 
     # Append more extra warning flags that only gcc 4.9+ knows about

--- a/config/gnu-fflags
+++ b/config/gnu-fflags
@@ -159,6 +159,8 @@ if test "X-gfortran" = "X-$f9x_vendor"; then
     # gfortran >= 4.8
     if test $f9x_vers_major -ge 5 -o $f9x_vers_major -eq 4 -a $f9x_vers_minor -ge 8; then
         H5_FCFLAGS="$H5_FCFLAGS $(load_gnu_arguments gfort-4.8)"
+        DEVELOPER_WARNING_FCFLAGS="$DEVELOPER_WARNING_FCFLAGS $(load_gnu_arguments gfort-developer-4.8)"
+        NO_DEVELOPER_WARNING_FCFLAGS="$NO_DEVELOPER_WARNING_FCFLAGS $(load_gnu_arguments gfort-no-developer-4.8)"
     fi
 
     # gfortran 4.9 (nothing new)

--- a/config/gnu-warnings/gfort-4.8
+++ b/config/gnu-warnings/gfort-4.8
@@ -1,5 +1,4 @@
 # warning flags added for gfortran >= 4.4
--Warray-temporaries
 -Wintrinsics-std
 
 # warning flag added for gfortran >= 4.5

--- a/config/gnu-warnings/gfort-developer-4.8
+++ b/config/gnu-warnings/gfort-developer-4.8
@@ -1,0 +1,3 @@
+# warning flags added for gfortran >= 4.4
+-Warray-temporaries
+

--- a/config/gnu-warnings/gfort-no-developer-4.8
+++ b/config/gnu-warnings/gfort-no-developer-4.8
@@ -1,0 +1,3 @@
+# warning flags added for gfortran >= 4.4
+-Wno-array-temporaries
+


### PR DESCRIPTION
These generate a LOT of noise that we are not going to address anytime soon.