### PR TITLE
Add no subsets option to h5diff like h5dump

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -352,6 +352,13 @@ Bug Fixes since HDF5-1.14.0 release
 
     Tools
     -----
+    - Names of objects with square brackets will have trouble without the
+      special argument, --no-compact-subset, on the h5dump command line.
+
+      h5diff did not have this option and now it has been added.
+
+      Fixes GitHub issue #2682
+
     - In the tools traverse function - an error in either visit call
       will bypass the cleanup of the local data variables.
 

--- a/tools/lib/h5diff.h
+++ b/tools/lib/h5diff.h
@@ -51,28 +51,29 @@ typedef struct {
     int                       mode_quiet;   /* quiet mode: no output at all */
     int                       mode_report;  /* report mode: print the data */
     int                       mode_verbose; /* verbose mode: print the data, list of objcets, warnings */
-    int                       mode_verbose_level; /* control verbose details */
-    int                       mode_list_not_cmp;  /* list not comparable messages */
-    int                       print_header;       /* print header */
-    int                       print_percentage;   /* print percentage */
-    int                       print_dims;         /* print dimension index */
-    int                       delta_bool;         /* delta, absolute value to compare */
-    double                    delta;              /* delta value */
-    int                       use_system_epsilon; /* flag to use system epsilon (1 or 0) */
-    int                       percent_bool;       /* relative error to compare*/
-    double                    percent;            /* relative error value */
-    hbool_t                   follow_links;       /* follow symbolic links */
-    int                       no_dangle_links;    /* return error when find dangling link */
-    int                       cmn_objs;           /* do we have common objects */
-    int                       not_cmp;            /* are the objects comparable */
-    int                       contents;           /* equal contents */
-    int                       do_nans;            /* consider Nans while diffing floats */
-    int                       exclude_path;       /* exclude path to an object */
-    int                       exclude_attr_path;  /* exclude path to an object */
-    struct exclude_path_list *exclude;            /* keep exclude path list */
-    struct exclude_path_list *exclude_attr;       /* keep exclude attribute list */
-    int                       count_bool;         /* count, compare up to count */
-    hsize_t                   count;              /* count value */
+    int                       mode_verbose_level;     /* control verbose details */
+    int                       mode_list_not_cmp;      /* list not comparable messages */
+    int                       print_header;           /* print header */
+    int                       print_percentage;       /* print percentage */
+    int                       print_dims;             /* print dimension index */
+    int                       delta_bool;             /* delta, absolute value to compare */
+    double                    delta;                  /* delta value */
+    int                       use_system_epsilon;     /* flag to use system epsilon (1 or 0) */
+    int                       percent_bool;           /* relative error to compare*/
+    double                    percent;                /* relative error value */
+    hbool_t                   follow_links;           /* follow symbolic links */
+    int                       no_dangle_links;        /* return error when find dangling link */
+    int                       cmn_objs;               /* do we have common objects */
+    int                       not_cmp;                /* are the objects comparable */
+    int                       contents;               /* equal contents */
+    int                       do_nans;                /* consider Nans while diffing floats */
+    int                       disable_compact_subset; /* disable compact form of subset notation */
+    int                       exclude_path;           /* exclude path to an object */
+    int                       exclude_attr_path;      /* exclude path to an object */
+    struct exclude_path_list *exclude;                /* keep exclude path list */
+    struct exclude_path_list *exclude_attr;           /* keep exclude attribute list */
+    int                       count_bool;             /* count, compare up to count */
+    hsize_t                   count;                  /* count value */
     diff_err_t                err_stat;  /* an error occurred (2, error, 1, differences, 0, no error) */
     hsize_t                   nelmts;    /* total number of elements */
     hsize_t                   hs_nelmts; /* number of elements to read at a time*/

--- a/tools/lib/h5tools_utils.c
+++ b/tools/lib/h5tools_utils.c
@@ -157,6 +157,128 @@ help_ref_msg(FILE *output)
     HDfprintf(output, "see the <%s> entry in the 'HDF5 Reference Manual'.\n", h5tools_getprogname());
 }
 
+/*-------------------------------------------------------------------------
+ * Function:    parse_hsize_list
+ *
+ * Purpose:     Parse a list of comma or space separated integers and return
+ *              them in a list. The string being passed into this function
+ *              should be at the start of the list you want to parse. You are
+ *              responsible for freeing the array returned from here.
+ *
+ *              Lists in the so-called "terse" syntax are separated by
+ *              semicolons (;). The lists themselves can be separated by
+ *              either commas (,) or white spaces.
+ *
+ * Return:      <none>
+ *-------------------------------------------------------------------------
+ */
+void
+parse_hsize_list(const char *h_list, subset_d *d)
+{
+    hsize_t     *p_list;
+    const char  *ptr;
+    unsigned int size_count = 0;
+    unsigned int i          = 0;
+    unsigned int last_digit = 0;
+
+    if (!h_list || !*h_list || *h_list == ';')
+        return;
+
+    H5TOOLS_START_DEBUG(" - h_list:%s", h_list);
+    /* count how many integers do we have */
+    for (ptr = h_list; ptr && *ptr && *ptr != ';' && *ptr != ']'; ptr++)
+        if (HDisdigit(*ptr)) {
+            if (!last_digit)
+                /* the last read character wasn't a digit */
+                size_count++;
+
+            last_digit = 1;
+        }
+        else
+            last_digit = 0;
+
+    if (size_count == 0) {
+        /* there aren't any integers to read */
+        H5TOOLS_ENDDEBUG("No integers to read");
+        return;
+    }
+    H5TOOLS_DEBUG("Number integers to read=%ld", size_count);
+
+    /* allocate an array for the integers in the list */
+    if ((p_list = (hsize_t *)HDcalloc(size_count, sizeof(hsize_t))) == NULL)
+        H5TOOLS_INFO("Unable to allocate space for subset data");
+
+    for (ptr = h_list; i < size_count && ptr && *ptr && *ptr != ';' && *ptr != ']'; ptr++)
+        if (HDisdigit(*ptr)) {
+            /* we should have an integer now */
+            p_list[i++] = (hsize_t)HDstrtoull(ptr, NULL, 0);
+
+            while (HDisdigit(*ptr))
+                /* scroll to end of integer */
+                ptr++;
+        }
+    d->data = p_list;
+    d->len  = size_count;
+    H5TOOLS_ENDDEBUG(" ");
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    parse_subset_params
+ *
+ * Purpose:     Parse the so-called "terse" syntax for specifying subsetting parameters.
+ *
+ * Return:      Success:    struct subset_t object
+ *              Failure:    NULL
+ *-------------------------------------------------------------------------
+ */
+struct subset_t *
+parse_subset_params(const char *dset)
+{
+    struct subset_t *s = NULL;
+    char            *brace;
+    const char      *q_dset;
+
+    H5TOOLS_START_DEBUG(" - dset:%s", dset);
+    /* if dset name is quoted wait till after second quote to look for subset brackets */
+    if (*dset == '"')
+        q_dset = HDstrchr(dset, '"');
+    else
+        q_dset = dset;
+    if ((brace = HDstrrchr(q_dset, '[')) != NULL) {
+        *brace++ = '\0';
+
+        s = (struct subset_t *)HDcalloc(1, sizeof(struct subset_t));
+        parse_hsize_list(brace, &s->start);
+
+        while (*brace && *brace != ';')
+            brace++;
+
+        if (*brace)
+            brace++;
+
+        parse_hsize_list(brace, &s->stride);
+
+        while (*brace && *brace != ';')
+            brace++;
+
+        if (*brace)
+            brace++;
+
+        parse_hsize_list(brace, &s->count);
+
+        while (*brace && *brace != ';')
+            brace++;
+
+        if (*brace)
+            brace++;
+
+        parse_hsize_list(brace, &s->block);
+    }
+    H5TOOLS_ENDDEBUG(" ");
+
+    return s;
+}
+
 /*****************************************************************************
  *
  * Function: parse_tuple()

--- a/tools/lib/h5tools_utils.h
+++ b/tools/lib/h5tools_utils.h
@@ -67,9 +67,12 @@ typedef struct find_objs_t {
 H5TOOLS_DLLVAR unsigned h5tools_nCols; /*max number of columns for outputting  */
 
 /* Definitions of useful routines */
+H5TOOLS_DLL struct subset_t *parse_subset_params(const char *dset);
+
 H5TOOLS_DLL void   indentation(unsigned);
 H5TOOLS_DLL void   print_version(const char *progname);
 H5TOOLS_DLL void   parallel_print(const char *format, ...) H5_ATTR_FORMAT(printf, 1, 2);
+H5TOOLS_DLL void   parse_hsize_list(const char *h_list, subset_d *d);
 H5TOOLS_DLL herr_t parse_tuple(const char *start, int sep, char **cpy_out, unsigned *nelems,
                                char ***ptrs_out);
 H5TOOLS_DLL void   error_msg(const char *fmt, ...) H5_ATTR_FORMAT(printf, 1, 2);

--- a/tools/src/h5diff/h5diff_common.c
+++ b/tools/src/h5diff/h5diff_common.c
@@ -24,23 +24,24 @@ static int check_d_input(const char *);
  * Command-line options: The user can specify short or long-named
  * parameters.
  */
-static const char            *s_opts   = "hVrv*qn:d:p:NcelxE:A:S*";
-static struct h5_long_options l_opts[] = {{"help", no_arg, 'h'},
-                                          {"version", no_arg, 'V'},
+static const char            *s_opts   = "cd:ehln:p:qrv*xA:CE:NS*V";
+static struct h5_long_options l_opts[] = {{"compare", no_arg, 'c'},
+                                          {"delta", require_arg, 'd'},
+                                          {"use-system-epsilon", no_arg, 'e'},
+                                          {"help", no_arg, 'h'},
+                                          {"follow-symlinks", no_arg, 'l'},
+                                          {"count", require_arg, 'n'},
+                                          {"relative", require_arg, 'p'},
+                                          {"quiet", no_arg, 'q'},
                                           {"report", no_arg, 'r'},
                                           {"verbose", optional_arg, 'v'},
-                                          {"quiet", no_arg, 'q'},
-                                          {"count", require_arg, 'n'},
-                                          {"delta", require_arg, 'd'},
-                                          {"relative", require_arg, 'p'},
-                                          {"nan", no_arg, 'N'},
-                                          {"compare", no_arg, 'c'},
-                                          {"use-system-epsilon", no_arg, 'e'},
-                                          {"follow-symlinks", no_arg, 'l'},
                                           {"no-dangling-links", no_arg, 'x'},
-                                          {"exclude-path", require_arg, 'E'},
                                           {"exclude-attribute", require_arg, 'A'},
+                                          {"no-compact-subset", no_arg, 'C'},
+                                          {"exclude-path", require_arg, 'E'},
+                                          {"nan", no_arg, 'N'},
                                           {"enable-error-stack", optional_arg, 'S'},
+                                          {"version", no_arg, 'V'},
                                           {"vol-value-1", require_arg, '1'},
                                           {"vol-name-1", require_arg, '2'},
                                           {"vol-info-1", require_arg, '3'},
@@ -101,122 +102,6 @@ check_options(diff_opt_t *opts)
                  PROGRAMNAME);
         h5diff_exit(EXIT_FAILURE);
     }
-}
-
-/*-------------------------------------------------------------------------
- * Function:    parse_hsize_list
- *
- * Purpose:     Parse a list of comma or space separated integers and return
- *              them in a list. The string being passed into this function
- *              should be at the start of the list you want to parse. You are
- *              responsible for freeing the array returned from here.
- *
- *              Lists in the so-called "terse" syntax are separated by
- *              semicolons (;). The lists themselves can be separated by
- *              either commas (,) or white spaces.
- *
- * Return:      <none>
- *-------------------------------------------------------------------------
- */
-static void
-parse_hsize_list(const char *h_list, subset_d *d)
-{
-    hsize_t     *p_list;
-    const char  *ptr;
-    unsigned int size_count = 0;
-    unsigned int i          = 0;
-    unsigned int last_digit = 0;
-
-    if (!h_list || !*h_list || *h_list == ';')
-        return;
-
-    H5TOOLS_START_DEBUG(" - h_list:%s", h_list);
-    /* count how many integers do we have */
-    for (ptr = h_list; ptr && *ptr && *ptr != ';' && *ptr != ']'; ptr++)
-        if (HDisdigit(*ptr)) {
-            if (!last_digit)
-                /* the last read character wasn't a digit */
-                size_count++;
-
-            last_digit = 1;
-        }
-        else
-            last_digit = 0;
-
-    if (size_count == 0) {
-        /* there aren't any integers to read */
-        H5TOOLS_ENDDEBUG("No integers to read");
-        return;
-    }
-    H5TOOLS_DEBUG("Number integers to read=%ld", size_count);
-
-    /* allocate an array for the integers in the list */
-    if ((p_list = (hsize_t *)HDcalloc(size_count, sizeof(hsize_t))) == NULL)
-        H5TOOLS_INFO("Unable to allocate space for subset data");
-
-    for (ptr = h_list; i < size_count && ptr && *ptr && *ptr != ';' && *ptr != ']'; ptr++)
-        if (HDisdigit(*ptr)) {
-            /* we should have an integer now */
-            p_list[i++] = (hsize_t)HDstrtoull(ptr, NULL, 0);
-
-            while (HDisdigit(*ptr))
-                /* scroll to end of integer */
-                ptr++;
-        }
-    d->data = p_list;
-    d->len  = size_count;
-    H5TOOLS_ENDDEBUG(" ");
-}
-
-/*-------------------------------------------------------------------------
- * Function:    parse_subset_params
- *
- * Purpose:     Parse the so-called "terse" syntax for specifying subsetting parameters.
- *
- * Return:      Success:    struct subset_t object
- *              Failure:    NULL
- *-------------------------------------------------------------------------
- */
-static struct subset_t *
-parse_subset_params(const char *dset)
-{
-    struct subset_t *s = NULL;
-    char            *brace;
-
-    H5TOOLS_START_DEBUG(" - dset:%s", dset);
-    if ((brace = HDstrrchr(dset, '[')) != NULL) {
-        *brace++ = '\0';
-
-        s = (struct subset_t *)HDcalloc(1, sizeof(struct subset_t));
-        parse_hsize_list(brace, &s->start);
-
-        while (*brace && *brace != ';')
-            brace++;
-
-        if (*brace)
-            brace++;
-
-        parse_hsize_list(brace, &s->stride);
-
-        while (*brace && *brace != ';')
-            brace++;
-
-        if (*brace)
-            brace++;
-
-        parse_hsize_list(brace, &s->count);
-
-        while (*brace && *brace != ';')
-            brace++;
-
-        if (*brace)
-            brace++;
-
-        parse_hsize_list(brace, &s->block);
-    }
-    H5TOOLS_ENDDEBUG(" ");
-
-    return s;
 }
 
 /*-------------------------------------------------------------------------
@@ -353,6 +238,10 @@ parse_command_line(int argc, const char *const *argv, const char **fname1, const
                     exclude_node->next = NULL;
                     exclude_prev->next = exclude_node;
                 }
+                break;
+
+            case 'C':
+                opts->disable_compact_subset = TRUE;
                 break;
 
             case 'A':
@@ -570,13 +459,10 @@ parse_command_line(int argc, const char *const *argv, const char **fname1, const
     }
     H5TOOLS_DEBUG("objname2 = %s", *objname2);
 
-    /*
-     * TRILABS_227 is complete except for an issue with printing indices
-     * the following calls will enable subsetting
-     */
-    opts->sset[0] = parse_subset_params(*objname1);
-
-    opts->sset[1] = parse_subset_params(*objname2);
+    if (!opts->disable_compact_subset) {
+        opts->sset[0] = parse_subset_params(*objname1);
+        opts->sset[1] = parse_subset_params(*objname2);
+    }
 
     H5TOOLS_ENDDEBUG(" ");
 }
@@ -935,6 +821,9 @@ usage(void)
      * the following will be needed for subsetting
      */
     PRINTVALSTREAM(rawoutstream, " Subsetting options:\n");
+    PRINTVALSTREAM(rawoutstream,
+                   "  --no-compact-subset  Disable compact form of subsetting and allow the use\n");
+    PRINTVALSTREAM(rawoutstream, "                          of \"[\" in dataset names.\n");
     PRINTVALSTREAM(rawoutstream,
                    "  Subsetting is available by using the fcompact form of subsetting, as follows:\n");
     PRINTVALSTREAM(rawoutstream, "    obj1 /foo/mydataset[START;STRIDE;COUNT;BLOCK]\n");

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -565,114 +565,6 @@ set_sort_order(const char *form)
 }
 
 /*-------------------------------------------------------------------------
- * Function:    parse_hsize_list
- *
- * Purpose:     Parse a list of comma or space separated integers and return
- *              them in a list. The string being passed into this function
- *              should be at the start of the list you want to parse. You are
- *              responsible for freeing the array returned from here.
- *
- *              Lists in the so-called "terse" syntax are separated by
- *              semicolons (;). The lists themselves can be separated by
- *              either commas (,) or white spaces.
- *
- * Return:      <none>
- *-------------------------------------------------------------------------
- */
-static void
-parse_hsize_list(const char *h_list, subset_d *d)
-{
-    hsize_t     *p_list;
-    const char  *ptr;
-    unsigned int size_count = 0;
-    unsigned int i          = 0;
-    unsigned int last_digit = 0;
-
-    if (!h_list || !*h_list || *h_list == ';')
-        return;
-
-    /* count how many integers do we have */
-    for (ptr = h_list; ptr && *ptr && *ptr != ';' && *ptr != ']'; ptr++)
-        if (HDisdigit(*ptr)) {
-            if (!last_digit)
-                /* the last read character wasn't a digit */
-                size_count++;
-
-            last_digit = 1;
-        }
-        else
-            last_digit = 0;
-
-    if (size_count == 0)
-        /* there aren't any integers to read */
-        return;
-
-    /* allocate an array for the integers in the list */
-    p_list = (hsize_t *)HDcalloc(size_count, sizeof(hsize_t));
-
-    for (ptr = h_list; i < size_count && ptr && *ptr && *ptr != ';' && *ptr != ']'; ptr++)
-        if (HDisdigit(*ptr)) {
-            /* we should have an integer now */
-            p_list[i++] = (hsize_t)HDstrtoull(ptr, NULL, 0);
-
-            while (HDisdigit(*ptr))
-                /* scroll to end of integer */
-                ptr++;
-        }
-    d->data = p_list;
-    d->len  = size_count;
-}
-
-/*-------------------------------------------------------------------------
- * Function:    parse_subset_params
- *
- * Purpose:     Parse the so-called "terse" syntax for specifying subsetting parameters.
- *
- * Return:      Success:    struct subset_t object
- *              Failure:    NULL
- *-------------------------------------------------------------------------
- */
-static struct subset_t *
-parse_subset_params(const char *dset)
-{
-    struct subset_t *s = NULL;
-    char            *brace;
-
-    if (!dump_opts.disable_compact_subset && ((brace = HDstrrchr(dset, '[')) != NULL)) {
-        *brace++ = '\0';
-
-        s = (struct subset_t *)HDcalloc(1, sizeof(struct subset_t));
-        parse_hsize_list(brace, &s->start);
-
-        while (*brace && *brace != ';')
-            brace++;
-
-        if (*brace)
-            brace++;
-
-        parse_hsize_list(brace, &s->stride);
-
-        while (*brace && *brace != ';')
-            brace++;
-
-        if (*brace)
-            brace++;
-
-        parse_hsize_list(brace, &s->count);
-
-        while (*brace && *brace != ';')
-            brace++;
-
-        if (*brace)
-            brace++;
-
-        parse_hsize_list(brace, &s->block);
-    }
-
-    return s;
-}
-
-/*-------------------------------------------------------------------------
  * Function:    parse_mask_list
  *
  * Purpose:     Parse a list of comma or space separated integers and fill
@@ -957,10 +849,11 @@ parse_start:
 
                 for (i = 0; i < argc; i++)
                     if (!hand[i].func) {
-                        hand[i].func        = handle_datasets;
-                        hand[i].obj         = HDstrdup(H5_optarg);
-                        hand[i].subset_info = parse_subset_params(hand[i].obj);
-                        last_dset           = &hand[i];
+                        hand[i].func = handle_datasets;
+                        hand[i].obj  = HDstrdup(H5_optarg);
+                        if (!dump_opts.disable_compact_subset)
+                            hand[i].subset_info = parse_subset_params(hand[i].obj);
+                        last_dset = &hand[i];
                         break;
                     }
 

--- a/tools/test/h5diff/testfiles/h5diff_10.txt
+++ b/tools/test/h5diff/testfiles/h5diff_10.txt
@@ -157,6 +157,8 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
        symbolic links are compared.).
 
  Subsetting options:
+  --no-compact-subset  Disable compact form of subsetting and allow the use
+                          of "[" in dataset names.
   Subsetting is available by using the fcompact form of subsetting, as follows:
     obj1 /foo/mydataset[START;STRIDE;COUNT;BLOCK]
   It is not required to use all parameters, but until the last parameter value used,

--- a/tools/test/h5diff/testfiles/h5diff_600.txt
+++ b/tools/test/h5diff/testfiles/h5diff_600.txt
@@ -157,6 +157,8 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
        symbolic links are compared.).
 
  Subsetting options:
+  --no-compact-subset  Disable compact form of subsetting and allow the use
+                          of "[" in dataset names.
   Subsetting is available by using the fcompact form of subsetting, as follows:
     obj1 /foo/mydataset[START;STRIDE;COUNT;BLOCK]
   It is not required to use all parameters, but until the last parameter value used,

--- a/tools/test/h5diff/testfiles/h5diff_603.txt
+++ b/tools/test/h5diff/testfiles/h5diff_603.txt
@@ -158,6 +158,8 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
        symbolic links are compared.).
 
  Subsetting options:
+  --no-compact-subset  Disable compact form of subsetting and allow the use
+                          of "[" in dataset names.
   Subsetting is available by using the fcompact form of subsetting, as follows:
     obj1 /foo/mydataset[START;STRIDE;COUNT;BLOCK]
   It is not required to use all parameters, but until the last parameter value used,

--- a/tools/test/h5diff/testfiles/h5diff_606.txt
+++ b/tools/test/h5diff/testfiles/h5diff_606.txt
@@ -158,6 +158,8 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
        symbolic links are compared.).
 
  Subsetting options:
+  --no-compact-subset  Disable compact form of subsetting and allow the use
+                          of "[" in dataset names.
   Subsetting is available by using the fcompact form of subsetting, as follows:
     obj1 /foo/mydataset[START;STRIDE;COUNT;BLOCK]
   It is not required to use all parameters, but until the last parameter value used,

--- a/tools/test/h5diff/testfiles/h5diff_612.txt
+++ b/tools/test/h5diff/testfiles/h5diff_612.txt
@@ -158,6 +158,8 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
        symbolic links are compared.).
 
  Subsetting options:
+  --no-compact-subset  Disable compact form of subsetting and allow the use
+                          of "[" in dataset names.
   Subsetting is available by using the fcompact form of subsetting, as follows:
     obj1 /foo/mydataset[START;STRIDE;COUNT;BLOCK]
   It is not required to use all parameters, but until the last parameter value used,

--- a/tools/test/h5diff/testfiles/h5diff_615.txt
+++ b/tools/test/h5diff/testfiles/h5diff_615.txt
@@ -158,6 +158,8 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
        symbolic links are compared.).
 
  Subsetting options:
+  --no-compact-subset  Disable compact form of subsetting and allow the use
+                          of "[" in dataset names.
   Subsetting is available by using the fcompact form of subsetting, as follows:
     obj1 /foo/mydataset[START;STRIDE;COUNT;BLOCK]
   It is not required to use all parameters, but until the last parameter value used,

--- a/tools/test/h5diff/testfiles/h5diff_621.txt
+++ b/tools/test/h5diff/testfiles/h5diff_621.txt
@@ -158,6 +158,8 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
        symbolic links are compared.).
 
  Subsetting options:
+  --no-compact-subset  Disable compact form of subsetting and allow the use
+                          of "[" in dataset names.
   Subsetting is available by using the fcompact form of subsetting, as follows:
     obj1 /foo/mydataset[START;STRIDE;COUNT;BLOCK]
   It is not required to use all parameters, but until the last parameter value used,

--- a/tools/test/h5diff/testfiles/h5diff_622.txt
+++ b/tools/test/h5diff/testfiles/h5diff_622.txt
@@ -158,6 +158,8 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
        symbolic links are compared.).
 
  Subsetting options:
+  --no-compact-subset  Disable compact form of subsetting and allow the use
+                          of "[" in dataset names.
   Subsetting is available by using the fcompact form of subsetting, as follows:
     obj1 /foo/mydataset[START;STRIDE;COUNT;BLOCK]
   It is not required to use all parameters, but until the last parameter value used,

--- a/tools/test/h5diff/testfiles/h5diff_623.txt
+++ b/tools/test/h5diff/testfiles/h5diff_623.txt
@@ -158,6 +158,8 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
        symbolic links are compared.).
 
  Subsetting options:
+  --no-compact-subset  Disable compact form of subsetting and allow the use
+                          of "[" in dataset names.
   Subsetting is available by using the fcompact form of subsetting, as follows:
     obj1 /foo/mydataset[START;STRIDE;COUNT;BLOCK]
   It is not required to use all parameters, but until the last parameter value used,

--- a/tools/test/h5diff/testfiles/h5diff_624.txt
+++ b/tools/test/h5diff/testfiles/h5diff_624.txt
@@ -158,6 +158,8 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
        symbolic links are compared.).
 
  Subsetting options:
+  --no-compact-subset  Disable compact form of subsetting and allow the use
+                          of "[" in dataset names.
   Subsetting is available by using the fcompact form of subsetting, as follows:
     obj1 /foo/mydataset[START;STRIDE;COUNT;BLOCK]
   It is not required to use all parameters, but until the last parameter value used,


### PR DESCRIPTION
h5dump fails to parse HDF5 path names containing certain ASCII characters 