### PR TITLE
Fix memory leaks when processing OH cont messages

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -151,6 +151,17 @@ Bug Fixes since HDF5-1.13.3 release
 ===================================
     Library
     -------
+    - Fixed memory leaks when processing malformed object header continuation messages
+
+      Malformed object header continuation messages can result in a too-small
+      buffer being passed to the decode function, which could lead to reading
+      past the end of the buffer. Additionally, errors in processing these
+      malformed messages can lead to allocated memory not being cleaned up.
+
+      This fix adds bounds checking and cleanup code to the object header
+      continuation message processing.
+
+      (DER - 2023/04/13 GH-2604)
 
     - Memory leak
 
@@ -178,7 +189,8 @@ Bug Fixes since HDF5-1.13.3 release
 
     - Fixed potential heap buffer overrun in group info header decoding from malformed file
 
-      H5O__ginfo_decode could sometimes read past allocated memory when parsing a group info message from the header of a malformed file.
+      H5O__ginfo_decode could sometimes read past allocated memory when parsing a
+      group info message from the header of a malformed file.
   
       It now checks buffer size before each read to properly throw an error in these cases.
   

--- a/src/H5Ocache.c
+++ b/src/H5Ocache.c
@@ -1510,8 +1510,9 @@ H5O__chunk_deserialize(H5O_t *oh, haddr_t addr, size_t chunk_size, const uint8_t
                 H5O_cont_t *cont;
 
                 /* Decode continuation message */
-                cont = (H5O_cont_t *)(H5O_MSG_CONT->decode)(udata->f, NULL, 0, &ioflags, mesg->raw_size,
-                                                            mesg->raw);
+                if (NULL == (cont = (H5O_cont_t *)(H5O_MSG_CONT->decode)(udata->f, NULL, 0, &ioflags,
+                                                                         mesg->raw_size, mesg->raw)))
+                    HGOTO_ERROR(H5E_OHDR, H5E_BADMESG, FAIL, "bad continuation message found")
                 H5_CHECKED_ASSIGN(cont->chunkno, unsigned, udata->cont_msg_info->nmsgs + 1,
                                   size_t); /* the next continuation message/chunk */
 

--- a/src/H5Ocont.c
+++ b/src/H5Ocont.c
@@ -98,7 +98,11 @@ H5O__cont_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNUSE
     if (H5_IS_BUFFER_OVERFLOW(p, H5F_sizeof_addr(f), p_end))
         HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
     H5F_addr_decode(f, &p, &(cont->addr));
+
+    if (H5_IS_BUFFER_OVERFLOW(p, H5F_sizeof_size(f), p_end))
+        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
     H5F_DECODE_LENGTH(f, p, cont->size);
+
     cont->chunkno = 0;
 
     /* Set return value */


### PR DESCRIPTION
Malformed object header continuation messages can result in a too-small buffer being passed to the decode function, which could lead to reading past the end of the buffer. Additionally, errors in processing these malformed messages can lead to allocated memory not being cleaned up.

This fix adds bounds checking and cleanup code to the object header continuation message processing.

Fixes #2604