### PR TITLE
Turn off GitHub concurrent actions

### DIFF
--- a/.github/workflows/hdfeos5.yml
+++ b/.github/workflows/hdfeos5.yml
@@ -15,9 +15,9 @@ on:
       - '**.md'
 
 # Using concurrency to cancel any in-progress job or run
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.ref }}
+#  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ on:
       - '**.md'
 
 # Using concurrency to cancel any in-progress job or run
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.ref }}
+#  cancel-in-progress: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or
 # in parallel. We just have one job, but the matrix items defined below will


### PR DESCRIPTION
This cancels way too much stuff inappropriately. We need to better understand how this feature works.