### PR TITLE
Skip page buffer test for "no selection I/O cause" when using split or multi driver

### DIFF
--- a/test/select_io_dset.c
+++ b/test/select_io_dset.c
@@ -2860,6 +2860,16 @@ test_no_selection_io_cause_mode(const char *filename, hid_t fapl, uint32_t test_
     int      rbuf[DSET_SELECT_DIM];
     int      i;
 
+    /* Check for (currently) incompatible combindations */
+    if (test_mode & TEST_PAGE_BUFFER) {
+        char *env_h5_drvr = NULL;
+
+        /* The split and multi driver are not compatible with page buffering.  No message since the other cases aren't skipped. */
+        env_h5_drvr = HDgetenv(HDF5_DRIVER);
+        if (env_h5_drvr && (!HDstrcmp(env_h5_drvr, "split") || !HDstrcmp(env_h5_drvr, "multi")))
+            return 0;
+    }
+
     if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
         FAIL_STACK_ERROR;
 

--- a/test/select_io_dset.c
+++ b/test/select_io_dset.c
@@ -2864,7 +2864,8 @@ test_no_selection_io_cause_mode(const char *filename, hid_t fapl, uint32_t test_
     if (test_mode & TEST_PAGE_BUFFER) {
         char *env_h5_drvr = NULL;
 
-        /* The split and multi driver are not compatible with page buffering.  No message since the other cases aren't skipped. */
+        /* The split and multi driver are not compatible with page buffering.  No message since the other
+         * cases aren't skipped. */
         env_h5_drvr = HDgetenv(HDF5_DRIVER);
         if (env_h5_drvr && (!HDstrcmp(env_h5_drvr, "split") || !HDstrcmp(env_h5_drvr, "multi")))
             return 0;

--- a/test/select_io_dset.c
+++ b/test/select_io_dset.c
@@ -2860,7 +2860,7 @@ test_no_selection_io_cause_mode(const char *filename, hid_t fapl, uint32_t test_
     int      rbuf[DSET_SELECT_DIM];
     int      i;
 
-    /* Check for (currently) incompatible combindations */
+    /* Check for (currently) incompatible combinations */
     if (test_mode & TEST_PAGE_BUFFER) {
         char *env_h5_drvr = NULL;
 


### PR DESCRIPTION
Fixes check-vfd failure