### PR TITLE
Remove selection I/O test from testphdf5 in CMake

### DIFF
--- a/testpar/CMakeLists.txt
+++ b/testpar/CMakeLists.txt
@@ -8,7 +8,6 @@ project (HDF5_TEST_PAR C)
 set (testphdf5_SOURCES
     ${HDF5_TEST_PAR_SOURCE_DIR}/testphdf5.c
     ${HDF5_TEST_PAR_SOURCE_DIR}/t_dset.c
-    ${HDF5_TEST_PAR_SOURCE_DIR}/t_select_io_dset.c
     ${HDF5_TEST_PAR_SOURCE_DIR}/t_file.c
     ${HDF5_TEST_PAR_SOURCE_DIR}/t_file_image.c
     ${HDF5_TEST_PAR_SOURCE_DIR}/t_mdset.c


### PR DESCRIPTION
t_select_io_dset is a stand-alone program, not a parth of testphdf5.