### PR TITLE
Run parallel clang-format tasks

### DIFF
--- a/bin/format_source
+++ b/bin/format_source
@@ -21,6 +21,6 @@ find . \( -type d -path ./config -prune -and -not -path ./config \) \
         -or -name H5overflow.h \
         \) \) \
     -and \( -iname *.h -or -iname *.c -or -iname *.cpp -or -iname *.hpp -or -iname *.java \) \) \
-    | xargs -P0 --max-args=1 clang-format -style=file -i -fallback-style=none
+    | xargs -P0 -n1 clang-format -style=file -i -fallback-style=none
 
 exit 0

--- a/bin/format_source
+++ b/bin/format_source
@@ -21,6 +21,6 @@ find . \( -type d -path ./config -prune -and -not -path ./config \) \
         -or -name H5overflow.h \
         \) \) \
     -and \( -iname *.h -or -iname *.c -or -iname *.cpp -or -iname *.hpp -or -iname *.java \) \) \
-    | xargs clang-format -style=file -i -fallback-style=none
+    | xargs -P0 --max-args=1 clang-format -style=file -i -fallback-style=none
 
 exit 0


### PR DESCRIPTION
This won't affect the GitHub actions since those run clang-format via python script.

On local machines, though, this dramatically speeds up running clang-format via bin/format_source (10s --> 3s on my machine).