### PR TITLE
Public header cleanup

### DIFF
--- a/src/H5ACpublic.h
+++ b/src/H5ACpublic.h
@@ -21,8 +21,8 @@
 #ifndef H5ACpublic_H
 #define H5ACpublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
-#include "H5Cpublic.h"          /* Cache                                    */
+#include "H5public.h"  /* Generic Functions                        */
+#include "H5Cpublic.h" /* Cache                                    */
 
 /****************************************************************************
  *

--- a/src/H5ACpublic.h
+++ b/src/H5ACpublic.h
@@ -13,19 +13,16 @@
 /*-------------------------------------------------------------------------
  *
  * Created:             H5ACpublic.h
- *                      Jul 10 1997
- *                      Robb Matzke
  *
- * Purpose:             Public include file for cache functions.
+ * Purpose:             Public include file for cache functions
  *
  *-------------------------------------------------------------------------
  */
 #ifndef H5ACpublic_H
 #define H5ACpublic_H
 
-/* Public headers needed by this file */
-#include "H5public.h"
-#include "H5Cpublic.h"
+#include "H5public.h"           /* Generic Functions                        */
+#include "H5Cpublic.h"          /* Cache                                    */
 
 /****************************************************************************
  *

--- a/src/H5Apublic.h
+++ b/src/H5Apublic.h
@@ -16,10 +16,10 @@
 #ifndef H5Apublic_H
 #define H5Apublic_H
 
-/* Public headers needed by this file */
-#include "H5Ipublic.h" /* IDs			  		*/
-#include "H5Opublic.h" /* Object Headers			*/
-#include "H5Tpublic.h" /* Datatypes				*/
+#include "H5public.h"           /* Generic Functions                        */
+#include "H5Ipublic.h"          /* Identifiers                              */
+#include "H5Opublic.h"          /* Object Headers                           */
+#include "H5Tpublic.h"          /* Datatypes                                */
 
 //! <!-- [H5A_info_t_snip] -->
 /**

--- a/src/H5Apublic.h
+++ b/src/H5Apublic.h
@@ -16,10 +16,10 @@
 #ifndef H5Apublic_H
 #define H5Apublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
-#include "H5Ipublic.h"          /* Identifiers                              */
-#include "H5Opublic.h"          /* Object Headers                           */
-#include "H5Tpublic.h"          /* Datatypes                                */
+#include "H5public.h"  /* Generic Functions                        */
+#include "H5Ipublic.h" /* Identifiers                              */
+#include "H5Opublic.h" /* Object Headers                           */
+#include "H5Tpublic.h" /* Datatypes                                */
 
 //! <!-- [H5A_info_t_snip] -->
 /**

--- a/src/H5Cpublic.h
+++ b/src/H5Cpublic.h
@@ -12,19 +12,16 @@
 
 /*-------------------------------------------------------------------------
  *
- * Created:	H5Cpublic.h
- *              June 4, 2005
- *              John Mainzer
+ * Created:     H5Cpublic.h
  *
- * Purpose:     Public include file for cache functions.
+ * Purpose:     Public header file for cache functions
  *
  *-------------------------------------------------------------------------
  */
 #ifndef H5Cpublic_H
 #define H5Cpublic_H
 
-/* Public headers needed by this file */
-#include "H5public.h"
+#include "H5public.h"           /* Generic Functions                        */
 
 enum H5C_cache_incr_mode {
     H5C_incr__off,

--- a/src/H5Cpublic.h
+++ b/src/H5Cpublic.h
@@ -21,7 +21,7 @@
 #ifndef H5Cpublic_H
 #define H5Cpublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
+#include "H5public.h" /* Generic Functions                        */
 
 enum H5C_cache_incr_mode {
     H5C_incr__off,

--- a/src/H5Dpublic.h
+++ b/src/H5Dpublic.h
@@ -16,8 +16,8 @@
 #ifndef H5Dpublic_H
 #define H5Dpublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
-#include "H5Ipublic.h"          /* Identifiers                              */
+#include "H5public.h"  /* Generic Functions                        */
+#include "H5Ipublic.h" /* Identifiers                              */
 
 /*****************/
 /* Public Macros */

--- a/src/H5Dpublic.h
+++ b/src/H5Dpublic.h
@@ -16,11 +16,8 @@
 #ifndef H5Dpublic_H
 #define H5Dpublic_H
 
-/* System headers needed by this file */
-
-/* Public headers needed by this file */
-#include "H5public.h"
-#include "H5Ipublic.h"
+#include "H5public.h"           /* Generic Functions                        */
+#include "H5Ipublic.h"          /* Identifiers                              */
 
 /*****************/
 /* Public Macros */

--- a/src/H5ESpublic.h
+++ b/src/H5ESpublic.h
@@ -17,8 +17,8 @@
 #ifndef H5ESpublic_H
 #define H5ESpublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
-#include "H5Ipublic.h"          /* Identifiers                              */
+#include "H5public.h"  /* Generic Functions                        */
+#include "H5Ipublic.h" /* Identifiers                              */
 
 /*****************/
 /* Public Macros */

--- a/src/H5ESpublic.h
+++ b/src/H5ESpublic.h
@@ -17,10 +17,8 @@
 #ifndef H5ESpublic_H
 #define H5ESpublic_H
 
-
 #include "H5public.h"  /* Generic Functions                        */
 #include "H5Ipublic.h" /* Identifiers                              */
-
 
 /*****************/
 /* Public Macros */

--- a/src/H5ESpublic.h
+++ b/src/H5ESpublic.h
@@ -17,8 +17,8 @@
 #ifndef H5ESpublic_H
 #define H5ESpublic_H
 
-/* Public headers needed by this file */
-#include "H5public.h" /* Generic Functions                    */
+#include "H5public.h"           /* Generic Functions                        */
+#include "H5Ipublic.h"          /* Identifiers                              */
 
 /*****************/
 /* Public Macros */

--- a/src/H5Epublic.h
+++ b/src/H5Epublic.h
@@ -18,8 +18,8 @@
 
 #include <stdio.h> /* FILE arg of H5Eprint() */
 
-#include "H5public.h"           /* Generic Functions                        */
-#include "H5Ipublic.h"          /* Identifiers                              */
+#include "H5public.h"  /* Generic Functions                        */
+#include "H5Ipublic.h" /* Identifiers                              */
 
 /* Value for the default error stack */
 #define H5E_DEFAULT 0 /* (hid_t) */

--- a/src/H5Epublic.h
+++ b/src/H5Epublic.h
@@ -16,11 +16,10 @@
 #ifndef H5Epublic_H
 #define H5Epublic_H
 
-#include <stdio.h> /*FILE arg of H5Eprint()                     */
+#include <stdio.h> /* FILE arg of H5Eprint() */
 
-/* Public headers needed by this file */
-#include "H5public.h"
-#include "H5Ipublic.h"
+#include "H5public.h"           /* Generic Functions                        */
+#include "H5Ipublic.h"          /* Identifiers                              */
 
 /* Value for the default error stack */
 #define H5E_DEFAULT 0 /* (hid_t) */

--- a/src/H5FDpublic.h
+++ b/src/H5FDpublic.h
@@ -13,9 +13,9 @@
 #ifndef H5FDpublic_H
 #define H5FDpublic_H
 
-/* Public headers needed by this file */
-#include "H5public.h"  /* Generic Functions */
-#include "H5Fpublic.h" /* Files */
+#include "H5public.h"           /* Generic Functions                        */
+#include "H5Fpublic.h"          /* Files                                    */
+#include "H5Ipublic.h"          /* Identifiers                              */
 
 /*****************/
 /* Public Macros */

--- a/src/H5FDpublic.h
+++ b/src/H5FDpublic.h
@@ -13,9 +13,9 @@
 #ifndef H5FDpublic_H
 #define H5FDpublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
-#include "H5Fpublic.h"          /* Files                                    */
-#include "H5Ipublic.h"          /* Identifiers                              */
+#include "H5public.h"  /* Generic Functions                        */
+#include "H5Fpublic.h" /* Files                                    */
+#include "H5Ipublic.h" /* Identifiers                              */
 
 /*****************/
 /* Public Macros */

--- a/src/H5Fpublic.h
+++ b/src/H5Fpublic.h
@@ -16,10 +16,9 @@
 #ifndef H5Fpublic_H
 #define H5Fpublic_H
 
-/* Public header files needed by this file */
-#include "H5public.h"
-#include "H5ACpublic.h"
-#include "H5Ipublic.h"
+#include "H5public.h"           /* Generic Functions                        */
+#include "H5ACpublic.h"         /* Metadata Cache                           */
+#include "H5Ipublic.h"          /* Identifiers                              */
 
 /* When this header is included from a private header, don't make calls to H5check() */
 #undef H5CHECK

--- a/src/H5Fpublic.h
+++ b/src/H5Fpublic.h
@@ -16,9 +16,9 @@
 #ifndef H5Fpublic_H
 #define H5Fpublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
-#include "H5ACpublic.h"         /* Metadata Cache                           */
-#include "H5Ipublic.h"          /* Identifiers                              */
+#include "H5public.h"   /* Generic Functions                        */
+#include "H5ACpublic.h" /* Metadata Cache                           */
+#include "H5Ipublic.h"  /* Identifiers                              */
 
 /* When this header is included from a private header, don't make calls to H5check() */
 #undef H5CHECK

--- a/src/H5Gpublic.h
+++ b/src/H5Gpublic.h
@@ -21,10 +21,10 @@
 #ifndef H5Gpublic_H
 #define H5Gpublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
-#include "H5Ipublic.h"          /* Identifiers                              */
-#include "H5Lpublic.h"          /* Links                                    */
-#include "H5Opublic.h"          /* Object Headers                           */
+#include "H5public.h"  /* Generic Functions                        */
+#include "H5Ipublic.h" /* Identifiers                              */
+#include "H5Lpublic.h" /* Links                                    */
+#include "H5Opublic.h" /* Object Headers                           */
 
 /*****************/
 /* Public Macros */

--- a/src/H5Gpublic.h
+++ b/src/H5Gpublic.h
@@ -13,8 +13,6 @@
 /*-------------------------------------------------------------------------
  *
  * Created:             H5Gpublic.h
- *                      Jul 11 1997
- *                      Robb Matzke
  *
  * Purpose:             Public declarations for the H5G package
  *
@@ -23,14 +21,10 @@
 #ifndef H5Gpublic_H
 #define H5Gpublic_H
 
-/* System headers needed by this file */
-#include <sys/types.h>
-
-/* Public headers needed by this file */
-#include "H5public.h"  /* Generic Functions			*/
-#include "H5Lpublic.h" /* Links                                */
-#include "H5Opublic.h" /* Object headers			*/
-#include "H5Tpublic.h" /* Datatypes				*/
+#include "H5public.h"           /* Generic Functions                        */
+#include "H5Ipublic.h"          /* Identifiers                              */
+#include "H5Lpublic.h"          /* Links                                    */
+#include "H5Opublic.h"          /* Object Headers                           */
 
 /*****************/
 /* Public Macros */

--- a/src/H5Ipublic.h
+++ b/src/H5Ipublic.h
@@ -17,8 +17,7 @@
 #ifndef H5Ipublic_H
 #define H5Ipublic_H
 
-/* Public headers needed by this file */
-#include "H5public.h"
+#include "H5public.h"           /* Generic Functions                        */
 
 /**
  * Library type values.

--- a/src/H5Ipublic.h
+++ b/src/H5Ipublic.h
@@ -17,7 +17,7 @@
 #ifndef H5Ipublic_H
 #define H5Ipublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
+#include "H5public.h" /* Generic Functions                        */
 
 /**
  * Library type values.

--- a/src/H5Lpublic.h
+++ b/src/H5Lpublic.h
@@ -21,10 +21,10 @@
 #ifndef H5Lpublic_H
 #define H5Lpublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
-#include "H5Ipublic.h"          /* Identifiers                              */
-#include "H5Opublic.h"          /* Object Headers                           */
-#include "H5Tpublic.h"          /* Datatypes                                */
+#include "H5public.h"  /* Generic Functions                        */
+#include "H5Ipublic.h" /* Identifiers                              */
+#include "H5Opublic.h" /* Object Headers                           */
+#include "H5Tpublic.h" /* Datatypes                                */
 
 /*****************/
 /* Public Macros */

--- a/src/H5Lpublic.h
+++ b/src/H5Lpublic.h
@@ -13,8 +13,6 @@
 /*-------------------------------------------------------------------------
  *
  * Created:             H5Lpublic.h
- *                      Dec 1 2005
- *                      James Laird
  *
  * Purpose:             Public declarations for the H5L package (links)
  *
@@ -23,11 +21,10 @@
 #ifndef H5Lpublic_H
 #define H5Lpublic_H
 
-/* Public headers needed by this file */
-#include "H5public.h"  /* Generic Functions            */
-#include "H5Ipublic.h" /* IDs                      */
-#include "H5Opublic.h" /* Object Headers            */
-#include "H5Tpublic.h" /* Datatypes                */
+#include "H5public.h"           /* Generic Functions                        */
+#include "H5Ipublic.h"          /* Identifiers                              */
+#include "H5Opublic.h"          /* Object Headers                           */
+#include "H5Tpublic.h"          /* Datatypes                                */
 
 /*****************/
 /* Public Macros */

--- a/src/H5MMpublic.h
+++ b/src/H5MMpublic.h
@@ -22,7 +22,7 @@
 #ifndef H5MMpublic_H
 #define H5MMpublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
+#include "H5public.h" /* Generic Functions                        */
 
 /* These typedefs are currently used for VL datatype allocation/freeing */
 //! <!-- [H5MM_allocate_t_snip] -->

--- a/src/H5MMpublic.h
+++ b/src/H5MMpublic.h
@@ -22,8 +22,7 @@
 #ifndef H5MMpublic_H
 #define H5MMpublic_H
 
-/* Public headers needed by this file */
-#include "H5public.h"
+#include "H5public.h"           /* Generic Functions                        */
 
 /* These typedefs are currently used for VL datatype allocation/freeing */
 //! <!-- [H5MM_allocate_t_snip] -->

--- a/src/H5Mpublic.h
+++ b/src/H5Mpublic.h
@@ -19,11 +19,11 @@
 #ifndef H5Mpublic_H
 #define H5Mpublic_H
 
-/* System headers needed by this file */
+#include "H5public.h"           /* Generic Functions                        */
+#include "H5Ipublic.h"          /* Identifiers                              */
+#include "H5VLpublic.h"         /* Virtual Object Layer                     */
 
-/* Public headers needed by this file */
-#include "H5public.h"
-#include "H5Ipublic.h"
+/* Exposes VOL connector types, so it needs the connector header */
 #include "H5VLconnector.h"
 
 /*****************/

--- a/src/H5Mpublic.h
+++ b/src/H5Mpublic.h
@@ -19,9 +19,9 @@
 #ifndef H5Mpublic_H
 #define H5Mpublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
-#include "H5Ipublic.h"          /* Identifiers                              */
-#include "H5VLpublic.h"         /* Virtual Object Layer                     */
+#include "H5public.h"   /* Generic Functions                        */
+#include "H5Ipublic.h"  /* Identifiers                              */
+#include "H5VLpublic.h" /* Virtual Object Layer                     */
 
 /* Exposes VOL connector types, so it needs the connector header */
 #include "H5VLconnector.h"

--- a/src/H5Opublic.h
+++ b/src/H5Opublic.h
@@ -13,21 +13,17 @@
 /*-------------------------------------------------------------------------
  *
  * Created:             H5Opublic.h
- *                      Aug  5 1997
- *                      Robb Matzke
  *
  * Purpose:             Public declarations for the H5O (object header)
- *                      package.
+ *                      package
  *
  *-------------------------------------------------------------------------
  */
 #ifndef H5Opublic_H
 #define H5Opublic_H
 
-/* Public headers needed by this file */
-#include "H5public.h"  /* Generic Functions            */
-#include "H5Ipublic.h" /* IDs                          */
-#include "H5Lpublic.h" /* Links                        */
+#include "H5public.h"           /* Generic Functions                        */
+#include "H5Ipublic.h"          /* Identifiers                              */
 
 /*****************/
 /* Public Macros */

--- a/src/H5Opublic.h
+++ b/src/H5Opublic.h
@@ -22,8 +22,8 @@
 #ifndef H5Opublic_H
 #define H5Opublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
-#include "H5Ipublic.h"          /* Identifiers                              */
+#include "H5public.h"  /* Generic Functions                        */
+#include "H5Ipublic.h" /* Identifiers                              */
 
 /*****************/
 /* Public Macros */

--- a/src/H5PLpublic.h
+++ b/src/H5PLpublic.h
@@ -17,7 +17,7 @@
 #ifndef H5PLpublic_H
 #define H5PLpublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
+#include "H5public.h" /* Generic Functions                        */
 
 /*******************/
 /* Public Typedefs */

--- a/src/H5PLpublic.h
+++ b/src/H5PLpublic.h
@@ -17,8 +17,7 @@
 #ifndef H5PLpublic_H
 #define H5PLpublic_H
 
-/* Public headers needed by this file */
-#include "H5public.h" /* Generic Functions                    */
+#include "H5public.h"           /* Generic Functions                        */
 
 /*******************/
 /* Public Typedefs */

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -17,18 +17,18 @@
 #ifndef H5Ppublic_H
 #define H5Ppublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
-#include "H5ACpublic.h"         /* Metadata Cache                           */
-#include "H5Dpublic.h"          /* Datasets                                 */
-#include "H5Fpublic.h"          /* Files                                    */
-#include "H5FDpublic.h"         /* (Virtual) File Drivers                   */
-#include "H5Ipublic.h"          /* Identifiers                              */
-#include "H5Lpublic.h"          /* Links                                    */
-#include "H5MMpublic.h"         /* Memory Management                        */
-#include "H5Opublic.h"          /* Object Headers                           */
-#include "H5Spublic.h"          /* Dataspaces                               */
-#include "H5Tpublic.h"          /* Datatypes                                */
-#include "H5Zpublic.h"          /* Data Filters                             */
+#include "H5public.h"   /* Generic Functions                        */
+#include "H5ACpublic.h" /* Metadata Cache                           */
+#include "H5Dpublic.h"  /* Datasets                                 */
+#include "H5Fpublic.h"  /* Files                                    */
+#include "H5FDpublic.h" /* (Virtual) File Drivers                   */
+#include "H5Ipublic.h"  /* Identifiers                              */
+#include "H5Lpublic.h"  /* Links                                    */
+#include "H5MMpublic.h" /* Memory Management                        */
+#include "H5Opublic.h"  /* Object Headers                           */
+#include "H5Spublic.h"  /* Dataspaces                               */
+#include "H5Tpublic.h"  /* Datatypes                                */
+#include "H5Zpublic.h"  /* Data Filters                             */
 
 /*****************/
 /* Public Macros */

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -17,21 +17,18 @@
 #ifndef H5Ppublic_H
 #define H5Ppublic_H
 
-/* System headers needed by this file */
-
-/* Public headers needed by this file */
-#include "H5public.h"
-#include "H5ACpublic.h" /* Metadata cache                           */
-#include "H5Dpublic.h"  /* Datasets                                 */
-#include "H5Fpublic.h"  /* Files                                    */
-#include "H5FDpublic.h" /* File drivers                             */
-#include "H5Ipublic.h"  /* ID management                            */
-#include "H5Lpublic.h"  /* Links                                    */
-#include "H5MMpublic.h" /* Memory management                        */
-#include "H5Opublic.h"  /* Object headers                           */
-#include "H5Spublic.h"  /* Dataspaces                               */
-#include "H5Tpublic.h"  /* Datatypes                                */
-#include "H5Zpublic.h"  /* Data filters                             */
+#include "H5public.h"           /* Generic Functions                        */
+#include "H5ACpublic.h"         /* Metadata Cache                           */
+#include "H5Dpublic.h"          /* Datasets                                 */
+#include "H5Fpublic.h"          /* Files                                    */
+#include "H5FDpublic.h"         /* (Virtual) File Drivers                   */
+#include "H5Ipublic.h"          /* Identifiers                              */
+#include "H5Lpublic.h"          /* Links                                    */
+#include "H5MMpublic.h"         /* Memory Management                        */
+#include "H5Opublic.h"          /* Object Headers                           */
+#include "H5Spublic.h"          /* Dataspaces                               */
+#include "H5Tpublic.h"          /* Datatypes                                */
+#include "H5Zpublic.h"          /* Data Filters                             */
 
 /*****************/
 /* Public Macros */

--- a/src/H5Rpublic.h
+++ b/src/H5Rpublic.h
@@ -16,10 +16,10 @@
 #ifndef H5Rpublic_H
 #define H5Rpublic_H
 
-/* Public headers needed by this file */
-#include "H5public.h"
-#include "H5Gpublic.h"
-#include "H5Ipublic.h"
+#include "H5public.h"           /* Generic Functions                        */
+#include "H5Gpublic.h"          /* Groups                                   */
+#include "H5Ipublic.h"          /* Identifiers                              */
+#include "H5Opublic.h"          /* Object Headers                           */
 
 /*****************/
 /* Public Macros */

--- a/src/H5Rpublic.h
+++ b/src/H5Rpublic.h
@@ -16,10 +16,10 @@
 #ifndef H5Rpublic_H
 #define H5Rpublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
-#include "H5Gpublic.h"          /* Groups                                   */
-#include "H5Ipublic.h"          /* Identifiers                              */
-#include "H5Opublic.h"          /* Object Headers                           */
+#include "H5public.h"  /* Generic Functions                        */
+#include "H5Gpublic.h" /* Groups                                   */
+#include "H5Ipublic.h" /* Identifiers                              */
+#include "H5Opublic.h" /* Object Headers                           */
 
 /*****************/
 /* Public Macros */

--- a/src/H5Spublic.h
+++ b/src/H5Spublic.h
@@ -16,9 +16,8 @@
 #ifndef H5Spublic_H
 #define H5Spublic_H
 
-/* Public headers needed by this file */
-#include "H5public.h"
-#include "H5Ipublic.h"
+#include "H5public.h"           /* Generic Functions                        */
+#include "H5Ipublic.h"          /* Identifiers                              */
 
 /* Define special dataspaces for dataset I/O operations */
 #define H5S_ALL   0 /* (hid_t) */

--- a/src/H5Spublic.h
+++ b/src/H5Spublic.h
@@ -16,8 +16,8 @@
 #ifndef H5Spublic_H
 #define H5Spublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
-#include "H5Ipublic.h"          /* Identifiers                              */
+#include "H5public.h"  /* Generic Functions                        */
+#include "H5Ipublic.h" /* Identifiers                              */
 
 /* Define special dataspaces for dataset I/O operations */
 #define H5S_ALL   0 /* (hid_t) */

--- a/src/H5Tpublic.h
+++ b/src/H5Tpublic.h
@@ -16,9 +16,8 @@
 #ifndef H5Tpublic_H
 #define H5Tpublic_H
 
-/* Public headers needed by this file */
-#include "H5public.h"
-#include "H5Ipublic.h"
+#include "H5public.h"           /* Generic Functions                        */
+#include "H5Ipublic.h"          /* Identifiers                              */
 
 #define HOFFSET(S, M) (offsetof(S, M))
 

--- a/src/H5Tpublic.h
+++ b/src/H5Tpublic.h
@@ -16,8 +16,8 @@
 #ifndef H5Tpublic_H
 #define H5Tpublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
-#include "H5Ipublic.h"          /* Identifiers                              */
+#include "H5public.h"  /* Generic Functions                        */
+#include "H5Ipublic.h" /* Identifiers                              */
 
 #define HOFFSET(S, M) (offsetof(S, M))
 

--- a/src/H5VLpublic.h
+++ b/src/H5VLpublic.h
@@ -17,8 +17,8 @@
 #ifndef H5VLpublic_H
 #define H5VLpublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
-#include "H5Ipublic.h"          /* Identifiers                              */
+#include "H5public.h"  /* Generic Functions                        */
+#include "H5Ipublic.h" /* Identifiers                              */
 
 /*****************/
 /* Public Macros */

--- a/src/H5VLpublic.h
+++ b/src/H5VLpublic.h
@@ -17,9 +17,8 @@
 #ifndef H5VLpublic_H
 #define H5VLpublic_H
 
-/* Public headers needed by this file */
-#include "H5public.h"  /* Generic Functions                    */
-#include "H5Ipublic.h" /* IDs                                  */
+#include "H5public.h"           /* Generic Functions                        */
+#include "H5Ipublic.h"          /* Identifiers                              */
 
 /*****************/
 /* Public Macros */

--- a/src/H5Zpublic.h
+++ b/src/H5Zpublic.h
@@ -13,7 +13,7 @@
 #ifndef H5Zpublic_H
 #define H5Zpublic_H
 
-#include "H5public.h"           /* Generic Functions                        */
+#include "H5public.h" /* Generic Functions                        */
 
 /**
  * \brief Filter identifiers

--- a/src/H5Zpublic.h
+++ b/src/H5Zpublic.h
@@ -13,8 +13,7 @@
 #ifndef H5Zpublic_H
 #define H5Zpublic_H
 
-/* Public headers needed by this file */
-#include "H5public.h"
+#include "H5public.h"           /* Generic Functions                        */
 
 /**
  * \brief Filter identifiers


### PR DESCRIPTION
Cleanup of public header files

Removes unnecessary headers and adds missing headers, ensuring
that headers can be included independently and in any order.

Fixes #2789 
