### PR TITLE
H5Odtype.c decode cleanup

### DIFF
--- a/src/H5Odtype.c
+++ b/src/H5Odtype.c
@@ -30,7 +30,7 @@
  * This is a separate macro since we don't want to inflict that behavior on
  * the rest of the library.
  */
-#define H5_DTYPE_IS_BUFFER_OVERFLOW(skip, ptr, size, buffer_end) \
+#define H5_DTYPE_IS_BUFFER_OVERFLOW(skip, ptr, size, buffer_end)                                             \
     (skip ? FALSE : ((ptr) + (size)-1) > (buffer_end))
 
 /* PRIVATE PROTOTYPES */
@@ -128,8 +128,8 @@ const H5O_msg_class_t H5O_MSG_DTYPE[1] = {{
  *-------------------------------------------------------------------------
  */
 static htri_t
-H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t *dt, 
-        hbool_t skip, const uint8_t *p_end)
+H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t *dt, hbool_t skip,
+                         const uint8_t *p_end)
 {
     unsigned flags;
     unsigned version;
@@ -249,7 +249,7 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
             break;
 
         case H5T_TIME:
-            /* 
+            /*
              * Time datatypes...
              */
             dt->shared->u.atomic.order = (flags & 0x1) ? H5T_ORDER_BE : H5T_ORDER_LE;
@@ -285,30 +285,29 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
             UINT16DECODE(*pp, dt->shared->u.atomic.prec);
             break;
 
-        case H5T_OPAQUE:
-            {
-                size_t z;
+        case H5T_OPAQUE: {
+            size_t z;
 
-                /*
-                 * Opaque types...
-                 */
+            /*
+             * Opaque types...
+             */
 
-                /* The opaque tag flag field must be aligned */
-                z = flags & (H5T_OPAQUE_TAG_MAX - 1);
-                if (0 != (z & 0x7))
-                    HGOTO_ERROR(H5E_OHDR, H5E_BADVALUE, FAIL, "opaque flag field must be aligned")
+            /* The opaque tag flag field must be aligned */
+            z = flags & (H5T_OPAQUE_TAG_MAX - 1);
+            if (0 != (z & 0x7))
+                HGOTO_ERROR(H5E_OHDR, H5E_BADVALUE, FAIL, "opaque flag field must be aligned")
 
-                if (NULL == (dt->shared->u.opaque.tag = (char *)H5MM_malloc(z + 1)))
-                    HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed")
+            if (NULL == (dt->shared->u.opaque.tag = (char *)H5MM_malloc(z + 1)))
+                HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed")
 
-                if (H5_DTYPE_IS_BUFFER_OVERFLOW(skip, *pp, z, p_end))
-                    HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
-                H5MM_memcpy(dt->shared->u.opaque.tag, *pp, z);
-                dt->shared->u.opaque.tag[z] = '\0';
+            if (H5_DTYPE_IS_BUFFER_OVERFLOW(skip, *pp, z, p_end))
+                HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
+            H5MM_memcpy(dt->shared->u.opaque.tag, *pp, z);
+            dt->shared->u.opaque.tag[z] = '\0';
 
-                *pp += z;
-                break;
-            }
+            *pp += z;
+            break;
+        }
 
         case H5T_COMPOUND: {
             unsigned nmembs;           /* Number of compound members */
@@ -337,8 +336,8 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
             for (dt->shared->u.compnd.nmembs = 0; dt->shared->u.compnd.nmembs < nmembs;
                  dt->shared->u.compnd.nmembs++) {
 
-                size_t actual_name_length;                  /* Actual length of name */
-                size_t max     = (size_t)(p_end - *pp + 1); /* Max possible name length */
+                size_t   actual_name_length;                /* Actual length of name */
+                size_t   max   = (size_t)(p_end - *pp + 1); /* Max possible name length */
                 unsigned ndims = 0;                         /* Number of dimensions of the array field */
                 htri_t   can_upgrade;                       /* Whether we can upgrade this type's version */
                 hsize_t  dim[H5O_LAYOUT_NDIMS];             /* Dimensions of the array */
@@ -362,13 +361,15 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
                 if (version >= H5O_DTYPE_VERSION_3) {
                     /* Advance past name, including null terminator */
                     if (H5_DTYPE_IS_BUFFER_OVERFLOW(skip, *pp, actual_name_length + 1, p_end))
-                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL,
+                                    "ran off end of input buffer while decoding");
                     *pp += actual_name_length + 1;
                 }
                 else {
                     /* Advance multiple of 8 w/ null terminator */
                     if (H5_DTYPE_IS_BUFFER_OVERFLOW(skip, *pp, ((actual_name_length + 8) / 8) * 8, p_end))
-                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL,
+                                    "ran off end of input buffer while decoding");
                     *pp += ((actual_name_length + 8) / 8) * 8;
                 }
 
@@ -376,13 +377,15 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
                 /* (starting with version 3 of the datatype message, use the minimum # of bytes required) */
                 if (version >= H5O_DTYPE_VERSION_3) {
                     if (H5_DTYPE_IS_BUFFER_OVERFLOW(skip, *pp, offset_nbytes, p_end))
-                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL,
+                                    "ran off end of input buffer while decoding");
                     UINT32DECODE_VAR(*pp, dt->shared->u.compnd.memb[dt->shared->u.compnd.nmembs].offset,
                                      offset_nbytes)
                 }
                 else {
                     if (H5_DTYPE_IS_BUFFER_OVERFLOW(skip, *pp, 4, p_end))
-                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL,
+                                    "ran off end of input buffer while decoding");
                     UINT32DECODE(*pp, dt->shared->u.compnd.memb[dt->shared->u.compnd.nmembs].offset)
                 }
 
@@ -392,7 +395,8 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
                 if (version == H5O_DTYPE_VERSION_1) {
                     /* Decode the number of dimensions */
                     if (H5_DTYPE_IS_BUFFER_OVERFLOW(skip, *pp, 1, p_end))
-                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL,
+                                    "ran off end of input buffer while decoding");
                     ndims = *(*pp)++;
 
                     /* Check that ndims is valid */
@@ -404,22 +408,26 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
 
                     /* Skip reserved bytes */
                     if (H5_DTYPE_IS_BUFFER_OVERFLOW(skip, *pp, 3, p_end))
-                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL,
+                                    "ran off end of input buffer while decoding");
                     *pp += 3;
 
                     /* Skip dimension permutation */
                     if (H5_DTYPE_IS_BUFFER_OVERFLOW(skip, *pp, 4, p_end))
-                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL,
+                                    "ran off end of input buffer while decoding");
                     *pp += 4;
 
                     /* Skip reserved bytes */
                     if (H5_DTYPE_IS_BUFFER_OVERFLOW(skip, *pp, 4, p_end))
-                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL,
+                                    "ran off end of input buffer while decoding");
                     *pp += 4;
 
                     /* Decode array dimension sizes */
                     if (H5_DTYPE_IS_BUFFER_OVERFLOW(skip, *pp, (4 * 4), p_end))
-                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL,
+                                    "ran off end of input buffer while decoding");
                     for (int i = 0; i < 4; i++)
                         UINT32DECODE(*pp, dim[i]);
                 }
@@ -551,7 +559,7 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
         } break;
 
         case H5T_REFERENCE:
-            /* 
+            /*
              * Reference datatypes...
              */
             dt->shared->u.atomic.order   = H5T_ORDER_NONE;
@@ -615,7 +623,7 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
             /* Names */
             for (dt->shared->u.enumer.nmembs = 0; dt->shared->u.enumer.nmembs < nmembs;
                  dt->shared->u.enumer.nmembs++) {
-                
+
                 size_t actual_name_length;              /* Actual length of name */
                 size_t max = (size_t)(p_end - *pp + 1); /* Max possible name length */
 
@@ -633,13 +641,15 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
                 if (version >= H5O_DTYPE_VERSION_3) {
                     /* Advance past name, including null terminator */
                     if (H5_DTYPE_IS_BUFFER_OVERFLOW(skip, *pp, actual_name_length + 1, p_end))
-                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL,
+                                    "ran off end of input buffer while decoding");
                     *pp += actual_name_length + 1;
                 }
                 else {
                     /* Advance multiple of 8 w/ null terminator */
                     if (H5_DTYPE_IS_BUFFER_OVERFLOW(skip, *pp, ((actual_name_length + 8) / 8) * 8, p_end))
-                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL,
+                                    "ran off end of input buffer while decoding");
                     *pp += ((actual_name_length + 8) / 8) * 8;
                 }
             }

--- a/test/dtypes.c
+++ b/test/dtypes.c
@@ -5965,34 +5965,37 @@ error:
  *
  * Purpose:     Tests functions of encoding and decoding datatype.
  *
- * Return:      Success:        0
- *
- *              Failure:        number of errors
- *
- * Programmer:  Raymond Lu
- *              July 14, 2004
- *
+ * Return:      Success:    0
+ *              Failure:    number of errors
  *-------------------------------------------------------------------------
  */
 static int
 test_encode(void)
 {
-    struct s1 {
+    struct cmpd {
         int    a;
         float  b;
         long   c;
         double d;
     };
-    hid_t          file = -1, tid1 = -1, tid2 = -1, tid3 = -1;
-    hid_t          decoded_tid1 = -1, decoded_tid2 = -1, decoded_tid3 = -1;
+    hid_t          file         = H5I_INVALID_HID;
+    hid_t          tid1         = H5I_INVALID_HID;
+    hid_t          tid2         = H5I_INVALID_HID;
+    hid_t          tid3         = H5I_INVALID_HID;
+    hid_t          decoded_tid1 = H5I_INVALID_HID;
+    hid_t          decoded_tid2 = H5I_INVALID_HID;
+    hid_t          decoded_tid3 = H5I_INVALID_HID;
     char           filename[1024];
-    char           compnd_type[] = "Compound_type", enum_type[] = "Enum_type";
-    char           vlstr_type[] = "VLstring_type";
+    char           compnd_type[] = "Compound_type";
+    char           enum_type[]   = "Enum_type";
+    char           vlstr_type[]  = "VLstring_type";
     short          enum_val;
     size_t         cmpd_buf_size  = 0;
     size_t         enum_buf_size  = 0;
     size_t         vlstr_buf_size = 0;
-    unsigned char *cmpd_buf = NULL, *enum_buf = NULL, *vlstr_buf = NULL;
+    unsigned char *cmpd_buf       = NULL;
+    unsigned char *enum_buf       = NULL;
+    unsigned char *vlstr_buf      = NULL;
     hid_t          ret_id;
     herr_t         ret;
 
@@ -6008,75 +6011,75 @@ test_encode(void)
      *-----------------------------------------------------------------------
      */
     /* Create a compound datatype */
-    if ((tid1 = H5Tcreate(H5T_COMPOUND, sizeof(struct s1))) < 0) {
+    if ((tid1 = H5Tcreate(H5T_COMPOUND, sizeof(struct cmpd))) < 0) {
         H5_FAILED();
         HDprintf("Can't create datatype!\n");
         goto error;
-    } /* end if */
-    if (H5Tinsert(tid1, "a", HOFFSET(struct s1, a), H5T_NATIVE_INT) < 0) {
+    }
+    if (H5Tinsert(tid1, "a", HOFFSET(struct cmpd, a), H5T_NATIVE_INT) < 0) {
         H5_FAILED();
         HDprintf("Can't insert field 'a'\n");
         goto error;
-    } /* end if */
-    if (H5Tinsert(tid1, "b", HOFFSET(struct s1, b), H5T_NATIVE_FLOAT) < 0) {
+    }
+    if (H5Tinsert(tid1, "b", HOFFSET(struct cmpd, b), H5T_NATIVE_FLOAT) < 0) {
         H5_FAILED();
         HDprintf("Can't insert field 'b'\n");
         goto error;
-    } /* end if */
-    if (H5Tinsert(tid1, "c", HOFFSET(struct s1, c), H5T_NATIVE_LONG) < 0) {
+    }
+    if (H5Tinsert(tid1, "c", HOFFSET(struct cmpd, c), H5T_NATIVE_LONG) < 0) {
         H5_FAILED();
         HDprintf("Can't insert field 'c'\n");
         goto error;
-    } /* end if */
-    if (H5Tinsert(tid1, "d", HOFFSET(struct s1, d), H5T_NATIVE_DOUBLE) < 0) {
+    }
+    if (H5Tinsert(tid1, "d", HOFFSET(struct cmpd, d), H5T_NATIVE_DOUBLE) < 0) {
         H5_FAILED();
         HDprintf("Can't insert field 'd'\n");
         goto error;
-    } /* end if */
+    }
 
     /* Create a enumerate datatype */
     if ((tid2 = H5Tcreate(H5T_ENUM, sizeof(short))) < 0) {
         H5_FAILED();
         HDprintf("Can't create enumerate type\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tenum_insert(tid2, "RED", (enum_val = 0, &enum_val)) < 0) {
         H5_FAILED();
         HDprintf("Can't insert field into enumeration type\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tenum_insert(tid2, "GREEN", (enum_val = 1, &enum_val)) < 0) {
         H5_FAILED();
         HDprintf("Can't insert field into enumeration type\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tenum_insert(tid2, "BLUE", (enum_val = 2, &enum_val)) < 0) {
         H5_FAILED();
         HDprintf("Can't insert field into enumeration type\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tenum_insert(tid2, "ORANGE", (enum_val = 3, &enum_val)) < 0) {
         H5_FAILED();
         HDprintf("Can't insert field into enumeration type\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tenum_insert(tid2, "YELLOW", (enum_val = 4, &enum_val)) < 0) {
         H5_FAILED();
         HDprintf("Can't insert field into enumeration type\n");
         goto error;
-    } /* end if */
+    }
 
     /* Create a variable-length string type */
     if ((tid3 = H5Tcopy(H5T_C_S1)) < 0) {
         H5_FAILED();
         HDprintf("Can't copy a string type\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tset_size(tid3, H5T_VARIABLE) < 0) {
         H5_FAILED();
         HDprintf("Can't the string type to be variable-length\n");
         goto error;
-    } /* end if */
+    }
 
     /*-----------------------------------------------------------------------
      * Test encoding and decoding compound, enumerate, and VL string datatypes
@@ -6087,12 +6090,12 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Can't encode compound type\n");
         goto error;
-    } /* end if */
+    }
 
     if (cmpd_buf_size > 0)
         cmpd_buf = (unsigned char *)HDcalloc((size_t)1, cmpd_buf_size);
 
-    /* Try decoding bogus buffer */
+    /* Try decoding an incorrect (empty) buffer (should fail) */
     H5E_BEGIN_TRY
     {
         ret_id = H5Tdecode(cmpd_buf);
@@ -6100,7 +6103,7 @@ test_encode(void)
     H5E_END_TRY;
     if (ret_id != FAIL) {
         H5_FAILED();
-        HDprintf("Decoded bogus buffer!\n");
+        HDprintf("Decoded an empty buffer!\n");
         goto error;
     }
 
@@ -6108,7 +6111,7 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Can't encode compound type\n");
         goto error;
-    } /* end if */
+    }
 
     /* Decode from the compound buffer and return an object handle */
     if ((decoded_tid1 = H5Tdecode(cmpd_buf)) < 0)
@@ -6119,26 +6122,26 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Datatype wasn't encoded & decoded identically\n");
         goto error;
-    } /* end if */
+    }
 
     /* Query member number and member index by name, for compound type. */
     if (H5Tget_nmembers(decoded_tid1) != 4) {
         H5_FAILED();
         HDprintf("Can't get member number\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tget_member_index(decoded_tid1, "c") != 2) {
         H5_FAILED();
         HDprintf("Can't get correct index number\n");
         goto error;
-    } /* end if */
+    }
 
     /* Encode enumerate type in a buffer */
     if (H5Tencode(tid2, NULL, &enum_buf_size) < 0) {
         H5_FAILED();
         HDprintf("Can't encode enumerate type\n");
         goto error;
-    } /* end if */
+    }
 
     if (enum_buf_size > 0)
         enum_buf = (unsigned char *)HDcalloc((size_t)1, enum_buf_size);
@@ -6147,40 +6150,40 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Can't encode enumerate type\n");
         goto error;
-    } /* end if */
+    }
 
     /* Decode from the enumerate buffer and return an object handle */
     if ((decoded_tid2 = H5Tdecode(enum_buf)) < 0) {
         H5_FAILED();
         HDprintf("Can't decode enumerate type\n");
         goto error;
-    } /* end if */
+    }
 
     /* Verify that the datatype was copied exactly */
     if (H5Tequal(decoded_tid2, tid2) <= 0) {
         H5_FAILED();
         HDprintf("Datatype wasn't encoded & decoded identically\n");
         goto error;
-    } /* end if */
+    }
 
     /* Query member number and member index by name, for enumeration type. */
     if (H5Tget_nmembers(decoded_tid2) != 5) {
         H5_FAILED();
         HDprintf("Can't get member number\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tget_member_index(decoded_tid2, "ORANGE") != 3) {
         H5_FAILED();
         HDprintf("Can't get correct index number\n");
         goto error;
-    } /* end if */
+    }
 
     /* Encode VL string type in a buffer */
     if (H5Tencode(tid3, NULL, &vlstr_buf_size) < 0) {
         H5_FAILED();
         HDprintf("Can't encode VL string type\n");
         goto error;
-    } /* end if */
+    }
 
     if (vlstr_buf_size > 0)
         vlstr_buf = (unsigned char *)HDcalloc((size_t)1, vlstr_buf_size);
@@ -6189,26 +6192,26 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Can't encode VL string type\n");
         goto error;
-    } /* end if */
+    }
 
     /* Decode from the VL string buffer and return an object handle */
     if ((decoded_tid3 = H5Tdecode(vlstr_buf)) < 0) {
         H5_FAILED();
         HDprintf("Can't decode VL string type\n");
         goto error;
-    } /* end if */
+    }
 
     /* Verify that the datatype was copied exactly */
     if (H5Tequal(decoded_tid3, tid3) <= 0) {
         H5_FAILED();
         HDprintf("Datatype wasn't encoded & decoded identically\n");
         goto error;
-    } /* end if */
+    }
     if (!H5Tis_variable_str(decoded_tid3)) {
         H5_FAILED();
         HDprintf("Datatype wasn't encoded & decoded identically\n");
         goto error;
-    } /* end if */
+    }
 
     /*-----------------------------------------------------------------------
      * Commit and reopen the compound, enumerate, VL string datatypes
@@ -6219,17 +6222,17 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Can't commit compound datatype\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tclose(tid1) < 0) {
         H5_FAILED();
         HDprintf("Can't close datatype\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tclose(decoded_tid1) < 0) {
         H5_FAILED();
         HDprintf("Can't close datatype\n");
         goto error;
-    } /* end if */
+    }
     HDfree(cmpd_buf);
     cmpd_buf_size = 0;
 
@@ -6238,17 +6241,17 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Can't commit compound datatype\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tclose(tid2) < 0) {
         H5_FAILED();
         HDprintf("Can't close datatype\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tclose(decoded_tid2) < 0) {
         H5_FAILED();
         HDprintf("Can't close datatype\n");
         goto error;
-    } /* end if */
+    }
     HDfree(enum_buf);
     enum_buf_size = 0;
 
@@ -6257,17 +6260,17 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Can't commit vl string datatype\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tclose(tid3) < 0) {
         H5_FAILED();
         HDprintf("Can't close datatype\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tclose(decoded_tid3) < 0) {
         H5_FAILED();
         HDprintf("Can't close datatype\n");
         goto error;
-    } /* end if */
+    }
     HDfree(vlstr_buf);
     vlstr_buf_size = 0;
 
@@ -6288,7 +6291,7 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Can't encode compound type\n");
         goto error;
-    } /* end if */
+    }
 
     if (cmpd_buf_size > 0)
         cmpd_buf = (unsigned char *)HDcalloc((size_t)1, cmpd_buf_size);
@@ -6297,7 +6300,7 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Can't encode compound type\n");
         goto error;
-    } /* end if */
+    }
 
     /* Decode from the compound buffer and return an object handle */
     if ((decoded_tid1 = H5Tdecode(cmpd_buf)) < 0)
@@ -6308,26 +6311,26 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Datatype wasn't encoded & decoded identically\n");
         goto error;
-    } /* end if */
+    }
 
     /* Query member number and member index by name, for compound type. */
     if (H5Tget_nmembers(decoded_tid1) != 4) {
         H5_FAILED();
         HDprintf("Can't get member number\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tget_member_index(decoded_tid1, "c") != 2) {
         H5_FAILED();
         HDprintf("Can't get correct index number\n");
         goto error;
-    } /* end if */
+    }
 
     /* Encode enumerate type in a buffer */
     if (H5Tencode(tid2, NULL, &enum_buf_size) < 0) {
         H5_FAILED();
         HDprintf("Can't encode enumerate type\n");
         goto error;
-    } /* end if */
+    }
 
     if (enum_buf_size > 0)
         enum_buf = (unsigned char *)HDcalloc((size_t)1, enum_buf_size);
@@ -6336,40 +6339,40 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Can't encode enumerate type\n");
         goto error;
-    } /* end if */
+    }
 
     /* Decode from the enumerate buffer and return an object handle */
     if ((decoded_tid2 = H5Tdecode(enum_buf)) < 0) {
         H5_FAILED();
         HDprintf("Can't decode enumerate type\n");
         goto error;
-    } /* end if */
+    }
 
     /* Verify that the datatype was copied exactly */
     if (H5Tequal(decoded_tid2, tid2) <= 0) {
         H5_FAILED();
         HDprintf("Datatype wasn't encoded & decoded identically\n");
         goto error;
-    } /* end if */
+    }
 
     /* Query member number and member index by name, for enumeration type. */
     if (H5Tget_nmembers(decoded_tid2) != 5) {
         H5_FAILED();
         HDprintf("Can't get member number\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tget_member_index(decoded_tid2, "ORANGE") != 3) {
         H5_FAILED();
         HDprintf("Can't get correct index number\n");
         goto error;
-    } /* end if */
+    }
 
     /* Encode VL string type in a buffer */
     if (H5Tencode(tid3, NULL, &vlstr_buf_size) < 0) {
         H5_FAILED();
         HDprintf("Can't encode VL string type\n");
         goto error;
-    } /* end if */
+    }
 
     if (vlstr_buf_size > 0)
         vlstr_buf = (unsigned char *)HDcalloc((size_t)1, vlstr_buf_size);
@@ -6378,14 +6381,14 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Can't encode VL string type\n");
         goto error;
-    } /* end if */
+    }
 
     /* Decode from the VL string buffer and return an object handle */
     if ((decoded_tid3 = H5Tdecode(vlstr_buf)) < 0) {
         H5_FAILED();
         HDprintf("Can't decode VL string type\n");
         goto error;
-    } /* end if */
+    }
     HDfree(vlstr_buf);
 
     /* Verify that the datatype was copied exactly */
@@ -6393,12 +6396,12 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Datatype wasn't encoded & decoded identically\n");
         goto error;
-    } /* end if */
+    }
     if (!H5Tis_variable_str(decoded_tid3)) {
         H5_FAILED();
         HDprintf("Datatype wasn't encoded & decoded identically\n");
         goto error;
-    } /* end if */
+    }
 
     /*-----------------------------------------------------------------------
      * Test the reference count of the decoded datatypes
@@ -6410,19 +6413,19 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Decoded datatype has incorrect reference count\n");
         goto error;
-    } /* end if */
+    }
 
     if (H5Iget_ref(decoded_tid2) != 1) {
         H5_FAILED();
         HDprintf("Decoded datatype has incorrect reference count\n");
         goto error;
-    } /* end if */
+    }
 
     if (H5Iget_ref(decoded_tid3) != 1) {
         H5_FAILED();
         HDprintf("Decoded datatype has incorrect reference count\n");
         goto error;
-    } /* end if */
+    }
 
     /* Make sure the reference counts for the decoded datatypes can be
      * decremented and the datatypes are closed. */
@@ -6430,19 +6433,19 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Decoded datatype can't close\n");
         goto error;
-    } /* end if */
+    }
 
     if (H5Idec_ref(decoded_tid2) != 0) {
         H5_FAILED();
         HDprintf("Decoded datatype can't close\n");
         goto error;
-    } /* end if */
+    }
 
     if (H5Idec_ref(decoded_tid3) != 0) {
         H5_FAILED();
         HDprintf("Decoded datatype can't close\n");
         goto error;
-    } /* end if */
+    }
 
     /* Make sure the decoded datatypes are already closed. */
     H5E_BEGIN_TRY
@@ -6487,23 +6490,23 @@ test_encode(void)
         H5_FAILED();
         HDprintf("Can't close datatype\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tclose(tid2) < 0) {
         H5_FAILED();
         HDprintf("Can't close datatype\n");
         goto error;
-    } /* end if */
+    }
     if (H5Tclose(tid3) < 0) {
         H5_FAILED();
         HDprintf("Can't close datatype\n");
         goto error;
-    } /* end if */
+    }
 
     if (H5Fclose(file) < 0) {
         H5_FAILED();
         HDprintf("Can't close file\n");
         goto error;
-    } /* end if */
+    }
 
     HDfree(cmpd_buf);
     HDfree(enum_buf);


### PR DESCRIPTION
Cleans up H5Odtype.c's decode call, which was complicated by H5Tdecode()
taking a buffer but not a size.