### PR TITLE
Removes programmer/date lines from src headers

### DIFF
--- a/src/H5ACmodule.h
+++ b/src/H5ACmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5AC package.  Including this header means that the source file
- *		is part of the H5AC package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5AC package.  Including this header means that the source file
+ *          is part of the H5AC package.
  */
 #ifndef H5ACmodule_H
 #define H5ACmodule_H

--- a/src/H5ACpkg.h
+++ b/src/H5ACpkg.h
@@ -11,18 +11,15 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer: John Mainzer -- 4/19/06
+ * Purpose: This file contains declarations which are normally visible
+ *          only within the H5AC package (just H5AC.c at present).
  *
- * Purpose:     This file contains declarations which are normally visible
- *              only within the H5AC package (just H5AC.c at present).
+ *          Source files outside the H5AC package should include
+ *          H5ACprivate.h instead.
  *
- *		Source files outside the H5AC package should include
- *		H5ACprivate.h instead.
- *
- *		The one exception to this rule is testpar/t_cache.c.  The
- *		test code is easier to write if it can look at H5AC_aux_t.
- *		Indeed, this is the main reason why this file was created.
- *
+ *          The one exception to this rule is testpar/t_cache.c.  The
+ *          test code is easier to write if it can look at H5AC_aux_t.
+ *          Indeed, this is the main reason why this file was created.
  */
 
 #if !(defined H5AC_FRIEND || defined H5AC_MODULE)

--- a/src/H5Amodule.h
+++ b/src/H5Amodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5A package.  Including this header means that the source file
- *		is part of the H5A package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5A package.  Including this header means that the source file
+ *          is part of the H5A package.
  */
 #ifndef H5Amodule_H
 #define H5Amodule_H

--- a/src/H5Apkg.h
+++ b/src/H5Apkg.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Quincey Koziol
- *              Monday, Apr 20
- *
  * Purpose:     This file contains declarations which are visible only within
  *              the H5A package.  Source files outside the H5A package should
  *              include H5Aprivate.h instead.

--- a/src/H5B2module.h
+++ b/src/H5B2module.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5B2 package.  Including this header means that the source file
- *		is part of the H5B2 package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5B2 package.  Including this header means that the source file
+ *          is part of the H5B2 package.
  */
 #ifndef H5B2module_H
 #define H5B2module_H

--- a/src/H5B2pkg.h
+++ b/src/H5B2pkg.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Monday, January 31, 2005
- *
- * Purpose:	This file contains declarations which are visible only within
- *		the H5B2 package.  Source files outside the H5B2 package should
- *		include H5B2private.h instead.
+ * Purpose: This file contains declarations which are visible only within
+ *          the H5B2 package.  Source files outside the H5B2 package should
+ *          include H5B2private.h instead.
  */
 #if !(defined H5B2_FRIEND || defined H5B2_MODULE)
 #error "Do not include this file outside the H5B2 package!"

--- a/src/H5Bmodule.h
+++ b/src/H5Bmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5B package.  Including this header means that the source file
- *		is part of the H5B package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5B package.  Including this header means that the source file
+ *          is part of the H5B package.
  */
 #ifndef H5Bmodule_H
 #define H5Bmodule_H

--- a/src/H5Bpkg.h
+++ b/src/H5Bpkg.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:    Quincey Koziol
- *        Thursday, May 15, 2003
- *
- * Purpose:    This file contains declarations which are visible only within
- *        the H5B package.  Source files outside the H5B package should
- *        include H5Bprivate.h instead.
+ * Purpose: This file contains declarations which are visible only within
+ *          the H5B package.  Source files outside the H5B package should
+ *          include H5Bprivate.h instead.
  */
 #if !(defined H5B_FRIEND || defined H5B_MODULE)
 #error "Do not include this file outside the H5B package!"

--- a/src/H5CXmodule.h
+++ b/src/H5CXmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Sunday, February 25, 2018
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5CX package.  Including this header means that the source file
- *		is part of the H5CX package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5CX package.  Including this header means that the source file
+ *          is part of the H5CX package.
  */
 #ifndef H5CXmodule_H
 #define H5CXmodule_H

--- a/src/H5Cmodule.h
+++ b/src/H5Cmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5C package.  Including this header means that the source file
- *		is part of the H5C package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5C package.  Including this header means that the source file
+ *          is part of the H5C package.
  */
 #ifndef H5Cmodule_H
 #define H5Cmodule_H

--- a/src/H5Dmodule.h
+++ b/src/H5Dmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5D package.  Including this header means that the source file
- *		is part of the H5D package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5D package.  Including this header means that the source file
+ *          is part of the H5D package.
  */
 #ifndef H5Dmodule_H
 #define H5Dmodule_H

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:    Quincey Koziol
- *        Monday, April 14, 2003
- *
- * Purpose:    This file contains declarations which are visible only within
- *        the H5D package.  Source files outside the H5D package should
- *        include H5Dprivate.h instead.
+ * Purpose: This file contains declarations which are visible only within
+ *          the H5D package.  Source files outside the H5D package should
+ *          include H5Dprivate.h instead.
  */
 #if !(defined H5D_FRIEND || defined H5D_MODULE)
 #error "Do not include this file outside the H5D package!"

--- a/src/H5EAmodule.h
+++ b/src/H5EAmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5EA package.  Including this header means that the source file
- *		is part of the H5EA package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5EA package.  Including this header means that the source file
+ *          is part of the H5EA package.
  */
 #ifndef H5EAmodule_H
 #define H5EAmodule_H

--- a/src/H5EApkg.h
+++ b/src/H5EApkg.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:      Quincey Koziol
- *                  Tuesday, June 17, 2008
- *
  * Purpose:         This file contains declarations which are visible only
  *                  within the H5EA package.  Source files outside the H5EA
  *                  package should include H5EAprivate.h instead.

--- a/src/H5ESmodule.h
+++ b/src/H5ESmodule.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Quincey Koziol
- *              Monday, April  6, 2020
- *
  * Purpose:     This file contains declarations which define macros for the
  *              H5ES package.  Including this header means that the source file
  *              is part of the H5ES package.

--- a/src/H5ESpkg.h
+++ b/src/H5ESpkg.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Quincey Koziol
- *              Wednesday, April 8, 2020
- *
- * Purpose:	This file contains declarations which are visible only within
- *		the H5ES package.  Source files outside the H5ES package should
- *		include H5ESprivate.h instead.
+ * Purpose: This file contains declarations which are visible only within
+ *          the H5ES package.  Source files outside the H5ES package should
+ *          include H5ESprivate.h instead.
  */
 #if !(defined H5ES_FRIEND || defined H5ES_MODULE)
 #error "Do not include this file outside the H5ES package!"

--- a/src/H5Emodule.h
+++ b/src/H5Emodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5E package.  Including this header means that the source file
- *		is part of the H5E package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5E package.  Including this header means that the source file
+ *          is part of the H5E package.
  */
 #ifndef H5Emodule_H
 #define H5Emodule_H

--- a/src/H5Epkg.h
+++ b/src/H5Epkg.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Wednesday, April 11, 2007
- *
- * Purpose:	This file contains declarations which are visible only within
- *		the H5E package.  Source files outside the H5E package should
- *		include H5Eprivate.h instead.
+ * Purpose: This file contains declarations which are visible only within
+ *          the H5E package.  Source files outside the H5E package should
+ *          include H5Eprivate.h instead.
  */
 #if !(defined H5E_FRIEND || defined H5E_MODULE)
 #error "Do not include this file outside the H5E package!"

--- a/src/H5FAmodule.h
+++ b/src/H5FAmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5FA package.  Including this header means that the source file
- *		is part of the H5FA package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5FA package.  Including this header means that the source file
+ *          is part of the H5FA package.
  */
 #ifndef H5FAmodule_H
 #define H5FAmodule_H

--- a/src/H5FApkg.h
+++ b/src/H5FApkg.h
@@ -11,11 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:
- *
- * Purpose:    This file contains declarations which are visible only within
- *        the H5FA package.  Source files outside the H5FA package should
- *        include H5FAprivate.h instead.
+ * Purpose: This file contains declarations which are visible only within
+ *          the H5FA package.  Source files outside the H5FA package should
+ *          include H5FAprivate.h instead.
  */
 #if !(defined(H5FA_FRIEND) | defined(H5FA_MODULE))
 #error "Do not include this file outside the H5FA package!"

--- a/src/H5FDcore.h
+++ b/src/H5FDcore.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Robb Matzke
- *              Monday, August  2, 1999
- *
  * Purpose:	The public header file for the core driver.
  */
 #ifndef H5FDcore_H

--- a/src/H5FDdirect.h
+++ b/src/H5FDdirect.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Raymond Lu
- *              Wednesday, 20 September 2006
- *
  * Purpose:	The public header file for the direct driver.
  */
 #ifndef H5FDdirect_H

--- a/src/H5FDdrvr_module.h
+++ b/src/H5FDdrvr_module.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5FD driver package.  Including this header means that the source file
- *		is part of the H5FD driver package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5FD driver package.  Including this header means that the source file
+ *          is part of the H5FD driver package.
  */
 #ifndef H5FDdrvr_module_H
 #define H5FDdrvr_module_H

--- a/src/H5FDfamily.h
+++ b/src/H5FDfamily.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Robb Matzke
- *              Monday, August  4, 1999
- *
  * Purpose:	The public header file for the family driver.
  */
 #ifndef H5FDfamily_H

--- a/src/H5FDhdfs.h
+++ b/src/H5FDhdfs.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Jacob Smith
- *              2018-04-23
- *
  * Purpose:    The public header file for the hdfs driver.
  */
 
@@ -89,11 +86,6 @@ extern "C" {
  *     Size (in bytes) of the file read stream buffer.
  *
  *     TBD: If -1, relies on a default value.
- *
- *
- *
- * Programmer: Jacob Smith
- *             2018-04-23
  *
  ****************************************************************************/
 

--- a/src/H5FDlog.h
+++ b/src/H5FDlog.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Quincey Koziol
- *              Monday, April 17, 2000
- *
  * Purpose:	The public header file for the log driver.
  */
 #ifndef H5FDlog_H

--- a/src/H5FDmodule.h
+++ b/src/H5FDmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5FD package.  Including this header means that the source file
- *		is part of the H5FD package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5FD package.  Including this header means that the source file
+ *          is part of the H5FD package.
  */
 #ifndef H5FDmodule_H
 #define H5FDmodule_H

--- a/src/H5FDmpi.h
+++ b/src/H5FDmpi.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Quincey Koziol
- *              Friday, January 30, 2004
- *
  * Purpose:	The public header file for common items for all MPI VFL drivers
  */
 #ifndef H5FDmpi_H

--- a/src/H5FDmpio.h
+++ b/src/H5FDmpio.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Robb Matzke
- *              Monday, August  2, 1999
- *
  * Purpose:	The public header file for the mpio driver.
  */
 #ifndef H5FDmpio_H

--- a/src/H5FDmulti.h
+++ b/src/H5FDmulti.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Robb Matzke
- *              Monday, August  2, 1999
- *
  * Purpose:	The public header file for the "multi" driver.
  */
 #ifndef H5FDmulti_H

--- a/src/H5FDpkg.h
+++ b/src/H5FDpkg.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Thursday, January  3, 2008
- *
- * Purpose:	This file contains declarations which are visible only within
- *		the H5FD package.  Source files outside the H5FD package should
- *		include H5FDprivate.h instead.
+ * Purpose: This file contains declarations which are visible only within
+ *          the H5FD package.  Source files outside the H5FD package should
+ *          include H5FDprivate.h instead.
  */
 #if !(defined H5FD_FRIEND || defined H5FD_MODULE)
 #error "Do not include this file outside the H5FD package!"

--- a/src/H5FDprivate.h
+++ b/src/H5FDprivate.h
@@ -10,10 +10,6 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/*
- * Programmer:  Robb Matzke
- *              Monday, July 26, 1999
- */
 #ifndef H5FDprivate_H
 #define H5FDprivate_H
 

--- a/src/H5FDpublic.h
+++ b/src/H5FDpublic.h
@@ -10,10 +10,6 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/*
- * Programmer:  Robb Matzke
- *              Monday, July 26, 1999
- */
 #ifndef H5FDpublic_H
 #define H5FDpublic_H
 

--- a/src/H5FDros3.h
+++ b/src/H5FDros3.h
@@ -13,9 +13,6 @@
 /*
  * Read-Only S3 Virtual File Driver (VFD)
  *
- * Programmer:  John Mainzer
- *              2017-10-10
- *
  * Purpose:    The public header file for the ros3 driver.
  */
 #ifndef H5FDros3_H

--- a/src/H5FDs3comms.h
+++ b/src/H5FDs3comms.h
@@ -45,11 +45,6 @@
  *     ```
  *     ...in destination buffer.
  *
- * TODO: put documentation in a consistent place and point to it from here.
- *
- * Programmer: Jacob Smith
- *             2017-11-30
- *
  *****************************************************************************/
 
 #include "H5private.h" /* Generic Functions        */

--- a/src/H5FDsec2.h
+++ b/src/H5FDsec2.h
@@ -11,10 +11,7 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Robb Matzke
- *              Monday, August  2, 1999
- *
- * Purpose:	The public header file for the sec2 driver.
+ * Purpose:	The public header file for the sec2 driver
  */
 #ifndef H5FDsec2_H
 #define H5FDsec2_H

--- a/src/H5FDstdio.h
+++ b/src/H5FDstdio.h
@@ -11,10 +11,7 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Robb Matzke
- *              Monday, August  2, 1999
- *
- * Purpose:	The public header file for the sec2 driver.
+ * Purpose:	The public header file for the C stdio driver
  */
 #ifndef H5FDstdio_H
 #define H5FDstdio_H

--- a/src/H5FDwindows.h
+++ b/src/H5FDwindows.h
@@ -11,11 +11,7 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Scott Wegner
- *		Based on code by Robb Matzke
- *              Thursday, May 24 2007
- *
- * Purpose:	The public header file for the windows driver.
+ * Purpose: The public header file for the Windows driver
  */
 #ifndef H5FDwindows_H
 #define H5FDwindows_H

--- a/src/H5FLmodule.h
+++ b/src/H5FLmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5FL package.  Including this header means that the source file
- *		is part of the H5FL package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5FL package.  Including this header means that the source file
+ *          is part of the H5FL package.
  */
 #ifndef H5FLmodule_H
 #define H5FLmodule_H

--- a/src/H5FSmodule.h
+++ b/src/H5FSmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5FS package.  Including this header means that the source file
- *		is part of the H5FS package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5FS package.  Including this header means that the source file
+ *          is part of the H5FS package.
  */
 #ifndef H5FSmodule_H
 #define H5FSmodule_H

--- a/src/H5FSpkg.h
+++ b/src/H5FSpkg.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Quincey Koziol
- *              Tuesday, May  2, 2006
- *
  * Purpose:     This file contains declarations which are visible only within
  *              the H5FS package.  Source files outside the H5FS package should
  *              include H5FSprivate.h instead.

--- a/src/H5Fmodule.h
+++ b/src/H5Fmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5F package.  Including this header means that the source file
- *		is part of the H5F package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5F package.  Including this header means that the source file
+ *          is part of the H5F package.
  */
 #ifndef H5Fmodule_H
 #define H5Fmodule_H

--- a/src/H5Fpkg.h
+++ b/src/H5Fpkg.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Thursday, September 28, 2000
- *
- * Purpose:	This file contains declarations which are visible only within
- *		the H5F package.  Source files outside the H5F package should
- *		include H5Fprivate.h instead.
+ * Purpose: This file contains declarations which are visible only within
+ *          the H5F package.  Source files outside the H5F package should
+ *          include H5Fprivate.h instead.
  */
 #if !(defined H5F_FRIEND || defined H5F_MODULE)
 #error "Do not include this file outside the H5F package!"

--- a/src/H5Gmodule.h
+++ b/src/H5Gmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5G package.  Including this header means that the source file
- *		is part of the H5G package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5G package.  Including this header means that the source file
+ *          is part of the H5G package.
  */
 #ifndef H5Gmodule_H
 #define H5Gmodule_H

--- a/src/H5Gpkg.h
+++ b/src/H5Gpkg.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer: Robb Matzke
- *             Thursday, September 18, 1997
- *
  * Purpose:     This file contains declarations which are visible
  *              only within the H5G package. Source files outside the
  *              H5G package should include H5Gprivate.h instead.

--- a/src/H5HFmodule.h
+++ b/src/H5HFmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5HF package.  Including this header means that the source file
- *		is part of the H5HF package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5HF package.  Including this header means that the source file
+ *          is part of the H5HF package.
  */
 #ifndef H5HFmodule_H
 #define H5HFmodule_H

--- a/src/H5HFpkg.h
+++ b/src/H5HFpkg.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Friday, February 24, 2006
- *
- * Purpose:	This file contains declarations which are visible only within
- *		the H5HF package.  Source files outside the H5HF package should
- *		include H5HFprivate.h instead.
+ * Purpose: This file contains declarations which are visible only within
+ *          the H5HF package.  Source files outside the H5HF package should
+ *          include H5HFprivate.h instead.
  */
 #if !(defined H5HF_FRIEND || defined H5HF_MODULE)
 #error "Do not include this file outside the H5HF package!"

--- a/src/H5HGmodule.h
+++ b/src/H5HGmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5HG package.  Including this header means that the source file
- *		is part of the H5HG package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5HG package.  Including this header means that the source file
+ *          is part of the H5HG package.
  */
 #ifndef H5HGmodule_H
 #define H5HGmodule_H

--- a/src/H5HGpkg.h
+++ b/src/H5HGpkg.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer: Quincey Koziol
- *             Wednesday, July 9, 2003
- *
  * Purpose:     This file contains declarations which are visible
  *              only within the H5HG package. Source files outside the
  *              H5HG package should include H5HGprivate.h instead.

--- a/src/H5HGprivate.h
+++ b/src/H5HGprivate.h
@@ -10,10 +10,6 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/*
- * Programmer:  Robb Matzke
- *              Friday, March 27, 1998
- */
 #ifndef H5HGprivate_H
 #define H5HGprivate_H
 

--- a/src/H5HLmodule.h
+++ b/src/H5HLmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5HL package.  Including this header means that the source file
- *		is part of the H5HL package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5HL package.  Including this header means that the source file
+ *          is part of the H5HL package.
  */
 #ifndef H5HLmodule_H
 #define H5HLmodule_H

--- a/src/H5HLpkg.h
+++ b/src/H5HLpkg.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer: Quincey Koziol
- *             Wednesday, July 9, 2003
- *
  * Purpose:     This file contains declarations which are visible
  *              only within the H5HL package. Source files outside the
  *              H5HL package should include H5HLprivate.h instead.

--- a/src/H5Imodule.h
+++ b/src/H5Imodule.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Quincey Koziol
- *              Saturday, September 12, 2015
- *
  * Purpose:     This file contains declarations which define macros for the
  *              H5I package.  Including this header means that the source file
  *              is part of the H5I package.

--- a/src/H5Ipkg.h
+++ b/src/H5Ipkg.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Thursday, May 15, 2003
- *
- * Purpose:	This file contains declarations which are visible only within
- *		the H5I package.  Source files outside the H5I package should
- *		include H5Iprivate.h instead.
+ * Purpose: This file contains declarations which are visible only within
+ *          the H5I package.  Source files outside the H5I package should
+ *          include H5Iprivate.h instead.
  */
 #if !(defined H5I_FRIEND || defined H5I_MODULE)
 #error "Do not include this file outside the H5I package!"

--- a/src/H5Lmodule.h
+++ b/src/H5Lmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5L package.  Including this header means that the source file
- *		is part of the H5L package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5L package.  Including this header means that the source file
+ *          is part of the H5L package.
  */
 #ifndef H5Lmodule_H
 #define H5Lmodule_H

--- a/src/H5Lpkg.h
+++ b/src/H5Lpkg.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer: James Laird
- *             Friday, December 1, 2005
- *
  * Purpose:     This file contains declarations which are visible
  *              only within the H5L package. Source files outside the
  *              H5L package should include H5Lprivate.h instead.

--- a/src/H5MFmodule.h
+++ b/src/H5MFmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5MF package.  Including this header means that the source file
- *		is part of the H5MF package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5MF package.  Including this header means that the source file
+ *          is part of the H5MF package.
  */
 #ifndef H5MFmodule_H
 #define H5MFmodule_H

--- a/src/H5MFpkg.h
+++ b/src/H5MFpkg.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  Quincey Koziol
- *              Tuesday, January 8, 2008
- *
  * Purpose:     This file contains declarations which are visible only within
  *              the H5MF package.  Source files outside the H5MF package should
  *              include H5MFprivate.h instead.

--- a/src/H5Omodule.h
+++ b/src/H5Omodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5O package.  Including this header means that the source file
- *		is part of the H5O package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5O package.  Including this header means that the source file
+ *          is part of the H5O package.
  */
 #ifndef H5Omodule_H
 #define H5Omodule_H

--- a/src/H5Oshared.h
+++ b/src/H5Oshared.h
@@ -11,16 +11,13 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Friday, January 19, 2007
- *
  * Purpose:	This file contains inline definitions for "generic" routines
- *		supporting a "shared message interface" (ala Java) for object
- *		header messages that can be shared.  This interface is
- *              dependent on a bunch of macros being defined which define
- *              the name of the interface and "real" methods which need to
- *              be implemented for each message class that supports the
- *              shared message interface.
+ *          supporting a "shared message interface" (ala Java) for object
+ *          header messages that can be shared.  This interface is
+ *          dependent on a bunch of macros being defined which define
+ *          the name of the interface and "real" methods which need to
+ *          be implemented for each message class that supports the
+ *          shared message interface.
  */
 
 #ifndef H5Oshared_H
@@ -31,16 +28,12 @@
  *
  * Purpose:     Decode an object header message that may be shared.
  *
- * Note:	The actual name of this routine can be different in each source
- *		file that this header file is included in, and must be defined
- *		prior to including this header file.
+ * Note:	    The actual name of this routine can be different in each source
+ *              file that this header file is included in, and must be defined
+ *              prior to including this header file.
  *
- * Return:      Success:        Pointer to the new message in native form
- *              Failure:        NULL
- *
- * Programmer:  Quincey Koziol
- *              Friday, January 19, 2007
- *
+ * Return:      Success:    Pointer to the new message in native form
+ *              Failure:    NULL
  *-------------------------------------------------------------------------
  */
 static inline void *
@@ -90,16 +83,11 @@ done:
  *
  * Purpose:     Encode an object header message that may be shared.
  *
- * Note:	The actual name of this routine can be different in each source
- *		file that this header file is included in, and must be defined
- *		prior to including this header file.
+ * Note:        The actual name of this routine can be different in each source
+ *              file that this header file is included in, and must be defined
+ *              prior to including this header file.
  *
- * Return:      Success:        Non-negative
- *              Failure:        Negative
- *
- * Programmer:  Quincey Koziol
- *              Friday, January 19, 2007
- *
+ * Return:      SUCCEED/FAIL
  *-------------------------------------------------------------------------
  */
 static inline herr_t
@@ -143,18 +131,14 @@ done:
 /*-------------------------------------------------------------------------
  * Function:    H5O_SHARED_SIZE
  *
- * Purpose:	Returns the length of an encoded message.
+ * Purpose:     Returns the length of an encoded message.
  *
- * Note:	The actual name of this routine can be different in each source
- *		file that this header file is included in, and must be defined
- *		prior to including this header file.
+ * Note:        The actual name of this routine can be different in each source
+ *              file that this header file is included in, and must be defined
+ *              prior to including this header file.
  *
- * Return:	Success:	Length
- *		Failure:	0
- *
- * Programmer:  Quincey Koziol
- *              Friday, January 19, 2007
- *
+ * Return:      Success:    Length
+ *              Failure:	0
  *-------------------------------------------------------------------------
  */
 static inline size_t
@@ -198,16 +182,11 @@ done:
  * Purpose:     Decrement reference count on any objects referenced by
  *              message
  *
- * Note:	The actual name of this routine can be different in each source
- *		file that this header file is included in, and must be defined
- *		prior to including this header file.
+ * Note:        The actual name of this routine can be different in each source
+ *              file that this header file is included in, and must be defined
+ *              prior to including this header file.
  *
- * Return:	Success:	Non-negative
- *		Failure:	Negative
- *
- * Programmer:  Quincey Koziol
- *              Friday, January 19, 2007
- *
+ * Return:      SUCCEED/FAIL
  *-------------------------------------------------------------------------
  */
 static inline herr_t
@@ -249,16 +228,11 @@ done:
  * Purpose:     Increment reference count on any objects referenced by
  *              message
  *
- * Note:	The actual name of this routine can be different in each source
- *		file that this header file is included in, and must be defined
- *		prior to including this header file.
+ * Note:        The actual name of this routine can be different in each source
+ *              file that this header file is included in, and must be defined
+ *              prior to including this header file.
  *
- * Return:	Success:	Non-negative
- *		Failure:	Negative
- *
- * Programmer:  Quincey Koziol
- *              Friday, January 19, 2007
- *
+ * Return:      SUCCEED/FAIL
  *-------------------------------------------------------------------------
  */
 static inline herr_t
@@ -299,16 +273,11 @@ done:
  *
  * Purpose:     Copies a message from _SRC to _DEST in file
  *
- * Note:	The actual name of this routine can be different in each source
- *		file that this header file is included in, and must be defined
- *		prior to including this header file.
+ * Note:        The actual name of this routine can be different in each source
+ *              file that this header file is included in, and must be defined
+ *              prior to including this header file.
  *
- * Return:	Success:	Non-negative
- *		Failure:	Negative
- *
- * Programmer:  Quincey Koziol
- *              Friday, January 19, 2007
- *
+ * Return:      SUCCEED/FAIL
  *-------------------------------------------------------------------------
  */
 static inline void *
@@ -366,12 +335,7 @@ done:
  *              file that this header file is included in, and must be defined
  *              prior to including this header file.
  *
- * Return:      Success:        Non-negative
- *              Failure:        Negative
- *
- * Programmer:  Peter Cao
- *              May 25, 2007
- *
+ * Return:      SUCCEED/FAIL
  *-------------------------------------------------------------------------
  */
 static inline herr_t
@@ -432,16 +396,11 @@ done:
  *
  * Purpose:     Prints debugging info for a potentially shared message.
  *
- * Note:	The actual name of this routine can be different in each source
- *		file that this header file is included in, and must be defined
- *		prior to including this header file.
+ * Note:        The actual name of this routine can be different in each source
+ *              file that this header file is included in, and must be defined
+ *              prior to including this header file.
  *
- * Return:	Success:	Non-negative
- *		Failure:	Negative
- *
- * Programmer:  Quincey Koziol
- *              Saturday, February  3, 2007
- *
+ * Return:      SUCCEED/FAIL
  *-------------------------------------------------------------------------
  */
 static inline herr_t

--- a/src/H5PBmodule.h
+++ b/src/H5PBmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5PB package.  Including this header means that the source file
- *		is part of the H5PB package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5PB package.  Including this header means that the source file
+ *          is part of the H5PB package.
  */
 #ifndef H5PBmodule_H
 #define H5PBmodule_H

--- a/src/H5Pmodule.h
+++ b/src/H5Pmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5P package.  Including this header means that the source file
- *		is part of the H5P package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5P package.  Including this header means that the source file
+ *          is part of the H5P package.
  */
 #ifndef H5Pmodule_H
 #define H5Pmodule_H

--- a/src/H5Ppkg.h
+++ b/src/H5Ppkg.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Friday, November 16, 2001
- *
- * Purpose:	This file contains declarations which are visible only within
- *		the H5P package.  Source files outside the H5P package should
- *		include H5Pprivate.h instead.
+ * Purpose: This file contains declarations which are visible only within
+ *          the H5P package.  Source files outside the H5P package should
+ *          include H5Pprivate.h instead.
  */
 #if !(defined H5P_FRIEND || defined H5P_MODULE)
 #error "Do not include this file outside the H5P package!"

--- a/src/H5RSmodule.h
+++ b/src/H5RSmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, October 10, 2020
- *
  * Purpose:	This file contains declarations which define macros for the
- *		H5RS package.  Including this header means that the source file
- *		is part of the H5RS package.
+ *          H5RS package.  Including this header means that the source file
+ *          is part of the H5RS package.
  */
 #ifndef H5RSmodule_H
 #define H5RSmodule_H

--- a/src/H5SLmodule.h
+++ b/src/H5SLmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5SL package.  Including this header means that the source file
- *		is part of the H5SL package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5SL package.  Including this header means that the source file
+ *          is part of the H5SL package.
  */
 #ifndef H5SLmodule_H
 #define H5SLmodule_H

--- a/src/H5SMmodule.h
+++ b/src/H5SMmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5SM package.  Including this header means that the source file
- *		is part of the H5SM package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5SM package.  Including this header means that the source file
+ *          is part of the H5SM package.
  */
 #ifndef H5SMmodule_H
 #define H5SMmodule_H

--- a/src/H5SMpkg.h
+++ b/src/H5SMpkg.h
@@ -11,9 +11,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:  James Laird
- *              Thursday, March 30, 2006
- *
  * Purpose:     This file contains declarations which are visible only within
  *              the H5SM shared object header messages package.  Source files
  *              outside the H5SM package should	include H5SMprivate.h instead.

--- a/src/H5SMprivate.h
+++ b/src/H5SMprivate.h
@@ -11,11 +11,8 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	James Laird
- *		Thursday, March 2, 2006
- *
- * Purpose:	This file contains private declarations for the H5SM
- *              shared object header messages module.
+ * Purpose: This file contains private declarations for the H5SM
+ *          shared object header messages module.
  */
 #ifndef H5SMprivate_H
 #define H5SMprivate_H

--- a/src/H5Smodule.h
+++ b/src/H5Smodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5S package.  Including this header means that the source file
- *		is part of the H5S package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5S package.  Including this header means that the source file
+ *          is part of the H5S package.
  */
 #ifndef H5Smodule_H
 #define H5Smodule_H

--- a/src/H5Spkg.h
+++ b/src/H5Spkg.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:    Quincey Koziol
- *        Thursday, September 28, 2000
- *
- * Purpose:    This file contains declarations which are visible only within
- *        the H5S package.  Source files outside the H5S package should
- *        include H5Sprivate.h instead.
+ * Purpose: This file contains declarations which are visible only within
+ *          the H5S package.  Source files outside the H5S package should
+ *          include H5Sprivate.h instead.
  */
 #if !(defined H5S_FRIEND || defined H5S_MODULE)
 #error "Do not include this file outside the H5S package!"

--- a/src/H5Tmodule.h
+++ b/src/H5Tmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5T package.  Including this header means that the source file
- *		is part of the H5T package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5T package.  Including this header means that the source file
+ *          is part of the H5T package.
  */
 #ifndef H5Tmodule_H
 #define H5Tmodule_H

--- a/src/H5Tpkg.h
+++ b/src/H5Tpkg.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Robb Matzke
- *		Monday, December  8, 1997
- *
- * Purpose:	This file contains declarations which are visible only within
- *		the H5T package.  Source files outside the H5T package should
- *		include H5Tprivate.h instead.
+ * Purpose: This file contains declarations which are visible only within
+ *          the H5T package.  Source files outside the H5T package should
+ *          include H5Tprivate.h instead.
  */
 #if !(defined H5T_FRIEND || defined H5T_MODULE)
 #error "Do not include this file outside the H5T package!"

--- a/src/H5VMprivate.h
+++ b/src/H5VMprivate.h
@@ -10,10 +10,6 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/*
- * Programmer: Robb Matzke
- *             Friday, October 10, 1997
- */
 #ifndef H5VMprivate_H
 #define H5VMprivate_H
 
@@ -133,13 +129,8 @@ H5_DLL ssize_t H5VM_memcpyvv(void *_dst, size_t dst_max_nseq, size_t *dst_curr_s
  *              only as an optimization and the naming (with a single underscore)
  *              reflects its inclusion in a "private" header file.
  *
- * Return:      Success:        Product of elements
- *
- *              Failure:        1 if N is zero
- *
- * Programmer:  Robb Matzke
- *              Friday, October 10, 1997
- *
+ * Return:      Success:    Product of elements
+ *              Failure:    1 if N is zero
  *-------------------------------------------------------------------------
  */
 static inline hsize_t H5_ATTR_UNUSED
@@ -168,14 +159,8 @@ done:
  *              only as an optimization and the naming (with a single underscore)
  *              reflects its inclusion in a "private" header file.
  *
- * Return:      Success:        TRUE if all elements are zero,
- *                              FALSE otherwise
- *
- *              Failure:        TRUE if N is zero
- *
- * Programmer:  Robb Matzke
- *              Friday, October 10, 1997
- *
+ * Return:      Success:    TRUE if all elements are zero,
+ *              Failure:    TRUE if N is zero
  *-------------------------------------------------------------------------
  */
 static inline htri_t H5_ATTR_UNUSED
@@ -205,14 +190,9 @@ done:
  *              only as an optimization and the naming (with a single underscore)
  *              reflects its inclusion in a "private" header file.
  *
- * Return:      Success:        TRUE if all elements are zero,
- *                              FALSE otherwise
- *
- *              Failure:        TRUE if N is zero
- *
- * Programmer:  Robb Matzke
- *              Friday, October 10, 1997
- *
+ * Return:      Success:    TRUE if all elements are zero,
+ *                          FALSE otherwise
+ *              Failure:    TRUE if N is zero
  *-------------------------------------------------------------------------
  */
 static inline htri_t H5_ATTR_UNUSED
@@ -243,15 +223,11 @@ done:
  *              only as an optimization and the naming (with a single underscore)
  *              reflects its inclusion in a "private" header file.
  *
- * Return:      Success:        -1 if V1 is less than V2
- *                              0 if they are equal
- *                              1 if V1 is greater than V2
+ * Return:      Success:    -1 if V1 is less than V2
+ *                          0 if they are equal
+ *                          1 if V1 is greater than V2
  *
- *              Failure:        0 if N is zero
- *
- * Programmer:  Robb Matzke
- *              Friday, October 10, 1997
- *
+ *              Failure:    0 if N is zero
  *-------------------------------------------------------------------------
  */
 static inline int H5_ATTR_UNUSED
@@ -291,15 +267,11 @@ done:
  *              only as an optimization and the naming (with a single underscore)
  *              reflects its inclusion in a "private" header file.
  *
- * Return:      Success:        -1 if V1 is less than V2
- *                              0 if they are equal
- *                              1 if V1 is greater than V2
+ * Return:      Success:    -1 if V1 is less than V2
+ *                          0 if they are equal
+ *                          1 if V1 is greater than V2
  *
- *              Failure:        0 if N is zero
- *
- * Programmer:  Robb Matzke
- *              Wednesday, April  8, 1998
- *
+ *              Failure:    0 if N is zero
  *-------------------------------------------------------------------------
  */
 static inline int H5_ATTR_UNUSED
@@ -339,10 +311,6 @@ done:
  *              reflects its inclusion in a "private" header file.
  *
  * Return:      void
- *
- * Programmer:  Robb Matzke
- *              Monday, October 13, 1997
- *
  *-------------------------------------------------------------------------
  */
 static inline void H5_ATTR_UNUSED
@@ -383,10 +351,6 @@ static const unsigned char LogTable256[] = {
  *              reflects its inclusion in a "private" header file.
  *
  * Return:      log2(n) (always - no failure condition)
- *
- * Programmer:  Quincey Koziol
- *              Monday, March  6, 2006
- *
  *-------------------------------------------------------------------------
  */
 static inline unsigned H5_ATTR_UNUSED
@@ -432,10 +396,6 @@ static const unsigned MultiplyDeBruijnBitPosition[32] = {0,  1,  28, 2,  29, 14,
  *              reflects its inclusion in a "private" header file.
  *
  * Return:      log2(n) (always - no failure condition)
- *
- * Programmer:  Quincey Koziol
- *              Monday, February 27, 2006
- *
  *-------------------------------------------------------------------------
  */
 static inline H5_ATTR_PURE unsigned
@@ -450,16 +410,13 @@ H5VM_log2_of2(uint32_t n)
 /*-------------------------------------------------------------------------
  * Function:    H5VM_power2up
  *
- * Purpose:    Round up a number to the next power of 2
+ * Purpose:     Round up a number to the next power of 2
  *
  * Note:        Although this routine is 'static' in this file, that's intended
  *              only as an optimization and the naming (with a single underscore)
  *              reflects its inclusion in a "private" header file.
  *
- * Return:    Return the number which is a power of 2
- *
- * Programmer:    Vailin Choi; Nov 2014
- *
+ * Return:      Return the number which is a power of 2
  *-------------------------------------------------------------------------
  */
 static inline H5_ATTR_CONST hsize_t
@@ -488,10 +445,6 @@ H5VM_power2up(hsize_t n)
  *              reflects its inclusion in a "private" header file.
  *
  * Return:      Number of bytes needed
- *
- * Programmer:  Quincey Koziol
- *              Thursday, March 13, 2008
- *
  *-------------------------------------------------------------------------
  */
 static inline unsigned H5_ATTR_UNUSED
@@ -520,10 +473,6 @@ static const unsigned char H5VM_bit_clear_g[8] = {0x7F, 0xBF, 0xDF, 0xEF, 0xF7, 
  *              reflects its inclusion in a "private" header file.
  *
  * Return:      TRUE/FALSE
- *
- * Programmer:  Quincey Koziol
- *              Tuesday, November 25, 2008
- *
  *-------------------------------------------------------------------------
  */
 static inline hbool_t H5_ATTR_UNUSED
@@ -549,11 +498,7 @@ H5VM_bit_get(const unsigned char *buf, size_t offset)
  *              only as an optimization and the naming (with a single underscore)
  *              reflects its inclusion in a "private" header file.
  *
- * Return:      None
- *
- * Programmer:  Quincey Koziol
- *              Tuesday, November 25, 2008
- *
+ * Return:      void
  *-------------------------------------------------------------------------
  */
 static inline void H5_ATTR_UNUSED

--- a/src/H5Zmodule.h
+++ b/src/H5Zmodule.h
@@ -11,12 +11,9 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*
- * Programmer:	Quincey Koziol
- *		Saturday, September 12, 2015
- *
- * Purpose:	This file contains declarations which define macros for the
- *		H5Z package.  Including this header means that the source file
- *		is part of the H5Z package.
+ * Purpose: This file contains declarations which define macros for the
+ *          H5Z package.  Including this header means that the source file
+ *          is part of the H5Z package.
  */
 #ifndef H5Zmodule_H
 #define H5Zmodule_H

--- a/src/H5Zprivate.h
+++ b/src/H5Zprivate.h
@@ -10,10 +10,6 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Robb Matzke
- *              Thursday, April 16, 1998
- */
-
 #ifndef H5Zprivate_H
 #define H5Zprivate_H
 

--- a/src/H5Zpublic.h
+++ b/src/H5Zpublic.h
@@ -10,10 +10,6 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Robb Matzke
- *              Thursday, April 16, 1998
- */
-
 #ifndef H5Zpublic_H
 #define H5Zpublic_H
 

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -10,14 +10,11 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Robb Matzke
- *    Friday, October 30, 1998
- *
- * Purpose:  This file is included by all HDF5 library source files to
- *    define common things which are not defined in the HDF5 API.
- *    The configuration constants like H5_HAVE_UNISTD_H etc. are
- *    defined in H5config.h which is included by H5public.h.
- *
+/*
+ * Purpose: This file is included by all HDF5 library source files to
+ *          define common things which are not defined in the HDF5 API.
+ *          The configuration constants like H5_HAVE_UNISTD_H etc. are
+ *          defined in H5config.h which is included by H5public.h.
  */
 
 #ifndef H5private_H
@@ -1866,9 +1863,6 @@ H5_DLL herr_t H5_trace_args(struct H5RS_str_t *rs, const char *type, va_list ap)
  *    use initializers that require special cleanup code to
  *    execute if FUNC_ENTER() fails since a failing FUNC_ENTER()
  *    returns immediately without branching to the `done' label.
- *
- * Programmer:  Quincey Koziol
- *
  *-------------------------------------------------------------------------
  */
 
@@ -2294,11 +2288,8 @@ H5_DLL herr_t H5CX_pop(hbool_t update_dxpl_props);
         FUNC_ENTER_COMMON_NOERR(H5_IS_PKG(__func__));
 
 /*-------------------------------------------------------------------------
- * Purpose:  Register function exit for code profiling.  This should be
- *    the last statement executed by a function.
- *
- * Programmer:  Quincey Koziol
- *
+ * Purpose: Register function exit for code profiling.  This should be
+ *          the last statement executed by a function.
  *-------------------------------------------------------------------------
  */
 /* Threadsafety termination code for API routines */


### PR DESCRIPTION
This is just meaningless noise. Other parts of the code will be handled in separate PRs (there's a lot to clean).