### PR TITLE
1.10: Drop non-1.10 branches in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   push:
   pull_request:
-    branches: [ develop, hdf5_1_14, hdf5_1_12, hdf5_1_10, hdf5_1_8 ]
+    branches: [ hdf5_1_10 ]
     paths-ignore:
       - '.github/CODEOWNERS'
       - '.github/FUNDING.yml'


### PR DESCRIPTION
There's no reason to list develop, etc. in the list of branches where this flavor of main.yml applies. Those branches have their own main.yml files.