### PR TITLE
Use additional CPUs in GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -514,12 +514,12 @@ jobs:
       #
 
       - name: Autotools Build
-        run: make
+        run: make -j3
         working-directory: ${{ runner.workspace }}/build
         if: matrix.generator == 'autogen'
 
       - name: CMake Build
-        run: cmake --build . --config ${{ matrix.build_mode.cmake }}
+        run: cmake --build . --parallel 3 --config ${{ matrix.build_mode.cmake }}
         working-directory: ${{ runner.workspace }}/build
         if: matrix.generator != 'autogen'
 
@@ -528,12 +528,12 @@ jobs:
       #
 
       - name: Autotools Run Tests
-        run: make check
+        run: make check -j2
         working-directory: ${{ runner.workspace }}/build
         if: (matrix.generator == 'autogen') && (matrix.run_tests)
 
       - name: CMake Run Tests
-        run: ctest --build . -C ${{ matrix.build_mode.cmake }} -V
+        run: ctest --build . --parallel 2 -C ${{ matrix.build_mode.cmake }} -V
         working-directory: ${{ runner.workspace }}/build
         # Skip Debug MSVC while we investigate H5L Java test timeouts
         if: (matrix.generator != 'autogen') && (matrix.run_tests) && ! ((matrix.name == 'Windows MSVC CMake') && (matrix.build_mode.cmake == 'Debug'))


### PR DESCRIPTION
* Build: 3 CPUs
* Tests: 2 CPUs

For both Autotools and CMake