### PR TITLE
fix: do not include subfiling before enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3011,10 +3011,6 @@ AC_SUBST([HAVE_MERCURY])
 SUBFILING_VFD=no
 HAVE_MERCURY="no"
 
-## Always include subfiling directory so public header files are available
-CPPFLAGS="$CPPFLAGS -I$ac_abs_confdir/src/H5FDsubfiling"
-AM_CPPFLAGS="$AM_CPPFLAGS -I$ac_abs_confdir/src/H5FDsubfiling"
-
 AC_MSG_CHECKING([if the subfiling I/O virtual file driver (VFD) is enabled])
 
 AC_ARG_ENABLE([subfiling-vfd],
@@ -3033,6 +3029,9 @@ if test "X$SUBFILING_VFD" = "Xyes"; then
     if test "X${PARALLEL}" != "Xyes"; then
       AC_MSG_ERROR([--enable-parallel is required for --enable-subfiling-vfd])
     fi
+    ## Always include subfiling directory so public header files are available
+    CPPFLAGS="$CPPFLAGS -I$ac_abs_confdir/src/H5FDsubfiling"
+    AM_CPPFLAGS="$AM_CPPFLAGS -I$ac_abs_confdir/src/H5FDsubfiling"
 
     ## ----------------------------------------------------------------------
     ## Check for MPI_Comm_split_type availability


### PR DESCRIPTION
Fixes: https://github.com/HDFGroup/hdf5/issues/2422

The build directory should probably not be referenced in the output, but if it should at least not before that setting is enabled.