### PR TITLE
Prevent buffer overrun in H5S_select_deserialize

### DIFF
--- a/src/H5Olayout.c
+++ b/src/H5Olayout.c
@@ -635,12 +635,12 @@ H5O__layout_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNU
 
                         /* Source selection */
                         if (H5S_SELECT_DESERIALIZE(&mesg->storage.u.virt.list[i].source_select,
-                                                   &heap_block_p) < 0)
+                                                   &heap_block_p, heap_block_p_end - heap_block_p + 1) < 0)
                             HGOTO_ERROR(H5E_OHDR, H5E_CANTDECODE, NULL, "can't decode source space selection")
 
                         /* Virtual selection */
                         if (H5S_SELECT_DESERIALIZE(&mesg->storage.u.virt.list[i].source_dset.virtual_select,
-                                                   &heap_block_p) < 0)
+                                                   &heap_block_p, heap_block_p_end - heap_block_p + 1) < 0)
                             HGOTO_ERROR(H5E_OHDR, H5E_CANTDECODE, NULL,
                                         "can't decode virtual space selection")
 

--- a/src/H5Olayout.c
+++ b/src/H5Olayout.c
@@ -634,13 +634,26 @@ H5O__layout_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNU
                         heap_block_p += tmp_size;
 
                         /* Source selection */
+                        avail_buffer_space = heap_block_p_end - heap_block_p + 1;
+
+                        if (avail_buffer_space <= 0)
+                            HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, NULL, "buffer overflow while decoding layout")
+
+
                         if (H5S_SELECT_DESERIALIZE(&mesg->storage.u.virt.list[i].source_select,
-                                                   &heap_block_p, heap_block_p_end - heap_block_p + 1) < 0)
+                                                   &heap_block_p, (size_t) (avail_buffer_space)) < 0)
                             HGOTO_ERROR(H5E_OHDR, H5E_CANTDECODE, NULL, "can't decode source space selection")
 
                         /* Virtual selection */
+
+                        /* Buffer space must be updated after previous deserialization */
+                        avail_buffer_space = heap_block_p_end - heap_block_p + 1;
+                        
+                         if (avail_buffer_space <= 0)
+                            HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, NULL, "buffer overflow while decoding layout")
+
                         if (H5S_SELECT_DESERIALIZE(&mesg->storage.u.virt.list[i].source_dset.virtual_select,
-                                                   &heap_block_p, heap_block_p_end - heap_block_p + 1) < 0)
+                                                   &heap_block_p, (size_t) (heap_block_p_end - heap_block_p + 1)) < 0)
                             HGOTO_ERROR(H5E_OHDR, H5E_CANTDECODE, NULL,
                                         "can't decode virtual space selection")
 

--- a/src/H5Olayout.c
+++ b/src/H5Olayout.c
@@ -637,23 +637,25 @@ H5O__layout_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNU
                         avail_buffer_space = heap_block_p_end - heap_block_p + 1;
 
                         if (avail_buffer_space <= 0)
-                            HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, NULL, "buffer overflow while decoding layout")
+                            HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, NULL,
+                                        "buffer overflow while decoding layout")
 
-
-                        if (H5S_SELECT_DESERIALIZE(&mesg->storage.u.virt.list[i].source_select,
-                                                   &heap_block_p, (size_t) (avail_buffer_space)) < 0)
+                        if (H5S_SELECT_DESERIALIZE(&mesg->storage.u.virt.list[i].source_select, &heap_block_p,
+                                                   (size_t)(avail_buffer_space)) < 0)
                             HGOTO_ERROR(H5E_OHDR, H5E_CANTDECODE, NULL, "can't decode source space selection")
 
                         /* Virtual selection */
 
                         /* Buffer space must be updated after previous deserialization */
                         avail_buffer_space = heap_block_p_end - heap_block_p + 1;
-                        
-                         if (avail_buffer_space <= 0)
-                            HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, NULL, "buffer overflow while decoding layout")
+
+                        if (avail_buffer_space <= 0)
+                            HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, NULL,
+                                        "buffer overflow while decoding layout")
 
                         if (H5S_SELECT_DESERIALIZE(&mesg->storage.u.virt.list[i].source_dset.virtual_select,
-                                                   &heap_block_p, (size_t) (heap_block_p_end - heap_block_p + 1)) < 0)
+                                                   &heap_block_p,
+                                                   (size_t)(avail_buffer_space)) < 0)
                             HGOTO_ERROR(H5E_OHDR, H5E_CANTDECODE, NULL,
                                         "can't decode virtual space selection")
 

--- a/src/H5Olayout.c
+++ b/src/H5Olayout.c
@@ -654,8 +654,7 @@ H5O__layout_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNU
                                         "buffer overflow while decoding layout")
 
                         if (H5S_SELECT_DESERIALIZE(&mesg->storage.u.virt.list[i].source_dset.virtual_select,
-                                                   &heap_block_p,
-                                                   (size_t)(avail_buffer_space)) < 0)
+                                                   &heap_block_p, (size_t)(avail_buffer_space)) < 0)
                             HGOTO_ERROR(H5E_OHDR, H5E_CANTDECODE, NULL,
                                         "can't decode virtual space selection")
 

--- a/src/H5Rint.c
+++ b/src/H5Rint.c
@@ -1177,7 +1177,7 @@ static herr_t
 H5R__decode_region(const unsigned char *buf, size_t *nbytes, H5S_t **space_ptr)
 {
     const uint8_t *p        = (const uint8_t *)buf;
-    const uint8_t *p_end = p + *nbytes - 1;
+    const uint8_t *p_end    = p + *nbytes - 1;
     size_t         buf_size = 0;
     unsigned       rank;
     H5S_t         *space;
@@ -1214,7 +1214,7 @@ H5R__decode_region(const unsigned char *buf, size_t *nbytes, H5S_t **space_ptr)
     if (p - 1 > p_end)
         HGOTO_ERROR(H5E_REFERENCE, H5E_CANTDECODE, FAIL, "Ran off end of buffer while decoding")
 
-    if (H5S_SELECT_DESERIALIZE(&space, &p, (size_t) (p_end - p + 1)) < 0)
+    if (H5S_SELECT_DESERIALIZE(&space, &p, (size_t)(p_end - p + 1)) < 0)
         HGOTO_ERROR(H5E_REFERENCE, H5E_CANTDECODE, FAIL, "can't deserialize selection")
 
     *nbytes    = buf_size;
@@ -1477,8 +1477,8 @@ H5R__decode_token_region_compat(H5F_t *f, const unsigned char *buf, size_t *nbyt
     unsigned char *data  = NULL;
     H5O_token_t    token = {0};
     size_t         data_size;
-    const uint8_t *p = NULL;
-    const uint8_t *p_end = NULL;
+    const uint8_t *p         = NULL;
+    const uint8_t *p_end     = NULL;
     H5S_t         *space     = NULL;
     herr_t         ret_value = SUCCEED;
 
@@ -1494,7 +1494,7 @@ H5R__decode_token_region_compat(H5F_t *f, const unsigned char *buf, size_t *nbyt
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier")
 
     /* Get object address */
-    p = (const uint8_t *)data;
+    p     = (const uint8_t *)data;
     p_end = p + data_size - 1;
     H5MM_memcpy(&token, p, token_size);
     p += token_size;
@@ -1519,7 +1519,7 @@ H5R__decode_token_region_compat(H5F_t *f, const unsigned char *buf, size_t *nbyt
         if (p - 1 >= p_end)
             HGOTO_ERROR(H5E_REFERENCE, H5E_CANTDECODE, FAIL, "Ran off end of buffer while deserializing")
 
-        if (H5S_SELECT_DESERIALIZE(&space, &p, (size_t) (p_end - p + 1)) < 0)
+        if (H5S_SELECT_DESERIALIZE(&space, &p, (size_t)(p_end - p + 1)) < 0)
             HGOTO_ERROR(H5E_REFERENCE, H5E_CANTDECODE, FAIL, "can't deserialize selection")
 
         *space_ptr = space;

--- a/src/H5Rint.c
+++ b/src/H5Rint.c
@@ -1209,7 +1209,7 @@ H5R__decode_region(const unsigned char *buf, size_t *nbytes, H5S_t **space_ptr)
         HGOTO_ERROR(H5E_REFERENCE, H5E_CANTDECODE, FAIL, "Buffer size is too small")
     if (H5S_set_extent_simple(space, rank, NULL, NULL) < 0)
         HGOTO_ERROR(H5E_REFERENCE, H5E_CANTSET, FAIL, "can't set extent rank for selection")
-    if (H5S_SELECT_DESERIALIZE(&space, &p) < 0)
+    if (H5S_SELECT_DESERIALIZE(&space, &p, *nbytes - 2 * sizeof(uint32_t)) < 0)
         HGOTO_ERROR(H5E_REFERENCE, H5E_CANTDECODE, FAIL, "can't deserialize selection")
 
     *nbytes    = buf_size;
@@ -1508,7 +1508,7 @@ H5R__decode_token_region_compat(H5F_t *f, const unsigned char *buf, size_t *nbyt
             HGOTO_ERROR(H5E_REFERENCE, H5E_NOTFOUND, FAIL, "not found")
 
         /* Unserialize the selection */
-        if (H5S_SELECT_DESERIALIZE(&space, &p) < 0)
+        if (H5S_SELECT_DESERIALIZE(&space, &p, data_size - token_size) < 0)
             HGOTO_ERROR(H5E_REFERENCE, H5E_CANTDECODE, FAIL, "can't deserialize selection")
 
         *space_ptr = space;

--- a/src/H5Rint.c
+++ b/src/H5Rint.c
@@ -1177,6 +1177,7 @@ static herr_t
 H5R__decode_region(const unsigned char *buf, size_t *nbytes, H5S_t **space_ptr)
 {
     const uint8_t *p        = (const uint8_t *)buf;
+    const uint8_t *p_end = p + *nbytes - 1;
     size_t         buf_size = 0;
     unsigned       rank;
     H5S_t         *space;
@@ -1209,7 +1210,11 @@ H5R__decode_region(const unsigned char *buf, size_t *nbytes, H5S_t **space_ptr)
         HGOTO_ERROR(H5E_REFERENCE, H5E_CANTDECODE, FAIL, "Buffer size is too small")
     if (H5S_set_extent_simple(space, rank, NULL, NULL) < 0)
         HGOTO_ERROR(H5E_REFERENCE, H5E_CANTSET, FAIL, "can't set extent rank for selection")
-    if (H5S_SELECT_DESERIALIZE(&space, &p, *nbytes - 2 * sizeof(uint32_t)) < 0)
+
+    if (p - 1 > p_end)
+        HGOTO_ERROR(H5E_REFERENCE, H5E_CANTDECODE, FAIL, "Ran off end of buffer while decoding")
+
+    if (H5S_SELECT_DESERIALIZE(&space, &p, (size_t) (p_end - p + 1)) < 0)
         HGOTO_ERROR(H5E_REFERENCE, H5E_CANTDECODE, FAIL, "can't deserialize selection")
 
     *nbytes    = buf_size;
@@ -1472,7 +1477,8 @@ H5R__decode_token_region_compat(H5F_t *f, const unsigned char *buf, size_t *nbyt
     unsigned char *data  = NULL;
     H5O_token_t    token = {0};
     size_t         data_size;
-    const uint8_t *p;
+    const uint8_t *p = NULL;
+    const uint8_t *p_end = NULL;
     H5S_t         *space     = NULL;
     herr_t         ret_value = SUCCEED;
 
@@ -1489,6 +1495,7 @@ H5R__decode_token_region_compat(H5F_t *f, const unsigned char *buf, size_t *nbyt
 
     /* Get object address */
     p = (const uint8_t *)data;
+    p_end = p + data_size - 1;
     H5MM_memcpy(&token, p, token_size);
     p += token_size;
 
@@ -1508,7 +1515,11 @@ H5R__decode_token_region_compat(H5F_t *f, const unsigned char *buf, size_t *nbyt
             HGOTO_ERROR(H5E_REFERENCE, H5E_NOTFOUND, FAIL, "not found")
 
         /* Unserialize the selection */
-        if (H5S_SELECT_DESERIALIZE(&space, &p, data_size - token_size) < 0)
+
+        if (p - 1 >= p_end)
+            HGOTO_ERROR(H5E_REFERENCE, H5E_CANTDECODE, FAIL, "Ran off end of buffer while deserializing")
+
+        if (H5S_SELECT_DESERIALIZE(&space, &p, (size_t) (p_end - p + 1)) < 0)
             HGOTO_ERROR(H5E_REFERENCE, H5E_CANTDECODE, FAIL, "can't deserialize selection")
 
         *space_ptr = space;

--- a/src/H5S.c
+++ b/src/H5S.c
@@ -1655,10 +1655,10 @@ H5S_decode(const unsigned char **p)
     if (H5S_select_all(ds, FALSE) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTSET, NULL, "unable to set all selection")
 
-    /* Decode the select part of dataspace.  I believe this part always exists. 
-    *  Because size of buffer is unknown, just assume arbitrarily large buffer to allow decoding. */
+    /* Decode the select part of dataspace.
+    *  Because size of buffer is unknown, assume arbitrarily large buffer to allow decoding. */
     *p = pp;
-    if (H5S_SELECT_DESERIALIZE(&ds, p, HDpow(2, sizeof(size_t)) - 1) < 0)
+    if (H5S_SELECT_DESERIALIZE(&ds, p, SIZE_MAX) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTDECODE, NULL, "can't decode space selection")
 
     /* Set return value */

--- a/src/H5S.c
+++ b/src/H5S.c
@@ -1655,9 +1655,10 @@ H5S_decode(const unsigned char **p)
     if (H5S_select_all(ds, FALSE) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTSET, NULL, "unable to set all selection")
 
-    /* Decode the select part of dataspace.  I believe this part always exists. */
+    /* Decode the select part of dataspace.  I believe this part always exists. 
+    *  Because size of buffer is unknown, just assume arbitrarily large buffer to allow decoding. */
     *p = pp;
-    if (H5S_SELECT_DESERIALIZE(&ds, p) < 0)
+    if (H5S_SELECT_DESERIALIZE(&ds, p, HDpow(2, sizeof(size_t)) - 1) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTDECODE, NULL, "can't decode space selection")
 
     /* Set return value */

--- a/src/H5S.c
+++ b/src/H5S.c
@@ -1656,7 +1656,7 @@ H5S_decode(const unsigned char **p)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTSET, NULL, "unable to set all selection")
 
     /* Decode the select part of dataspace.
-    *  Because size of buffer is unknown, assume arbitrarily large buffer to allow decoding. */
+     *  Because size of buffer is unknown, assume arbitrarily large buffer to allow decoding. */
     *p = pp;
     if (H5S_SELECT_DESERIALIZE(&ds, p, SIZE_MAX) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTDECODE, NULL, "can't decode space selection")

--- a/src/H5Sall.c
+++ b/src/H5Sall.c
@@ -50,7 +50,7 @@ static herr_t   H5S__all_release(H5S_t *space);
 static htri_t   H5S__all_is_valid(const H5S_t *space);
 static hssize_t H5S__all_serial_size(H5S_t *space);
 static herr_t   H5S__all_serialize(H5S_t *space, uint8_t **p);
-static herr_t   H5S__all_deserialize(H5S_t **space, const uint8_t **p);
+static herr_t   H5S__all_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size);
 static herr_t   H5S__all_bounds(const H5S_t *space, hsize_t *start, hsize_t *end);
 static herr_t   H5S__all_offset(const H5S_t *space, hsize_t *off);
 static int      H5S__all_unlim_dim(const H5S_t *space);
@@ -637,13 +637,13 @@ H5S__all_serialize(H5S_t *space, uint8_t **p)
  REVISION LOG
 --------------------------------------------------------------------------*/
 static herr_t
-H5S__all_deserialize(H5S_t **space, const uint8_t **p)
+H5S__all_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
 {
     uint32_t version;           /* Version number */
     H5S_t   *tmp_space = NULL;  /* Pointer to actual dataspace to use,
                                    either *space or a newly allocated one */
     herr_t ret_value = SUCCEED; /* return value */
-
+    char   *p_end = *p + p_size - 1; /* Pointer to last valid byte in buffer */
     FUNC_ENTER_PACKAGE
 
     HDassert(p);
@@ -663,12 +663,16 @@ H5S__all_deserialize(H5S_t **space, const uint8_t **p)
         tmp_space = *space;
 
     /* Decode version */
+    if (H5_IS_BUFFER_OVERFLOW(*p, sizeof(uint32_t), p_end))
+        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection version")
     UINT32DECODE(*p, version);
 
     if (version < H5S_ALL_VERSION_1 || version > H5S_ALL_VERSION_LATEST)
         HGOTO_ERROR(H5E_DATASPACE, H5E_BADVALUE, FAIL, "bad version number for all selection")
 
     /* Skip over the remainder of the header */
+    if (H5_IS_BUFFER_OVERFLOW(*p, 8, p_end))
+        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding header")
     *p += 8;
 
     /* Change to "all" selection */

--- a/src/H5Sall.c
+++ b/src/H5Sall.c
@@ -50,7 +50,7 @@ static herr_t   H5S__all_release(H5S_t *space);
 static htri_t   H5S__all_is_valid(const H5S_t *space);
 static hssize_t H5S__all_serial_size(H5S_t *space);
 static herr_t   H5S__all_serialize(H5S_t *space, uint8_t **p);
-static herr_t   H5S__all_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size);
+static herr_t   H5S__all_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hbool_t skip);
 static herr_t   H5S__all_bounds(const H5S_t *space, hsize_t *start, hsize_t *end);
 static herr_t   H5S__all_offset(const H5S_t *space, hsize_t *off);
 static int      H5S__all_unlim_dim(const H5S_t *space);
@@ -637,13 +637,13 @@ H5S__all_serialize(H5S_t *space, uint8_t **p)
  REVISION LOG
 --------------------------------------------------------------------------*/
 static herr_t
-H5S__all_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
+H5S__all_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hbool_t skip)
 {
     uint32_t version;           /* Version number */
     H5S_t   *tmp_space = NULL;  /* Pointer to actual dataspace to use,
                                    either *space or a newly allocated one */
     herr_t ret_value = SUCCEED; /* return value */
-    char   *p_end = *p + p_size - 1; /* Pointer to last valid byte in buffer */
+    const uint8_t  *p_end =  *p + p_size - 1; /* Pointer to last valid byte in buffer */
     FUNC_ENTER_PACKAGE
 
     HDassert(p);
@@ -663,7 +663,7 @@ H5S__all_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
         tmp_space = *space;
 
     /* Decode version */
-    if (H5_IS_BUFFER_OVERFLOW(*p, sizeof(uint32_t), p_end))
+    if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, *p, sizeof(uint32_t), p_end))
         HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection version")
     UINT32DECODE(*p, version);
 
@@ -671,7 +671,7 @@ H5S__all_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
         HGOTO_ERROR(H5E_DATASPACE, H5E_BADVALUE, FAIL, "bad version number for all selection")
 
     /* Skip over the remainder of the header */
-    if (H5_IS_BUFFER_OVERFLOW(*p, 8, p_end))
+    if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, *p, 8, p_end))
         HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding header")
     *p += 8;
 

--- a/src/H5Sall.c
+++ b/src/H5Sall.c
@@ -639,11 +639,11 @@ H5S__all_serialize(H5S_t *space, uint8_t **p)
 static herr_t
 H5S__all_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hbool_t skip)
 {
-    uint32_t version;           /* Version number */
-    H5S_t   *tmp_space = NULL;  /* Pointer to actual dataspace to use,
-                                   either *space or a newly allocated one */
-    herr_t ret_value = SUCCEED; /* return value */
-    const uint8_t  *p_end =  *p + p_size - 1; /* Pointer to last valid byte in buffer */
+    uint32_t version;                           /* Version number */
+    H5S_t   *tmp_space = NULL;                  /* Pointer to actual dataspace to use,
+                                                   either *space or a newly allocated one */
+    herr_t         ret_value = SUCCEED;         /* return value */
+    const uint8_t *p_end     = *p + p_size - 1; /* Pointer to last valid byte in buffer */
     FUNC_ENTER_PACKAGE
 
     HDassert(p);

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -175,7 +175,7 @@ static htri_t   H5S__hyper_is_valid(const H5S_t *space);
 static hsize_t  H5S__hyper_span_nblocks(H5S_hyper_span_info_t *spans);
 static hssize_t H5S__hyper_serial_size(H5S_t *space);
 static herr_t   H5S__hyper_serialize(H5S_t *space, uint8_t **p);
-static herr_t   H5S__hyper_deserialize(H5S_t **space, const uint8_t **p);
+static herr_t   H5S__hyper_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size);
 static herr_t   H5S__hyper_bounds(const H5S_t *space, hsize_t *start, hsize_t *end);
 static herr_t   H5S__hyper_offset(const H5S_t *space, hsize_t *offset);
 static int      H5S__hyper_unlim_dim(const H5S_t *space);
@@ -4239,7 +4239,7 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 static herr_t
-H5S__hyper_deserialize(H5S_t **space, const uint8_t **p)
+H5S__hyper_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
 {
     H5S_t *tmp_space = NULL;            /* Pointer to actual dataspace to use,
                                            either *space or a newly allocated one */
@@ -4253,7 +4253,7 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p)
     const uint8_t *pp;                  /* Local pointer for decoding */
     unsigned       u;                   /* Local counting variable */
     herr_t         ret_value = FAIL;    /* return value */
-
+    char          *p_end = *p + p_size - 1; /* Pointer to last valid byte in buffer */
     FUNC_ENTER_PACKAGE
 
     /* Check args */
@@ -4274,6 +4274,8 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p)
         tmp_space = *space;
 
     /* Decode version */
+    if (H5_IS_BUFFER_OVERFLOW(pp, sizeof(uint32_t), p_end))
+        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection version")
     UINT32DECODE(pp, version);
 
     if (version < H5S_HYPER_VERSION_1 || version > H5S_HYPER_VERSION_LATEST)
@@ -4281,13 +4283,19 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p)
 
     if (version >= (uint32_t)H5S_HYPER_VERSION_2) {
         /* Decode flags */
+        if (H5_IS_BUFFER_OVERFLOW(pp, 1, p_end))
+            HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection flags")
         flags = *(pp)++;
 
-        if (version >= (uint32_t)H5S_HYPER_VERSION_3)
+        if (version >= (uint32_t)H5S_HYPER_VERSION_3) {
             /* decode size of offset info */
+            if (H5_IS_BUFFER_OVERFLOW(pp, 1, p_end))
+                HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection encoding size")
             enc_size = *(pp)++;
-        else {
+        } else {
             /* Skip over the remainder of the header */
+            if (H5_IS_BUFFER_OVERFLOW(pp, 4, p_end))
+                HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection header")
             pp += 4;
             enc_size = H5S_SELECT_INFO_ENC_SIZE_8;
         } /* end else */
@@ -4298,6 +4306,8 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p)
     }
     else {
         /* Skip over the remainder of the header */
+        if (H5_IS_BUFFER_OVERFLOW(pp, 8, p_end))
+            HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection header")
         pp += 8;
         enc_size = H5S_SELECT_INFO_ENC_SIZE_4;
     } /* end else */
@@ -4307,6 +4317,8 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTLOAD, FAIL, "unknown size of point/offset info for selection")
 
     /* Decode the rank of the point selection */
+    if (H5_IS_BUFFER_OVERFLOW(pp, sizeof(uint32_t), p_end))
+        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection rank")
     UINT32DECODE(pp, rank);
 
     if (!*space) {
@@ -4333,6 +4345,9 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p)
         switch (enc_size) {
             case H5S_SELECT_INFO_ENC_SIZE_2:
                 for (u = 0; u < tmp_space->extent.rank; u++) {
+                    if (H5_IS_BUFFER_OVERFLOW(pp, 4 * sizeof(uint16_t), p_end))
+                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection ranks")
+
                     UINT16DECODE(pp, start[u]);
                     UINT16DECODE(pp, stride[u]);
 
@@ -4348,6 +4363,9 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p)
 
             case H5S_SELECT_INFO_ENC_SIZE_4:
                 for (u = 0; u < tmp_space->extent.rank; u++) {
+                    if (H5_IS_BUFFER_OVERFLOW(pp, 4 * sizeof(uint32_t), p_end))
+                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection ranks")
+
                     UINT32DECODE(pp, start[u]);
                     UINT32DECODE(pp, stride[u]);
 
@@ -4363,6 +4381,9 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p)
 
             case H5S_SELECT_INFO_ENC_SIZE_8:
                 for (u = 0; u < tmp_space->extent.rank; u++) {
+                    if (H5_IS_BUFFER_OVERFLOW(pp, 4 * sizeof(uint64_t), p_end))
+                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection ranks")
+
                     UINT64DECODE(pp, start[u]);
                     UINT64DECODE(pp, stride[u]);
 
@@ -4398,14 +4419,20 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p)
         /* Decode the number of blocks */
         switch (enc_size) {
             case H5S_SELECT_INFO_ENC_SIZE_2:
+                if (H5_IS_BUFFER_OVERFLOW(pp, sizeof(uint16_t), p_end))
+                    HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding number of selection blocks")
                 UINT16DECODE(pp, num_elem);
                 break;
 
             case H5S_SELECT_INFO_ENC_SIZE_4:
+                if (H5_IS_BUFFER_OVERFLOW(pp, sizeof(uint32_t), p_end))
+                    HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding number of selection blocks")
                 UINT32DECODE(pp, num_elem);
                 break;
 
             case H5S_SELECT_INFO_ENC_SIZE_8:
+                if (H5_IS_BUFFER_OVERFLOW(pp, sizeof(uint64_t), p_end))
+                    HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding number of selection blocks")
                 UINT64DECODE(pp, num_elem);
                 break;
 
@@ -4422,6 +4449,9 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p)
             /* Decode the starting and ending points */
             switch (enc_size) {
                 case H5S_SELECT_INFO_ENC_SIZE_2:
+                    if (H5_IS_BUFFER_OVERFLOW(pp, rank * 2 * sizeof(uint16_t), p_end))
+                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection coordinates")
+
                     for (tstart = start, v = 0; v < rank; v++, tstart++)
                         UINT16DECODE(pp, *tstart);
                     for (tend = end, v = 0; v < rank; v++, tend++)
@@ -4429,6 +4459,9 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p)
                     break;
 
                 case H5S_SELECT_INFO_ENC_SIZE_4:
+                    if (H5_IS_BUFFER_OVERFLOW(pp, rank * 2 * sizeof(uint32_t), p_end))
+                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection coordinates")
+                    
                     for (tstart = start, v = 0; v < rank; v++, tstart++)
                         UINT32DECODE(pp, *tstart);
                     for (tend = end, v = 0; v < rank; v++, tend++)
@@ -4436,6 +4469,9 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p)
                     break;
 
                 case H5S_SELECT_INFO_ENC_SIZE_8:
+                    if (H5_IS_BUFFER_OVERFLOW(pp, rank * 2 * sizeof(uint64_t), p_end))
+                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection coordinates")
+
                     for (tstart = start, v = 0; v < rank; v++, tstart++)
                         UINT64DECODE(pp, *tstart);
                     for (tend = end, v = 0; v < rank; v++, tend++)

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -4241,19 +4241,19 @@ done:
 static herr_t
 H5S__hyper_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hbool_t skip)
 {
-    H5S_t *tmp_space = NULL;            /* Pointer to actual dataspace to use,
-                                           either *space or a newly allocated one */
-    hsize_t        dims[H5S_MAX_RANK];  /* Dimension sizes */
-    hsize_t        start[H5S_MAX_RANK]; /* hyperslab start information */
-    hsize_t        block[H5S_MAX_RANK]; /* hyperslab block information */
-    uint32_t       version;             /* Version number */
-    uint8_t        flags    = 0;        /* Flags */
-    uint8_t        enc_size = 0;        /* Encoded size of selection info */
-    unsigned       rank;                /* rank of points */
-    const uint8_t *pp;                  /* Local pointer for decoding */
-    unsigned       u;                   /* Local counting variable */
-    herr_t         ret_value = FAIL;    /* return value */
-    const uint8_t *p_end = *p + p_size - 1; /* Pointer to last valid byte in buffer */
+    H5S_t *tmp_space = NULL;                    /* Pointer to actual dataspace to use,
+                                                   either *space or a newly allocated one */
+    hsize_t        dims[H5S_MAX_RANK];          /* Dimension sizes */
+    hsize_t        start[H5S_MAX_RANK];         /* hyperslab start information */
+    hsize_t        block[H5S_MAX_RANK];         /* hyperslab block information */
+    uint32_t       version;                     /* Version number */
+    uint8_t        flags    = 0;                /* Flags */
+    uint8_t        enc_size = 0;                /* Encoded size of selection info */
+    unsigned       rank;                        /* rank of points */
+    const uint8_t *pp;                          /* Local pointer for decoding */
+    unsigned       u;                           /* Local counting variable */
+    herr_t         ret_value = FAIL;            /* return value */
+    const uint8_t *p_end     = *p + p_size - 1; /* Pointer to last valid byte in buffer */
     FUNC_ENTER_PACKAGE
 
     /* Check args */
@@ -4290,12 +4290,15 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hb
         if (version >= (uint32_t)H5S_HYPER_VERSION_3) {
             /* decode size of offset info */
             if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, 1, p_end))
-                HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection encoding size")
+                HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL,
+                            "buffer overflow while decoding selection encoding size")
             enc_size = *(pp)++;
-        } else {
+        }
+        else {
             /* Skip over the remainder of the header */
             if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, 4, p_end))
-                HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection header")
+                HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL,
+                            "buffer overflow while decoding selection header")
             pp += 4;
             enc_size = H5S_SELECT_INFO_ENC_SIZE_8;
         } /* end else */
@@ -4346,7 +4349,8 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hb
             case H5S_SELECT_INFO_ENC_SIZE_2:
                 for (u = 0; u < tmp_space->extent.rank; u++) {
                     if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, 4 * sizeof(uint16_t), p_end))
-                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection ranks")
+                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL,
+                                    "buffer overflow while decoding selection ranks")
 
                     UINT16DECODE(pp, start[u]);
                     UINT16DECODE(pp, stride[u]);
@@ -4364,7 +4368,8 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hb
             case H5S_SELECT_INFO_ENC_SIZE_4:
                 for (u = 0; u < tmp_space->extent.rank; u++) {
                     if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, 4 * sizeof(uint32_t), p_end))
-                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection ranks")
+                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL,
+                                    "buffer overflow while decoding selection ranks")
 
                     UINT32DECODE(pp, start[u]);
                     UINT32DECODE(pp, stride[u]);
@@ -4382,7 +4387,8 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hb
             case H5S_SELECT_INFO_ENC_SIZE_8:
                 for (u = 0; u < tmp_space->extent.rank; u++) {
                     if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, 4 * sizeof(uint64_t), p_end))
-                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection ranks")
+                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL,
+                                    "buffer overflow while decoding selection ranks")
 
                     UINT64DECODE(pp, start[u]);
                     UINT64DECODE(pp, stride[u]);
@@ -4420,19 +4426,22 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hb
         switch (enc_size) {
             case H5S_SELECT_INFO_ENC_SIZE_2:
                 if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, sizeof(uint16_t), p_end))
-                    HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding number of selection blocks")
+                    HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL,
+                                "buffer overflow while decoding number of selection blocks")
                 UINT16DECODE(pp, num_elem);
                 break;
 
             case H5S_SELECT_INFO_ENC_SIZE_4:
                 if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, sizeof(uint32_t), p_end))
-                    HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding number of selection blocks")
+                    HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL,
+                                "buffer overflow while decoding number of selection blocks")
                 UINT32DECODE(pp, num_elem);
                 break;
 
             case H5S_SELECT_INFO_ENC_SIZE_8:
                 if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, sizeof(uint64_t), p_end))
-                    HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding number of selection blocks")
+                    HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL,
+                                "buffer overflow while decoding number of selection blocks")
                 UINT64DECODE(pp, num_elem);
                 break;
 
@@ -4450,7 +4459,8 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hb
             switch (enc_size) {
                 case H5S_SELECT_INFO_ENC_SIZE_2:
                     if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, rank * 2 * sizeof(uint16_t), p_end))
-                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection coordinates")
+                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL,
+                                    "buffer overflow while decoding selection coordinates")
 
                     for (tstart = start, v = 0; v < rank; v++, tstart++)
                         UINT16DECODE(pp, *tstart);
@@ -4460,8 +4470,9 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hb
 
                 case H5S_SELECT_INFO_ENC_SIZE_4:
                     if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, rank * 2 * sizeof(uint32_t), p_end))
-                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection coordinates")
-                    
+                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL,
+                                    "buffer overflow while decoding selection coordinates")
+
                     for (tstart = start, v = 0; v < rank; v++, tstart++)
                         UINT32DECODE(pp, *tstart);
                     for (tend = end, v = 0; v < rank; v++, tend++)
@@ -4470,7 +4481,8 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hb
 
                 case H5S_SELECT_INFO_ENC_SIZE_8:
                     if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, rank * 2 * sizeof(uint64_t), p_end))
-                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection coordinates")
+                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL,
+                                    "buffer overflow while decoding selection coordinates")
 
                     for (tstart = start, v = 0; v < rank; v++, tstart++)
                         UINT64DECODE(pp, *tstart);

--- a/src/H5Snone.c
+++ b/src/H5Snone.c
@@ -595,11 +595,11 @@ H5S__none_serialize(H5S_t *space, uint8_t **p)
 static herr_t
 H5S__none_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hbool_t skip)
 {
-    H5S_t *tmp_space = NULL;      /* Pointer to actual dataspace to use,
-                                     either *space or a newly allocated one */
-    uint32_t version;             /* Version number */
-    herr_t   ret_value = SUCCEED; /* return value */
-    const uint8_t    *p_end = *p + p_size - 1; /* Pointer to last valid byte in buffer */
+    H5S_t *tmp_space = NULL;                    /* Pointer to actual dataspace to use,
+                                                   either *space or a newly allocated one */
+    uint32_t       version;                     /* Version number */
+    herr_t         ret_value = SUCCEED;         /* return value */
+    const uint8_t *p_end     = *p + p_size - 1; /* Pointer to last valid byte in buffer */
 
     FUNC_ENTER_PACKAGE
 

--- a/src/H5Snone.c
+++ b/src/H5Snone.c
@@ -50,7 +50,7 @@ static herr_t   H5S__none_release(H5S_t *space);
 static htri_t   H5S__none_is_valid(const H5S_t *space);
 static hssize_t H5S__none_serial_size(H5S_t *space);
 static herr_t   H5S__none_serialize(H5S_t *space, uint8_t **p);
-static herr_t   H5S__none_deserialize(H5S_t **space, const uint8_t **p);
+static herr_t   H5S__none_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size);
 static herr_t   H5S__none_bounds(const H5S_t *space, hsize_t *start, hsize_t *end);
 static herr_t   H5S__none_offset(const H5S_t *space, hsize_t *off);
 static int      H5S__none_unlim_dim(const H5S_t *space);
@@ -593,12 +593,13 @@ H5S__none_serialize(H5S_t *space, uint8_t **p)
  REVISION LOG
 --------------------------------------------------------------------------*/
 static herr_t
-H5S__none_deserialize(H5S_t **space, const uint8_t **p)
+H5S__none_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
 {
     H5S_t *tmp_space = NULL;      /* Pointer to actual dataspace to use,
                                      either *space or a newly allocated one */
     uint32_t version;             /* Version number */
     herr_t   ret_value = SUCCEED; /* return value */
+    char    *p_end = *p + p_size - 1; /* Pointer to last valid byte in buffer */
 
     FUNC_ENTER_PACKAGE
 
@@ -618,12 +619,16 @@ H5S__none_deserialize(H5S_t **space, const uint8_t **p)
         tmp_space = *space;
 
     /* Decode version */
+    if (H5_IS_BUFFER_OVERFLOW(*p, sizeof(uint32_t), p_end))
+        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection version")
     UINT32DECODE(*p, version);
 
     if (version < H5S_NONE_VERSION_1 || version > H5S_NONE_VERSION_LATEST)
         HGOTO_ERROR(H5E_DATASPACE, H5E_BADVALUE, FAIL, "bad version number for none selection")
 
     /* Skip over the remainder of the header */
+    if (H5_IS_BUFFER_OVERFLOW(*p, 8, p_end))
+        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection header")
     *p += 8;
 
     /* Change to "none" selection */

--- a/src/H5Snone.c
+++ b/src/H5Snone.c
@@ -50,7 +50,7 @@ static herr_t   H5S__none_release(H5S_t *space);
 static htri_t   H5S__none_is_valid(const H5S_t *space);
 static hssize_t H5S__none_serial_size(H5S_t *space);
 static herr_t   H5S__none_serialize(H5S_t *space, uint8_t **p);
-static herr_t   H5S__none_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size);
+static herr_t   H5S__none_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hbool_t skip);
 static herr_t   H5S__none_bounds(const H5S_t *space, hsize_t *start, hsize_t *end);
 static herr_t   H5S__none_offset(const H5S_t *space, hsize_t *off);
 static int      H5S__none_unlim_dim(const H5S_t *space);
@@ -593,13 +593,13 @@ H5S__none_serialize(H5S_t *space, uint8_t **p)
  REVISION LOG
 --------------------------------------------------------------------------*/
 static herr_t
-H5S__none_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
+H5S__none_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hbool_t skip)
 {
     H5S_t *tmp_space = NULL;      /* Pointer to actual dataspace to use,
                                      either *space or a newly allocated one */
     uint32_t version;             /* Version number */
     herr_t   ret_value = SUCCEED; /* return value */
-    char    *p_end = *p + p_size - 1; /* Pointer to last valid byte in buffer */
+    const uint8_t    *p_end = *p + p_size - 1; /* Pointer to last valid byte in buffer */
 
     FUNC_ENTER_PACKAGE
 
@@ -619,7 +619,7 @@ H5S__none_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
         tmp_space = *space;
 
     /* Decode version */
-    if (H5_IS_BUFFER_OVERFLOW(*p, sizeof(uint32_t), p_end))
+    if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, *p, sizeof(uint32_t), p_end))
         HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection version")
     UINT32DECODE(*p, version);
 
@@ -627,7 +627,7 @@ H5S__none_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
         HGOTO_ERROR(H5E_DATASPACE, H5E_BADVALUE, FAIL, "bad version number for none selection")
 
     /* Skip over the remainder of the header */
-    if (H5_IS_BUFFER_OVERFLOW(*p, 8, p_end))
+    if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, *p, 8, p_end))
         HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection header")
     *p += 8;
 

--- a/src/H5Spkg.h
+++ b/src/H5Spkg.h
@@ -242,7 +242,7 @@ typedef hssize_t (*H5S_sel_serial_size_func_t)(H5S_t *space);
 /* Method to store current selection in "serialized" form (a byte sequence suitable for storing on disk) */
 typedef herr_t (*H5S_sel_serialize_func_t)(H5S_t *space, uint8_t **p);
 /* Method to create selection from "serialized" form (a byte sequence suitable for storing on disk) */
-typedef herr_t (*H5S_sel_deserialize_func_t)(H5S_t **space, const uint8_t **p);
+typedef herr_t (*H5S_sel_deserialize_func_t)(H5S_t **space, const uint8_t **p, const size_t p_size);
 /* Method to determine smallest n-D bounding box containing the current selection */
 typedef herr_t (*H5S_sel_bounds_func_t)(const H5S_t *space, hsize_t *start, hsize_t *end);
 /* Method to determine linear offset of initial element in selection within dataspace */

--- a/src/H5Spkg.h
+++ b/src/H5Spkg.h
@@ -242,7 +242,7 @@ typedef hssize_t (*H5S_sel_serial_size_func_t)(H5S_t *space);
 /* Method to store current selection in "serialized" form (a byte sequence suitable for storing on disk) */
 typedef herr_t (*H5S_sel_serialize_func_t)(H5S_t *space, uint8_t **p);
 /* Method to create selection from "serialized" form (a byte sequence suitable for storing on disk) */
-typedef herr_t (*H5S_sel_deserialize_func_t)(H5S_t **space, const uint8_t **p, const size_t p_size);
+typedef herr_t (*H5S_sel_deserialize_func_t)(H5S_t **space, const uint8_t **p, const size_t p_size, hbool_t skip);
 /* Method to determine smallest n-D bounding box containing the current selection */
 typedef herr_t (*H5S_sel_bounds_func_t)(const H5S_t *space, hsize_t *start, hsize_t *end);
 /* Method to determine linear offset of initial element in selection within dataspace */

--- a/src/H5Spkg.h
+++ b/src/H5Spkg.h
@@ -242,7 +242,8 @@ typedef hssize_t (*H5S_sel_serial_size_func_t)(H5S_t *space);
 /* Method to store current selection in "serialized" form (a byte sequence suitable for storing on disk) */
 typedef herr_t (*H5S_sel_serialize_func_t)(H5S_t *space, uint8_t **p);
 /* Method to create selection from "serialized" form (a byte sequence suitable for storing on disk) */
-typedef herr_t (*H5S_sel_deserialize_func_t)(H5S_t **space, const uint8_t **p, const size_t p_size, hbool_t skip);
+typedef herr_t (*H5S_sel_deserialize_func_t)(H5S_t **space, const uint8_t **p, const size_t p_size,
+                                             hbool_t skip);
 /* Method to determine smallest n-D bounding box containing the current selection */
 typedef herr_t (*H5S_sel_bounds_func_t)(const H5S_t *space, hsize_t *start, hsize_t *end);
 /* Method to determine linear offset of initial element in selection within dataspace */

--- a/src/H5Spoint.c
+++ b/src/H5Spoint.c
@@ -60,7 +60,7 @@ static herr_t   H5S__point_release(H5S_t *space);
 static htri_t   H5S__point_is_valid(const H5S_t *space);
 static hssize_t H5S__point_serial_size(H5S_t *space);
 static herr_t   H5S__point_serialize(H5S_t *space, uint8_t **p);
-static herr_t   H5S__point_deserialize(H5S_t **space, const uint8_t **p);
+static herr_t   H5S__point_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size);
 static herr_t   H5S__point_bounds(const H5S_t *space, hsize_t *start, hsize_t *end);
 static herr_t   H5S__point_offset(const H5S_t *space, hsize_t *off);
 static int      H5S__point_unlim_dim(const H5S_t *space);
@@ -1352,7 +1352,7 @@ done:
  REVISION LOG
 --------------------------------------------------------------------------*/
 static herr_t
-H5S__point_deserialize(H5S_t **space, const uint8_t **p)
+H5S__point_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
 {
     H5S_t *tmp_space = NULL;                 /* Pointer to actual dataspace to use,
                                                 either *space or a newly allocated one */
@@ -1365,7 +1365,7 @@ H5S__point_deserialize(H5S_t **space, const uint8_t **p)
     unsigned       rank;                     /* Rank of points */
     unsigned       i, j;                     /* local counting variables */
     herr_t         ret_value = SUCCEED;      /* Return value */
-
+    char          *p_end = *p + p_size - 1; /* Pointer to last valid byte in buffer */
     FUNC_ENTER_PACKAGE
 
     /* Check args */
@@ -1386,16 +1386,22 @@ H5S__point_deserialize(H5S_t **space, const uint8_t **p)
         tmp_space = *space;
 
     /* Decode version */
+    if (H5_IS_BUFFER_OVERFLOW(pp, sizeof(uint32_t), p_end))
+        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection version")
     UINT32DECODE(pp, version);
 
     if (version < H5S_POINT_VERSION_1 || version > H5S_POINT_VERSION_LATEST)
         HGOTO_ERROR(H5E_DATASPACE, H5E_BADVALUE, FAIL, "bad version number for point selection")
 
-    if (version >= (uint32_t)H5S_POINT_VERSION_2)
+    if (version >= (uint32_t)H5S_POINT_VERSION_2) {
         /* Decode size of point info */
+        if (H5_IS_BUFFER_OVERFLOW(pp, 1, p_end))
+            HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding point info")
         enc_size = *(pp)++;
-    else {
+    } else {
         /* Skip over the remainder of the header */
+        if (H5_IS_BUFFER_OVERFLOW(pp, 8, p_end))
+            HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection headers")
         pp += 8;
         enc_size = H5S_SELECT_INFO_ENC_SIZE_4;
     }
@@ -1405,6 +1411,8 @@ H5S__point_deserialize(H5S_t **space, const uint8_t **p)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTLOAD, FAIL, "unknown size of point/offset info for selection")
 
     /* Decode the rank of the point selection */
+    if (H5_IS_BUFFER_OVERFLOW(pp, sizeof(uint32_t), p_end))
+        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection rank")
     UINT32DECODE(pp, rank);
 
     if (!*space) {
@@ -1422,12 +1430,21 @@ H5S__point_deserialize(H5S_t **space, const uint8_t **p)
     /* decode the number of points */
     switch (enc_size) {
         case H5S_SELECT_INFO_ENC_SIZE_2:
+            if (H5_IS_BUFFER_OVERFLOW(pp, sizeof(uint16_t), p_end))
+                HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding number of points")
+            
             UINT16DECODE(pp, num_elem);
             break;
         case H5S_SELECT_INFO_ENC_SIZE_4:
+            if (H5_IS_BUFFER_OVERFLOW(pp, sizeof(uint32_t), p_end))
+                HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding number of points")
+
             UINT32DECODE(pp, num_elem);
             break;
         case H5S_SELECT_INFO_ENC_SIZE_8:
+            if (H5_IS_BUFFER_OVERFLOW(pp, sizeof(uint64_t), p_end))
+                HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding number of points")
+            
             UINT64DECODE(pp, num_elem);
             break;
         default:
@@ -1444,14 +1461,23 @@ H5S__point_deserialize(H5S_t **space, const uint8_t **p)
         for (j = 0; j < (unsigned)rank; j++, tcoord++)
             switch (enc_size) {
                 case H5S_SELECT_INFO_ENC_SIZE_2:
+                    if (H5_IS_BUFFER_OVERFLOW(pp, sizeof(uint16_t), p_end))
+                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection coordinates")
+                    
                     UINT16DECODE(pp, *tcoord);
                     break;
 
                 case H5S_SELECT_INFO_ENC_SIZE_4:
+                    if (H5_IS_BUFFER_OVERFLOW(pp, sizeof(uint32_t), p_end))
+                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection coordinates")
+
                     UINT32DECODE(pp, *tcoord);
                     break;
 
                 case H5S_SELECT_INFO_ENC_SIZE_8:
+                    if (H5_IS_BUFFER_OVERFLOW(pp, sizeof(uint64_t), p_end))
+                        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection coordinates")
+
                     UINT64DECODE(pp, *tcoord);
                     break;
                 default:

--- a/src/H5Spoint.c
+++ b/src/H5Spoint.c
@@ -1354,18 +1354,18 @@ done:
 static herr_t
 H5S__point_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hbool_t skip)
 {
-    H5S_t *tmp_space = NULL;                 /* Pointer to actual dataspace to use,
-                                                either *space or a newly allocated one */
-    hsize_t        dims[H5S_MAX_RANK];       /* Dimension sizes */
-    uint32_t       version;                  /* Version number */
-    uint8_t        enc_size = 0;             /* Encoded size of selection info */
-    hsize_t       *coord    = NULL, *tcoord; /* Pointer to array of elements */
-    const uint8_t *pp;                       /* Local pointer for decoding */
-    uint64_t       num_elem = 0;             /* Number of elements in selection */
-    unsigned       rank;                     /* Rank of points */
-    unsigned       i, j;                     /* local counting variables */
-    herr_t         ret_value = SUCCEED;      /* Return value */
-    const uint8_t *p_end = *p + p_size - 1; /* Pointer to last valid byte in buffer */
+    H5S_t *tmp_space = NULL;                    /* Pointer to actual dataspace to use,
+                                                   either *space or a newly allocated one */
+    hsize_t        dims[H5S_MAX_RANK];          /* Dimension sizes */
+    uint32_t       version;                     /* Version number */
+    uint8_t        enc_size = 0;                /* Encoded size of selection info */
+    hsize_t       *coord    = NULL, *tcoord;    /* Pointer to array of elements */
+    const uint8_t *pp;                          /* Local pointer for decoding */
+    uint64_t       num_elem = 0;                /* Number of elements in selection */
+    unsigned       rank;                        /* Rank of points */
+    unsigned       i, j;                        /* local counting variables */
+    herr_t         ret_value = SUCCEED;         /* Return value */
+    const uint8_t *p_end     = *p + p_size - 1; /* Pointer to last valid byte in buffer */
     FUNC_ENTER_PACKAGE
 
     /* Check args */
@@ -1398,7 +1398,8 @@ H5S__point_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hb
         if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, 1, p_end))
             HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding point info")
         enc_size = *(pp)++;
-    } else {
+    }
+    else {
         /* Skip over the remainder of the header */
         if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, 8, p_end))
             HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection headers")
@@ -1431,20 +1432,23 @@ H5S__point_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hb
     switch (enc_size) {
         case H5S_SELECT_INFO_ENC_SIZE_2:
             if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, sizeof(uint16_t), p_end))
-                HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding number of points")
-            
+                HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL,
+                            "buffer overflow while decoding number of points")
+
             UINT16DECODE(pp, num_elem);
             break;
         case H5S_SELECT_INFO_ENC_SIZE_4:
             if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, sizeof(uint32_t), p_end))
-                HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding number of points")
+                HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL,
+                            "buffer overflow while decoding number of points")
 
             UINT32DECODE(pp, num_elem);
             break;
         case H5S_SELECT_INFO_ENC_SIZE_8:
             if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, sizeof(uint64_t), p_end))
-                HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding number of points")
-            
+                HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL,
+                            "buffer overflow while decoding number of points")
+
             UINT64DECODE(pp, num_elem);
             break;
         default:
@@ -1459,7 +1463,7 @@ H5S__point_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hb
     /* Determine necessary size of buffer for coordinates */
     size_t enc_type_size = 0;
 
-    switch(enc_size) {
+    switch (enc_size) {
         case H5S_SELECT_INFO_ENC_SIZE_2:
             enc_type_size = sizeof(uint16_t);
             break;

--- a/src/H5Sprivate.h
+++ b/src/H5Sprivate.h
@@ -190,7 +190,7 @@ typedef struct H5S_sel_iter_op_t {
 #define H5S_SELECT_SHAPE_SAME(S1, S2)             (H5S_select_shape_same(S1, S2))
 #define H5S_SELECT_INTERSECT_BLOCK(S, START, END) (H5S_select_intersect_block(S, START, END))
 #define H5S_SELECT_RELEASE(S)                     (H5S_select_release(S))
-#define H5S_SELECT_DESERIALIZE(S, BUF, BUF_SIZE)            (H5S_select_deserialize(S, BUF, BUF_SIZE))
+#define H5S_SELECT_DESERIALIZE(S, BUF, BUF_SIZE)  (H5S_select_deserialize(S, BUF, BUF_SIZE))
 
 /* Forward declaration of structs used below */
 struct H5O_t;

--- a/src/H5Sprivate.h
+++ b/src/H5Sprivate.h
@@ -190,7 +190,7 @@ typedef struct H5S_sel_iter_op_t {
 #define H5S_SELECT_SHAPE_SAME(S1, S2)             (H5S_select_shape_same(S1, S2))
 #define H5S_SELECT_INTERSECT_BLOCK(S, START, END) (H5S_select_intersect_block(S, START, END))
 #define H5S_SELECT_RELEASE(S)                     (H5S_select_release(S))
-#define H5S_SELECT_DESERIALIZE(S, BUF)            (H5S_select_deserialize(S, BUF))
+#define H5S_SELECT_DESERIALIZE(S, BUF, BUF_SIZE)            (H5S_select_deserialize(S, BUF, BUF_SIZE))
 
 /* Forward declaration of structs used below */
 struct H5O_t;
@@ -229,7 +229,7 @@ H5_DLL htri_t  H5S_extent_equal(const H5S_t *ds1, const H5S_t *ds2);
 H5_DLL herr_t  H5S_extent_copy(H5S_t *dst, const H5S_t *src);
 
 /* Operations on selections */
-H5_DLL herr_t       H5S_select_deserialize(H5S_t **space, const uint8_t **p);
+H5_DLL herr_t       H5S_select_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size);
 H5_DLL H5S_sel_type H5S_get_select_type(const H5S_t *space);
 H5_DLL herr_t   H5S_select_iterate(void *buf, const H5T_t *type, H5S_t *space, const H5S_sel_iter_op_t *op,
                                    void *op_data);

--- a/src/H5Sselect.c
+++ b/src/H5Sselect.c
@@ -523,10 +523,10 @@ H5S_select_valid(const H5S_t *space)
 herr_t
 H5S_select_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
 {
-    uint32_t sel_type;         /* Pointer to the selection type */
-    herr_t   ret_value = FAIL; /* Return value */
-    const uint8_t  *p_end = *p + p_size - 1; /* Pointer to last valid byte in buffer */
-    hbool_t skip = (p_size == SIZE_MAX ? TRUE : FALSE); /* If p_size is unknown, skip buffer checks */
+    uint32_t       sel_type;                                   /* Pointer to the selection type */
+    herr_t         ret_value = FAIL;                           /* Return value */
+    const uint8_t *p_end     = *p + p_size - 1;                /* Pointer to last valid byte in buffer */
+    hbool_t        skip = (p_size == SIZE_MAX ? TRUE : FALSE); /* If p_size is unknown, skip buffer checks */
     FUNC_ENTER_NOAPI(FAIL)
 
     HDassert(space);

--- a/src/H5Sselect.c
+++ b/src/H5Sselect.c
@@ -525,7 +525,8 @@ H5S_select_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
 {
     uint32_t sel_type;         /* Pointer to the selection type */
     herr_t   ret_value = FAIL; /* Return value */
-    char    *p_end = (char*) (*p + p_size - 1); /* Pointer to last valid byte in buffer */
+    const uint8_t  *p_end = *p + p_size - 1; /* Pointer to last valid byte in buffer */
+    hbool_t skip = (p_size == SIZE_MAX ? TRUE : FALSE); /* If p_size is unknown, skip buffer checks */
     FUNC_ENTER_NOAPI(FAIL)
 
     HDassert(space);
@@ -533,26 +534,26 @@ H5S_select_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
     /* Selection-type specific coding is moved to the callbacks. */
 
     /* Decode selection type */
-    if (H5_IS_BUFFER_OVERFLOW(*p, sizeof(uint32_t), p_end))
+    if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, *p, sizeof(uint32_t), p_end))
         HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection type")
     UINT32DECODE(*p, sel_type);
 
     /* Make routine for selection type */
     switch (sel_type) {
         case H5S_SEL_POINTS: /* Sequence of points selected */
-            ret_value = (*H5S_sel_point->deserialize)(space, p, p_size - sizeof(uint32_t));
+            ret_value = (*H5S_sel_point->deserialize)(space, p, p_size - sizeof(uint32_t), skip);
             break;
 
         case H5S_SEL_HYPERSLABS: /* Hyperslab selection defined */
-            ret_value = (*H5S_sel_hyper->deserialize)(space, p, p_size - sizeof(uint32_t));
+            ret_value = (*H5S_sel_hyper->deserialize)(space, p, p_size - sizeof(uint32_t), skip);
             break;
 
         case H5S_SEL_ALL: /* Entire extent selected */
-            ret_value = (*H5S_sel_all->deserialize)(space, p, p_size - sizeof(uint32_t));
+            ret_value = (*H5S_sel_all->deserialize)(space, p, p_size - sizeof(uint32_t), skip);
             break;
 
         case H5S_SEL_NONE: /* Nothing selected */
-            ret_value = (*H5S_sel_none->deserialize)(space, p, p_size - sizeof(uint32_t));
+            ret_value = (*H5S_sel_none->deserialize)(space, p, p_size - sizeof(uint32_t), skip);
             break;
 
         default:

--- a/src/H5Sselect.c
+++ b/src/H5Sselect.c
@@ -521,11 +521,11 @@ H5S_select_valid(const H5S_t *space)
  REVISION LOG
 --------------------------------------------------------------------------*/
 herr_t
-H5S_select_deserialize(H5S_t **space, const uint8_t **p)
+H5S_select_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
 {
     uint32_t sel_type;         /* Pointer to the selection type */
     herr_t   ret_value = FAIL; /* Return value */
-
+    char    *p_end = (char*) (*p + p_size - 1); /* Pointer to last valid byte in buffer */
     FUNC_ENTER_NOAPI(FAIL)
 
     HDassert(space);
@@ -533,24 +533,26 @@ H5S_select_deserialize(H5S_t **space, const uint8_t **p)
     /* Selection-type specific coding is moved to the callbacks. */
 
     /* Decode selection type */
+    if (H5_IS_BUFFER_OVERFLOW(*p, sizeof(uint32_t), p_end))
+        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection type")
     UINT32DECODE(*p, sel_type);
 
     /* Make routine for selection type */
     switch (sel_type) {
         case H5S_SEL_POINTS: /* Sequence of points selected */
-            ret_value = (*H5S_sel_point->deserialize)(space, p);
+            ret_value = (*H5S_sel_point->deserialize)(space, p, p_size - sizeof(uint32_t));
             break;
 
         case H5S_SEL_HYPERSLABS: /* Hyperslab selection defined */
-            ret_value = (*H5S_sel_hyper->deserialize)(space, p);
+            ret_value = (*H5S_sel_hyper->deserialize)(space, p, p_size - sizeof(uint32_t));
             break;
 
         case H5S_SEL_ALL: /* Entire extent selected */
-            ret_value = (*H5S_sel_all->deserialize)(space, p);
+            ret_value = (*H5S_sel_all->deserialize)(space, p, p_size - sizeof(uint32_t));
             break;
 
         case H5S_SEL_NONE: /* Nothing selected */
-            ret_value = (*H5S_sel_none->deserialize)(space, p);
+            ret_value = (*H5S_sel_none->deserialize)(space, p, p_size - sizeof(uint32_t));
             break;
 
         default:

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -327,7 +327,7 @@
  */
 #define H5_IS_BUFFER_OVERFLOW(ptr, size, buffer_end) (((ptr) + (size)-1) > (buffer_end))
 
-/* Variant of H5_IS_BUFFER_OVERFLOW, used with functions such as H5Tdecode() 
+/* Variant of H5_IS_BUFFER_OVERFLOW, used with functions such as H5Tdecode()
  * that don't take a size parameter, where we need to skip the bounds checks.
  *
  * This is a separate macro since we don't want to inflict that behavior on

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -327,6 +327,15 @@
  */
 #define H5_IS_BUFFER_OVERFLOW(ptr, size, buffer_end) (((ptr) + (size)-1) > (buffer_end))
 
+/* Variant of H5_IS_BUFFER_OVERFLOW, used with functions such as H5Tdecode() 
+ * that don't take a size parameter, where we need to skip the bounds checks.
+ *
+ * This is a separate macro since we don't want to inflict that behavior on
+ * the entire library.
+ */
+#define H5_IS_KNOWN_BUFFER_OVERFLOW(skip, ptr, size, buffer_end)                                             \
+    (skip ? FALSE : ((ptr) + (size)-1) > (buffer_end))
+
 /*
  * HDF Boolean type.
  */


### PR DESCRIPTION
Fix for #2680.

The call to `H5S_select_deserialize` from `H5S_decode` doesn't have the buffer size available to it, so to allow decoding there I set it to assume a max size buffer for now.

Making the buffer size known in `H5S_decode` could be done by modifying the external API's `H5Sdecode`, or splitting `H5Sdecode` into two functions using a macro (similar to `H5Sencode`), with the macro taking one argument and assuming a max buffer size.