### PR TITLE
Add a clang-format comment about permissions

### DIFF
--- a/.github/workflows/clang-format-fix.yml
+++ b/.github/workflows/clang-format-fix.yml
@@ -1,3 +1,12 @@
+# NOTE: This action requires write permissions to be set in your GitHub
+#       repo/fork for it to be able to commit changes.
+#
+# This is currently enabled via:
+#
+#   settings > Actions > General > Workflow permissions
+#
+# which you will need to set to "Read and write permissions"
+#
 name: clang-format Commit Changes
 on: 
   workflow_dispatch:


### PR DESCRIPTION
There is a GitHub setting that must be enabled in order for the clang-format fix action to automatically correct your code. This adds a comment about where that setting is located (helpful for new forks and when we move this file to other repositories).