### PR TITLE
Fix 2nd argument of Java H5Fis_accessible

### DIFF
--- a/java/src/hdf/hdf5lib/H5.java
+++ b/java/src/hdf/hdf5lib/H5.java
@@ -5112,8 +5112,8 @@ public class H5 implements java.io.Serializable {
      *
      * @param name
      *            IN: File name to check.
-     * @param file_id
-     *            IN: File identifier for a currently-open HDF5 file
+     * @param fapl_id
+     *            IN: File access property list identifier
      *
      * @return true if file is accessible, false if not.
      *
@@ -5122,7 +5122,7 @@ public class H5 implements java.io.Serializable {
      * @exception NullPointerException
      *            name is null.
      **/
-    public synchronized static native boolean H5Fis_accessible(String name, long file_id)
+    public synchronized static native boolean H5Fis_accessible(String name, long fapl_id)
         throws HDF5LibraryException, NullPointerException;
 
     /**

--- a/java/src/jni/h5fImp.c
+++ b/java/src/jni/h5fImp.c
@@ -188,7 +188,7 @@ done:
  * Signature: (Ljava/lang/String;J)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_hdf_hdf5lib_H5_H5Fis_1accessible(JNIEnv *env, jclass clss, jstring name, jlong file_id)
+Java_hdf_hdf5lib_H5_H5Fis_1accessible(JNIEnv *env, jclass clss, jstring name, jlong fapl_id)
 {
     const char *fileName = NULL;
     htri_t      bval     = JNI_FALSE;
@@ -200,7 +200,7 @@ Java_hdf_hdf5lib_H5_H5Fis_1accessible(JNIEnv *env, jclass clss, jstring name, jl
 
     PIN_JAVA_STRING(ENVONLY, name, fileName, NULL, "H5Fis_accessible: file name not pinned");
 
-    if ((bval = H5Fis_accessible(fileName, (hid_t)file_id)) < 0)
+    if ((bval = H5Fis_accessible(fileName, (hid_t)fapl_id)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
 
     bval = (bval > 0) ? JNI_TRUE : JNI_FALSE;


### PR DESCRIPTION
The second argument was wrongly stated to be the `file_id` when it should be the `fapl_id`.