### PR TITLE
Remove unused variable warning in H5C.c

### DIFF
--- a/src/H5C.c
+++ b/src/H5C.c
@@ -6579,7 +6579,7 @@ H5C__make_space_in_cache(H5F_t *f, size_t space_needed, hbool_t write_permitted)
     H5C_cache_entry_t *entry_ptr;
     H5C_cache_entry_t *prev_ptr;
     H5C_cache_entry_t *next_ptr;
-    herr_t             ret_value          = SUCCEED; /* Return value */
+    herr_t             ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 

--- a/src/H5C.c
+++ b/src/H5C.c
@@ -6579,8 +6579,8 @@ H5C__make_space_in_cache(H5F_t *f, size_t space_needed, hbool_t write_permitted)
     H5C_cache_entry_t *entry_ptr;
     H5C_cache_entry_t *prev_ptr;
     H5C_cache_entry_t *next_ptr;
-    uint32_t num_corked_entries = 0;
-    herr_t ret_value = SUCCEED; /* Return value */
+    uint32_t           num_corked_entries = 0;
+    herr_t             ret_value          = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -6629,7 +6629,7 @@ H5C__make_space_in_cache(H5F_t *f, size_t space_needed, hbool_t write_permitted)
             if (entry_ptr->is_dirty && (entry_ptr->tag_info && entry_ptr->tag_info->corked)) {
                 /* Skip "dirty" corked entries.  */
                 num_corked_entries = num_corked_entries + 1;
-                didnt_flush_entry = TRUE;
+                didnt_flush_entry  = TRUE;
             }
             else if ((entry_ptr->type->id != H5AC_EPOCH_MARKER_ID) && !entry_ptr->flush_in_progress &&
                      !entry_ptr->prefetched_dirty) {

--- a/src/H5C.c
+++ b/src/H5C.c
@@ -6628,7 +6628,7 @@ H5C__make_space_in_cache(H5F_t *f, size_t space_needed, hbool_t write_permitted)
 
             if (entry_ptr->is_dirty && (entry_ptr->tag_info && entry_ptr->tag_info->corked)) {
                 /* Skip "dirty" corked entries.  */
-                num_corked_entries = num_corked_netries + 1;
+                num_corked_entries = num_corked_entries + 1;
                 didnt_flush_entry = TRUE;
             }
             else if ((entry_ptr->type->id != H5AC_EPOCH_MARKER_ID) && !entry_ptr->flush_in_progress &&

--- a/src/H5C.c
+++ b/src/H5C.c
@@ -6579,9 +6579,7 @@ H5C__make_space_in_cache(H5F_t *f, size_t space_needed, hbool_t write_permitted)
     H5C_cache_entry_t *entry_ptr;
     H5C_cache_entry_t *prev_ptr;
     H5C_cache_entry_t *next_ptr;
-#if !defined(SYCL_LANGUAGE_VERSION) || !defined(__INTEL_LLVM_COMPILER)
     uint32_t num_corked_entries = 0;
-#endif
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -6630,7 +6628,7 @@ H5C__make_space_in_cache(H5F_t *f, size_t space_needed, hbool_t write_permitted)
 
             if (entry_ptr->is_dirty && (entry_ptr->tag_info && entry_ptr->tag_info->corked)) {
                 /* Skip "dirty" corked entries.  */
-                ++num_corked_entries;
+                num_corked_entries = num_corked_netries + 1;
                 didnt_flush_entry = TRUE;
             }
             else if ((entry_ptr->type->id != H5AC_EPOCH_MARKER_ID) && !entry_ptr->flush_in_progress &&

--- a/src/H5C.c
+++ b/src/H5C.c
@@ -6579,6 +6579,9 @@ H5C__make_space_in_cache(H5F_t *f, size_t space_needed, hbool_t write_permitted)
     H5C_cache_entry_t *entry_ptr;
     H5C_cache_entry_t *prev_ptr;
     H5C_cache_entry_t *next_ptr;
+#if !defined(SYCL_LANGUAGE_VERSION) || !defined (__INTEL_LLVM_COMPILER)
+    uint32_t num_corked_entries = 0;
+#endif    
     herr_t             ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE

--- a/src/H5C.c
+++ b/src/H5C.c
@@ -6579,7 +6579,6 @@ H5C__make_space_in_cache(H5F_t *f, size_t space_needed, hbool_t write_permitted)
     H5C_cache_entry_t *entry_ptr;
     H5C_cache_entry_t *prev_ptr;
     H5C_cache_entry_t *next_ptr;
-    uint32_t           num_corked_entries = 0;
     herr_t             ret_value          = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE

--- a/src/H5C.c
+++ b/src/H5C.c
@@ -6579,10 +6579,10 @@ H5C__make_space_in_cache(H5F_t *f, size_t space_needed, hbool_t write_permitted)
     H5C_cache_entry_t *entry_ptr;
     H5C_cache_entry_t *prev_ptr;
     H5C_cache_entry_t *next_ptr;
-#if !defined(SYCL_LANGUAGE_VERSION) || !defined (__INTEL_LLVM_COMPILER)
+#if !defined(SYCL_LANGUAGE_VERSION) || !defined(__INTEL_LLVM_COMPILER)
     uint32_t num_corked_entries = 0;
-#endif    
-    herr_t             ret_value = SUCCEED; /* Return value */
+#endif
+    herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 


### PR DESCRIPTION
Sunspot compiler (icx) throws a warning.

`CMAKE_C_COMPILER:FILEPATH=/soft/restricted/CNDA/updates/2022.12.30.001/oneapi/\
cmpiler/trunk-20230201/compiler/linux/bin/icx`

See https://my.cdash.org/viewBuildError.php?type=1&buildid=2327793 for details.