### PR TITLE
Fix H5Dchunk_iter doxygen example, cherry-pick of ef3bed6

### DIFF
--- a/doxygen/examples/H5D_examples.c
+++ b/doxygen/examples/H5D_examples.c
@@ -7,10 +7,10 @@
 
 //! <!-- [H5Dchunk_iter_cb] -->
 int
-chunk_cb(const hsize_t *offset, uint32_t filter_mask, haddr_t addr, uint32_t nbytes, void *op_data)
+chunk_cb(const hsize_t *offset, unsigned filter_mask, haddr_t addr, hsize_t size, void *op_data)
 {
     // only print the allocated chunk size only
-    printf("%d\n", nbytes);
+    printf("%ld\n", size);
     return EXIT_SUCCESS;
 }
 //! <!-- [H5Dchunk_iter_cb] -->
@@ -67,7 +67,7 @@ H5Ovisit_cb(hid_t obj, const char *name, const H5O_info2_t *info, void *op_data)
                 retval = -1;
                 goto fail_fig;
             }
-
+fail_fig:
 fail_shape:
             H5Sclose(dspace);
 fail_dspace:


### PR DESCRIPTION
This is a minimalist version of #2380 that only modifies the doxygen documentation example for the develop branch.

The main reason this exists is so that this minimal change can be ported to the 1.12 and 1.10 branches.

This pull request should affect documentation only. Unlike #2380 it makes no change to the build process.