### PR TITLE
Remove duplicated H5_IS_BUFFER_OVERFLOW macro

### DIFF
--- a/src/H5private.h
+++ b/src/H5private.h
@@ -2436,11 +2436,6 @@ H5_DLL herr_t H5CX_pop(hbool_t update_dxpl_props);
   #define HDcompile_assert(e)     do { typedef struct { unsigned int b: (e); } x; } while(0)
 */
 
-/* Check if a read of size bytes starting at ptr would overflow past
- * the last valid byte, pointed to by buffer_end .
- */
-#define H5_IS_BUFFER_OVERFLOW(ptr, size, buffer_end) (((ptr) + (size)-1) > (buffer_end))
-
 /* Private typedefs */
 
 /* Union for const/non-const pointer for use by functions that manipulate


### PR DESCRIPTION
Macro was duplicated as a result of merging between PRs