### PR TITLE
[1.12 Merge] CMake - Match Autotools behavior for library instrumentation (#2648)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,9 +655,15 @@ option (HDF5_BUILD_GENERATORS "Build Test Generators" OFF)
 #-----------------------------------------------------------------------------
 option (HDF5_ENABLE_TRACE "Enable API tracing capability" OFF)
 mark_as_advanced (HDF5_ENABLE_TRACE)
-if (${HDF_CFG_NAME} MATCHES "Debug")
+if (${HDF_CFG_NAME} MATCHES "Debug" OR ${HDF_CFG_NAME} MATCHES "Developer")
   # Enable instrumenting of the library's internal operations
   option (HDF5_ENABLE_INSTRUMENT "Instrument The library" OFF)
+
+  # Instrumenting is enabled by default for parallel debug builds
+  if (HDF5_ENABLE_PARALLEL)
+    set (HDF5_ENABLE_INSTRUMENT ON CACHE BOOL "Instrument The library" FORCE)
+  endif ()
+
   if (HDF5_ENABLE_INSTRUMENT)
     set (H5_HAVE_INSTRUMENTED_LIBRARY 1)
   endif ()

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -47,6 +47,16 @@ New Features
 
     Configuration:
     -------------
+    - Enabled instrumentation of the library by default in CMake for parallel
+      debug builds
+
+      HDF5 can be configured to instrument portions of the parallel library to
+      aid in debugging. Autotools builds of HDF5 turn this capability on by
+      default for parallel debug builds and off by default for other build types.
+      CMake has been updated to match this behavior.
+
+      (JTH - 2023/03/29)
+
     - Added new option to build libaec and zlib inline with CMake.
 
       Using the CMake FetchContent module, the external filters can populate


### PR DESCRIPTION
Enable library instrumentation by default for parallel debug builds