### PR TITLE
Fix out of bounds in `hdf5/src/H5Fint.c:2859`

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -275,7 +275,7 @@ Bug Fixes since HDF5-1.13.3 release
 
     - Fixed buffer overflow error in image decoding function.
 
-      The error occured in the function for decoding address from the specified
+      The error occurred in the function for decoding address from the specified
       buffer, which is called many times from the function responsible for image
       decoding. The length of the buffer is known in the image decoding function,
       but no checks are produced, so the buffer overflow can occur in many places,

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -273,6 +273,18 @@ Bug Fixes since HDF5-1.13.3 release
 
       (JTH - 2023/02/16, GH #2433)
 
+    - Fixed buffer overflow error in image decoding function.
+
+      The error occured in the function for decoding address from the specified
+      buffer, which is called many times from the function responsible for image
+      decoding. The length of the buffer is known in the image decoding function,
+      but no checks are produced, so the buffer overflow can occur in many places,
+      including callee functions for address decoding. 
+
+      The error was fixed by inserting corresponding checks for buffer overflow.
+
+      (KE - 2023/02/07 GH #2432)
+
 
     Java Library
     ------------

--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -39,6 +39,8 @@
 
 #include "H5VLnative_private.h" /* Native VOL connector                     */
 
+#include <stdio.h>
+
 /****************/
 /* Local Macros */
 /****************/
@@ -2886,6 +2888,8 @@ H5F_addr_decode_len(size_t addr_len, const uint8_t **pp /*in,out*/, haddr_t *add
         uint8_t c; /* Local decoded byte */
 
         /* Get decoded byte (and advance pointer) */
+	printf("this is *pp ptr: %p\n", *pp);
+	printf("this is addr_len: %lu\n\n", addr_len);
         c = *(*pp)++;
 
         /* Check for non-undefined address byte value */

--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -39,8 +39,6 @@
 
 #include "H5VLnative_private.h" /* Native VOL connector                     */
 
-#include <stdio.h>
-
 /****************/
 /* Local Macros */
 /****************/
@@ -2888,8 +2886,6 @@ H5F_addr_decode_len(size_t addr_len, const uint8_t **pp /*in,out*/, haddr_t *add
         uint8_t c; /* Local decoded byte */
 
         /* Get decoded byte (and advance pointer) */
-	printf("this is *pp ptr: %p\n", *pp);
-	printf("this is addr_len: %lu\n\n", addr_len);
         c = *(*pp)++;
 
         /* Check for non-undefined address byte value */

--- a/src/H5Fsuper_cache.c
+++ b/src/H5Fsuper_cache.c
@@ -41,8 +41,6 @@
 #include "H5MMprivate.h" /* Memory management                    */
 #include "H5Pprivate.h"  /* Property lists			*/
 
-#include <stdio.h>
-
 /****************/
 /* Local Macros */
 /****************/

--- a/src/H5Fsuper_cache.c
+++ b/src/H5Fsuper_cache.c
@@ -433,7 +433,7 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
     if (H5F__superblock_prefix_decode(sblock, &image, udata, FALSE) < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTDECODE, NULL, "can't decode file superblock prefix")
 
-    const uint8_t *image_end = _image + len - 1;
+    const uint8_t *image_end = image + len - 1;
 
     /* Check for older version of superblock format */
     if (sblock->super_vers < HDF5_SUPERBLOCK_VERSION_2) {
@@ -444,7 +444,7 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
 
         /* Check whether the image pointer is out of bounds */
         if (H5_IS_BUFFER_OVERFLOW(image, 1, image_end))
-	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+            HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* Freespace version (hard-wired) */
         if (HDF5_FREESPACE_VERSION != *image++)
@@ -452,7 +452,7 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
 
         /* Check whether the image pointer is out of bounds */
         if (H5_IS_BUFFER_OVERFLOW(image, 1, image_end))
-	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+            HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* Root group version number (hard-wired) */
         if (HDF5_OBJECTDIR_VERSION != *image++)
@@ -463,7 +463,7 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
 
         /* Check whether the image pointer is out of bounds */
         if (H5_IS_BUFFER_OVERFLOW(image, 1, image_end))
-	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+            HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* Shared header version number (hard-wired) */
         if (HDF5_SHAREDHEADER_VERSION != *image++)
@@ -481,8 +481,8 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
         image++;
 
         /* Check whether the image pointer is out of bounds */
-	if (H5_IS_BUFFER_OVERFLOW(image, sizeof(uint16_t), image_end))
-	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+        if (H5_IS_BUFFER_OVERFLOW(image, sizeof(uint16_t), image_end))
+            HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* Various B-tree sizes */
         UINT16DECODE(image, sym_leaf_k);
@@ -491,8 +491,8 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
         udata->sym_leaf_k = sym_leaf_k; /* Keep a local copy also */
 
         /* Check whether the image pointer is out of bounds */
-	if (H5_IS_BUFFER_OVERFLOW(image, sizeof(uint16_t), image_end))
-	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+        if (H5_IS_BUFFER_OVERFLOW(image, sizeof(uint16_t), image_end))
+            HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* Need 'get' call to set other array values */
         UINT16DECODE(image, snode_btree_k);
@@ -506,8 +506,8 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
          */
 
         /* Check whether the image pointer is out of bounds */
-	if (H5_IS_BUFFER_OVERFLOW(image, sizeof(uint32_t), image_end))
-	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+        if (H5_IS_BUFFER_OVERFLOW(image, sizeof(uint32_t), image_end))
+            HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* File status flags (not really used yet) */
         UINT32DECODE(image, status_flags);
@@ -521,9 +521,9 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
          * storage B-tree internal 'K' value
          */
         if (sblock->super_vers > HDF5_SUPERBLOCK_VERSION_DEF) {
-	    /* Check whether the image pointer is out of bounds */
-	    if (H5_IS_BUFFER_OVERFLOW(image, sizeof(uint16_t), image_end))
-	        HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+            /* Check whether the image pointer is out of bounds */
+            if (H5_IS_BUFFER_OVERFLOW(image, sizeof(uint16_t), image_end))
+                HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
             UINT16DECODE(image, chunk_btree_k);
 
@@ -531,18 +531,18 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
             if (sblock->super_vers == HDF5_SUPERBLOCK_VERSION_1) {
                 image += 2; /* reserved */
 
-		/* Check whether the image pointer is out of bounds */
-		if (H5_IS_BUFFER_OVERFLOW(image, 1, image_end))
-		    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
-	    }
-	}                   /* end if */
+                /* Check whether the image pointer is out of bounds */
+                if (H5_IS_BUFFER_OVERFLOW(image, 1, image_end))
+                    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+            }
+        } /* end if */
         else
             chunk_btree_k = HDF5_BTREE_CHUNK_IK_DEF;
         udata->btree_k[H5B_CHUNK_ID] = chunk_btree_k;
 
-	/* Check whether the image pointer will be out of bounds */
-	if (H5_IS_BUFFER_OVERFLOW(image, H5F_SIZEOF_ADDR(udata->f) * 4, image_end))
-	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+        /* Check whether the image pointer will be out of bounds */
+        if (H5_IS_BUFFER_OVERFLOW(image, H5F_SIZEOF_ADDR(udata->f) * 4, image_end))
+            HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* Remainder of "variable-sized" portion of superblock */
         H5F_addr_decode(udata->f, (const uint8_t **)&image, &sblock->base_addr /*out*/);
@@ -589,16 +589,16 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
 
         /* Check whether the image pointer is out of bounds */
         if (H5_IS_BUFFER_OVERFLOW(image, 1, image_end))
-	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+            HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* File status flags (not really used yet) */
         sblock->status_flags = *image++;
         if (sblock->status_flags & ~H5F_SUPER_ALL_FLAGS)
             HGOTO_ERROR(H5E_FILE, H5E_BADVALUE, NULL, "bad flag value for superblock")
 
-	/* Check whether the image pointer will be out of bounds */
-	if (H5_IS_BUFFER_OVERFLOW(image, H5F_SIZEOF_ADDR(udata->f) * 4, image_end))
-	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+        /* Check whether the image pointer will be out of bounds */
+        if (H5_IS_BUFFER_OVERFLOW(image, H5F_SIZEOF_ADDR(udata->f) * 4, image_end))
+            HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* Base, superblock extension, end of file & root group object header addresses */
         H5F_addr_decode(udata->f, (const uint8_t **)&image, &sblock->base_addr /*out*/);
@@ -608,9 +608,9 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
 
         /* checksum verification already done in verify_chksum cb */
 
-	/* Check whether the image pointer will be out of bounds */
-	if (H5_IS_BUFFER_OVERFLOW(image, sizeof(uint32_t), image_end))
-	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+        /* Check whether the image pointer will be out of bounds */
+        if (H5_IS_BUFFER_OVERFLOW(image, sizeof(uint32_t), image_end))
+            HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* Decode checksum */
         UINT32DECODE(image, read_chksum);

--- a/src/H5Fsuper_cache.c
+++ b/src/H5Fsuper_cache.c
@@ -41,6 +41,8 @@
 #include "H5MMprivate.h" /* Memory management                    */
 #include "H5Pprivate.h"  /* Property lists			*/
 
+#include <stdio.h>
+
 /****************/
 /* Local Macros */
 /****************/
@@ -517,6 +519,10 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
             HGOTO_ERROR(H5E_FILE, H5E_CANTALLOC, NULL,
                         "can't allocate space for root group symbol table entry")
 
+	printf("\nlen is %lu\n", len);
+	printf("image: %p\n", image);
+	printf("_image: %p\n\n", _image);
+	HDassert((size_t)(image + 136 - (const uint8_t *)_image) <= len);
         /* decode the root group symbol table entry */
         if (H5G_ent_decode(udata->f, (const uint8_t **)&image, sblock->root_ent) < 0)
             HGOTO_ERROR(H5E_FILE, H5E_CANTDECODE, NULL, "can't decode root group symbol table entry")

--- a/src/H5Fsuper_cache.c
+++ b/src/H5Fsuper_cache.c
@@ -442,13 +442,17 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
         unsigned snode_btree_k; /* B-tree symbol table internal node 'K' value */
         unsigned chunk_btree_k; /* B-tree chunk internal node 'K' value */
 
+        /* Check whether the image pointer is out of bounds */
+        if (image >= image_end)
+	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+
         /* Freespace version (hard-wired) */
         if (HDF5_FREESPACE_VERSION != *image++)
             HGOTO_ERROR(H5E_FILE, H5E_BADVALUE, NULL, "bad free space version number")
 
         /* Check whether the image pointer is out of bounds */
         if (image >= image_end)
-	    HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* Root group version number (hard-wired) */
         if (HDF5_OBJECTDIR_VERSION != *image++)
@@ -459,7 +463,7 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
 
         /* Check whether the image pointer is out of bounds */
         if (image >= image_end)
-	    HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* Shared header version number (hard-wired) */
         if (HDF5_SHAREDHEADER_VERSION != *image++)
@@ -477,8 +481,8 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
         image++;
 
         /* Check whether the image pointer is out of bounds */
-        if (image + 2 >= image_end)
-	    HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+        if (image + sizeof(uint16_t) >= image_end)
+	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* Various B-tree sizes */
         UINT16DECODE(image, sym_leaf_k);
@@ -517,7 +521,7 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
 
 		/* Check whether the image pointer is out of bounds */
 		if (image >= image_end)
-		    HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+		    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 	    }
 	}                   /* end if */
         else
@@ -526,7 +530,7 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
 
 	/* Check whether the image pointer will be out of bounds */
 	if (image + H5F_SIZEOF_ADDR(udata->f) * 4 >= image_end)
-	    HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* Remainder of "variable-sized" portion of superblock */
         H5F_addr_decode(udata->f, (const uint8_t **)&image, &sblock->base_addr /*out*/);
@@ -573,7 +577,7 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
 
         /* Check whether the image pointer is out of bounds */
         if (image >= image_end)
-	    HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* File status flags (not really used yet) */
         sblock->status_flags = *image++;
@@ -582,7 +586,7 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
 
 	/* Check whether the image pointer will be out of bounds */
 	if (image + H5F_SIZEOF_ADDR(udata->f) * 4 >= image_end)
-	    HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* Base, superblock extension, end of file & root group object header addresses */
         H5F_addr_decode(udata->f, (const uint8_t **)&image, &sblock->base_addr /*out*/);
@@ -593,8 +597,8 @@ H5F__cache_superblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUS
         /* checksum verification already done in verify_chksum cb */
 
 	/* Check whether the image pointer will be out of bounds */
-	if (image + 4 >= image_end)
-	    HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+	if (image + sizeof(uint32_t) >= image_end)
+	    HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
         /* Decode checksum */
         UINT32DECODE(image, read_chksum);

--- a/src/H5Gent.c
+++ b/src/H5Gent.c
@@ -177,7 +177,7 @@ H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent,
     *pp = p_ret + H5G_SIZEOF_ENTRY_FILE(f);
 
     if (*pp >= p_end)
-        HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+        HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Gent.c
+++ b/src/H5Gent.c
@@ -93,7 +93,7 @@ H5G__ent_decode_vec(const H5F_t *f, const uint8_t **pp, const uint8_t *p_end, H5
     for (u = 0; u < n; u++) {
         if (*pp > p_end)
             HGOTO_ERROR(H5E_SYM, H5E_CANTDECODE, FAIL, "ran off the end of the image buffer")
-        if (H5G_ent_decode(f, pp, ent + u) < 0)
+        if (H5G_ent_decode(f, pp, ent + u, p_end) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_CANTDECODE, FAIL, "can't decode")
     }
 
@@ -117,7 +117,8 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent)
+H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent,
+	       const uint8_t *p_end)
 {
     const uint8_t *p_ret = *pp;
     uint32_t       tmp;
@@ -130,11 +131,22 @@ H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent)
     HDassert(pp);
     HDassert(ent);
 
+    if (*pp + ent->name_off >= p_end)
+        HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+
     /* decode header */
     H5F_DECODE_LENGTH(f, *pp, ent->name_off);
+
+    if (*pp + H5F_SIZEOF_ADDR(f) + 4 >= p_end)
+        HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+
     H5F_addr_decode(f, pp, &(ent->header));
     UINT32DECODE(*pp, tmp);
     *pp += 4; /*reserved*/
+
+    if (*pp >= p_end)
+        HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+
     ent->type = (H5G_cache_type_t)tmp;
 
     /* decode scratch-pad */
@@ -144,11 +156,15 @@ H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent)
 
         case H5G_CACHED_STAB:
             HDassert(2 * H5F_SIZEOF_ADDR(f) <= H5G_SIZEOF_SCRATCH);
+	    if (*pp + H5F_SIZEOF_ADDR(f) * 2 >= p_end)
+		HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
             H5F_addr_decode(f, pp, &(ent->cache.stab.btree_addr));
             H5F_addr_decode(f, pp, &(ent->cache.stab.heap_addr));
             break;
 
         case H5G_CACHED_SLINK:
+	    if (*pp + 4 >= p_end)
+		HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
             UINT32DECODE(*pp, ent->cache.slink.lval_offset);
             break;
 
@@ -159,6 +175,9 @@ H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent)
     } /* end switch */
 
     *pp = p_ret + H5G_SIZEOF_ENTRY_FILE(f);
+
+    if (*pp >= p_end)
+        HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Gent.c
+++ b/src/H5Gent.c
@@ -175,9 +175,6 @@ H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent, const uint8
 
     *pp = p_ret + H5G_SIZEOF_ENTRY_FILE(f);
 
-    if (H5_IS_BUFFER_OVERFLOW(*pp, 1, p_end))
-        HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, FAIL, "image pointer is out of bounds")
-
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5G_ent_decode() */

--- a/src/H5Gent.c
+++ b/src/H5Gent.c
@@ -131,20 +131,20 @@ H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent, const uint8
     HDassert(ent);
 
     if (H5_IS_BUFFER_OVERFLOW(*pp, ent->name_off, p_end))
-        HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+        HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, FAIL, "image pointer is out of bounds")
 
     /* decode header */
     H5F_DECODE_LENGTH(f, *pp, ent->name_off);
 
     if (H5_IS_BUFFER_OVERFLOW(*pp, H5F_SIZEOF_ADDR(f) + sizeof(uint32_t), p_end))
-        HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+        HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, FAIL, "image pointer is out of bounds")
 
     H5F_addr_decode(f, pp, &(ent->header));
     UINT32DECODE(*pp, tmp);
     *pp += 4; /*reserved*/
 
     if (H5_IS_BUFFER_OVERFLOW(*pp, 1, p_end))
-        HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+        HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, FAIL, "image pointer is out of bounds")
 
     ent->type = (H5G_cache_type_t)tmp;
 
@@ -156,14 +156,14 @@ H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent, const uint8
         case H5G_CACHED_STAB:
             HDassert(2 * H5F_SIZEOF_ADDR(f) <= H5G_SIZEOF_SCRATCH);
             if (H5_IS_BUFFER_OVERFLOW(*pp, H5F_SIZEOF_ADDR(f) * 2, p_end))
-                HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+                HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, FAIL, "image pointer is out of bounds")
             H5F_addr_decode(f, pp, &(ent->cache.stab.btree_addr));
             H5F_addr_decode(f, pp, &(ent->cache.stab.heap_addr));
             break;
 
         case H5G_CACHED_SLINK:
             if (H5_IS_BUFFER_OVERFLOW(*pp, sizeof(uint32_t), p_end))
-                HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+                HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, FAIL, "image pointer is out of bounds")
             UINT32DECODE(*pp, ent->cache.slink.lval_offset);
             break;
 
@@ -176,7 +176,7 @@ H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent, const uint8
     *pp = p_ret + H5G_SIZEOF_ENTRY_FILE(f);
 
     if (H5_IS_BUFFER_OVERFLOW(*pp, 1, p_end))
-        HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+        HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, FAIL, "image pointer is out of bounds")
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Gent.c
+++ b/src/H5Gent.c
@@ -131,20 +131,20 @@ H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent,
     HDassert(pp);
     HDassert(ent);
 
-    if (*pp + ent->name_off >= p_end)
+    if (H5_IS_BUFFER_OVERFLOW(*pp, ent->name_off, p_end))
         HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
     /* decode header */
     H5F_DECODE_LENGTH(f, *pp, ent->name_off);
 
-    if (*pp + H5F_SIZEOF_ADDR(f) + sizeof(uint32_t) >= p_end)
+    if (H5_IS_BUFFER_OVERFLOW(*pp, H5F_SIZEOF_ADDR(f) + sizeof(uint32_t), p_end))
         HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
     H5F_addr_decode(f, pp, &(ent->header));
     UINT32DECODE(*pp, tmp);
     *pp += 4; /*reserved*/
 
-    if (*pp >= p_end)
+    if (H5_IS_BUFFER_OVERFLOW(*pp, 1, p_end))
         HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
     ent->type = (H5G_cache_type_t)tmp;
@@ -156,14 +156,14 @@ H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent,
 
         case H5G_CACHED_STAB:
             HDassert(2 * H5F_SIZEOF_ADDR(f) <= H5G_SIZEOF_SCRATCH);
-	    if (*pp + H5F_SIZEOF_ADDR(f) * 2 >= p_end)
+	    if (H5_IS_BUFFER_OVERFLOW(*pp, H5F_SIZEOF_ADDR(f) * 2, p_end))
 		HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
             H5F_addr_decode(f, pp, &(ent->cache.stab.btree_addr));
             H5F_addr_decode(f, pp, &(ent->cache.stab.heap_addr));
             break;
 
         case H5G_CACHED_SLINK:
-	    if (*pp + sizeof(uint32_t) >= p_end)
+	    if (H5_IS_BUFFER_OVERFLOW(*pp, sizeof(uint32_t), p_end))
 		HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
             UINT32DECODE(*pp, ent->cache.slink.lval_offset);
             break;
@@ -176,7 +176,7 @@ H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent,
 
     *pp = p_ret + H5G_SIZEOF_ENTRY_FILE(f);
 
-    if (*pp >= p_end)
+    if (H5_IS_BUFFER_OVERFLOW(*pp, 1, p_end))
         HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
 done:

--- a/src/H5Gent.c
+++ b/src/H5Gent.c
@@ -132,20 +132,20 @@ H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent,
     HDassert(ent);
 
     if (*pp + ent->name_off >= p_end)
-        HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+        HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
     /* decode header */
     H5F_DECODE_LENGTH(f, *pp, ent->name_off);
 
-    if (*pp + H5F_SIZEOF_ADDR(f) + 4 >= p_end)
-        HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+    if (*pp + H5F_SIZEOF_ADDR(f) + sizeof(uint32_t) >= p_end)
+        HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
     H5F_addr_decode(f, pp, &(ent->header));
     UINT32DECODE(*pp, tmp);
     *pp += 4; /*reserved*/
 
     if (*pp >= p_end)
-        HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+        HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
 
     ent->type = (H5G_cache_type_t)tmp;
 
@@ -157,14 +157,14 @@ H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent,
         case H5G_CACHED_STAB:
             HDassert(2 * H5F_SIZEOF_ADDR(f) <= H5G_SIZEOF_SCRATCH);
 	    if (*pp + H5F_SIZEOF_ADDR(f) * 2 >= p_end)
-		HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+		HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
             H5F_addr_decode(f, pp, &(ent->cache.stab.btree_addr));
             H5F_addr_decode(f, pp, &(ent->cache.stab.heap_addr));
             break;
 
         case H5G_CACHED_SLINK:
-	    if (*pp + 4 >= p_end)
-		HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, NULL, "image pointer is out of bounds")
+	    if (*pp + sizeof(uint32_t) >= p_end)
+		HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
             UINT32DECODE(*pp, ent->cache.slink.lval_offset);
             break;
 

--- a/src/H5Gent.c
+++ b/src/H5Gent.c
@@ -117,8 +117,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent,
-	       const uint8_t *p_end)
+H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent, const uint8_t *p_end)
 {
     const uint8_t *p_ret = *pp;
     uint32_t       tmp;
@@ -156,15 +155,15 @@ H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent,
 
         case H5G_CACHED_STAB:
             HDassert(2 * H5F_SIZEOF_ADDR(f) <= H5G_SIZEOF_SCRATCH);
-	    if (H5_IS_BUFFER_OVERFLOW(*pp, H5F_SIZEOF_ADDR(f) * 2, p_end))
-		HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+            if (H5_IS_BUFFER_OVERFLOW(*pp, H5F_SIZEOF_ADDR(f) * 2, p_end))
+                HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
             H5F_addr_decode(f, pp, &(ent->cache.stab.btree_addr));
             H5F_addr_decode(f, pp, &(ent->cache.stab.heap_addr));
             break;
 
         case H5G_CACHED_SLINK:
-	    if (H5_IS_BUFFER_OVERFLOW(*pp, sizeof(uint32_t), p_end))
-		HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
+            if (H5_IS_BUFFER_OVERFLOW(*pp, sizeof(uint32_t), p_end))
+                HGOTO_ERROR(H5E_FILE, H5E_OVERFLOW, NULL, "image pointer is out of bounds")
             UINT32DECODE(*pp, ent->cache.slink.lval_offset);
             break;
 

--- a/src/H5Gprivate.h
+++ b/src/H5Gprivate.h
@@ -248,8 +248,7 @@ H5_DLL herr_t H5G_node_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, i
  * These functions operate on group object locations.
  */
 H5_DLL herr_t H5G_ent_encode(const H5F_t *f, uint8_t **pp, const H5G_entry_t *ent);
-H5_DLL herr_t H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent,
-		             const uint8_t *p_end);
+H5_DLL herr_t H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent, const uint8_t *p_end);
 
 /*
  * These functions operate on group hierarchy names.

--- a/src/H5Gprivate.h
+++ b/src/H5Gprivate.h
@@ -248,7 +248,8 @@ H5_DLL herr_t H5G_node_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, i
  * These functions operate on group object locations.
  */
 H5_DLL herr_t H5G_ent_encode(const H5F_t *f, uint8_t **pp, const H5G_entry_t *ent);
-H5_DLL herr_t H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent);
+H5_DLL herr_t H5G_ent_decode(const H5F_t *f, const uint8_t **pp, H5G_entry_t *ent,
+		             const uint8_t *p_end);
 
 /*
  * These functions operate on group hierarchy names.


### PR DESCRIPTION
Hi! Some time ago I reported an out of bounds error in `hdf5/src/H5Fint.c:2859` #2432.
I fixed the error by myself by adding some checks on `image` pointer. I've tested the fixed version on the input that led to error, now it works fine.

Closes #2432 