### PR TITLE
Add concurrency option to cancel in-progress jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
       - 'COPYING**'
       - '**.md'
 
-# Using concurrency to cancel any in-progress job or run
+#  Using concurrency to cancel any in-progress job or run
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
       - 'COPYING**'
       - '**.md'
 
-#  Using concurrency to cancel any in-progress job or run
+# Using concurrency to cancel any in-progress job or run
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,12 @@ on:
       - 'ACKNOWLEDGEMENTS'
       - 'COPYING**'
       - '**.md'
-    
+
+# Using concurrency to cancel any in-progress job or run
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 # A workflow run is made up of one or more jobs that can run sequentially or
 # in parallel. We just have one job, but the matrix items defined below will
 # run in parallel.


### PR DESCRIPTION
cancel a GitHub action if a new commit supersedes it.