### PR TITLE
Fix a possible uninitialized variable in pio_perf

### DIFF
--- a/tools/src/h5perf/pio_perf.c
+++ b/tools/src/h5perf/pio_perf.c
@@ -311,7 +311,7 @@ run_test_loop(struct options *opts)
 {
     parameters parms;
     int        num_procs;
-    int        doing_pio; /* if this process is doing PIO */
+    int        doing_pio = 0; /* if this process is doing parallel IO */
 
     parms.num_files     = opts->num_files;
     parms.num_dsets     = opts->num_dsets;


### PR DESCRIPTION
This should be the last warning we need to clean to build parallel with -Werror