### PR TITLE
Include shlwapi.h explicitly on Windows

### DIFF
--- a/config/cmake/ConfigureChecks.cmake
+++ b/config/cmake/ConfigureChecks.cmake
@@ -131,6 +131,8 @@ CHECK_INCLUDE_FILE_CONCAT ("netdb.h"         ${HDF_PREFIX}_HAVE_NETDB_H)
 CHECK_INCLUDE_FILE_CONCAT ("arpa/inet.h"     ${HDF_PREFIX}_HAVE_ARPA_INET_H)
 if (WINDOWS)
   CHECK_INCLUDE_FILE_CONCAT ("shlwapi.h"         ${HDF_PREFIX}_HAVE_SHLWAPI_H)
+  # Checking for StrStrIA in the library is not relaible for mingw32 to stdcall
+  set (LINK_LIBS ${LINK_LIBS} "shlwapi")
 endif ()
 
 ## Check for non-standard extension quadmath.h
@@ -154,10 +156,6 @@ if (MINGW OR NOT WINDOWS)
   CHECK_LIBRARY_EXISTS_CONCAT ("dl" dlopen     ${HDF_PREFIX}_HAVE_LIBDL)
   CHECK_LIBRARY_EXISTS_CONCAT ("ws2_32" WSAStartup  ${HDF_PREFIX}_HAVE_LIBWS2_32)
   CHECK_LIBRARY_EXISTS_CONCAT ("wsock32" gethostbyname ${HDF_PREFIX}_HAVE_LIBWSOCK32)
-endif ()
-
-if (WINDOWS)
-  CHECK_LIBRARY_EXISTS_CONCAT ("shlwapi" StrStrIA ${HDF_PREFIX}_HAVE_SHLWAPI)
 endif ()
 
 # UCB (BSD) compatibility library

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -125,6 +125,7 @@
 #include <direct.h>   /* For _getcwd() */
 #include <io.h>       /* POSIX I/O */
 #include <winsock2.h> /* For GetUserName() */
+#include <shlwapi.h>  /* For StrStrIA */
 
 #ifdef H5_HAVE_THREADSAFE
 #include <process.h> /* For _beginthread() */


### PR DESCRIPTION
This fixes builds on mingw32 and other compilers.

I suspect this will fix https://github.com/HDFGroup/hdf5/issues/2396 , #2408