### PR TITLE
Normalize platform-independence code w/ develop

### DIFF
--- a/config/clang-cxxflags
+++ b/config/clang-cxxflags
@@ -112,7 +112,7 @@ if test "X-clang" = "X-$cxx_vendor" -o "X-Apple LLVM" = "X-$cxx_vendor"; then
             ;;
     esac
 
-    H5_CXXFLAGS="$H5_CXXFLAGS $arch"
+    H5_CXXFLAGS="$H5_CXXFLAGS $arch -std=c++98"
 
     ##############
     # Production #

--- a/config/gnu-cxxflags
+++ b/config/gnu-cxxflags
@@ -118,7 +118,7 @@ if test "X-g++" = "X-$cxx_vendor"; then
     esac
 
     # C++-specific
-    H5_CXXFLAGS="$H5_CXXFLAGS $arch"
+    H5_CXXFLAGS="$H5_CXXFLAGS $arch -std=c++98"
 
     ##############
     # Production #

--- a/config/intel-cxxflags
+++ b/config/intel-cxxflags
@@ -81,7 +81,7 @@ if test "X-icpc" = "X-$cxx_vendor"; then
     # General #
     ###########
 
-    H5_CXXFLAGS="$H5_CXXFLAGS $arch"
+    H5_CXXFLAGS="$H5_CXXFLAGS $arch -std=c++98"
 
     ##############
     # Production #

--- a/config/pgi-cxxflags
+++ b/config/pgi-cxxflags
@@ -48,7 +48,7 @@ if test "X-pgc++" = "X-$cxx_vendor"; then
     # General #
     ###########
 
-    H5_CXXFLAGS="$H5_CXXFLAGS -Minform=warn"
+    H5_CXXFLAGS="$H5_CXXFLAGS -std=c++98 -Minform=warn"
 
     ##############
     # Production #

--- a/src/H5Defl.c
+++ b/src/H5Defl.c
@@ -254,7 +254,7 @@ H5D__efl_read(const H5O_efl_t *efl, const H5D_t *dset, haddr_t addr, size_t size
     /* Check args */
     HDassert(efl && efl->nused > 0);
     HDassert(H5F_addr_defined(addr));
-    HDassert(size < SIZET_MAX);
+    HDassert(size < SIZE_MAX);
     HDassert(buf || 0 == size);
 
     /* Find the first efl member from which to read */
@@ -342,7 +342,7 @@ H5D__efl_write(const H5O_efl_t *efl, const H5D_t *dset, haddr_t addr, size_t siz
     /* Check args */
     HDassert(efl && efl->nused > 0);
     HDassert(H5F_addr_defined(addr));
-    HDassert(size < SIZET_MAX);
+    HDassert(size < SIZE_MAX);
     HDassert(buf || 0 == size);
 
     /* Find the first efl member in which to write */

--- a/src/H5FDfamily.c
+++ b/src/H5FDfamily.c
@@ -1116,8 +1116,8 @@ H5FD__family_read(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, s
          * is 4 bytes, to prevent overflow when user application is trying to
          * write files bigger than 4GB. */
         tempreq = file->memb_size - sub;
-        if (tempreq > SIZET_MAX)
-            tempreq = SIZET_MAX;
+        if (tempreq > SIZE_MAX)
+            tempreq = SIZE_MAX;
         req = MIN(size, (size_t)tempreq);
 
         HDassert(u < file->nmembs);
@@ -1181,8 +1181,8 @@ H5FD__family_write(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, 
          * is 4 bytes, to prevent overflow when user application is trying to
          * write files bigger than 4GB. */
         tempreq = file->memb_size - sub;
-        if (tempreq > SIZET_MAX)
-            tempreq = SIZET_MAX;
+        if (tempreq > SIZE_MAX)
+            tempreq = SIZE_MAX;
         req = MIN(size, (size_t)tempreq);
 
         HDassert(u < file->nmembs);

--- a/src/H5MM.c
+++ b/src/H5MM.c
@@ -151,7 +151,7 @@ H5MM__sanity_check_block(const H5MM_block_t *block)
     HDassert(block->u.info.size > 0);
     HDassert(block->u.info.in_use);
     /* Check for head & tail guards, if not head of linked list */
-    if (block->u.info.size != SIZET_MAX) {
+    if (block->u.info.size != SIZE_MAX) {
         HDassert(0 == HDmemcmp(block->b, H5MM_block_head_guard_s, H5MM_HEAD_GUARD_SIZE));
         HDassert(0 == HDmemcmp(block->b + H5MM_HEAD_GUARD_SIZE + block->u.info.size, H5MM_block_tail_guard_s,
                                H5MM_TAIL_GUARD_SIZE));
@@ -266,7 +266,7 @@ H5MM_malloc(size_t size)
         H5MM_memcpy(H5MM_block_head_s.sig, H5MM_block_signature_s, H5MM_SIG_SIZE);
         H5MM_block_head_s.next          = &H5MM_block_head_s;
         H5MM_block_head_s.prev          = &H5MM_block_head_s;
-        H5MM_block_head_s.u.info.size   = SIZET_MAX;
+        H5MM_block_head_s.u.info.size   = SIZE_MAX;
         H5MM_block_head_s.u.info.in_use = TRUE;
 
         H5MM_init_s = TRUE;

--- a/src/H5VM.c
+++ b/src/H5VM.c
@@ -609,7 +609,7 @@ H5VM_stride_fill(unsigned n, hsize_t elmt_size, const hsize_t *size, const hsize
 
     FUNC_ENTER_NOAPI_NOINIT_NOERR
 
-    HDassert(elmt_size < SIZET_MAX);
+    HDassert(elmt_size < SIZE_MAX);
 
     H5VM_vector_cpy(n, idx, size);
     nelmts = H5VM_vector_reduce_product(n, size);
@@ -667,7 +667,7 @@ H5VM_stride_copy(unsigned n, hsize_t elmt_size, const hsize_t *size, const hsize
 
     FUNC_ENTER_NOAPI_NOINIT_NOERR
 
-    HDassert(elmt_size < SIZET_MAX);
+    HDassert(elmt_size < SIZE_MAX);
 
     if (n) {
         H5VM_vector_cpy(n, idx, size);
@@ -733,7 +733,7 @@ H5VM_stride_copy_s(unsigned n, hsize_t elmt_size, const hsize_t *size, const hss
 
     FUNC_ENTER_NOAPI_NOINIT_NOERR
 
-    HDassert(elmt_size < SIZET_MAX);
+    HDassert(elmt_size < SIZE_MAX);
 
     if (n) {
         H5VM_vector_cpy(n, idx, size);
@@ -802,7 +802,7 @@ H5VM__stride_copy2(hsize_t nelmts, hsize_t elmt_size,
 
     FUNC_ENTER_STATIC_NOERR
 
-    HDassert(elmt_size < SIZET_MAX);
+    HDassert(elmt_size < SIZE_MAX);
     HDassert(dst_n > 0);
     HDassert(src_n > 0);
 
@@ -866,8 +866,8 @@ H5VM_array_fill(void *_dst, const void *src, size_t size, size_t count)
 
     HDassert(dst);
     HDassert(src);
-    HDassert(size < SIZET_MAX && size > 0);
-    HDassert(count < SIZET_MAX && count > 0);
+    HDassert(size < SIZE_MAX && size > 0);
+    HDassert(count < SIZE_MAX && count > 0);
 
     H5MM_memcpy(dst, src, size); /* copy first item */
 

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -36,6 +36,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 /* POSIX headers */
 #ifdef H5_HAVE_SYS_TIME_H
@@ -43,7 +44,6 @@
 #endif
 #ifdef H5_HAVE_UNISTD_H
 #include <unistd.h>
-#include <sys/types.h>
 #endif
 #ifdef H5_HAVE_PWD_H
 #include <pwd.h>
@@ -64,25 +64,6 @@
  */
 #ifdef H5_HAVE_SYS_STAT_H
 #include <sys/stat.h>
-#endif
-
-/*
- * If a program may include both `time.h' and `sys/time.h' then
- * TIME_WITH_SYS_TIME is defined (see AC_HEADER_TIME in configure.ac).
- * On some older systems, `sys/time.h' includes `time.h' but `time.h' is not
- * protected against multiple inclusion, so programs should not explicitly
- * include both files. This macro is useful in programs that use, for example,
- * `struct timeval' or `struct timezone' as well as `struct tm'.  It is best
- * used in conjunction with `HAVE_SYS_TIME_H', whose existence is checked
- * by `AC_CHECK_HEADERS(sys/time.h)' in configure.ac.
- */
-#if defined(H5_TIME_WITH_SYS_TIME)
-#include <sys/time.h>
-#include <time.h>
-#elif defined(H5_HAVE_SYS_TIME_H)
-#include <sys/time.h>
-#else
-#include <time.h>
 #endif
 
 /*
@@ -126,8 +107,8 @@
 #include <dirent.h>
 #endif
 
-/* Define the default VFD for this platform.
- * Since the removal of the Windows VFD, this is sec2 for all platforms.
+/* Define the default VFD for this platform.  Since the removal of the
+ * Windows VFD, this is sec2 for all platforms.
  */
 #define H5_DEFAULT_VFD H5FD_SEC2
 
@@ -401,91 +382,16 @@
 #endif
 
 /*
- * Numeric data types.  Some of these might be defined in Posix.1g, otherwise
- * we define them with the closest available type which is at least as large
- * as the number of bits indicated in the type name.  The `int8' types *must*
- * be exactly one byte wide because we use it for pointer calculations to
- * void* memory.
+ * The max value for ssize_t.
+ *
+ * Only needed where ssize_t isn't a thing (e.g., Windows)
  */
-#if H5_SIZEOF_INT8_T == 0
-typedef signed char int8_t;
-#undef H5_SIZEOF_INT8_T
-#define H5_SIZEOF_INT8_T H5_SIZEOF_CHAR
-#elif H5_SIZEOF_INT8_T == 1
-#else
-#error "the int8_t type must be 1 byte wide"
-#endif
-
-#if H5_SIZEOF_UINT8_T == 0
-typedef unsigned char uint8_t;
-#undef H5_SIZEOF_UINT8_T
-#define H5_SIZEOF_UINT8_T H5_SIZEOF_CHAR
-#elif H5_SIZEOF_UINT8_T == 1
-#else
-#error "the uint8_t type must be 1 byte wide"
-#endif
-
-#if H5_SIZEOF_INT16_T >= 2
-#elif H5_SIZEOF_SHORT >= 2
-typedef short          int16_t;
-#undef H5_SIZEOF_INT16_T
-#define H5_SIZEOF_INT16_T H5_SIZEOF_SHORT
-#elif H5_SIZEOF_INT >= 2
-typedef int      int16_t;
-#undef H5_SIZEOF_INT16_T
-#define H5_SIZEOF_INT16_T H5_SIZEOF_INT
-#else
-#error "nothing appropriate for int16_t"
-#endif
-
-#if H5_SIZEOF_UINT16_T >= 2
-#elif H5_SIZEOF_SHORT >= 2
-typedef unsigned short uint16_t;
-#undef H5_SIZEOF_UINT16_T
-#define H5_SIZEOF_UINT16_T H5_SIZEOF_SHORT
-#elif H5_SIZEOF_INT >= 2
-typedef unsigned uint16_t;
-#undef H5_SIZEOF_UINT16_T
-#define H5_SIZEOF_UINT16_T H5_SIZEOF_INT
-#else
-#error "nothing appropriate for uint16_t"
-#endif
-
-#if H5_SIZEOF_INT32_T >= 4
-#elif H5_SIZEOF_SHORT >= 4
-typedef short          int32_t;
-#undef H5_SIZEOF_INT32_T
-#define H5_SIZEOF_INT32_T H5_SIZEOF_SHORT
-#elif H5_SIZEOF_INT >= 4
-typedef int      int32_t;
-#undef H5_SIZEOF_INT32_T
-#define H5_SIZEOF_INT32_T H5_SIZEOF_INT
-#elif H5_SIZEOF_LONG >= 4
-typedef long int32_t;
-#undef H5_SIZEOF_INT32_T
-#define H5_SIZEOF_INT32_T H5_SIZEOF_LONG
-#else
-#error "nothing appropriate for int32_t"
+#ifndef SSIZE_MAX
+#define SSIZE_MAX ((ssize_t)(((size_t)1 << (8 * sizeof(ssize_t) - 1)) - 1))
 #endif
 
 /*
- * Maximum and minimum values.  These should be defined in <limits.h> for the
- * most part.
- */
-#ifndef LLONG_MAX
-#define LLONG_MAX ((long long)(((unsigned long long)1 << (8 * sizeof(long long) - 1)) - 1))
-#define LLONG_MIN ((long long)(-LLONG_MAX) - 1)
-#endif
-#ifndef ULLONG_MAX
-#define ULLONG_MAX ((unsigned long long)((long long)(-1)))
-#endif
-#ifndef SIZET_MAX
-#define SIZET_MAX  ((size_t)(ssize_t)(-1))
-#define SSIZET_MAX ((ssize_t)(((size_t)1 << (8 * sizeof(ssize_t) - 1)) - 1))
-#endif
-
-/*
- * Maximum & minimum values for our typedefs.
+ * Maximum & minimum values for HDF5 typedefs.
  */
 #define HSIZET_MAX  ((hsize_t)ULLONG_MAX)
 #define HSSIZET_MAX ((hssize_t)LLONG_MAX)
@@ -525,7 +431,7 @@ typedef long int32_t;
 #else
 #define h5_posix_io_t         size_t
 #define h5_posix_io_ret_t     ssize_t
-#define H5_POSIX_MAX_IO_BYTES SSIZET_MAX
+#define H5_POSIX_MAX_IO_BYTES SSIZE_MAX
 #endif
 
 /* POSIX I/O mode used as the third parameter to open/_open
@@ -634,14 +540,29 @@ typedef struct {
     haddr_t       addr;   /* The unique address of the object's header in that file */
 } H5_obj_t;
 
-/*
- * Redefine all the POSIX functions.  We should never see a POSIX
- * function (or any other non-HDF5 function) in the source!
- */
+#define H5_SIZEOF_H5_STAT_SIZE_T H5_SIZEOF_OFF_T
 
-/* Put all platform-specific definitions in the following file */
-/* so that the following definitions are platform free. */
-#include "H5win32defs.h" /* For Windows-specific definitions */
+/* Put all Windows-specific definitions in H5win32defs.h so we
+ * can (mostly) assume a POSIX platform. Not all of the POSIX calls
+ * will have a Windows equivalent so some #ifdef protection is still
+ * necessary (e.g., fork()).
+ */
+#include "H5win32defs.h"
+
+/* Platform-independent definitions for struct stat and off_t */
+#ifndef H5_HAVE_WIN32_API
+/* These definitions differ in Windows and are defined in
+ * H5win32defs for that platform.
+ */
+typedef struct stat h5_stat_t;
+typedef off_t       h5_stat_size_t;
+#define HDoff_t off_t
+#endif
+
+/* Redefine all the POSIX and C functions.  We should never see an
+ * undecorated POSIX or C function (or any other non-HDF5 function)
+ * in the source.
+ */
 
 #ifndef HDabort
 #define HDabort() abort()
@@ -659,11 +580,7 @@ typedef struct {
 #define HDacos(X) acos(X)
 #endif
 #ifndef HDalarm
-#ifdef H5_HAVE_ALARM
 #define HDalarm(N) alarm(N)
-#else
-#define HDalarm(N) (0)
-#endif
 #endif
 #ifndef HDasctime
 #define HDasctime(T) asctime(T)
@@ -768,11 +685,7 @@ typedef struct {
 #define HDcuserid(S) cuserid(S)
 #endif
 #ifndef HDdifftime
-#ifdef H5_HAVE_DIFFTIME
 #define HDdifftime(X, Y) difftime(X, Y)
-#else
-#define HDdifftime(X, Y) ((double)(X) - (double)(Y))
-#endif
 #endif
 #ifndef HDdiv
 #define HDdiv(X, Y) div(X, Y)
@@ -783,9 +696,6 @@ typedef struct {
 #ifndef HDdup2
 #define HDdup2(F, I) dup2(F, I)
 #endif
-/* execl() variable arguments */
-/* execle() variable arguments */
-/* execlp() variable arguments */
 #ifndef HDexecv
 #define HDexecv(S, AV) execv(S, AV)
 #endif
@@ -819,10 +729,8 @@ typedef struct {
 #ifndef HDfclose
 #define HDfclose(F) fclose(F)
 #endif
-#ifdef H5_HAVE_FCNTL
 #ifndef HDfcntl
 #define HDfcntl(F, C, ...) fcntl(F, C, __VA_ARGS__)
-#endif
 #endif
 #ifndef HDfdopen
 #define HDfdopen(N, S) fdopen(N, S)
@@ -910,20 +818,11 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #ifndef HDfrexp
 #define HDfrexp(X, N) frexp(X, N)
 #endif
-/* Check for Cray-specific 'frexpf()' and 'frexpl()' routines */
 #ifndef HDfrexpf
-#ifdef H5_HAVE_FREXPF
 #define HDfrexpf(X, N) frexpf(X, N)
-#else
-#define HDfrexpf(X, N) frexp(X, N)
-#endif
 #endif
 #ifndef HDfrexpl
-#ifdef H5_HAVE_FREXPL
 #define HDfrexpl(X, N) frexpl(X, N)
-#else
-#define HDfrexpl(X, N) frexp(X, N)
-#endif
 #endif
 #ifndef HDfscanf
 #define HDfscanf fscanf
@@ -937,24 +836,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #ifndef HDfstat
 #define HDfstat(F, B) fstat(F, B)
 #endif
-#ifndef HDlstat
-#define HDlstat(S, B) lstat(S, B)
-#endif
-#ifndef HDstat
-#define HDstat(S, B) stat(S, B)
-#endif
-
-#ifndef H5_HAVE_WIN32_API
-/* These definitions differ in Windows and are defined in
- * H5win32defs for that platform.
- */
-typedef struct stat h5_stat_t;
-typedef off_t       h5_stat_size_t;
-#define HDoff_t off_t
-#endif /* H5_HAVE_WIN32_API */
-
-#define H5_SIZEOF_H5_STAT_SIZE_T H5_SIZEOF_OFF_T
-
 #ifndef HDftell
 #define HDftell(F) ftell(F)
 #endif
@@ -1150,6 +1031,9 @@ typedef off_t       h5_stat_size_t;
 #ifndef HDlseek
 #define HDlseek(F, O, W) lseek(F, O, W)
 #endif
+#ifndef HDlstat
+#define HDlstat(S, B) lstat(S, B)
+#endif
 #ifndef HDmalloc
 #define HDmalloc(Z) malloc(Z)
 #endif
@@ -1325,7 +1209,9 @@ typedef off_t       h5_stat_size_t;
 #ifndef HDrmdir
 #define HDrmdir(S) rmdir(S)
 #endif
-/* scanf() variable arguments */
+#ifndef HDscanf
+#define HDscanf scanf /*varargs*/
+#endif
 #ifndef HDselect
 #define HDselect(N, RD, WR, ER, T) select(N, RD, WR, ER, T)
 #endif
@@ -1420,7 +1306,10 @@ typedef off_t       h5_stat_size_t;
 #define HDsqrt(X) sqrt(X)
 #endif
 #ifndef HDsscanf
-#define HDsscanf(S, FMT, ...) sscanf(S, FMT, __VA_ARGS__)
+#define HDsscanf sscanf /*varargs*/
+#endif
+#ifndef HDstat
+#define HDstat(S, B) stat(S, B)
 #endif
 #ifndef HDstrcat
 #define HDstrcat(X, Y) strcat(X, Y)
@@ -1489,11 +1378,7 @@ typedef off_t       h5_stat_size_t;
 #define HDstrtol(S, R, N) strtol(S, R, N)
 #endif
 #ifndef HDstrtoll
-#ifdef H5_HAVE_STRTOLL
 #define HDstrtoll(S, R, N) strtoll(S, R, N)
-#else
-H5_DLL int64_t HDstrtoll(const char *s, const char **rest, int base);
-#endif
 #endif
 #ifndef HDstrtoul
 #define HDstrtoul(S, R, N) strtoul(S, R, N)
@@ -1507,10 +1392,8 @@ H5_DLL int64_t HDstrtoll(const char *s, const char **rest, int base);
 #ifndef HDstrxfrm
 #define HDstrxfrm(X, Y, Z) strxfrm(X, Y, Z)
 #endif
-#ifdef H5_HAVE_SYMLINK
 #ifndef HDsymlink
 #define HDsymlink(F1, F2) symlink(F1, F2)
-#endif
 #endif
 #ifndef HDsysconf
 #define HDsysconf(N) sysconf(N)
@@ -1592,7 +1475,7 @@ H5_DLL int64_t HDstrtoll(const char *s, const char **rest, int base);
 #ifdef H5_HAVE_VASPRINTF
 #define HDvasprintf(RET, FMT, A) vasprintf(RET, FMT, A)
 #else
-H5_DLL int     HDvasprintf(char **bufp, const char *fmt, va_list _ap);
+H5_DLL int HDvasprintf(char **bufp, const char *fmt, va_list _ap);
 #endif
 #endif
 
@@ -1850,51 +1733,52 @@ extern char H5libhdf5_settings[]; /* embedded library information */
 
 #define H5TRACE0(R, T)                                                                                       \
     RTYPE    = R;                                                                                            \
-    CALLTIME = H5_trace(NULL, FUNC, T)
+    CALLTIME = H5_trace(NULL, __func__, T)
 #define H5TRACE1(R, T, A0)                                                                                   \
     RTYPE    = R;                                                                                            \
-    CALLTIME = H5_trace(NULL, FUNC, T, #A0, A0)
+    CALLTIME = H5_trace(NULL, __func__, T, #A0, A0)
 #define H5TRACE2(R, T, A0, A1)                                                                               \
     RTYPE    = R;                                                                                            \
-    CALLTIME = H5_trace(NULL, FUNC, T, #A0, A0, #A1, A1)
+    CALLTIME = H5_trace(NULL, __func__, T, #A0, A0, #A1, A1)
 #define H5TRACE3(R, T, A0, A1, A2)                                                                           \
     RTYPE    = R;                                                                                            \
-    CALLTIME = H5_trace(NULL, FUNC, T, #A0, A0, #A1, A1, #A2, A2)
+    CALLTIME = H5_trace(NULL, __func__, T, #A0, A0, #A1, A1, #A2, A2)
 #define H5TRACE4(R, T, A0, A1, A2, A3)                                                                       \
     RTYPE    = R;                                                                                            \
-    CALLTIME = H5_trace(NULL, FUNC, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3)
+    CALLTIME = H5_trace(NULL, __func__, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3)
 #define H5TRACE5(R, T, A0, A1, A2, A3, A4)                                                                   \
     RTYPE    = R;                                                                                            \
-    CALLTIME = H5_trace(NULL, FUNC, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4)
+    CALLTIME = H5_trace(NULL, __func__, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4)
 #define H5TRACE6(R, T, A0, A1, A2, A3, A4, A5)                                                               \
     RTYPE    = R;                                                                                            \
-    CALLTIME = H5_trace(NULL, FUNC, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5)
+    CALLTIME = H5_trace(NULL, __func__, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5)
 #define H5TRACE7(R, T, A0, A1, A2, A3, A4, A5, A6)                                                           \
     RTYPE    = R;                                                                                            \
-    CALLTIME = H5_trace(NULL, FUNC, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6)
+    CALLTIME = H5_trace(NULL, __func__, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6)
 #define H5TRACE8(R, T, A0, A1, A2, A3, A4, A5, A6, A7)                                                       \
-    RTYPE    = R;                                                                                            \
-    CALLTIME = H5_trace(NULL, FUNC, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6, #A7, A7)
+    RTYPE = R;                                                                                               \
+    CALLTIME =                                                                                               \
+        H5_trace(NULL, __func__, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6, #A7, A7)
 #define H5TRACE9(R, T, A0, A1, A2, A3, A4, A5, A6, A7, A8)                                                   \
     RTYPE    = R;                                                                                            \
-    CALLTIME = H5_trace(NULL, FUNC, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6, #A7,   \
-                        A7, #A8, A8)
+    CALLTIME = H5_trace(NULL, __func__, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6,    \
+                        #A7, A7, #A8, A8)
 #define H5TRACE10(R, T, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9)                                              \
     RTYPE    = R;                                                                                            \
-    CALLTIME = H5_trace(NULL, FUNC, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6, #A7,   \
-                        A7, #A8, A8, #A9, A9)
+    CALLTIME = H5_trace(NULL, __func__, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6,    \
+                        #A7, A7, #A8, A8, #A9, A9)
 #define H5TRACE11(R, T, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)                                         \
     RTYPE    = R;                                                                                            \
-    CALLTIME = H5_trace(NULL, FUNC, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6, #A7,   \
-                        A7, #A8, A8, #A9, A9, #A10, A10)
+    CALLTIME = H5_trace(NULL, __func__, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6,    \
+                        #A7, A7, #A8, A8, #A9, A9, #A10, A10)
 #define H5TRACE12(R, T, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)                                    \
     RTYPE    = R;                                                                                            \
-    CALLTIME = H5_trace(NULL, FUNC, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6, #A7,   \
-                        A7, #A8, A8, #A9, A9, #A10, A10, #A11, A11)
+    CALLTIME = H5_trace(NULL, __func__, T, #A0, A0, #A1, A1, #A2, A2, #A3, A3, #A4, A4, #A5, A5, #A6, A6,    \
+                        #A7, A7, #A8, A8, #A9, A9, #A10, A10, #A11, A11)
 
 #define H5TRACE_RETURN(V)                                                                                    \
     if (RTYPE) {                                                                                             \
-        H5_trace(&CALLTIME, FUNC, RTYPE, NULL, V);                                                           \
+        H5_trace(&CALLTIME, __func__, RTYPE, NULL, V);                                                       \
         RTYPE = NULL;                                                                                        \
     }
 #else
@@ -2041,7 +1925,7 @@ extern hbool_t H5_libterm_g; /* Is the library being shutdown? */
 /* Include required function stack header */
 #include "H5CSprivate.h"
 
-#define H5_PUSH_FUNC H5CS_push(FUNC);
+#define H5_PUSH_FUNC H5CS_push(__func__);
 #define H5_POP_FUNC  H5CS_pop();
 #else                /* H5_HAVE_CODESTACK */
 #define H5_PUSH_FUNC /* void */
@@ -2126,7 +2010,7 @@ H5_DLL herr_t H5CX_pop(void);
 
 #define FUNC_ENTER_API_COMMON                                                                                \
     FUNC_ENTER_API_VARS                                                                                      \
-    FUNC_ENTER_COMMON(H5_IS_API(FUNC));                                                                      \
+    FUNC_ENTER_COMMON(H5_IS_API(__func__));                                                                  \
     FUNC_ENTER_API_THREADSAFE;
 
 #define FUNC_ENTER_API_INIT(err)                                                                             \
@@ -2135,7 +2019,7 @@ H5_DLL herr_t H5CX_pop(void);
         H5_INIT_GLOBAL = TRUE;                                                                               \
         if (H5_init_library() < 0)                                                                           \
             HGOTO_ERROR(H5E_FUNC, H5E_CANTINIT, err, "library initialization failed")                        \
-    } /* end if */                                                                                           \
+    }                                                                                                        \
                                                                                                              \
     /* Initialize the package, if appropriate */                                                             \
     H5_PACKAGE_INIT(H5_MY_PKG_INIT, err)
@@ -2207,7 +2091,7 @@ H5_DLL herr_t H5CX_pop(void);
             {                                                                                                \
                 {                                                                                            \
                     FUNC_ENTER_API_VARS                                                                      \
-                    FUNC_ENTER_COMMON_NOERR(H5_IS_API(FUNC));                                                \
+                    FUNC_ENTER_COMMON_NOERR(H5_IS_API(__func__));                                            \
                     FUNC_ENTER_API_THREADSAFE;                                                               \
                     BEGIN_MPE_LOG                                                                            \
                     {
@@ -2224,7 +2108,7 @@ H5_DLL herr_t H5CX_pop(void);
             {                                                                                                \
                 {                                                                                            \
                     {                                                                                        \
-                        FUNC_ENTER_COMMON(H5_IS_API(FUNC));                                                  \
+                        FUNC_ENTER_COMMON(H5_IS_API(__func__));                                              \
                         FUNC_ENTER_API_THREADSAFE;                                                           \
                         FUNC_ENTER_API_INIT(err);                                                            \
                         {
@@ -2240,14 +2124,14 @@ H5_DLL herr_t H5CX_pop(void);
 /* Use this macro for all "normal" non-API functions */
 #define FUNC_ENTER_NOAPI(err)                                                                                \
     {                                                                                                        \
-        FUNC_ENTER_COMMON(!H5_IS_API(FUNC));                                                                 \
+        FUNC_ENTER_COMMON(!H5_IS_API(__func__));                                                             \
         FUNC_ENTER_NOAPI_INIT(err)                                                                           \
         if (H5_PKG_INIT_VAR || !H5_TERM_GLOBAL) {
 
 /* Use this macro for all non-API functions, which propagate errors, but don't issue them */
 #define FUNC_ENTER_NOAPI_NOERR                                                                               \
     {                                                                                                        \
-        FUNC_ENTER_COMMON_NOERR(!H5_IS_API(FUNC));                                                           \
+        FUNC_ENTER_COMMON_NOERR(!H5_IS_API(__func__));                                                       \
         FUNC_ENTER_NOAPI_INIT(-)                                                                             \
         if (H5_PKG_INIT_VAR || !H5_TERM_GLOBAL) {
 
@@ -2261,7 +2145,7 @@ H5_DLL herr_t H5CX_pop(void);
  */
 #define FUNC_ENTER_NOAPI_NOINIT                                                                              \
     {                                                                                                        \
-        FUNC_ENTER_COMMON(!H5_IS_API(FUNC));                                                                 \
+        FUNC_ENTER_COMMON(!H5_IS_API(__func__));                                                             \
         H5_PUSH_FUNC                                                                                         \
         if (H5_PKG_INIT_VAR || !H5_TERM_GLOBAL) {
 
@@ -2276,7 +2160,7 @@ H5_DLL herr_t H5CX_pop(void);
  */
 #define FUNC_ENTER_NOAPI_NOINIT_NOERR                                                                        \
     {                                                                                                        \
-        FUNC_ENTER_COMMON_NOERR(!H5_IS_API(FUNC));                                                           \
+        FUNC_ENTER_COMMON_NOERR(!H5_IS_API(__func__));                                                       \
         H5_PUSH_FUNC                                                                                         \
         if (H5_PKG_INIT_VAR || !H5_TERM_GLOBAL) {
 
@@ -2288,7 +2172,7 @@ H5_DLL herr_t H5CX_pop(void);
  */
 #define FUNC_ENTER_NOAPI_NOFS                                                                                \
     {                                                                                                        \
-        FUNC_ENTER_COMMON(!H5_IS_API(FUNC));                                                                 \
+        FUNC_ENTER_COMMON(!H5_IS_API(__func__));                                                             \
                                                                                                              \
         /* Initialize the package, if appropriate */                                                         \
         H5_PACKAGE_INIT(H5_MY_PKG_INIT, err)                                                                 \
@@ -2305,7 +2189,7 @@ H5_DLL herr_t H5CX_pop(void);
  */
 #define FUNC_ENTER_NOAPI_NOERR_NOFS                                                                          \
     {                                                                                                        \
-        FUNC_ENTER_COMMON_NOERR(!H5_IS_API(FUNC));                                                           \
+        FUNC_ENTER_COMMON_NOERR(!H5_IS_API(__func__));                                                       \
         if (H5_PKG_INIT_VAR || !H5_TERM_GLOBAL) {
 
 /* Use the following two macros as replacements for the FUNC_ENTER_NOAPI
@@ -2315,7 +2199,7 @@ H5_DLL herr_t H5CX_pop(void);
     {                                                                                                        \
         haddr_t prev_tag = HADDR_UNDEF;                                                                      \
                                                                                                              \
-        FUNC_ENTER_COMMON(!H5_IS_API(FUNC));                                                                 \
+        FUNC_ENTER_COMMON(!H5_IS_API(__func__));                                                             \
         H5AC_tag(tag, &prev_tag);                                                                            \
         FUNC_ENTER_NOAPI_INIT(err)                                                                           \
         if (H5_PKG_INIT_VAR || !H5_TERM_GLOBAL) {
@@ -2324,7 +2208,7 @@ H5_DLL herr_t H5CX_pop(void);
     {                                                                                                        \
         haddr_t prev_tag = HADDR_UNDEF;                                                                      \
                                                                                                              \
-        FUNC_ENTER_COMMON(!H5_IS_API(FUNC));                                                                 \
+        FUNC_ENTER_COMMON(!H5_IS_API(__func__));                                                             \
         H5AC_tag(tag, &prev_tag);                                                                            \
         H5_PUSH_FUNC                                                                                         \
         if (H5_PKG_INIT_VAR || !H5_TERM_GLOBAL) {
@@ -2332,14 +2216,14 @@ H5_DLL herr_t H5CX_pop(void);
 /* Use this macro for all "normal" package-level functions */
 #define FUNC_ENTER_PACKAGE                                                                                   \
     {                                                                                                        \
-        FUNC_ENTER_COMMON(H5_IS_PKG(FUNC));                                                                  \
+        FUNC_ENTER_COMMON(H5_IS_PKG(__func__));                                                              \
         H5_PUSH_FUNC                                                                                         \
         if (H5_PKG_INIT_VAR || !H5_TERM_GLOBAL) {
 
 /* Use this macro for package-level functions which propgate errors, but don't issue them */
 #define FUNC_ENTER_PACKAGE_NOERR                                                                             \
     {                                                                                                        \
-        FUNC_ENTER_COMMON_NOERR(H5_IS_PKG(FUNC));                                                            \
+        FUNC_ENTER_COMMON_NOERR(H5_IS_PKG(__func__));                                                        \
         H5_PUSH_FUNC                                                                                         \
         if (H5_PKG_INIT_VAR || !H5_TERM_GLOBAL) {
 
@@ -2349,7 +2233,7 @@ H5_DLL herr_t H5CX_pop(void);
     {                                                                                                        \
         haddr_t prev_tag = HADDR_UNDEF;                                                                      \
                                                                                                              \
-        FUNC_ENTER_COMMON(H5_IS_PKG(FUNC));                                                                  \
+        FUNC_ENTER_COMMON(H5_IS_PKG(__func__));                                                              \
         H5AC_tag(tag, &prev_tag);                                                                            \
         H5_PUSH_FUNC                                                                                         \
         if (H5_PKG_INIT_VAR || !H5_TERM_GLOBAL) {
@@ -2357,14 +2241,14 @@ H5_DLL herr_t H5CX_pop(void);
 /* Use this macro for all "normal" staticly-scoped functions */
 #define FUNC_ENTER_STATIC                                                                                    \
     {                                                                                                        \
-        FUNC_ENTER_COMMON(H5_IS_PKG(FUNC));                                                                  \
+        FUNC_ENTER_COMMON(H5_IS_PKG(__func__));                                                              \
         H5_PUSH_FUNC                                                                                         \
         if (H5_PKG_INIT_VAR || !H5_TERM_GLOBAL) {
 
 /* Use this macro for staticly-scoped functions which propgate errors, but don't issue them */
 #define FUNC_ENTER_STATIC_NOERR                                                                              \
     {                                                                                                        \
-        FUNC_ENTER_COMMON_NOERR(H5_IS_PKG(FUNC));                                                            \
+        FUNC_ENTER_COMMON_NOERR(H5_IS_PKG(__func__));                                                        \
         H5_PUSH_FUNC                                                                                         \
         if (H5_PKG_INIT_VAR || !H5_TERM_GLOBAL) {
 
@@ -2372,7 +2256,7 @@ H5_DLL herr_t H5CX_pop(void);
 /* And that shouldn't push their name on the function stack */
 #define FUNC_ENTER_STATIC_NOERR_NOFS                                                                         \
     {                                                                                                        \
-        FUNC_ENTER_COMMON_NOERR(H5_IS_PKG(FUNC));                                                            \
+        FUNC_ENTER_COMMON_NOERR(H5_IS_PKG(__func__));                                                        \
         if (H5_PKG_INIT_VAR || !H5_TERM_GLOBAL) {
 
 /* Use the following macro as replacement for the FUNC_ENTER_STATIC
@@ -2381,7 +2265,7 @@ H5_DLL herr_t H5CX_pop(void);
     {                                                                                                        \
         haddr_t prev_tag = HADDR_UNDEF;                                                                      \
                                                                                                              \
-        FUNC_ENTER_COMMON(H5_IS_PKG(FUNC));                                                                  \
+        FUNC_ENTER_COMMON(H5_IS_PKG(__func__));                                                              \
         H5AC_tag(tag, &prev_tag);                                                                            \
         H5_PUSH_FUNC                                                                                         \
         if (H5_PKG_INIT_VAR || !H5_TERM_GLOBAL) {
@@ -2531,6 +2415,18 @@ H5_PKG_DECLARE_FUNC(H5_MY_PKG_INIT, H5_MY_PKG)
   #define HDcompile_assert(e)     do { enum { compile_assert__ = 1 / (e) }; } while(0)
   #define HDcompile_assert(e)     do { typedef struct { unsigned int b: (e); } x; } while(0)
 */
+
+/* Private typedefs */
+
+/* Union for const/non-const pointer for use by functions that manipulate
+ * pointers but do not write to their targets or return pointers to const
+ * specified locations.  Also used for I/O functions that work for read and
+ * write - these functions are expected to never write to these locations in the
+ * write case.  This helps us avoid compiler warnings. */
+typedef union {
+    void       *vp;
+    const void *cvp;
+} H5_flexible_const_ptr_t;
 
 /* Private functions, not part of the publicly documented API */
 H5_DLL herr_t H5_init_library(void);

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -35,11 +35,7 @@
 #endif
 
 /* C library header files for things that appear in HDF5 public headers */
-#ifdef __cplusplus
-#include <cinttypes>
-#else
 #include <inttypes.h>
-#endif
 #include <limits.h>
 #include <stdarg.h>
 #include <stdbool.h>

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -229,7 +229,6 @@ typedef int herr_t;
  * (true). The typical true value is 1 but don't bet on it.
  * \attention Boolean functions cannot fail.
  */
-#include <stdbool.h>
 typedef bool hbool_t;
 /**
  * Three-valued Boolean type. Functions that return #htri_t however return zero

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -33,27 +33,25 @@
 #ifdef H5_HAVE_FEATURES_H
 #include <features.h> /* For setting POSIX, BSD, etc. compatibility */
 #endif
+
+/* C library header files for things that appear in HDF5 public headers */
+#ifdef __cplusplus
+#include <cinttypes>
+#else
+#include <inttypes.h>
+#endif
+#include <limits.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* Unlike most sys/ headers, which are POSIX-only, sys/types.h is available
+ * on Windows, though it doesn't necessarily contain all the POSIX types
+ * we need for HDF5 (e.g. ssize_t).
+ */
 #ifdef H5_HAVE_SYS_TYPES_H
 #include <sys/types.h>
-#endif
-#ifdef H5_STDC_HEADERS
-#include <limits.h> /* For H5T_NATIVE_CHAR defn in H5Tpublic.h  */
-#include <stdarg.h> /* For variadic functions in H5VLpublic.h   */
-#endif
-#ifndef __cplusplus
-#ifdef H5_HAVE_STDINT_H
-#include <stdint.h> /* For C9x types */
-#endif
-#else
-#ifdef H5_HAVE_STDINT_H_CXX
-#include <stdint.h> /* For C9x types (when included from C++) */
-#endif
-#endif
-#ifdef H5_HAVE_INTTYPES_H
-#include <inttypes.h> /* C99/POSIX.1 header for uint64_t, PRIu64 */
-#endif
-#ifdef H5_HAVE_STDDEF_H
-#include <stddef.h>
 #endif
 
 #ifdef H5_HAVE_PARALLEL
@@ -68,13 +66,6 @@
 #ifndef MPI_FILE_NULL /* MPIO may be defined in mpi.h already */
 #include <mpio.h>
 #endif
-#endif
-
-/* Include the Windows API adapter header early */
-#include "H5api_adpt.h"
-
-#ifdef __cplusplus
-extern "C" {
 #endif
 
 /* Macros for enabling/disabling particular GCC / clang warnings
@@ -238,11 +229,17 @@ extern "C" {
 typedef int herr_t;
 
 /**
- * Boolean type.  Successful return values are zero (false) or positive
- * (true). The typical true value is 1 but don't bet on it.  Boolean
- * functions cannot fail.  Functions that return #htri_t however return zero
- * (false), positive (true), or negative (failure). The proper way to test
- * for truth from a #htri_t function is:
+ * C99-style Boolean type. Successful return values are zero (false) or positive
+ * (true). The typical true value is 1 but don't bet on it.
+ * \attention Boolean functions cannot fail.
+ */
+#include <stdbool.h>
+typedef bool hbool_t;
+/**
+ * Three-valued Boolean type. Functions that return #htri_t however return zero
+ * (false), positive (true), or negative (failure).
+ *
+ * The proper way to test for truth from a #htri_t function is:
  * \code
  * if ((retval = H5Tcommitted(type)) > 0) {
  *     printf("data type is committed\n");
@@ -253,21 +250,7 @@ typedef int herr_t;
  * }
  * \endcode
  */
-#ifdef H5_HAVE_STDBOOL_H
-#include <stdbool.h>
-#else /* H5_HAVE_STDBOOL_H */
-#ifndef __cplusplus
-#if defined(H5_SIZEOF_BOOL) && (H5_SIZEOF_BOOL != 0)
-#define bool _Bool
-#else
-#define bool unsigned int
-#endif
-#define true 1
-#define false 0
-#endif /* __cplusplus */
-#endif /* H5_HAVE_STDBOOL_H */
-typedef bool hbool_t;
-typedef int  htri_t;
+typedef int htri_t;
 
 /* The signed version of size_t
  *
@@ -299,47 +282,10 @@ typedef long long ssize_t;
  *
  * \internal Defined as a (minimum) 64-bit integer type.
  */
-#if H5_SIZEOF_INT64_T >= 8
-#elif H5_SIZEOF_INT >= 8
-typedef int           int64_t;
-#undef H5_SIZEOF_INT64_T
-#define H5_SIZEOF_INT64_T H5_SIZEOF_INT
-#elif H5_SIZEOF_LONG >= 8
-typedef long               int64_t;
-#undef H5_SIZEOF_INT64_T
-#define H5_SIZEOF_INT64_T H5_SIZEOF_LONG
-#elif H5_SIZEOF_LONG_LONG >= 8
-typedef long long          int64_t;
-#undef H5_SIZEOF_INT64_T
-#define H5_SIZEOF_INT64_T H5_SIZEOF_LONG_LONG
-#else
-#error "nothing appropriate for int64_t"
-#endif
+typedef uint64_t hsize_t;
 
-/* uint64_t type is used for fields for H5O_info_t.  It may be
- * defined in Posix.1g, otherwise it is defined here.
- */
-#if H5_SIZEOF_UINT64_T >= 8
-#ifndef UINT64_MAX
-#define UINT64_MAX ((uint64_t)-1)
-#endif
-#elif H5_SIZEOF_INT >= 8
-typedef unsigned      uint64_t;
-#define UINT64_MAX UINT_MAX
-#undef H5_SIZEOF_UINT64_T
-#define H5_SIZEOF_UINT64_T H5_SIZEOF_INT
-#elif H5_SIZEOF_LONG >= 8
-typedef unsigned long      uint64_t;
-#define UINT64_MAX ULONG_MAX
-#undef H5_SIZEOF_UINT64_T
-#define H5_SIZEOF_UINT64_T H5_SIZEOF_LONG
-#elif H5_SIZEOF_LONG_LONG >= 8
-typedef unsigned long long uint64_t;
-#define UINT64_MAX ULLONG_MAX
-#undef H5_SIZEOF_UINT64_T
-#define H5_SIZEOF_UINT64_T H5_SIZEOF_LONG_LONG
-#else
-#error "nothing appropriate for uint64_t"
+#ifdef H5_HAVE_PARALLEL
+#define HSIZE_AS_MPI_TYPE MPI_UINT64_T
 #endif
 
 /**
@@ -348,93 +294,35 @@ typedef unsigned long long uint64_t;
  * \internal Defined as a (minimum) 64-bit integer type. Use of hssize_t
  * should be discouraged in new code.
  */
-#if H5_SIZEOF_LONG_LONG >= 8
-H5_GCC_DIAG_OFF("long-long")
-typedef unsigned long long hsize_t;
-typedef signed long long   hssize_t;
-H5_GCC_DIAG_ON("long-long")
-#define PRIdHSIZE          H5_PRINTF_LL_WIDTH "d"
-#define PRIiHSIZE          H5_PRINTF_LL_WIDTH "i"
-#define PRIoHSIZE          H5_PRINTF_LL_WIDTH "o"
-#define PRIuHSIZE          H5_PRINTF_LL_WIDTH "u"
-#define PRIxHSIZE          H5_PRINTF_LL_WIDTH "x"
-#define PRIXHSIZE          H5_PRINTF_LL_WIDTH "X"
-#define H5_SIZEOF_HSIZE_T  H5_SIZEOF_LONG_LONG
-#define H5_SIZEOF_HSSIZE_T H5_SIZEOF_LONG_LONG
-#define HSIZE_UNDEF        ULLONG_MAX
-#else
-#error "nothing appropriate for hsize_t"
-#endif
-
-#ifdef H5_HAVE_PARALLEL
-#define HSIZE_AS_MPI_TYPE MPI_UINT64_T
-#endif
+typedef int64_t hssize_t;
+#define PRIdHSIZE          PRId64
+#define PRIiHSIZE          PRIi64
+#define PRIoHSIZE          PRIo64
+#define PRIuHSIZE          PRIu64
+#define PRIxHSIZE          PRIx64
+#define PRIXHSIZE          PRIX64
+#define H5_SIZEOF_HSIZE_T  8
+#define H5_SIZEOF_HSSIZE_T 8
+#define HSIZE_UNDEF        UINT64_MAX
 
 /**
  * The address of an object in the file.
  *
  * \internal Defined as a (minimum) 64-bit unsigned integer type.
  */
-#if H5_SIZEOF_INT >= 8
-typedef unsigned haddr_t;
-#define HADDR_UNDEF       UINT_MAX
-#define H5_SIZEOF_HADDR_T H5_SIZEOF_INT
-#ifdef H5_HAVE_PARALLEL
-#define HADDR_AS_MPI_TYPE MPI_UNSIGNED
-#endif /* H5_HAVE_PARALLEL */
-#define PRIdHADDR "d"
-#define PRIoHADDR "o"
-#define PRIuHADDR "u"
-#define PRIxHADDR "x"
-#define PRIXHADDR "X"
-#elif H5_SIZEOF_LONG >= 8
-typedef unsigned long haddr_t;
-#define HADDR_UNDEF       ULONG_MAX
-#define H5_SIZEOF_HADDR_T H5_SIZEOF_LONG
-#ifdef H5_HAVE_PARALLEL
-#define HADDR_AS_MPI_TYPE MPI_UNSIGNED_LONG
-#endif /* H5_HAVE_PARALLEL */
-#define PRIdHADDR "ld"
-#define PRIoHADDR "lo"
-#define PRIuHADDR "lu"
-#define PRIxHADDR "lx"
-#define PRIXHADDR "lX"
-#elif H5_SIZEOF_LONG_LONG >= 8
-typedef unsigned long long haddr_t;
-#define HADDR_UNDEF       ULLONG_MAX
-#define H5_SIZEOF_HADDR_T H5_SIZEOF_LONG_LONG
-#ifdef H5_HAVE_PARALLEL
-#define HADDR_AS_MPI_TYPE MPI_LONG_LONG_INT
-#endif /* H5_HAVE_PARALLEL */
-#define PRIdHADDR H5_PRINTF_LL_WIDTH "d"
-#define PRIoHADDR H5_PRINTF_LL_WIDTH "o"
-#define PRIuHADDR H5_PRINTF_LL_WIDTH "u"
-#define PRIxHADDR H5_PRINTF_LL_WIDTH "x"
-#define PRIXHADDR H5_PRINTF_LL_WIDTH "X"
-#else
-#error "nothing appropriate for haddr_t"
-#endif
+typedef uint64_t haddr_t;
+#define PRIdHADDR           PRId64
+#define PRIoHADDR           PRIo64
+#define PRIuHADDR           PRIu64
+#define PRIxHADDR           PRIx64
+#define PRIXHADDR           PRIX64
+#define H5_SIZEOF_HADDR_T   8
+#define HADDR_UNDEF         UINT64_MAX
 #define H5_PRINTF_HADDR_FMT "%" PRIuHADDR
 #define HADDR_MAX           (HADDR_UNDEF - 1)
 
-/* uint32_t type is used for creation order field for messages.  It may be
- * defined in Posix.1g, otherwise it is defined here.
- */
-#if H5_SIZEOF_UINT32_T >= 4
-#elif H5_SIZEOF_SHORT >= 4
-typedef short         uint32_t;
-#undef H5_SIZEOF_UINT32_T
-#define H5_SIZEOF_UINT32_T H5_SIZEOF_SHORT
-#elif H5_SIZEOF_INT >= 4
-typedef unsigned int       uint32_t;
-#undef H5_SIZEOF_UINT32_T
-#define H5_SIZEOF_UINT32_T H5_SIZEOF_INT
-#elif H5_SIZEOF_LONG >= 4
-typedef unsigned long      uint32_t;
-#undef H5_SIZEOF_UINT32_T
-#define H5_SIZEOF_UINT32_T H5_SIZEOF_LONG
-#else
-#error "nothing appropriate for uint32_t"
+#ifdef H5_HAVE_PARALLEL
+#define HADDR_AS_MPI_TYPE MPI_UINT64_T
 #endif
 
 //! <!-- [H5_iter_order_t_snip] -->
@@ -495,6 +383,13 @@ typedef struct H5_alloc_stats_t {
     size_t             peak_alloc_blocks_count;  /**< Peak # of blocks allocated */
 } H5_alloc_stats_t;
 
+/* API adapter header (defines H5_DLL, etc.) */
+#include "H5api_adpt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Functions in H5.c */
 /**
  * \ingroup H5
@@ -508,7 +403,7 @@ typedef struct H5_alloc_stats_t {
  *          issued. If one finds that an HDF5 library function is failing
  *          inexplicably, H5open() can be called first. It is safe to call
  *          H5open() before an application issues any other function calls to
- *          the HDF5 library as there are no damaging side effects in calling
+ *          the HDF5 library, as there are no damaging side effects in calling
  *          it more than once.
  */
 H5_DLL herr_t H5open(void);
@@ -534,13 +429,13 @@ H5_DLL herr_t H5close(void);
  *          function is in situations where the library is dynamically linked
  *          into an application and is un-linked from the application before
  *          exit() gets called. In those situations, a routine installed with
- *          atexit() would jump to a routine which was no longer in memory,
+ *          atexit() would jump to a routine that was no longer in memory,
  *          causing errors.
  *
  * \attention In order to be effective, this routine \Emph{must} be called
  *            before any other HDF5 function calls, and must be called each
  *            time the library is loaded/linked into the application (the first
- *            time and after it's been un-loaded).
+ *            time and after it's been unloaded).
  */
 H5_DLL herr_t H5dont_atexit(void);
 /**
@@ -552,7 +447,7 @@ H5_DLL herr_t H5dont_atexit(void);
  *          of the library, freeing any unused memory.
  *
  *          It is not required that H5garbage_collect() be called at any
- *          particular time; it is only necessary in certain situations where
+ *          particular time; it is only necessary for certain situations where
  *          the application has performed actions that cause the library to
  *          allocate many objects. The application should call
  *          H5garbage_collect() if it eventually releases those objects and
@@ -743,7 +638,7 @@ H5_DLL herr_t H5is_library_threadsafe(hbool_t *is_ts);
  * \param[in] mem Buffer to be freed. Can be NULL
  * \return \herr_t
  *
- * \details H5free_memory() frees memory that has been allocated by the caller
+ * \details H5free_memory() frees the memory that has been allocated by the caller
  *          with H5allocate_memory() or by the HDF5 library on behalf of the
  *          caller.
  *
@@ -793,7 +688,7 @@ H5_DLL herr_t H5free_memory(void *mem);
  *          initialized.
  *
  *          This function is intended to have the semantics of malloc() and
- *          calloc(). However, unlike malloc() and calloc() which allow for a
+ *          calloc(). However, unlike malloc() and calloc(), which allow for a
  *          "special" pointer to be returned instead of NULL, this function
  *          always returns NULL on failure or when size is set to 0 (zero).
  *
@@ -805,7 +700,7 @@ H5_DLL herr_t H5free_memory(void *mem);
  *            the same library that initially allocated it. In most cases, the
  *            HDF5 API uses resources that are allocated and freed either
  *            entirely by the user or entirely by the library, so this is not a
- *            problem. In rare cases, however, HDF5 API calls will free memory
+ *            problem. In rare cases, however, HDF5 API calls will free the memory
  *            that the user allocated. This function allows the user to safely
  *            allocate this memory.\n
  *            It is particularly important to use this function to allocate

--- a/src/H5system.c
+++ b/src/H5system.c
@@ -96,131 +96,6 @@ HDvasprintf(char **bufp, const char *fmt, va_list _ap)
 #endif /* H5_HAVE_VASPRINTF */
 
 /*-------------------------------------------------------------------------
- * Function:  HDstrtoll
- *
- * Purpose:  Converts the string S to an int64_t value according to the
- *    given BASE, which must be between 2 and 36 inclusive, or be
- *    the special value zero.
- *
- *    The string must begin with an arbitrary amount of white space
- *    (as determined by isspace(3c)) followed by a single optional
- *              `+' or `-' sign.  If BASE is zero or 16 the string may then
- *    include a `0x' or `0X' prefix, and the number will be read in
- *    base 16; otherwise a zero BASE is taken as 10 (decimal)
- *    unless the next character is a `0', in which case it is taken
- *    as 8 (octal).
- *
- *    The remainder of the string is converted to an int64_t in the
- *    obvious manner, stopping at the first character which is not
- *    a valid digit in the given base.  (In bases above 10, the
- *    letter `A' in either upper or lower case represetns 10, `B'
- *    represents 11, and so forth, with `Z' representing 35.)
- *
- *    If REST is not null, the address of the first invalid
- *    character in S is stored in *REST.  If there were no digits
- *    at all, the original value of S is stored in *REST.  Thus, if
- *    *S is not `\0' but **REST is `\0' on return the entire string
- *    was valid.
- *
- * Return:  Success:  The result.
- *
- *    Failure:  If the input string does not contain any
- *        digits then zero is returned and REST points
- *        to the original value of S.  If an overflow
- *        or underflow occurs then the maximum or
- *        minimum possible value is returned and the
- *        global `errno' is set to ERANGE.  If BASE is
- *        incorrect then zero is returned.
- *
- * Programmer:  Robb Matzke
- *              Thursday, April  9, 1998
- *
- *-------------------------------------------------------------------------
- */
-#ifndef HDstrtoll
-int64_t
-HDstrtoll(const char *s, const char **rest, int base)
-{
-    int64_t sign = 1, acc = 0;
-    hbool_t overflow = FALSE;
-
-    errno = 0;
-    if (!s || (base && (base < 2 || base > 36))) {
-        if (rest)
-            *rest = s;
-        return 0;
-    }
-
-    /* Skip white space */
-    while (HDisspace(*s))
-        s++;
-
-    /* Optional minus or plus sign */
-    if ('+' == *s) {
-        s++;
-    }
-    else if ('-' == *s) {
-        sign = -1;
-        s++;
-    }
-
-    /* Zero base prefix */
-    if (0 == base && '0' == *s && ('x' == s[1] || 'X' == s[1])) {
-        base = 16;
-        s += 2;
-    }
-    else if (0 == base && '0' == *s) {
-        base = 8;
-        s++;
-    }
-    else if (0 == base) {
-        base = 10;
-    }
-
-    /* Digits */
-    while ((base <= 10 && *s >= '0' && *s < '0' + base) ||
-           (base > 10 && ((*s >= '0' && *s <= '9') || (*s >= 'a' && *s < 'a' + base - 10) ||
-                          (*s >= 'A' && *s < 'A' + base - 10)))) {
-        if (!overflow) {
-            int64_t digit = 0;
-
-            if (*s >= '0' && *s <= '9')
-                digit = *s - '0';
-            else if (*s >= 'a' && *s <= 'z')
-                digit = (*s - 'a') + 10;
-            else
-                digit = (*s - 'A') + 10;
-
-            if (acc * base + digit < acc) {
-                overflow = TRUE;
-            }
-            else {
-                acc = acc * base + digit;
-            }
-        }
-        s++;
-    }
-
-    /* Overflow */
-    if (overflow) {
-        if (sign > 0) {
-            acc = ((uint64_t)1 << (8 * sizeof(int64_t) - 1)) - 1;
-        }
-        else {
-            acc = (int64_t)((uint64_t)1 << (8 * sizeof(int64_t) - 1));
-        }
-        errno = ERANGE;
-    }
-
-    /* Return values */
-    acc *= sign;
-    if (rest)
-        *rest = s;
-    return acc;
-} /* end HDstrtoll() */
-#endif
-
-/*-------------------------------------------------------------------------
  * Function:  HDrand/HDsrand
  *
  * Purpose:  Wrapper function for rand.  If rand_r exists on this system,
@@ -459,6 +334,9 @@ Wgettimeofday(struct timeval *tv, struct timezone *tz)
  *              Interestingly, getenv *is* available in the Windows
  *              POSIX layer, just not setenv.
  *
+ * Note:        Passing an empty string ("") for the value will remove
+ *              the variable from the environment (like unsetenv(3))
+ *
  * Return:      Success:    0
  *              Failure:    non-zero error code
  *
@@ -470,14 +348,14 @@ Wgettimeofday(struct timeval *tv, struct timezone *tz)
 int
 Wsetenv(const char *name, const char *value, int overwrite)
 {
-    size_t  bufsize;
-    errno_t err;
-
     /* If we're not overwriting, check if the environment variable exists.
      * If it does (i.e.: the required buffer size to store the variable's
      * value is non-zero), then return an error code.
      */
     if (!overwrite) {
+        size_t  bufsize;
+        errno_t err;
+
         err = getenv_s(&bufsize, NULL, 0, name);
         if (err || bufsize)
             return (int)err;
@@ -983,7 +861,7 @@ H5_nanosleep(uint64_t nanosec)
 
 #else
 
-    const uint64_t  nanosec_per_sec = 1000 * 1000 * 1000;
+    const uint64_t  nanosec_per_sec = 1000 * 1000L * 1000;
     struct timespec sleeptime; /* Struct to hold time to sleep */
 
     /* Set up time to sleep
@@ -1079,8 +957,8 @@ const char *H5_optarg;     /* Flag argument (or value)               */
 int
 H5_get_option(int argc, const char *const *argv, const char *opts, const struct h5_long_options *l_opts)
 {
-    static int sp     = 1;   /* character index in current token */
-    int        optopt = '?'; /* option character passed back to user */
+    static int sp      = 1;   /* character index in current token */
+    int        optchar = '?'; /* option character passed back to user */
 
     if (sp == 1) {
         /* check for more flag-like tokens */
@@ -1111,7 +989,7 @@ H5_get_option(int argc, const char *const *argv, const char *opts, const struct 
         for (i = 0; l_opts && l_opts[i].name; i++) {
             if (HDstrcmp(arg, l_opts[i].name) == 0) {
                 /* we've found a matching long command line flag */
-                optopt = l_opts[i].shortval;
+                optchar = l_opts[i].shortval;
 
                 if (l_opts[i].has_arg != no_arg) {
                     if (H5_optarg == NULL) {
@@ -1124,7 +1002,7 @@ H5_get_option(int argc, const char *const *argv, const char *opts, const struct 
                             if (H5_opterr)
                                 HDfprintf(stderr, "%s: option required for \"--%s\" flag\n", argv[0], arg);
 
-                            optopt = '?';
+                            optchar = '?';
                         }
                     }
                 }
@@ -1133,7 +1011,7 @@ H5_get_option(int argc, const char *const *argv, const char *opts, const struct 
                         if (H5_opterr)
                             HDfprintf(stderr, "%s: no option required for \"%s\" flag\n", argv[0], arg);
 
-                        optopt = '?';
+                        optchar = '?';
                     }
                 }
                 break;
@@ -1145,7 +1023,7 @@ H5_get_option(int argc, const char *const *argv, const char *opts, const struct 
             if (H5_opterr)
                 HDfprintf(stderr, "%s: unknown option \"%s\"\n", argv[0], arg);
 
-            optopt = '?';
+            optchar = '?';
         }
 
         H5_optind++;
@@ -1154,14 +1032,14 @@ H5_get_option(int argc, const char *const *argv, const char *opts, const struct 
         HDfree(arg);
     }
     else {
-        register char *cp; /* pointer into current token */
+        char *cp; /* pointer into current token */
 
         /* short command line option */
-        optopt = argv[H5_optind][sp];
+        optchar = argv[H5_optind][sp];
 
-        if (optopt == ':' || (cp = HDstrchr(opts, optopt)) == 0) {
+        if (optchar == ':' || (cp = HDstrchr(opts, optchar)) == 0) {
             if (H5_opterr)
-                HDfprintf(stderr, "%s: unknown option \"%c\"\n", argv[0], optopt);
+                HDfprintf(stderr, "%s: unknown option \"%c\"\n", argv[0], optchar);
 
             /* if no chars left in this token, move to next token */
             if (argv[H5_optind][++sp] == '\0') {
@@ -1179,9 +1057,9 @@ H5_get_option(int argc, const char *const *argv, const char *opts, const struct 
             }
             else if (++H5_optind >= argc) {
                 if (H5_opterr)
-                    HDfprintf(stderr, "%s: value expected for option \"%c\"\n", argv[0], optopt);
+                    HDfprintf(stderr, "%s: value expected for option \"%c\"\n", argv[0], optchar);
 
-                optopt = '?';
+                optchar = '?';
             }
             else {
                 /* flag value is next token */
@@ -1219,5 +1097,5 @@ H5_get_option(int argc, const char *const *argv, const char *opts, const struct 
     }
 
     /* return the current flag character found */
-    return optopt;
+    return optchar;
 }

--- a/src/H5win32defs.h
+++ b/src/H5win32defs.h
@@ -25,26 +25,45 @@
  */
 #ifdef H5_HAVE_WIN32_API
 
+/* __int64 is the correct type for the st_size field of the _stati64 struct.
+ * MSDN isn't very clear about this.
+ */
 typedef struct _stati64 h5_stat_t;
 typedef __int64         h5_stat_size_t;
 
-#define HDaccess(F, M) _access(F, M)
-#define HDchdir(S)     _chdir(S)
-#define HDclose(F)     _close(F)
-#define HDcreat(S, M)  Wopen_utf8(S, O_CREAT | O_TRUNC | O_RDWR, M)
-#define HDdup(F)       _dup(F)
-#define HDfdopen(N, S) _fdopen(N, S)
-#define HDfileno(F)    _fileno(F)
-#define HDfstat(F, B)  _fstati64(F, B)
-#define HDisatty(F)    _isatty(F)
+#ifdef H5_HAVE_VISUAL_STUDIO
 
-#define HDgetcwd(S, Z)     _getcwd(S, Z)
-#define HDgetdcwd(D, S, Z) _getdcwd(D, S, Z)
-#define HDgetdrive()       _getdrive()
-#define HDlseek(F, O, W)   _lseeki64(F, O, W)
-#define HDlstat(S, B)      _lstati64(S, B)
-#define HDmkdir(S, M)      _mkdir(S)
-#define HDoff_t            __int64
+struct timezone {
+    int tz_minuteswest;
+    int tz_dsttime;
+};
+
+#endif /* H5_HAVE_VISUAL_STUDIO */
+
+#define HDaccess(F, M)       _access(F, M)
+#define HDchdir(S)           _chdir(S)
+#define HDclose(F)           _close(F)
+#define HDcreat(S, M)        Wopen_utf8(S, O_CREAT | O_TRUNC | O_RDWR, M)
+#define HDdup(F)             _dup(F)
+#define HDfdopen(N, S)       _fdopen(N, S)
+#define HDfileno(F)          _fileno(F)
+#define HDflock(F, L)        Wflock(F, L)
+#define HDfstat(F, B)        _fstati64(F, B)
+#define HDgetcwd(S, Z)       _getcwd(S, Z)
+#define HDgetdcwd(D, S, Z)   _getdcwd(D, S, Z)
+#define HDgetdrive()         _getdrive()
+#define HDgetlogin()         Wgetlogin()
+#define HDgettimeofday(V, Z) Wgettimeofday(V, Z)
+#define HDisatty(F)          _isatty(F)
+#define HDlseek(F, O, W)     _lseeki64(F, O, W)
+#define HDlstat(S, B)        _lstati64(S, B)
+#define HDmkdir(S, M)        _mkdir(S)
+
+/* off_t exists on Windows, but is always a 32-bit long, even on 64-bit Windows,
+ * so we define HDoff_t to be __int64, which is the type of the st_size field
+ * of the _stati64 struct.
+ */
+#define HDoff_t __int64
 
 /* Note that the variadic HDopen macro is using a VC++ extension
  * where the comma is dropped if nothing is passed to the ellipsis.
@@ -58,6 +77,7 @@ typedef __int64         h5_stat_size_t;
 #define HDread(F, M, Z)       _read(F, M, Z)
 #define HDremove(S)           Wremove_utf8(S)
 #define HDrmdir(S)            _rmdir(S)
+#define HDsetenv(N, V, O)     Wsetenv(N, V, O)
 #define HDsetvbuf(F, S, M, Z) setvbuf(F, S, M, (Z > 1 ? Z : 2))
 #define HDsleep(S)            Sleep(S * 1000)
 #define HDstat(S, B)          _stati64(S, B)
@@ -68,19 +88,10 @@ typedef __int64         h5_stat_size_t;
 #define HDunlink(S)           _unlink(S)
 #define HDwrite(F, M, Z)      _write(F, M, Z)
 
-#ifdef H5_HAVE_VISUAL_STUDIO
-
-/*
- * The (void*) cast just avoids a compiler warning in MSVC
- */
-#define HDmemset(X, C, Z) memset((void *)(X), C, Z)
-
-struct timezone {
-    int tz_minuteswest;
-    int tz_dsttime;
-};
-
-#endif /* H5_HAVE_VISUAL_STUDIO */
+#ifndef H5_HAVE_MINGW
+#define HDftruncate(F, L) _chsize_s(F, L)
+#define HDfseek(F, O, W)  _fseeki64(F, O, W)
+#endif /* H5_HAVE_MINGW */
 
 #ifdef __cplusplus
 extern "C" {
@@ -97,17 +108,5 @@ H5_DLL int      H5_get_win32_times(H5_timevals_t *tvs);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-
-#define HDgettimeofday(V, Z) Wgettimeofday(V, Z)
-#define HDsetenv(N, V, O)    Wsetenv(N, V, O)
-#define HDflock(F, L)        Wflock(F, L)
-#define HDgetlogin()         Wgetlogin()
-
-/* Non-POSIX functions */
-
-#ifndef H5_HAVE_MINGW
-#define HDftruncate(F, L) _chsize_s(F, L)
-#define HDfseek(F, O, W)  _fseeki64(F, O, W)
-#endif /* H5_HAVE_MINGW */
 
 #endif /* H5_HAVE_WIN32_API */

--- a/src/libhdf5.settings.in
+++ b/src/libhdf5.settings.in
@@ -52,6 +52,7 @@ Languages:
 @BUILD_FORTRAN_CONDITIONAL_TRUE@               AM Fortran Flags: @AM_FCFLAGS@
 @BUILD_FORTRAN_CONDITIONAL_TRUE@         Shared Fortran Library: @H5_FORTRAN_SHARED@
 @BUILD_FORTRAN_CONDITIONAL_TRUE@         Static Fortran Library: @enable_static@
+@BUILD_FORTRAN_CONDITIONAL_TRUE@               Module Directory: @fmoddir@
 
                             C++: @HDF_CXX@
 @BUILD_CXX_CONDITIONAL_TRUE@                   C++ Compiler: @CXX_VERSION@

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -161,12 +161,8 @@ H5TEST_DLLVAR MPI_Info h5_io_info_g; /* MPI INFO object for IO */
         goto error;                                                                                          \
     }
 
-/*
- * Alarm definitions to wait up (terminate) a test that runs too long.
- */
+/* Number of seconds to wait before killing a test (requires alarm(2)) */
 #define H5_ALARM_SEC 1200 /* default is 20 minutes */
-#define ALARM_ON     TestAlarmOn()
-#define ALARM_OFF    HDalarm(0)
 
 /* Flags for h5_fileaccess_flags() */
 #define H5_FILEACCESS_VFD 0x01

--- a/test/testframe.c
+++ b/test/testframe.c
@@ -319,9 +319,9 @@ PerformTests(void)
             MESSAGE(5, ("===============================================\n"));
             Test[Loop].NumErrors = num_errs;
             Test_parameters      = Test[Loop].Parameters;
-            ALARM_ON;
+            TestAlarmOn();
             Test[Loop].Call();
-            ALARM_OFF;
+            TestAlarmOff();
             Test[Loop].NumErrors = num_errs - Test[Loop].NumErrors;
             MESSAGE(5, ("===============================================\n"));
             MESSAGE(5, ("There were %d errors detected.\n\n", (int)Test[Loop].NumErrors));
@@ -632,12 +632,15 @@ SetTest(const char *testname, int action)
     }
 }
 
-/*
- * Enable alarm on test execution, configurable by environment variable
+/* Enable a test timer that will kill long-running tests, the time is configurable
+ * via an environment variable.
+ *
+ * Only useful on POSIX systems where alarm(2) is present.
  */
 void
 TestAlarmOn(void)
 {
+#ifdef H5_HAVE_ALARM
     char         *env_val   = HDgetenv("HDF5_ALARM_SECONDS"); /* Alarm environment */
     unsigned long alarm_sec = H5_ALARM_SEC;                   /* Number of seconds before alarm goes off */
 
@@ -647,4 +650,15 @@ TestAlarmOn(void)
 
     /* Set the number of seconds before alarm goes off */
     HDalarm((unsigned)alarm_sec);
+#endif
+}
+
+/* Disable the test timer */
+void
+TestAlarmOff(void)
+{
+#ifdef H5_HAVE_ALARM
+    /* Set the number of seconds to zero */
+    HDalarm(0);
+#endif
 }

--- a/test/testhdf5.h
+++ b/test/testhdf5.h
@@ -55,7 +55,7 @@
     {                                                                                                        \
         if (VERBOSE_HI) {                                                                                    \
             print_func("   Call to routine: %15s at line %4d in %s returned %p\n", (where), (int)__LINE__,   \
-                       __FILE__, (ret));                                                                     \
+                       __FILE__, ((const void *)ret));                                                       \
         }                                                                                                    \
         if (!(ret)) {                                                                                        \
             TestErrPrintf("*** UNEXPECTED RETURN from %s is NULL line %4d in %s\n", (where), (int)__LINE__,  \
@@ -69,7 +69,7 @@
     {                                                                                                        \
         if (VERBOSE_HI) {                                                                                    \
             print_func("   Call to routine: %15s at line %4d in %s returned %p\n", (where), (int)__LINE__,   \
-                       __FILE__, (ret));                                                                     \
+                       __FILE__, ((const void *)ret));                                                       \
         }                                                                                                    \
         if (ret) {                                                                                           \
             TestErrPrintf("*** UNEXPECTED RETURN from %s is not NULL line %4d in %s\n", (where),             \

--- a/testpar/t_bigio.c
+++ b/testpar/t_bigio.c
@@ -1849,7 +1849,7 @@ main(int argc, char **argv)
         HDprintf("Failed to turn off atexit processing. Continue.\n");
 
     /* set alarm. */
-    ALARM_ON;
+    TestAlarmOn();
 
     ExpressMode = do_express_test(mpi_rank_g);
 
@@ -1872,7 +1872,7 @@ main(int argc, char **argv)
     }
 
     /* turn off alarm */
-    ALARM_OFF;
+    TestAlarmOff();
 
     if (mpi_rank_g == 0)
         HDremove(FILENAME[0]);

--- a/testpar/t_filters_parallel.c
+++ b/testpar/t_filters_parallel.c
@@ -8799,7 +8799,7 @@ main(int argc, char **argv)
     if (VERBOSE_MED)
         h5_show_hostname();
 
-    ALARM_ON;
+    TestAlarmOn();
 
     num_filters = ARRAY_SIZE(filterIDs);
 
@@ -8967,7 +8967,7 @@ exit:
         if (MAINPROCESS)
             HDprintf("*** %d TEST ERROR%s OCCURRED ***\n", nerrors, nerrors > 1 ? "S" : "");
 
-    ALARM_OFF;
+    TestAlarmOff();
 
     h5_clean_files(FILENAME, fapl_id);
     fapl_id = H5I_INVALID_HID;

--- a/testpar/t_mpi.c
+++ b/testpar/t_mpi.c
@@ -1095,7 +1095,7 @@ main(int argc, char **argv)
     H5Pset_fapl_mpio(fapl, MPI_COMM_WORLD, MPI_INFO_NULL);
 
     /* set alarm. */
-    ALARM_ON;
+    TestAlarmOn();
 
     /*=======================================
      * MPIO 1 write Many read test
@@ -1204,7 +1204,7 @@ finish:
     }
 
     /* turn off alarm */
-    ALARM_OFF;
+    TestAlarmOff();
 
     h5_clean_files(FILENAME, fapl);
     H5close();


### PR DESCRIPTION
* Use C99 types and functions in lieu of C89 work-arounds
* Align key files with develop - H5public.h - H5private.h - H5system.c - H5win32defs.h
* Minor fixes elsewhere to support changes in above files
* Incidentally brings Fortran mod directory settings file change over

This does NOT change the configure/build files. Those will still do the checks needed for the C89 work-around cruft until the perf and perform code gets cleaned up.