### PR TITLE
Re-enable Debug MSVC tests in GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -535,8 +535,7 @@ jobs:
       - name: CMake Run Tests
         run: ctest --build . --parallel 2 -C ${{ matrix.build_mode.cmake }} -V
         working-directory: ${{ runner.workspace }}/build
-        # Skip Debug MSVC while we investigate H5L Java test timeouts
-        if: (matrix.generator != 'autogen') && (matrix.run_tests) && ! ((matrix.name == 'Windows MSVC CMake') && (matrix.build_mode.cmake == 'Debug'))
+        if: (matrix.generator != 'autogen') && (matrix.run_tests)
 
       #
       # INSTALL (note that this runs even when we don't run the tests)


### PR DESCRIPTION
This was skipped due to Java H5L concurrent test issues