### PR TITLE
Remove -Wunused-but-set-variable warnings in tests

### DIFF
--- a/test/dt_arith.c
+++ b/test/dt_arith.c
@@ -2828,7 +2828,6 @@ test_conv_flt_1(const char *name, int run_test, hid_t src, hid_t dst)
     unsigned char *hw = NULL;    /*ptr to hardware-conv'd*/
     int            underflow;    /*underflow occurred    */
     int            overflow = 0; /*overflow occurred    */
-    int            uflow    = 0; /*underflow debug counters*/
     size_t         j, k;         /*counters        */
     int            sendian;      /* source type endianness */
     int            dendian;      /* Destination type endianness */
@@ -3117,9 +3116,6 @@ test_conv_flt_1(const char *name, int run_test, hid_t src, hid_t dst)
                 hw    = (unsigned char *)&hw_ld;
             }
 #endif
-        }
-        if (underflow) {
-            uflow++;
         }
 
         /* For Intel machines, the size of "long double" is 12 bytes, precision

--- a/test/tattr.c
+++ b/test/tattr.c
@@ -7103,8 +7103,14 @@ attr_iterate_check(hid_t fid, const char *dsetname, hid_t obj_id, H5_index_t idx
             VERIFY(iter_info->visited[v], TRUE, "H5Aiterate2");
     } /* end if */
     else {
+        unsigned nvisit = 0; /* # of links visited */
+
         HDassert(order == H5_ITER_NATIVE);
-        VERIFY(skip, (max_attrs / 2), "H5Aiterate2");
+        for (v = 0; v < max_attrs; v++)
+            if (iter_info->visited[v] == TRUE)
+                nvisit++;
+
+        VERIFY(nvisit, max_attrs, "H5Aiterate2");
     } /* end else */
 
     /* Skip over some attributes on object */
@@ -7128,8 +7134,14 @@ attr_iterate_check(hid_t fid, const char *dsetname, hid_t obj_id, H5_index_t idx
             VERIFY(iter_info->visited[v], TRUE, "H5Aiterate_by_name");
     } /* end if */
     else {
+        unsigned nvisit = 0; /* # of links visited */
+
         HDassert(order == H5_ITER_NATIVE);
-        VERIFY(skip, (max_attrs / 2), "H5Aiterate_by_name");
+        for (v = 0; v < max_attrs; v++)
+            if (iter_info->visited[v] == TRUE)
+                nvisit++;
+
+        VERIFY(nvisit, max_attrs, "H5Aiterate_by_name");
     } /* end else */
 
     /* Skip over some attributes on object */
@@ -7153,8 +7165,14 @@ attr_iterate_check(hid_t fid, const char *dsetname, hid_t obj_id, H5_index_t idx
             VERIFY(iter_info->visited[v], TRUE, "H5Aiterate_by_name");
     } /* end if */
     else {
+        unsigned nvisit = 0; /* # of links visited */
+
         HDassert(order == H5_ITER_NATIVE);
-        VERIFY(skip, (max_attrs / 2), "H5Aiterate_by_name");
+        for (v = 0; v < max_attrs; v++)
+            if (iter_info->visited[v] == TRUE)
+                nvisit++;
+
+        VERIFY(nvisit, max_attrs, "H5Aiterate_by_name");
     } /* end else */
 
 #ifndef H5_NO_DEPRECATED_SYMBOLS
@@ -7179,8 +7197,14 @@ attr_iterate_check(hid_t fid, const char *dsetname, hid_t obj_id, H5_index_t idx
             VERIFY(iter_info->visited[v], TRUE, "H5Aiterate1");
     } /* end if */
     else {
+        unsigned nvisit = 0; /* # of links visited */
+
         HDassert(order == H5_ITER_NATIVE);
-        VERIFY(skip, (max_attrs / 2), "H5Aiterate1");
+        for (v = 0; v < max_attrs; v++)
+            if (iter_info->visited[v] == TRUE)
+                nvisit++;
+
+        VERIFY(nvisit, max_attrs, "H5Aiterate1");
     }  /* end else */
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
 

--- a/test/tattr.c
+++ b/test/tattr.c
@@ -7103,13 +7103,7 @@ attr_iterate_check(hid_t fid, const char *dsetname, hid_t obj_id, H5_index_t idx
             VERIFY(iter_info->visited[v], TRUE, "H5Aiterate2");
     } /* end if */
     else {
-        unsigned nvisit = 0; /* # of links visited */
-
         HDassert(order == H5_ITER_NATIVE);
-        for (v = 0; v < max_attrs; v++)
-            if (iter_info->visited[v] == TRUE)
-                nvisit++;
-
         VERIFY(skip, (max_attrs / 2), "H5Aiterate2");
     } /* end else */
 
@@ -7134,13 +7128,7 @@ attr_iterate_check(hid_t fid, const char *dsetname, hid_t obj_id, H5_index_t idx
             VERIFY(iter_info->visited[v], TRUE, "H5Aiterate_by_name");
     } /* end if */
     else {
-        unsigned nvisit = 0; /* # of links visited */
-
         HDassert(order == H5_ITER_NATIVE);
-        for (v = 0; v < max_attrs; v++)
-            if (iter_info->visited[v] == TRUE)
-                nvisit++;
-
         VERIFY(skip, (max_attrs / 2), "H5Aiterate_by_name");
     } /* end else */
 
@@ -7165,13 +7153,7 @@ attr_iterate_check(hid_t fid, const char *dsetname, hid_t obj_id, H5_index_t idx
             VERIFY(iter_info->visited[v], TRUE, "H5Aiterate_by_name");
     } /* end if */
     else {
-        unsigned nvisit = 0; /* # of links visited */
-
         HDassert(order == H5_ITER_NATIVE);
-        for (v = 0; v < max_attrs; v++)
-            if (iter_info->visited[v] == TRUE)
-                nvisit++;
-
         VERIFY(skip, (max_attrs / 2), "H5Aiterate_by_name");
     } /* end else */
 
@@ -7197,13 +7179,7 @@ attr_iterate_check(hid_t fid, const char *dsetname, hid_t obj_id, H5_index_t idx
             VERIFY(iter_info->visited[v], TRUE, "H5Aiterate1");
     } /* end if */
     else {
-        unsigned nvisit = 0; /* # of links visited */
-
         HDassert(order == H5_ITER_NATIVE);
-        for (v = 0; v < max_attrs; v++)
-            if (iter_info->visited[v] == TRUE)
-                nvisit++;
-
         VERIFY(skip, (max_attrs / 2), "H5Aiterate1");
     }  /* end else */
 #endif /* H5_NO_DEPRECATED_SYMBOLS */

--- a/test/twriteorder.c
+++ b/test/twriteorder.c
@@ -408,9 +408,6 @@ main(int argc, char *argv[])
     /* launch writer */
     /* ============= */
     /* this process continues to launch the writer */
-#ifdef DEBUG
-    HDprintf("%d: continue as the writer process\n", mypid);
-#endif
     if (write_wo_file() < 0) {
         HDfprintf(stderr, "write_wo_file encountered error\n");
         Hgoto_error(1);

--- a/test/twriteorder.c
+++ b/test/twriteorder.c
@@ -307,7 +307,9 @@ read_wo_file(void)
     int               read_fd;
     int               blkaddr           = 0;
     h5_posix_io_ret_t bytes_read        = -1; /* # of bytes actually read */
+#ifdef DEBUG
     int               linkedblocks_read = 0;
+#endif
     char              buffer[BLOCKSIZE_DFT];
 
     /* Open the data file */
@@ -324,7 +326,9 @@ read_wo_file(void)
             return -1;
         }
     }
+#ifdef DEBUG
     linkedblocks_read++;
+#endif
 
     /* got a non-zero blkaddr. Proceed down the linked blocks. */
 #ifdef DEBUG
@@ -336,7 +340,9 @@ read_wo_file(void)
             HDprintf("blkaddr read failed in partition %d\n", 0);
             return -1;
         }
+#ifdef DEBUG
         linkedblocks_read++;
+#endif
 
         /* retrieve the block address in byte 0-3 */
         HDmemcpy(&blkaddr, &buffer[0], sizeof(blkaddr));

--- a/test/twriteorder.c
+++ b/test/twriteorder.c
@@ -305,12 +305,12 @@ int
 read_wo_file(void)
 {
     int               read_fd;
-    int               blkaddr           = 0;
-    h5_posix_io_ret_t bytes_read        = -1; /* # of bytes actually read */
+    int               blkaddr    = 0;
+    h5_posix_io_ret_t bytes_read = -1; /* # of bytes actually read */
 #ifdef DEBUG
-    int               linkedblocks_read = 0;
+    int linkedblocks_read = 0;
 #endif
-    char              buffer[BLOCKSIZE_DFT];
+    char buffer[BLOCKSIZE_DFT];
 
     /* Open the data file */
     if ((read_fd = HDopen(DATAFILE, O_RDONLY)) < 0) {

--- a/test/twriteorder.c
+++ b/test/twriteorder.c
@@ -273,9 +273,6 @@ write_wo_file(void)
         HDmemset(&buffer[4], i & 0xff, (size_t)(BLOCKSIZE_DFT - 4));
 
         /* write the block */
-#ifdef DEBUG
-        HDprintf("writing block at %d\n", blkaddr);
-#endif
         HDlseek(write_fd_g, (HDoff_t)blkaddr, SEEK_SET);
         if ((bytes_wrote = HDwrite(write_fd_g, buffer, (size_t)blocksize_g)) != blocksize_g) {
             HDprintf("blkaddr write failed in partition %d\n", i);
@@ -295,9 +292,6 @@ write_wo_file(void)
     }
 
     /* all writes done. return success. */
-#ifdef DEBUG
-    HDprintf("wrote %d blocks\n", nlinkedblock_g);
-#endif
     return 0;
 }
 

--- a/test/twriteorder.c
+++ b/test/twriteorder.c
@@ -307,7 +307,7 @@ read_wo_file(void)
     int               read_fd;
     int               blkaddr    = 0;
     h5_posix_io_ret_t bytes_read = -1; /* # of bytes actually read */
-    char buffer[BLOCKSIZE_DFT];
+    char              buffer[BLOCKSIZE_DFT];
 
     /* Open the data file */
     if ((read_fd = HDopen(DATAFILE, O_RDONLY)) < 0) {

--- a/test/twriteorder.c
+++ b/test/twriteorder.c
@@ -307,9 +307,6 @@ read_wo_file(void)
     int               read_fd;
     int               blkaddr    = 0;
     h5_posix_io_ret_t bytes_read = -1; /* # of bytes actually read */
-#ifdef DEBUG
-    int linkedblocks_read = 0;
-#endif
     char buffer[BLOCKSIZE_DFT];
 
     /* Open the data file */
@@ -326,34 +323,19 @@ read_wo_file(void)
             return -1;
         }
     }
-#ifdef DEBUG
-    linkedblocks_read++;
-#endif
 
     /* got a non-zero blkaddr. Proceed down the linked blocks. */
-#ifdef DEBUG
-    HDprintf("got initial block address=%d\n", blkaddr);
-#endif
     while (blkaddr != 0) {
         HDlseek(read_fd, (HDoff_t)blkaddr, SEEK_SET);
         if ((bytes_read = HDread(read_fd, buffer, (size_t)blocksize_g)) != blocksize_g) {
             HDprintf("blkaddr read failed in partition %d\n", 0);
             return -1;
         }
-#ifdef DEBUG
-        linkedblocks_read++;
-#endif
 
         /* retrieve the block address in byte 0-3 */
         HDmemcpy(&blkaddr, &buffer[0], sizeof(blkaddr));
-#ifdef DEBUG
-        HDprintf("got next block address=%d\n", blkaddr);
-#endif
     }
 
-#ifdef DEBUG
-    HDprintf("read %d blocks\n", linkedblocks_read);
-#endif
     return 0;
 }
 


### PR DESCRIPTION
These three tests produced warnings on variables set but unused.
These changes were simple, but maybe others have better recommendations.