### PR TITLE
CMake: Find MPI in HDF5 config

### DIFF
--- a/config/cmake/hdf5-config.cmake.in
+++ b/config/cmake/hdf5-config.cmake.in
@@ -63,6 +63,8 @@ if (${HDF5_PACKAGE_NAME}_ENABLE_PARALLEL)
     set (${HDF5_PACKAGE_NAME}_MPI_Fortran_INCLUDE_PATH "@MPI_Fortran_INCLUDE_DIRS@")
     set (${HDF5_PACKAGE_NAME}_MPI_Fortran_LIBRARIES    "@MPI_Fortran_LIBRARIES@")
   endif ()
+
+  find_package(MPI QUIET REQUIRED)
 endif ()
 
 if (${HDF5_PACKAGE_NAME}_BUILD_JAVA)


### PR DESCRIPTION
Downstream packages depending on HDF5 that don't perform `find_package(MPI)` before `find_package(hdf5)` fail to configure. A possible fix to this is to move the MPI link dependency to a private scope.

@lrknox Here is a patch that fixes the MPI linking issue observed in the spack CI. I tested this as a patch in spack and it fixes the issue for SZ and likely others.