### PR TITLE
Update concurrency group for main CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ on:
 
 # Using concurrency to cancel any in-progress job or run
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number }}
   cancel-in-progress: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or


### PR DESCRIPTION
Updates main CI workflow concurrency group so that the group should be a unique string formed as "workflow file-commit" or "workflow file-PR number". This should only cancel actions for a PR if the same PR is committed to while the actions are running.