### PR TITLE
OESS-330/HDFFV-11282: Improve failure message when a VOL connector can't be loaded

### DIFF
--- a/src/H5PLint.c
+++ b/src/H5PLint.c
@@ -254,13 +254,13 @@ H5PL_load(H5PL_type_t type, const H5PL_key_t *key)
     /* If not found, try iterating through the path table to find an appropriate plugin */
     if (!found)
         if (H5PL__find_plugin_in_path_table(&search_params, &found, &plugin_info) < 0)
-            HGOTO_ERROR(H5E_PLUGIN, H5E_CANTGET, NULL, "search in path table failed")
+            HGOTO_ERROR(H5E_PLUGIN, H5E_CANTGET, NULL, "can't find plugin in the paths either set by HDF5_PLUGIN_PATH, or default location, or set by H5PLxxx functions")
 
     /* Set the return value we found the plugin */
     if (found)
         ret_value = plugin_info;
     else
-        HGOTO_ERROR(H5E_PLUGIN, H5E_NOTFOUND, NULL, "unable to locate plugin")
+        HGOTO_ERROR(H5E_PLUGIN, H5E_NOTFOUND, NULL, "can't find plugin. Check either HDF5_VOL_CONNECTOR, HDF5_PLUGIN_PATH, default location, or path set by H5PLxxx functions")
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5PLint.c
+++ b/src/H5PLint.c
@@ -254,13 +254,17 @@ H5PL_load(H5PL_type_t type, const H5PL_key_t *key)
     /* If not found, try iterating through the path table to find an appropriate plugin */
     if (!found)
         if (H5PL__find_plugin_in_path_table(&search_params, &found, &plugin_info) < 0)
-            HGOTO_ERROR(H5E_PLUGIN, H5E_CANTGET, NULL, "can't find plugin in the paths either set by HDF5_PLUGIN_PATH, or default location, or set by H5PLxxx functions")
+            HGOTO_ERROR(H5E_PLUGIN, H5E_CANTGET, NULL,
+                        "can't find plugin in the paths either set by HDF5_PLUGIN_PATH, or default location, "
+                        "or set by H5PLxxx functions")
 
     /* Set the return value we found the plugin */
     if (found)
         ret_value = plugin_info;
     else
-        HGOTO_ERROR(H5E_PLUGIN, H5E_NOTFOUND, NULL, "can't find plugin. Check either HDF5_VOL_CONNECTOR, HDF5_PLUGIN_PATH, default location, or path set by H5PLxxx functions")
+        HGOTO_ERROR(H5E_PLUGIN, H5E_NOTFOUND, NULL,
+                    "can't find plugin. Check either HDF5_VOL_CONNECTOR, HDF5_PLUGIN_PATH, default location, "
+                    "or path set by H5PLxxx functions")
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5PLpath.c
+++ b/src/H5PLpath.c
@@ -854,7 +854,7 @@ H5PL__find_plugin_in_path(const H5PL_search_params_t *search_params, hbool_t *fo
 
     /* Open the directory */
     if (!(dirp = HDopendir(dir)))
-        HGOTO_ERROR(H5E_PLUGIN, H5E_OPENERROR, FAIL, "can't open directory: %s", dir)
+        HGOTO_ERROR(H5E_PLUGIN, H5E_OPENERROR, FAIL, "can't open directory (%s). Please verify its existence", dir)
 
     /* Iterate through all entries in the directory */
     while (NULL != (dp = HDreaddir(dirp))) {

--- a/src/H5PLpath.c
+++ b/src/H5PLpath.c
@@ -854,7 +854,8 @@ H5PL__find_plugin_in_path(const H5PL_search_params_t *search_params, hbool_t *fo
 
     /* Open the directory */
     if (!(dirp = HDopendir(dir)))
-        HGOTO_ERROR(H5E_PLUGIN, H5E_OPENERROR, FAIL, "can't open directory (%s). Please verify its existence", dir)
+        HGOTO_ERROR(H5E_PLUGIN, H5E_OPENERROR, FAIL, "can't open directory (%s). Please verify its existence",
+                    dir)
 
     /* Iterate through all entries in the directory */
     while (NULL != (dp = HDreaddir(dirp))) {


### PR DESCRIPTION
Made the error message clearer when the library can't find a plugin in the path table that contains the paths set by HDF5_PLUGIN_PATH and the default location and maybe set by H5PLxxx functions.