### PR TITLE
1.10: Add szip/libaec to GitHub CI and fix warnings (#2438)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,6 +109,7 @@ jobs:
             direct_vfd: enable
             deprec_sym: enable
             default_api: v110
+            szip: yes
             toolchain: ""
             generator: "autogen"
             flags: ""
@@ -129,6 +130,7 @@ jobs:
             direct_vfd: disable
             deprec_sym: enable
             default_api: v110
+            szip: yes
             toolchain: ""
             generator: "autogen"
             flags: "CC=mpicc"
@@ -169,6 +171,7 @@ jobs:
             direct_vfd: enable
             deprec_sym: enable
             default_api: v16
+            szip: yes
             toolchain: ""
             generator: "autogen"
             flags: ""
@@ -191,6 +194,7 @@ jobs:
             direct_vfd: enable
             deprec_sym: enable
             default_api: v18
+            szip: yes
             toolchain: ""
             generator: "autogen"
             flags: ""
@@ -213,6 +217,7 @@ jobs:
             direct_vfd: enable
             deprec_sym: enable
             default_api: v110
+            szip: yes
             toolchain: ""
             generator: "autogen"
             flags: ""
@@ -235,6 +240,7 @@ jobs:
             direct_vfd: enable
             deprec_sym: disable
             default_api: v110
+            szip: yes
             toolchain: ""
             generator: "autogen"
             flags: ""
@@ -279,6 +285,7 @@ jobs:
            echo "CC=gcc-11" >> $GITHUB_ENV
            echo "CXX=g++-11" >> $GITHUB_ENV
            echo "FC=gfortran-11" >> $GITHUB_ENV
+           sudo apt install libaec0 libaec-dev
         if: (matrix.generator == 'autogen') && (matrix.parallel != 'enable')
 
       - name: Install Autotools Dependencies (Linux, parallel)
@@ -288,6 +295,7 @@ jobs:
            sudo apt install openmpi-bin openmpi-common mpi-default-dev
            echo "CC=mpicc" >> $GITHUB_ENV
            echo "FC=mpif90" >> $GITHUB_ENV
+           sudo apt install libaec0 libaec-dev
         if: (matrix.generator == 'autogen') && (matrix.parallel == 'enable')
 
       - name: Install Dependencies (Windows)
@@ -318,7 +326,7 @@ jobs:
           sh ./autogen.sh
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
-          ${{ matrix.flags }} $GITHUB_WORKSPACE/configure --enable-build-mode=${{ matrix.build_mode.autotools }} --${{ matrix.deprec_sym }}-deprecated-symbols --with-default-api-version=${{ matrix.default_api }} --enable-shared --${{ matrix.parallel }}-parallel --${{ matrix.cpp }}-cxx --${{ matrix.fortran }}-fortran --${{ matrix.java }}-java --${{ matrix.mirror_vfd }}-mirror-vfd --${{ matrix.direct_vfd }}-direct-vfd
+          ${{ matrix.flags }} $GITHUB_WORKSPACE/configure --enable-build-mode=${{ matrix.build_mode.autotools }} --${{ matrix.deprec_sym }}-deprecated-symbols --with-default-api-version=${{ matrix.default_api }} --enable-shared --${{ matrix.parallel }}-parallel --${{ matrix.cpp }}-cxx --${{ matrix.fortran }}-fortran --${{ matrix.java }}-java --${{ matrix.mirror_vfd }}-mirror-vfd --${{ matrix.direct_vfd }}-direct-vfd --with-szlib=${{ matrix.szip }}
         shell: bash
         if: (matrix.generator == 'autogen') && (! matrix.thread_safe.enabled)
 
@@ -327,7 +335,7 @@ jobs:
           sh ./autogen.sh
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
-          ${{ matrix.flags }} $GITHUB_WORKSPACE/configure --enable-build-mode=${{ matrix.build_mode.autotools }} --enable-shared --enable-threadsafe --disable-hl --${{ matrix.parallel }}-parallel --${{ matrix.mirror_vfd }}-mirror-vfd --${{ matrix.direct_vfd }}-direct-vfd
+          ${{ matrix.flags }} $GITHUB_WORKSPACE/configure --enable-build-mode=${{ matrix.build_mode.autotools }} --enable-shared --enable-threadsafe --disable-hl --${{ matrix.parallel }}-parallel --${{ matrix.mirror_vfd }}-mirror-vfd --${{ matrix.direct_vfd }}-direct-vfd --with-szlib=${{ matrix.szip }}
         shell: bash
         if: (matrix.generator == 'autogen') && (matrix.thread_safe.enabled)
 

--- a/src/H5Z.c
+++ b/src/H5Z.c
@@ -104,9 +104,15 @@ H5Z__init_package(void)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "unable to register deflate filter")
 #endif /* H5_HAVE_FILTER_DEFLATE */
 #ifdef H5_HAVE_FILTER_SZIP
-    H5Z_SZIP->encoder_present = SZ_encoder_enabled();
-    if (H5Z_register(H5Z_SZIP) < 0)
-        HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "unable to register szip filter")
+    {
+        int encoder_enabled = SZ_encoder_enabled();
+        if (encoder_enabled < 0)
+            HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "check for szip encoder failed")
+
+        H5Z_SZIP->encoder_present = (unsigned)encoder_enabled;
+        if (H5Z_register(H5Z_SZIP) < 0)
+            HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "unable to register szip filter")
+    }
 #endif /* H5_HAVE_FILTER_SZIP */
 
 done:

--- a/src/H5Zszip.c
+++ b/src/H5Zszip.c
@@ -73,7 +73,7 @@ static htri_t
 H5Z__can_apply_szip(hid_t H5_ATTR_UNUSED dcpl_id, hid_t type_id, hid_t H5_ATTR_UNUSED space_id)
 {
     const H5T_t *type;             /* Datatype */
-    unsigned     dtype_size;       /* Datatype's size (in bits) */
+    size_t       dtype_size;       /* Datatype's size (in bits) */
     H5T_order_t  dtype_order;      /* Datatype's endianness order */
     htri_t       ret_value = TRUE; /* Return value */
 
@@ -131,7 +131,7 @@ H5Z__set_local_szip(hid_t dcpl_id, hid_t type_id, hid_t space_id)
     H5T_order_t     dtype_order;                      /* Datatype's endianness order */
     size_t          dtype_size;                       /* Datatype's size (in bits) */
     size_t          dtype_precision;                  /* Datatype's precision (in bits) */
-    size_t          dtype_offset;                     /* Datatype's offset (in bits) */
+    int             dtype_offset;                     /* Datatype's offset (in bits) */
     hsize_t         scanline;                         /* Size of dataspace's fastest changing dimension */
     herr_t          ret_value = SUCCEED;              /* Return value */
 
@@ -161,16 +161,16 @@ H5Z__set_local_szip(hid_t dcpl_id, hid_t type_id, hid_t space_id)
         dtype_offset = H5T_get_offset(type);
         if (dtype_offset != 0)
             dtype_precision = dtype_size;
-    } /* end if */
+    }
     if (dtype_precision > 24) {
         if (dtype_precision <= 32)
             dtype_precision = 32;
         else if (dtype_precision <= 64)
             dtype_precision = 64;
-    } /* end if */
+    }
 
     /* Set "local" parameter for this dataset's "bits-per-pixel" */
-    cd_values[H5Z_SZIP_PARM_BPP] = dtype_precision;
+    cd_values[H5Z_SZIP_PARM_BPP] = (unsigned)dtype_precision;
 
     /* Get dataspace */
     if (NULL == (ds = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
@@ -200,7 +200,7 @@ H5Z__set_local_szip(hid_t dcpl_id, hid_t type_id, hid_t space_id)
         if (npoints < cd_values[H5Z_SZIP_PARM_PPB])
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL,
                         "pixels per block greater than total number of elements in the chunk")
-        scanline = MIN((cd_values[H5Z_SZIP_PARM_PPB] * SZ_MAX_BLOCKS_PER_SCANLINE), npoints);
+        scanline = (hsize_t)MIN((cd_values[H5Z_SZIP_PARM_PPB] * SZ_MAX_BLOCKS_PER_SCANLINE), npoints);
     }
     else {
         if (scanline <= SZ_MAX_PIXELS_PER_SCANLINE)
@@ -218,7 +218,7 @@ H5Z__set_local_szip(hid_t dcpl_id, hid_t type_id, hid_t space_id)
 
     /* Set the correct endianness flag for szip */
     /* (Note: this may not handle non-atomic datatypes well) */
-    cd_values[H5Z_SZIP_PARM_MASK] &= ~(SZ_LSB_OPTION_MASK | SZ_MSB_OPTION_MASK);
+    cd_values[H5Z_SZIP_PARM_MASK] &= ~((unsigned)SZ_LSB_OPTION_MASK | (unsigned)SZ_MSB_OPTION_MASK);
     switch (dtype_order) {
         case H5T_ORDER_LE: /* Little-endian byte order */
             cd_values[H5Z_SZIP_PARM_MASK] |= SZ_LSB_OPTION_MASK;

--- a/test/dsets.c
+++ b/test/dsets.c
@@ -2490,11 +2490,7 @@ error:
  *-------------------------------------------------------------------------
  */
 static herr_t
-test_filters(hid_t file, hid_t
-#ifndef H5_HAVE_FILTER_SZIP
-                             H5_ATTR_UNUSED
-#endif /* H5_HAVE_FILTER_SZIP */
-                                 fapl)
+test_filters(hid_t file)
 {
     hid_t         dc; /* Dataset creation property list ID */
     const hsize_t chunk_size[2] = {FILTER_CHUNK_DIM1, FILTER_CHUNK_DIM2}; /* Chunk dimensions */
@@ -15335,7 +15331,7 @@ main(void)
                 nerrors += (test_compact_open_close_dirty(my_fapl) < 0 ? 1 : 0);
                 nerrors += (test_conv_buffer(file) < 0 ? 1 : 0);
                 nerrors += (test_tconv(file) < 0 ? 1 : 0);
-                nerrors += (test_filters(file, my_fapl) < 0 ? 1 : 0);
+                nerrors += (test_filters(file) < 0 ? 1 : 0);
                 nerrors += (test_onebyte_shuffle(file) < 0 ? 1 : 0);
                 nerrors += (test_nbit_int(file) < 0 ? 1 : 0);
                 nerrors += (test_nbit_float(file) < 0 ? 1 : 0);

--- a/test/tmisc.c
+++ b/test/tmisc.c
@@ -3828,7 +3828,7 @@ test_misc22(void)
     unsigned int flags;
     size_t       cd_nelmts = 32;
     unsigned int cd_values[32];
-    unsigned     correct;
+    size_t       correct;
 
     if (h5_szip_can_encode() != 1)
         return;
@@ -3922,7 +3922,7 @@ test_misc22(void)
                                            NULL);
                 CHECK(ret, FAIL, "H5Pget_filter_by_id2");
 
-                VERIFY(cd_values[2], correct, "SZIP filter returned value for precision");
+                VERIFY(cd_values[2], (unsigned)correct, "SZIP filter returned value for precision");
 
                 ret = H5Dclose(dsid);
                 CHECK(ret, FAIL, "H5Dclose");


### PR DESCRIPTION
szip (or libaec) is currently not tested in CI. This adds szip to the the Autotools GitHub CI actions on Linux when building with the Autotools.

This PR also cleans up a few warnings that remained in the szip- related code so the -Werror check will pass.