### PR TITLE
Remove an obsolete comment from the MDS test

### DIFF
--- a/testpar/t_pmulti_dset.c
+++ b/testpar/t_pmulti_dset.c
@@ -17,10 +17,6 @@
  * Purpose:     Test H5Dwrite_multi() and H5Dread_multi using randomized
  *              parameters in parallel.  Also tests H5Dwrite() and H5Dread()
  *              using a similar method.
- *
- *              Note that this test currently relies on all processes generating
- *              the same sequence of random numbers after using a shared seed
- *              value, therefore it may not work across multiple machines.
  */
 
 #include "h5test.h"


### PR DESCRIPTION
The seed is now broadcast from rank 0, so the warning about multiple machines having different seeds is unnecessary.